### PR TITLE
test: Add test for logger.error

### DIFF
--- a/lib/src/logger.dart
+++ b/lib/src/logger.dart
@@ -20,3 +20,8 @@ R runWithLogger<R>(Logger logger, R Function() fn) {
 void setVerboseLogging() {
   logger.level = Level.verbose;
 }
+
+/// Log an error message.
+void error(String message) {
+  logger.err(message);
+}

--- a/test/logger_test.dart
+++ b/test/logger_test.dart
@@ -1,0 +1,18 @@
+import 'package:mason_logger/mason_logger.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:space_gen/src/logger.dart';
+import 'package:test/test.dart';
+
+class MockLogger extends Mock implements Logger {}
+
+void main() {
+  group('logger', () {
+    test('error', () {
+      final logger = MockLogger();
+      runWithLogger(logger, () {
+        error('test message');
+      });
+      verify(() => logger.err('test message')).called(1);
+    });
+  });
+}


### PR DESCRIPTION
This commit also adds the previously missing error function to the logger.