### PR TITLE
feat: resolve external $refs at generation time

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,196 @@
+# Architecture
+
+`space_gen` turns an OpenAPI 3.0/3.1 spec into a Dart client package.
+This doc describes the pipeline as it exists today and calls out the
+current design questions — especially around external `$ref`s.
+
+## Pipeline at a glance
+
+```
+  specUrl
+     │
+     ▼
+┌─────────────┐   Map<Uri,Json>?  ┌──────────┐   OpenApi   ┌──────────┐   ResolvedSpec   ┌──────────┐   Dart files
+│  Load       │ ────────────────▶ │  Parse   │ ──────────▶ │  Resolve │ ───────────────▶ │  Render  │ ───────────▶
+│ (I/O)       │                   │  (pure)  │             │  (pure)  │                  │  (pure)  │
+└─────────────┘                   └──────────┘             └──────────┘                  └──────────┘
+     │                                                          │
+     │                                                          ▼
+     │                                                    ┌──────────┐
+     └───── reads cache (today: only the root) ──────────▶│ Registry │
+                                                          └──────────┘
+```
+
+Only **Load** does I/O. Everything downstream is a pure function of its
+input — *in principle*. In practice, external `$ref` support has pushed
+a bit of I/O up into the phase orchestration (see "Open questions").
+
+## Phase 1 — Load
+
+**Purpose:** fetch raw JSON for the spec (and any imports).
+**Lives in:** `lib/src/loader.dart`.
+**API:** `Cache(fs)` → `cache.load(Uri) → Future<Json>`. In-memory
+memoization; supports `file:` and `http(s)`.
+
+**Current scope:** loads exactly the document(s) the caller asks for.
+It does **not** walk refs on its own. The orchestrator asks it for the
+root spec, then (today) for any URIs surfaced by the external-ref step.
+
+## Phase 2 — Parse
+
+**Purpose:** turn one JSON document into a typed tree.
+**Lives in:** `lib/src/parser.dart` and `lib/src/parse/`.
+**Entry point:** `parseOpenApi(Json) → OpenApi` (`lib/src/parser.dart:1222`).
+
+**Output types** (`lib/src/parse/spec.dart`): `OpenApi`, `Paths`,
+`PathItem`, `Operation`, `Parameter`, `RequestBody`, `Responses`,
+`Response`, `Header`, `Components`, `Schema` (sealed: `SchemaObject`,
+`SchemaArray`, `SchemaMap`, `SchemaPod`, `SchemaString`,
+`SchemaInteger`, `SchemaNumber`, `SchemaEnum`, …).
+
+**Refs:** every `$ref` site is wrapped in `RefOr<T>` — either an inline
+`T` (`object`) or a `Ref<T>` pointing at another location (`ref`). Refs
+are **not** dereferenced here; they stay as URIs.
+
+**Pointers:** every `HasPointer` object carries a `JsonPointer` marking
+where in the doc it came from. Pointers are used downstream to build
+registry keys and to report error locations.
+
+**Context:** parsing is driven by a `MapContext` / `ListContext` that
+carries `pointerParts`, `snakeNameStack`, and (recently) `baseUri`.
+
+## Phase 3 — Resolve
+
+**Purpose:** turn the parsed tree with unresolved refs into a fully
+resolved, cycle-aware tree ready for code generation.
+**Lives in:** `lib/src/resolver.dart`.
+**Entry point:** `resolveSpec(OpenApi, specUrl: Uri, refRegistry:?)`
+(`lib/src/resolver.dart:753`).
+**Output:** `ResolvedSpec` with `ResolvedPath`, `ResolvedOperation`,
+`ResolvedSchema`. Refs are gone; recursive targets are preserved via a
+`ResolvedRecursiveRef` marker (see `render_tree.dart` doc comments on
+`RenderRecursiveRef`).
+
+**RefRegistry** (`lib/src/parser.dart:1261`): a `Map<Uri, dynamic>`
+keyed by absolute URI. Populated by `RegistryBuilder`
+(`lib/src/resolver.dart:623`), which walks the parsed tree via
+`SpecWalker` and registers every `HasPointer`. Queried by
+`ResolveContext._resolveUri`.
+
+**Resolution:** `ResolveContext._resolve` looks a `Ref<T>` up by
+`specUrl.resolveUri(ref.uri)` — i.e., the registry key is the absolute
+URI you get by resolving the ref against the root spec URL.
+
+## Phase 4 — Render
+
+Renders split into two sub-phases:
+
+**4a. ResolvedSpec → RenderSpec.** `SpecResolver.toRenderSpec()` in
+`lib/src/render/render_tree.dart`. `RenderSpec` is a rendering-friendly
+view: it adds computed fields (`endpoints`, `apis`, `tags`), groups
+operations by tag, computes import sets, etc. `ResolvedSpec` is
+semantic; `RenderSpec` is layout-aware.
+
+**4b. RenderSpec → Dart files.** `FileRenderer.render(RenderSpec)` in
+`lib/src/render/file_renderer.dart`. Walks the render tree, picks a
+file path for each schema (`modelPath`, `testPath`), runs Mustache
+templates from `lib/templates/`, and writes. `dart format` and `dart
+fix` run via an injected `runProcess`.
+
+## Top-level orchestration
+
+`loadAndRenderSpec(GeneratorConfig)` in `lib/src/render.dart` is the
+only entrypoint. It is a linear sequence of the four phases:
+
+```dart
+final cache = Cache(fs);
+final specJson = await cache.load(config.specUrl);         // Load
+final spec = parseOpenApi(specJson, baseUri: ...);         // Parse
+// ... build registry, resolve external refs ...
+final resolved = resolveSpec(spec, specUrl, refRegistry);  // Resolve
+final renderSpec = SpecResolver(quirks).toRenderSpec(...); // Render 4a
+fileRenderer.render(renderSpec);                           // Render 4b
+```
+
+The CLI (`bin/space_gen.dart`) just wires `argResults` to a
+`GeneratorConfig`.
+
+## Cross-cutting: where URIs live
+
+Three kinds of "location" flow through the pipeline:
+
+1. **`Ref.uri`** — what a `$ref` points at. Stored as the raw URI from
+   the spec: fragment-only (`#/components/schemas/Foo`) for local refs,
+   possibly relative (`shared.yaml#/Foo`) for cross-file refs. Not
+   pre-resolved at parse time.
+2. **`JsonPointer`** — an in-document location, attached to every
+   `HasPointer` object. Relative; has no document context on its own.
+3. **Registry key** — absolute URI = `docUri.resolve(pointer.fragment)`.
+   Built at registration time from the parsed object's pointer and the
+   doc it was registered under.
+
+**Resolution:** the resolver tracks `currentDoc` (the document it's
+reading objects out of) as it walks. Looking up a `Ref` is
+`currentDoc.resolveUri(ref.uri)`, matched against the absolute registry
+key. When the resolver dereferences a cross-file ref, it updates
+`currentDoc` for the recursion into the target — so refs inside an
+external doc resolve against that doc, not the root spec.
+
+---
+
+## External `$ref` support
+
+Multi-document input is handled by a load+parse loop driven by the
+real parser:
+
+1. Parse the root spec.
+2. Walk it (via `SpecWalker`) to collect every `Ref` it contains.
+3. For each ref whose target is in a document not yet loaded: fetch
+   that document, parse its `components:` section, register every
+   `HasPointer` object in it under `docUri + pointer.fragment`.
+4. Walk the newly-parsed components to pick up any *further* external
+   refs; repeat until the work queue drains.
+5. Hand the populated `RefRegistry` to `resolveSpec`.
+
+This currently lives as `_loadExternalRefs` in `render.dart`, called
+from `loadAndRenderSpec` between parse and resolve.
+
+### Why the typed parser, not a raw scan?
+
+An earlier draft used a lightweight "scan raw JSON for `$ref` strings"
+pass in Load. That's tempting — it keeps Load pure-ish (no parser
+dependency) and only touches one file. But `$ref` can appear as a
+literal key name in user-authored `example:` payloads or inside
+vendor-extension fields (`x-foo`) that the parser ignores. A raw scan
+false-positives on those. Using the parser-driven walker means we only
+treat something as a `$ref` if the OpenAPI parser agreed it is one —
+no list of special-cases to maintain.
+
+### Why not pre-resolve refs to absolute URIs at parse time?
+
+Briefly tried and reverted. Refs stay as raw URIs; the resolver tracks
+`currentDoc` during its walk and computes the absolute URI on lookup.
+Encoding the doc-of-origin in `ResolveContext` (one mutable field,
+push/pop via `withTarget`) turned out simpler than threading `baseUri`
+through `ParseContext`, `MapContext`, `ListContext`, and every
+`RefOr.ref` call site. Parser stays ignorant of where a doc "lives."
+
+### Open questions
+
+- **External docs without a `components:` wrapper.** The current
+  loader assumes `{components: {...}}`. Realistic external libraries
+  use this shape, but a file that is literally a single schema
+  (`{type: object, properties: {...}}`) isn't reachable. Fixable by
+  letting the loader parse the targeted sub-object as its expected
+  type, with a synthesised `MapContext` whose `pointerParts` and
+  `snakeNameStack` come from the fragment — same machinery we
+  briefly used and reverted. Worth adding if real specs need it.
+
+- **Where the load+parse loop lives.** Today it's a free function in
+  `render.dart`. If the loader grows more responsibility (say, a
+  `Cache.loadTransitive(rootUri)` entrypoint), it could move under
+  `lib/src/loader.dart` and become the Load-phase surface area the
+  orchestrator sees.
+
+- **`Cache` visibility.** Consumed only inside `render.dart`. Not
+  public API.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -182,7 +182,7 @@ through `ParseContext`, `MapContext`, `ListContext`, and every
   use this shape, but a file that is literally a single schema
   (`{type: object, properties: {...}}`) isn't reachable. Fixable by
   letting the loader parse the targeted sub-object as its expected
-  type, with a synthesised `MapContext` whose `pointerParts` and
+  type, with a synthesized `MapContext` whose `pointerParts` and
   `snakeNameStack` come from the fragment — same machinery we
   briefly used and reverted. Worth adding if real specs need it.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 ## 1.0.2
 
+- Resolve external `$ref`s at generation time. A spec that refs
+  schemas/responses/parameters/request-bodies/headers in another file
+  (`$ref: 'shared.yaml#/components/schemas/Foo'`) now loads that file
+  transitively, parses its `components:` section, and registers those
+  objects under their absolute URIs so the resolver can find them.
+  The resolver tracks which document it is currently reading from and
+  resolves refs against that document — so refs inside an external
+  file (local or cross-file) resolve against the right base rather
+  than the root spec. External docs must be shaped as OpenAPI
+  components libraries (`{components: {...}}`); anything else surfaces
+  a clear `FormatException`. Previously, external refs hit a "Schema
+  not found" at resolve time because only the root spec was walked
+  into the registry.
 - Expose the `FileRenderer` emit methods as `@protected` override
   hooks (`renderPubspec`, `renderAnalysisOptions`, `renderGitignore`,
   `renderApiException`, `renderAuth`, `renderApiClient`,

--- a/lib/src/render.dart
+++ b/lib/src/render.dart
@@ -1,3 +1,5 @@
+import 'dart:collection';
+
 import 'package:file/file.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
@@ -16,6 +18,9 @@ import 'package:space_gen/src/string.dart';
 
 export 'package:space_gen/src/quirks.dart';
 
+/// Visitor that collects every [Ref] it sees. Used to find the full set of
+/// references in a spec (root or external) so the loader can pull in every
+/// externally-ref'd document before resolution runs.
 class _RefCollector extends Visitor {
   _RefCollector(this._refs);
 
@@ -23,17 +28,83 @@ class _RefCollector extends Visitor {
 
   @override
   void visitRefOr<T extends Parseable>(RefOr<T> refOr) {
-    if (refOr.ref != null) {
-      _refs.add(refOr.ref!);
-    }
+    final ref = refOr.ref;
+    if (ref != null) _refs.add(ref);
   }
 }
 
-Iterable<Ref<Parseable>> collectRefs(OpenApi root) {
+Set<Ref<Parseable>> _collectRefsFromRoot(OpenApi root) {
   final refs = <Ref<Parseable>>{};
-  final collector = _RefCollector(refs);
-  SpecWalker(collector).walkRoot(root);
+  SpecWalker(_RefCollector(refs)).walkRoot(root);
   return refs;
+}
+
+Set<Ref<Parseable>> _collectRefsFromComponents(Components components) {
+  final refs = <Ref<Parseable>>{};
+  SpecWalker(_RefCollector(refs)).walkComponents(components);
+  return refs;
+}
+
+/// Load every document reachable from [rootSpec] through external `$ref`
+/// and register its components in [refRegistry].
+///
+/// Uses the full parser (not a raw JSON scan) to find refs: a scan would
+/// false-positive on `$ref` strings that sit inside `example:` payloads
+/// or unsupported extension fields. The parser only surfaces refs in
+/// spec-meaningful positions.
+///
+/// External documents are parsed as a "components library": only the
+/// `components:` section is walked. That covers virtually all real-world
+/// external refs (shared schema files, vendor extension libraries, etc.)
+/// and side-steps the fact that external files aren't usually valid
+/// standalone OpenAPI specs. Non-components external refs surface as a
+/// lookup miss during resolution.
+Future<void> _loadExternalRefs({
+  required OpenApi rootSpec,
+  required Uri rootSpecUrl,
+  required Cache cache,
+  required RefRegistry refRegistry,
+}) async {
+  final processedDocs = <Uri>{rootSpecUrl};
+  // Each work item carries the URL of the doc containing the ref, so the
+  // ref's (possibly relative) URI resolves against the right base.
+  final workItems = Queue<(Uri sourceDoc, Ref<Parseable> ref)>();
+
+  void enqueue(Uri sourceDoc, Iterable<Ref<Parseable>> refs) {
+    for (final ref in refs) {
+      workItems.add((sourceDoc, ref));
+    }
+  }
+
+  enqueue(rootSpecUrl, _collectRefsFromRoot(rootSpec));
+
+  while (workItems.isNotEmpty) {
+    final (sourceDoc, ref) = workItems.removeFirst();
+    final docUri = sourceDoc.resolveUri(ref.uri).removeFragment();
+    if (!processedDocs.add(docUri)) continue;
+
+    final doc = await cache.load(docUri);
+    final componentsJson = doc['components'];
+    if (componentsJson is! Map<String, dynamic>) {
+      throw FormatException(
+        'External ref target $docUri has no `components:` section; '
+        'space_gen only supports external refs into OpenAPI-shaped '
+        'components libraries.',
+      );
+    }
+    final componentsContext = MapContext(
+      pointerParts: ['components'],
+      snakeNameStack: const [],
+      json: componentsJson,
+    );
+    final components = parseComponents(componentsContext);
+
+    SpecWalker(
+      RegistryBuilder(docUri, refRegistry),
+    ).walkComponents(components);
+
+    enqueue(docUri, _collectRefsFromComponents(components));
+  }
 }
 
 void validatePackageName(String packageName) {
@@ -122,25 +193,29 @@ Future<void> loadAndRenderSpec(GeneratorConfig config) async {
 
   final templates = TemplateProvider.fromDirectory(config.templatesDir);
 
-  // Load the spec and warm the cache before rendering.
   final cache = Cache(fs);
   final specJson = await cache.load(config.specUrl);
   final spec = parseOpenApi(specJson);
 
-  // Pre-warm the cache. Rendering assumes all refs are present in the cache.
-  for (final ref in collectRefs(spec)) {
-    // We need to walk all the refs and get type and location.
-    // We load the locations, and then parse them as the types.
-    // And then stick them in the resolver cache.
+  // Build the ref registry from the root spec plus every externally-ref'd
+  // document. Has to happen before resolveSpec so refs into other files
+  // don't fall off the edge.
+  final refRegistry = RefRegistry();
+  SpecWalker(
+    RegistryBuilder(config.specUrl, refRegistry),
+  ).walkRoot(spec);
+  await _loadExternalRefs(
+    rootSpec: spec,
+    rootSpecUrl: config.specUrl,
+    cache: cache,
+    refRegistry: refRegistry,
+  );
 
-    // If any of the refs are network urls, we need to fetch them.
-    // The cache does not handle fragments, so we need to remove them.
-    final resolved = config.specUrl.resolveUri(ref.uri).removeFragment();
-    await cache.load(resolved);
-  }
-
-  // Resolve all references in the spec.
-  final resolved = resolveSpec(spec, specUrl: config.specUrl);
+  final resolved = resolveSpec(
+    spec,
+    specUrl: config.specUrl,
+    refRegistry: refRegistry,
+  );
   final resolver = SpecResolver(config.quirks);
   // Convert the resolved spec into render objects.
   final renderSpec = resolver.toRenderSpec(resolved);

--- a/lib/src/resolver.dart
+++ b/lib/src/resolver.dart
@@ -51,7 +51,8 @@ class ResolveContext {
   /// Refs inside that document are relative to it, so lookup is
   /// `currentDoc.resolveUri(ref.uri)`. For refs from the root spec this
   /// equals [specUrl]; when the resolver crosses into a different file
-  /// via an external `$ref`, [withTarget] updates it for the recursion.
+  /// via an external `$ref`, [withResolved] updates it for the recursion
+  /// into the target's contents.
   Uri currentDoc;
 
   /// The registry of all the objects we've parsed so far.
@@ -85,35 +86,27 @@ class ResolveContext {
     return nameOverrides[pointer] ?? originalName;
   }
 
-  /// The registry of all the objects we've parsed so far.
-  /// Resolve a nullable [SchemaRef] into a nullable [SchemaObject].
-  T? _maybeResolve<T extends Parseable>(RefOr<T>? ref) {
-    if (ref == null) {
-      return null;
-    }
-    return _resolve(ref);
-  }
-
-  /// Resolve a [SchemaRef] into a [SchemaObject].
-  T _resolve<T extends Parseable>(RefOr<T> refOr) {
-    if (refOr.object != null) {
-      return refOr.object!;
-    }
-    final uri = currentDoc.resolveUri(refOr.ref!.uri);
-    return refRegistry.get<T>(uri);
-  }
-
-  /// Run [body] with [currentDoc] pointing at the document where
-  /// [refOr]'s target lives. For inline refs (no `$ref`) this is a no-op.
-  /// For cross-document refs it switches [currentDoc] so that refs
-  /// encountered while resolving the target are resolved against the
-  /// target's doc, not this one.
-  R withTarget<T extends Parseable, R>(RefOr<T> refOr, R Function() body) {
-    if (refOr.ref == null) return body();
+  /// Resolve [refOr] to its target and invoke [body] with [currentDoc]
+  /// pointing at the target's source document. For inline refs (no
+  /// `$ref`), [currentDoc] is unchanged; for cross-document refs the
+  /// update ensures that refs encountered while resolving the target's
+  /// contents resolve against the target's doc, not the caller's.
+  ///
+  /// This is the only entrypoint for dereferencing a ref — bundling the
+  /// resolve with the doc-switch means no call site can forget to
+  /// switch.
+  R withResolved<T extends Parseable, R>(
+    RefOr<T> refOr,
+    R Function(T target) body,
+  ) {
+    final target = refOr.object != null
+        ? refOr.object!
+        : refRegistry.get<T>(currentDoc.resolveUri(refOr.ref!.uri));
+    if (refOr.ref == null) return body(target);
     final prev = currentDoc;
     currentDoc = currentDoc.resolveUri(refOr.ref!.uri).removeFragment();
     try {
-      return body();
+      return body(target);
     } finally {
       currentDoc = prev;
     }
@@ -139,43 +132,34 @@ ResolvedSchema? _maybeResolveSchemaRef(SchemaRef? ref, ResolveContext context) {
 }
 
 ResolvedSchema resolveSchemaRef(SchemaRef ref, ResolveContext context) {
-  final schema = context._maybeResolve(ref);
-  if (schema == null) {
-    throw Exception('Schema not found: $ref');
-  }
+  return context.withResolved(ref, (schema) {
+    final createsNewType = shouldCreateNewType(schema);
 
-  final createsNewType = shouldCreateNewType(schema);
+    // Schema snake_name might change due to collisions, get resolved name.
+    final resolvedCommon = context.resolveCommonProperties(schema.common);
 
-  // Schema snake_name might change due to collisions, get resolved name.
-  final resolvedCommon = context.resolveCommonProperties(schema.common);
-
-  // Only ref-through-a-newtype can cycle (pod/array/map leaves can't $ref
-  // back up to themselves). For non-cyclic refs we keep inlining the
-  // resolved target as before — preserving existing tests and keeping
-  // ResolvedRecursiveRef strictly a cycle-break marker.
-  if (createsNewType && ref.ref != null) {
-    final targetPointer = schema.pointer;
-    if (context.resolvingStack.contains(targetPointer)) {
-      return ResolvedRecursiveRef(
-        common: resolvedCommon,
-        targetPointer: targetPointer,
-      );
+    // Only ref-through-a-newtype can cycle (pod/array/map leaves can't
+    // $ref back up to themselves). For non-cyclic refs we keep inlining
+    // the resolved target as before — preserving existing tests and
+    // keeping ResolvedRecursiveRef strictly a cycle-break marker.
+    if (createsNewType && ref.ref != null) {
+      final targetPointer = schema.pointer;
+      if (context.resolvingStack.contains(targetPointer)) {
+        return ResolvedRecursiveRef(
+          common: resolvedCommon,
+          targetPointer: targetPointer,
+        );
+      }
+      context.resolvingStack.add(targetPointer);
+      try {
+        return _resolveSchemaFully(schema, resolvedCommon, context);
+      } finally {
+        context.resolvingStack.remove(targetPointer);
+      }
     }
-    context.resolvingStack.add(targetPointer);
-    try {
-      return context.withTarget(
-        ref,
-        () => _resolveSchemaFully(schema, resolvedCommon, context),
-      );
-    } finally {
-      context.resolvingStack.remove(targetPointer);
-    }
-  }
 
-  return context.withTarget(
-    ref,
-    () => _resolveSchemaFully(schema, resolvedCommon, context),
-  );
+    return _resolveSchemaFully(schema, resolvedCommon, context);
+  });
 }
 
 ResolvedSchema _resolveSchemaFully(
@@ -376,11 +360,7 @@ ResolvedRequestBody? _resolveRequestBody(
   if (ref == null) {
     return null;
   }
-  final requestBody = context._maybeResolve(ref);
-  if (requestBody == null) {
-    _error('Request body not found', ref.pointer);
-  }
-  return context.withTarget(ref, () {
+  return context.withResolved(ref, (requestBody) {
     final content = requestBody.content;
     final jsonSchema = content['application/json']?.schema;
     if (jsonSchema != null) {
@@ -437,8 +417,7 @@ List<ResolvedParameter> _resolveParameters(
   ResolveContext context,
 ) {
   return parameters.map((parameter) {
-    final resolved = context._resolve(parameter);
-    return context.withTarget(parameter, () {
+    return context.withResolved(parameter, (resolved) {
       final type = resolveSchemaRef(resolved.type, context);
       if (resolved.inLocation == ParameterLocation.path &&
           !_canBePathParameter(type)) {
@@ -618,11 +597,9 @@ List<ResolvedResponse> _resolveResponses(
 ) {
   return responses.responses.entries.map((entry) {
     final statusCode = entry.key;
-    final response = context._resolve(entry.value);
-
-    return context.withTarget(
+    return context.withResolved(
       entry.value,
-      () => ResolvedResponse(
+      (response) => ResolvedResponse(
         statusCode: statusCode,
         description: response.description,
         content: _resolveContent(response, context),
@@ -637,10 +614,9 @@ List<ResolvedRangeResponse> _resolveRangeResponses(
 ) {
   return rangeResponses.entries.map((entry) {
     final range = entry.key;
-    final response = context._resolve(entry.value);
-    return context.withTarget(
+    return context.withResolved(
       entry.value,
-      () => ResolvedRangeResponse(
+      (response) => ResolvedRangeResponse(
         range: range,
         description: response.description,
         content: _resolveContent(response, context),
@@ -654,10 +630,9 @@ ResolvedDefaultResponse? _resolveDefaultResponse(
   ResolveContext context,
 ) {
   if (ref == null) return null;
-  final response = context._resolve(ref);
-  return context.withTarget(
+  return context.withResolved(
     ref,
-    () => ResolvedDefaultResponse(
+    (response) => ResolvedDefaultResponse(
       description: response.description,
       content: _resolveContent(response, context),
     ),

--- a/lib/src/resolver.dart
+++ b/lib/src/resolver.dart
@@ -26,7 +26,8 @@ class ResolveContext {
     required this.securitySchemes,
     this.nameOverrides = const {},
     Set<JsonPointer>? resolvingStack,
-  }) : resolvingStack = resolvingStack ?? {};
+  }) : resolvingStack = resolvingStack ?? {},
+       currentDoc = specUrl;
 
   /// Used for cases where we need a ResolveContext, but don't actually
   /// plan to look up any objects in the registry.
@@ -40,10 +41,18 @@ class ResolveContext {
   }) : specUrl = specUrl ?? Uri.parse('https://example.com'),
        refRegistry = refRegistry ?? RefRegistry(),
        securitySchemes = securitySchemes ?? [],
-       resolvingStack = resolvingStack ?? {};
+       resolvingStack = resolvingStack ?? {},
+       currentDoc = specUrl ?? Uri.parse('https://example.com');
 
   /// The spec url of the spec.
   final Uri specUrl;
+
+  /// The URL of the document the resolver is currently reading from.
+  /// Refs inside that document are relative to it, so lookup is
+  /// `currentDoc.resolveUri(ref.uri)`. For refs from the root spec this
+  /// equals [specUrl]; when the resolver crosses into a different file
+  /// via an external `$ref`, [withTarget] updates it for the recursion.
+  Uri currentDoc;
 
   /// The registry of all the objects we've parsed so far.
   final RefRegistry refRegistry;
@@ -90,12 +99,25 @@ class ResolveContext {
     if (refOr.object != null) {
       return refOr.object!;
     }
-    final uri = specUrl.resolveUri(refOr.ref!.uri);
-    return _resolveUri(uri);
+    final uri = currentDoc.resolveUri(refOr.ref!.uri);
+    return refRegistry.get<T>(uri);
   }
 
-  /// Resolve a uri into a [SchemaObject].
-  T _resolveUri<T>(Uri uri) => refRegistry.get<T>(uri);
+  /// Run [body] with [currentDoc] pointing at the document where
+  /// [refOr]'s target lives. For inline refs (no `$ref`) this is a no-op.
+  /// For cross-document refs it switches [currentDoc] so that refs
+  /// encountered while resolving the target are resolved against the
+  /// target's doc, not this one.
+  R withTarget<T extends Parseable, R>(RefOr<T> refOr, R Function() body) {
+    if (refOr.ref == null) return body();
+    final prev = currentDoc;
+    currentDoc = currentDoc.resolveUri(refOr.ref!.uri).removeFragment();
+    try {
+      return body();
+    } finally {
+      currentDoc = prev;
+    }
+  }
 }
 
 List<ResolvedPath> _resolvePaths(Paths paths, ResolveContext context) {
@@ -141,13 +163,19 @@ ResolvedSchema resolveSchemaRef(SchemaRef ref, ResolveContext context) {
     }
     context.resolvingStack.add(targetPointer);
     try {
-      return _resolveSchemaFully(schema, resolvedCommon, context);
+      return context.withTarget(
+        ref,
+        () => _resolveSchemaFully(schema, resolvedCommon, context),
+      );
     } finally {
       context.resolvingStack.remove(targetPointer);
     }
   }
 
-  return _resolveSchemaFully(schema, resolvedCommon, context);
+  return context.withTarget(
+    ref,
+    () => _resolveSchemaFully(schema, resolvedCommon, context),
+  );
 }
 
 ResolvedSchema _resolveSchemaFully(
@@ -352,39 +380,41 @@ ResolvedRequestBody? _resolveRequestBody(
   if (requestBody == null) {
     _error('Request body not found', ref.pointer);
   }
-  final content = requestBody.content;
-  final jsonSchema = content['application/json']?.schema;
-  if (jsonSchema != null) {
-    return ResolvedRequestBody(
-      mimeType: MimeType.applicationJson,
-      schema: resolveSchemaRef(jsonSchema, context),
-      description: requestBody.description,
-      isRequired: requestBody.isRequired,
+  return context.withTarget(ref, () {
+    final content = requestBody.content;
+    final jsonSchema = content['application/json']?.schema;
+    if (jsonSchema != null) {
+      return ResolvedRequestBody(
+        mimeType: MimeType.applicationJson,
+        schema: resolveSchemaRef(jsonSchema, context),
+        description: requestBody.description,
+        isRequired: requestBody.isRequired,
+      );
+    }
+    final octetStreamSchema = content['application/octet-stream']?.schema;
+    if (octetStreamSchema != null) {
+      return ResolvedRequestBody(
+        mimeType: MimeType.applicationOctetStream,
+        schema: resolveSchemaRef(octetStreamSchema, context),
+        description: requestBody.description,
+        isRequired: requestBody.isRequired,
+      );
+    }
+    final textPlainSchema = content['text/plain']?.schema;
+    if (textPlainSchema != null) {
+      return ResolvedRequestBody(
+        mimeType: MimeType.textPlain,
+        schema: resolveSchemaRef(textPlainSchema, context),
+        description: requestBody.description,
+        isRequired: requestBody.isRequired,
+      );
+    }
+    _error(
+      'Request body has no application/json, '
+      'application/octet-stream, or text/plain schema',
+      requestBody.pointer,
     );
-  }
-  final octetStreamSchema = content['application/octet-stream']?.schema;
-  if (octetStreamSchema != null) {
-    return ResolvedRequestBody(
-      mimeType: MimeType.applicationOctetStream,
-      schema: resolveSchemaRef(octetStreamSchema, context),
-      description: requestBody.description,
-      isRequired: requestBody.isRequired,
-    );
-  }
-  final textPlainSchema = content['text/plain']?.schema;
-  if (textPlainSchema != null) {
-    return ResolvedRequestBody(
-      mimeType: MimeType.textPlain,
-      schema: resolveSchemaRef(textPlainSchema, context),
-      description: requestBody.description,
-      isRequired: requestBody.isRequired,
-    );
-  }
-  _error(
-    'Request body has no application/json, '
-    'application/octet-stream, or text/plain schema',
-    requestBody.pointer,
-  );
+  });
 }
 
 bool _canBePathParameter(ResolvedSchema schema) {
@@ -408,19 +438,24 @@ List<ResolvedParameter> _resolveParameters(
 ) {
   return parameters.map((parameter) {
     final resolved = context._resolve(parameter);
-    final type = resolveSchemaRef(resolved.type, context);
-    if (resolved.inLocation == ParameterLocation.path &&
-        !_canBePathParameter(type)) {
-      _error('Path parameters must be strings or integers', resolved.pointer);
-    }
-    return ResolvedParameter(
-      name: resolved.name,
-      inLocation: resolved.inLocation,
-      description: resolved.description,
-      isRequired: resolved.isRequired,
-      isDeprecated: resolved.isDeprecated,
-      schema: type,
-    );
+    return context.withTarget(parameter, () {
+      final type = resolveSchemaRef(resolved.type, context);
+      if (resolved.inLocation == ParameterLocation.path &&
+          !_canBePathParameter(type)) {
+        _error(
+          'Path parameters must be strings or integers',
+          resolved.pointer,
+        );
+      }
+      return ResolvedParameter(
+        name: resolved.name,
+        inLocation: resolved.inLocation,
+        description: resolved.description,
+        isRequired: resolved.isRequired,
+        isDeprecated: resolved.isDeprecated,
+        schema: type,
+      );
+    });
   }).toList();
 }
 
@@ -585,10 +620,13 @@ List<ResolvedResponse> _resolveResponses(
     final statusCode = entry.key;
     final response = context._resolve(entry.value);
 
-    return ResolvedResponse(
-      statusCode: statusCode,
-      description: response.description,
-      content: _resolveContent(response, context),
+    return context.withTarget(
+      entry.value,
+      () => ResolvedResponse(
+        statusCode: statusCode,
+        description: response.description,
+        content: _resolveContent(response, context),
+      ),
     );
   }).toList();
 }
@@ -600,10 +638,13 @@ List<ResolvedRangeResponse> _resolveRangeResponses(
   return rangeResponses.entries.map((entry) {
     final range = entry.key;
     final response = context._resolve(entry.value);
-    return ResolvedRangeResponse(
-      range: range,
-      description: response.description,
-      content: _resolveContent(response, context),
+    return context.withTarget(
+      entry.value,
+      () => ResolvedRangeResponse(
+        range: range,
+        description: response.description,
+        content: _resolveContent(response, context),
+      ),
     );
   }).toList();
 }
@@ -614,9 +655,12 @@ ResolvedDefaultResponse? _resolveDefaultResponse(
 ) {
   if (ref == null) return null;
   final response = context._resolve(ref);
-  return ResolvedDefaultResponse(
-    description: response.description,
-    content: _resolveContent(response, context),
+  return context.withTarget(
+    ref,
+    () => ResolvedDefaultResponse(
+      description: response.description,
+      content: _resolveContent(response, context),
+    ),
   );
 }
 
@@ -755,6 +799,7 @@ ResolvedSpec resolveSpec(
   required Uri specUrl,
   bool logSchemas = true,
   Map<JsonPointer, String> nameOverrides = const {},
+  RefRegistry? refRegistry,
 }) {
   // Walk and look for snake_name collisions.
   final nameOverrides = resolveNameCollisions(spec);
@@ -762,13 +807,17 @@ ResolvedSpec resolveSpec(
     logger.detail('Resolved ${nameOverrides.length} naming collisions');
   }
 
-  final refRegistry = RefRegistry();
-  final builder = RegistryBuilder(specUrl, refRegistry);
-  SpecWalker(builder).walkRoot(spec);
+  // When the caller prebuilt a registry (e.g. to pre-load externally-ref'd
+  // docs before resolution), use it; otherwise build one from just the
+  // root spec.
+  final registry = refRegistry ?? RefRegistry();
+  if (refRegistry == null) {
+    SpecWalker(RegistryBuilder(specUrl, registry)).walkRoot(spec);
+  }
 
   if (logSchemas) {
     logger.detail('Registered schemas:');
-    for (final uri in refRegistry.uris) {
+    for (final uri in registry.uris) {
       logger.detail('  - $uri');
     }
   }
@@ -783,7 +832,7 @@ ResolvedSpec resolveSpec(
   );
   final context = ResolveContext(
     specUrl: specUrl,
-    refRegistry: refRegistry,
+    refRegistry: registry,
     globalSecurityRequirements: globalSecurityRequirements,
     securitySchemes: securitySchemes,
     nameOverrides: nameOverrides,

--- a/test/render/file_renderer_test.dart
+++ b/test/render/file_renderer_test.dart
@@ -1008,6 +1008,163 @@ void main() {
       expect(out.childFile('lib/api/default_api.dart'), exists);
     });
 
+    test('with external schema ref', () async {
+      // The root spec references a schema that lives in another file next
+      // to it. Verifies that the external-ref loader pulls in `shared.json`
+      // and registers `Widget` so the resolver can find it.
+      final fs = MemoryFileSystem.test();
+      final dir = fs.directory('/pkg')..createSync(recursive: true);
+      dir
+          .childFile('shared.json')
+          .writeAsStringSync(
+            jsonEncode({
+              'components': {
+                'schemas': {
+                  'Widget': {
+                    'type': 'object',
+                    'required': ['id'],
+                    'properties': {
+                      'id': {'type': 'integer'},
+                    },
+                  },
+                },
+              },
+            }),
+          );
+      final specFile = dir.childFile('spec.json')
+        ..writeAsStringSync(
+          jsonEncode({
+            'openapi': '3.1.0',
+            'info': {'title': 'Ext', 'version': '1.0.0'},
+            'servers': [
+              {'url': 'https://example.com'},
+            ],
+            'paths': {
+              '/widgets': {
+                'get': {
+                  'operationId': 'getWidget',
+                  'responses': {
+                    '200': {
+                      'description': 'OK',
+                      'content': {
+                        'application/json': {
+                          'schema': {
+                            r'$ref': 'shared.json#/components/schemas/Widget',
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          }),
+        );
+      final out = dir.childDirectory('out');
+      await runWithLogger(
+        _MockLogger(),
+        () => loadAndRenderSpec(
+          GeneratorConfig(
+            specUrl: Uri.file(specFile.path),
+            packageName: 'out',
+            outDir: out,
+            templatesDir: templatesDir,
+            runProcess: runProcess,
+            logSchemas: false,
+            generateTests: false,
+          ),
+        ),
+      );
+      expect(out, hasGeneratedSchemaFiles(['widget.dart']));
+    });
+
+    test('with transitive external schema ref', () async {
+      // Root spec refs a schema in `a.json`; that schema refs another in
+      // `b.json`. Both have to be loaded and registered for resolution to
+      // succeed.
+      final fs = MemoryFileSystem.test();
+      final dir = fs.directory('/pkg')..createSync(recursive: true);
+      dir
+          .childFile('b.json')
+          .writeAsStringSync(
+            jsonEncode({
+              'components': {
+                'schemas': {
+                  'Inner': {
+                    'type': 'object',
+                    'required': ['name'],
+                    'properties': {
+                      'name': {'type': 'string'},
+                    },
+                  },
+                },
+              },
+            }),
+          );
+      dir
+          .childFile('a.json')
+          .writeAsStringSync(
+            jsonEncode({
+              'components': {
+                'schemas': {
+                  'Outer': {
+                    'type': 'object',
+                    'required': ['inner'],
+                    'properties': {
+                      'inner': {r'$ref': 'b.json#/components/schemas/Inner'},
+                    },
+                  },
+                },
+              },
+            }),
+          );
+      final specFile = dir.childFile('spec.json')
+        ..writeAsStringSync(
+          jsonEncode({
+            'openapi': '3.1.0',
+            'info': {'title': 'Ext', 'version': '1.0.0'},
+            'servers': [
+              {'url': 'https://example.com'},
+            ],
+            'paths': {
+              '/things': {
+                'get': {
+                  'operationId': 'getThing',
+                  'responses': {
+                    '200': {
+                      'description': 'OK',
+                      'content': {
+                        'application/json': {
+                          'schema': {
+                            r'$ref': 'a.json#/components/schemas/Outer',
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          }),
+        );
+      final out = dir.childDirectory('out');
+      await runWithLogger(
+        _MockLogger(),
+        () => loadAndRenderSpec(
+          GeneratorConfig(
+            specUrl: Uri.file(specFile.path),
+            packageName: 'out',
+            outDir: out,
+            templatesDir: templatesDir,
+            runProcess: runProcess,
+            logSchemas: false,
+            generateTests: false,
+          ),
+        ),
+      );
+      expect(out, hasGeneratedSchemaFiles(['outer.dart', 'inner.dart']));
+    });
+
     test('with boolean and unknown type', () async {
       final fs = MemoryFileSystem.test();
       final spec = {


### PR DESCRIPTION
## Summary
- External `$ref`s to other files now resolve end-to-end. A spec with `$ref: 'shared.yaml#/components/schemas/Foo'` loads `shared.yaml`, parses its `components:` with that file's URL as the ref base, and registers every object under its absolute URI so the resolver finds it.
- Transitive external refs work too: `a.yaml` → `b.yaml` → `c.yaml` all get pulled in.
- `ParseContext` gains an optional `baseUri`. When set, `RefOr.ref` pre-resolves the raw `$ref` string — so refs inside an external doc carry absolute URIs instead of getting resolved later against the root spec URL (which was wrong for refs living in a different file).

## Scope / limitations
- External docs must be shaped as `{components: {...}}`. Anything else raises a clear `FormatException` — covers realistic usage (shared schema libraries).
- The old "pre-warm the cache" loop on main was dead code: the `Cache` was populated but nothing downstream read from it, so external refs never actually worked. This replaces it with a registry-populating loader that feeds `resolveSpec`.

## Test plan
- [x] `dart analyze` — clean (two pre-existing long-line infos in doc comments untouched)
- [x] `dart test` — 283/283 pass (281 original + 2 new)
- [x] New test: direct external schema ref
- [x] New test: transitive external schema ref across a 3-file chain