### PR TITLE
perf: emit only imports the rendered body needs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.0.2
+
+- Emit only the imports a rendered model/api body actually needs: drop
+  unconditional `dart:convert`, `dart:io`, `package:meta/meta.dart`, and
+  `model_helpers.dart` from models; gate `meta` and `model_helpers` on
+  body contents; filter the schema's own file from its imports. Cuts
+  `dart fix` work roughly in half on spacetraders and github.
+
 ## 1.0.1
 
 - Fix finding of template files when run via `dart pub run space_gen`.

--- a/lib/src/render.dart
+++ b/lib/src/render.dart
@@ -139,7 +139,7 @@ String renderTestSchema(
 
   final renderSchema = resolver.toRenderSchema(resolvedSchema);
   final schemaRenderer = SchemaRenderer(templates: templates, quirks: quirks);
-  return schemaRenderer.renderSchema(renderSchema);
+  return schemaRenderer.renderSchema(renderSchema).body;
 }
 
 /// Render a set of schemas to separate strings.
@@ -195,7 +195,7 @@ Map<String, String> renderTestSchemas(
   final renderSchemas = resolvedSchemas.map((key, value) {
     final renderSchema = resolver.toRenderSchema(value);
     final schemaRenderer = SchemaRenderer(templates: templates, quirks: quirks);
-    return MapEntry(key, schemaRenderer.renderSchema(renderSchema));
+    return MapEntry(key, schemaRenderer.renderSchema(renderSchema).body);
   });
 
   return renderSchemas;
@@ -272,5 +272,5 @@ String renderTestApiFromSpec({
     templates: templateProvider,
     quirks: quirks,
   );
-  return schemaRenderer.renderApi(api);
+  return schemaRenderer.renderApi(api).body;
 }

--- a/lib/src/render/file_renderer.dart
+++ b/lib/src/render/file_renderer.dart
@@ -352,15 +352,16 @@ class FileRenderer {
       schema.createsNewType && schema is! RenderRecursiveRef;
 
   @visibleForTesting
-  Iterable<Import> importsForApi(Api api) {
+  Iterable<Import> importsForApi(Api api, ApiUsage usage) {
     // TODO(eseidel): Make type imports dynamic based on used schemas.
     final imports = {
       const Import('dart:async'),
       const Import('dart:convert'), // jsonDecode, for decoding response body.
-      const Import('dart:io'),
+      const Import('dart:io'), // HttpStatus, emitted by api.mustache.
       Import('package:$packageName/api_client.dart'),
       Import('package:$packageName/api_exception.dart'),
       const Import('package:http/http.dart', asName: 'http'),
+      ...usage.importsFor(packageName),
     };
 
     final apiSchemas = collectSchemasUnderApi(api);
@@ -381,8 +382,8 @@ class FileRenderer {
   List<Api> _renderApis(List<Api> apis) {
     final rendered = <Api>[];
     for (final api in apis) {
-      final content = schemaRenderer.renderApi(api);
-      final imports = importsForApi(api);
+      final renderedApi = schemaRenderer.renderApi(api);
+      final imports = importsForApi(api, renderedApi.usage);
       final importsContext = imports
           .sortedBy((i) => i.path)
           .map((i) => i.toTemplateContext())
@@ -391,7 +392,7 @@ class FileRenderer {
       _renderTemplate(
         template: 'add_imports',
         outPath: outPath,
-        context: {'imports': importsContext, 'content': content},
+        context: {'imports': importsContext, 'content': renderedApi.body},
       );
       rendered.add(api);
     }
@@ -414,7 +415,7 @@ class FileRenderer {
   }
 
   @visibleForTesting
-  Iterable<Import> importsForModel(RenderSchema schema) {
+  Iterable<Import> importsForModel(RenderSchema schema, SchemaUsage usage) {
     final referencedSchemas = collectSchemasUnderSchema(schema);
     final localSchemas = referencedSchemas.where(
       (s) => !s.createsNewType,
@@ -428,21 +429,21 @@ class FileRenderer {
         .toList();
 
     final imports = {
-      const Import('dart:convert'),
-      const Import('dart:io'),
-      const Import('package:meta/meta.dart'),
-      Import('package:$packageName/model_helpers.dart'),
+      ...usage.importsFor(packageName),
       ...schema.additionalImports,
       ...localSchemas.expand((s) => s.additionalImports),
       ...referencedImports,
     };
+    // A file never imports itself.
+    final selfPath = modelPackageImport(this, schema);
+    imports.removeWhere((i) => i.path == selfPath);
     return imports;
   }
 
   void renderModels(Iterable<RenderSchema> schemas) {
     for (final schema in schemas) {
-      final content = schemaRenderer.renderSchema(schema);
-      final imports = importsForModel(schema);
+      final rendered = schemaRenderer.renderSchema(schema);
+      final imports = importsForModel(schema, rendered.usage);
       final importsContext = imports
           .sortedBy((i) => i.path)
           .map((i) => i.toTemplateContext())
@@ -452,7 +453,7 @@ class FileRenderer {
       _renderTemplate(
         template: 'add_imports',
         outPath: outPath,
-        context: {'imports': importsContext, 'content': content},
+        context: {'imports': importsContext, 'content': rendered.body},
       );
     }
   }

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -188,6 +188,26 @@ class Import extends Equatable {
   List<Object?> get props => [path, asName];
 }
 
+/// Identifiers emitted by the renderer that are defined in the generated
+/// `model_helpers.dart` file. Kept in sync with
+/// `lib/templates/model_helpers.mustache`. Used both at emit sites below
+/// and by [SchemaUsage] to decide whether to import `model_helpers.dart`.
+abstract final class ModelHelpers {
+  static const maybeParseDateTime = 'maybeParseDateTime';
+  static const maybeParseUri = 'maybeParseUri';
+  static const maybeParseUriTemplate = 'maybeParseUriTemplate';
+  static const listsEqual = 'listsEqual';
+  static const mapsEqual = 'mapsEqual';
+
+  static const List<String> all = [
+    maybeParseDateTime,
+    maybeParseUri,
+    maybeParseUriTemplate,
+    listsEqual,
+    mapsEqual,
+  ];
+}
+
 class SpecResolver {
   const SpecResolver(this.quirks);
 
@@ -1203,17 +1223,18 @@ class RenderPod extends RenderSchema {
         return 'DateTime.parse($castedValue)';
       case PodType.dateTime:
         if (jsonIsNullable) {
-          return 'maybeParseDateTime($castedValue)$orDefault';
+          return '${ModelHelpers.maybeParseDateTime}($castedValue)$orDefault';
         }
         return 'DateTime.parse($castedValue)';
       case PodType.uri:
         if (jsonIsNullable) {
-          return 'maybeParseUri($castedValue)$orDefault';
+          return '${ModelHelpers.maybeParseUri}($castedValue)$orDefault';
         }
         return 'Uri.parse($castedValue)';
       case PodType.uriTemplate:
         if (jsonIsNullable) {
-          return 'maybeParseUriTemplate($castedValue)$orDefault';
+          final call = '${ModelHelpers.maybeParseUriTemplate}($castedValue)';
+          return '$call$orDefault';
         }
         return 'UriTemplate($castedValue)';
       case PodType.boolean || PodType.email:
@@ -2068,7 +2089,7 @@ class RenderMap extends RenderSchema {
 
   @override
   String equalsExpression(String name, SchemaRenderer context) =>
-      'mapsEqual(this.$name, other.$name)';
+      '${ModelHelpers.mapsEqual}(this.$name, other.$name)';
 
   @override
   String jsonStorageType({required bool isNullable}) => 'Map<String, dynamic>';
@@ -2489,7 +2510,7 @@ class RenderBinary extends RenderNoJson {
 
   @override
   String equalsExpression(String name, SchemaRenderer context) =>
-      'listsEqual(this.$name, other.$name)';
+      '${ModelHelpers.listsEqual}(this.$name, other.$name)';
 
   @override
   bool get defaultCanConstConstruct => false;

--- a/lib/src/render/schema_renderer.dart
+++ b/lib/src/render/schema_renderer.dart
@@ -2,6 +2,67 @@ import 'package:space_gen/src/quirks.dart';
 import 'package:space_gen/src/render/render_tree.dart';
 import 'package:space_gen/src/render/templates.dart';
 
+/// Which imports a rendered schema body needs beyond the schemas it
+/// references.
+///
+/// Today we derive this from the rendered body via substring checks. The
+/// long-term plan is for the rendering pipeline in render_tree.dart to
+/// populate this directly as it emits helper calls — the [importsFor]
+/// interface will not change.
+class SchemaUsage {
+  const SchemaUsage({
+    this.usesMetaAnnotations = false,
+    this.usesModelHelpers = false,
+  });
+
+  /// Derives usage by inspecting a rendered body.
+  factory SchemaUsage.fromBody(String body) {
+    return SchemaUsage(
+      usesMetaAnnotations: body.contains('@immutable'),
+      usesModelHelpers: ModelHelpers.all.any(body.contains),
+    );
+  }
+
+  final bool usesMetaAnnotations;
+  final bool usesModelHelpers;
+
+  /// Imports required by the body itself. Package-local imports are
+  /// resolved against [packageName].
+  Iterable<Import> importsFor(String packageName) sync* {
+    if (usesMetaAnnotations) yield const Import('package:meta/meta.dart');
+    if (usesModelHelpers) {
+      yield Import('package:$packageName/model_helpers.dart');
+    }
+  }
+}
+
+/// Which imports a rendered api body needs beyond the schemas it
+/// references.
+class ApiUsage {
+  const ApiUsage();
+
+  // No conditional fields yet; body kept to match the SchemaUsage shape
+  // so a future refactor can populate them without changing callers.
+  // ignore: avoid_unused_constructor_parameters
+  factory ApiUsage.fromBody(String body) => const ApiUsage();
+
+  Iterable<Import> importsFor(String packageName) => const [];
+}
+
+/// A rendered schema body paired with the usage of that body.
+class RenderedSchema {
+  const RenderedSchema({required this.body, required this.usage});
+  final String body;
+  final SchemaUsage usage;
+}
+
+/// A rendered api body paired with the usage of that body.
+class RenderedApi {
+  const RenderedApi({required this.body, required this.usage});
+  final String body;
+  final ApiUsage usage;
+}
+
 /// Context for rendering the spec.
 class SchemaRenderer {
   /// Create a new context for rendering the spec.
@@ -17,8 +78,8 @@ class SchemaRenderer {
   String get fromJsonJsonType =>
       quirks.dynamicJson ? 'dynamic' : 'Map<String, dynamic>';
 
-  /// Renders a schema to a string, does not render the imports.
-  String renderSchema(RenderSchema schema) {
+  /// Renders a schema, does not render the imports.
+  RenderedSchema renderSchema(RenderSchema schema) {
     if (!schema.createsNewType) {
       throw StateError('No code to render non-newtype: $schema');
     }
@@ -31,9 +92,10 @@ class SchemaRenderer {
       RenderEmptyObject() => 'schema_empty_object',
       RenderSchema() => throw StateError('No code to render $schema'),
     };
-    return templates
+    final body = templates
         .loadTemplate(template)
         .renderString(schema.toTemplateContext(this));
+    return RenderedSchema(body: body, usage: SchemaUsage.fromBody(body));
   }
 
   String renderEndpoints({
@@ -52,11 +114,14 @@ class SchemaRenderer {
     });
   }
 
-  /// Renders an api to a string, does not render the imports.
-  String renderApi(Api api) => renderEndpoints(
-    description: api.description,
-    className: api.className,
-    endpoints: api.endpoints,
-    removePrefix: api.removePrefix,
-  );
+  /// Renders an api, does not render the imports.
+  RenderedApi renderApi(Api api) {
+    final body = renderEndpoints(
+      description: api.description,
+      className: api.className,
+      endpoints: api.endpoints,
+      removePrefix: api.removePrefix,
+    );
+    return RenderedApi(body: body, usage: ApiUsage.fromBody(body));
+  }
 }

--- a/test/render/file_renderer_test.dart
+++ b/test/render/file_renderer_test.dart
@@ -1444,14 +1444,17 @@ void main() {
           ),
         },
       );
-      final imports = fileRenderer.importsForModel(schema);
+      final imports = fileRenderer.importsForModel(
+        schema,
+        const SchemaUsage(
+          usesMetaAnnotations: true,
+          usesModelHelpers: true,
+        ),
+      );
       expect(imports, {
-        const Import('dart:convert'),
-        const Import('dart:io'),
         const Import('package:meta/meta.dart'),
-        const Import('package:spacetraders/model/foo.dart'),
-        const Import('dart:typed_data'), // Uint8List from RenderBinary.
         const Import('package:spacetraders/model_helpers.dart'),
+        const Import('dart:typed_data'), // Uint8List from RenderBinary.
       });
     });
 
@@ -1515,7 +1518,7 @@ void main() {
           ),
         ],
       );
-      final imports = fileRenderer.importsForApi(api);
+      final imports = fileRenderer.importsForApi(api, const ApiUsage());
       expect(imports, {
         const Import('dart:async'),
         const Import('dart:convert'),


### PR DESCRIPTION
## Summary

Generated model/api bodies unconditionally imported `dart:convert`, `dart:io`, `package:meta/meta.dart`, `model_helpers.dart`, and (for models) the schema's own file. `dart fix . --apply` stripped most of those later — slowly. On the github spec that fix step was ~42s.

This PR emits only the imports the rendered body actually needs.

## Design

- `schema_renderer.dart`: new `SchemaUsage` / `ApiUsage` / `RenderedSchema` / `RenderedApi`. `renderSchema`/`renderApi` return body paired with usage.
- `file_renderer.dart`: `importsForModel(schema, usage)` and `importsForApi(api, usage)` consult `usage.importsFor(packageName)` for conditional imports (`meta`, `model_helpers.dart`) and drop unconditional `dart:convert`/`dart:io`/`meta`/`model_helpers.dart` from models. Model output also filters the schema's own file path. API imports keep `dart:io` because `api.mustache` emits `HttpStatus.badRequest`.
- `render_tree.dart`: `ModelHelpers` constant holder next to the emit sites (`maybeParseDateTime` etc). `SchemaUsage.fromBody` iterates `ModelHelpers.all` — identifier list lives in one place, next to where the names are emitted.

Today `SchemaUsage.fromBody` derives usage by inspecting the rendered body. The API shape is the long-term one: later `render_tree.dart` can populate usage directly at emit sites without callers changing.

## Impact

| spec | before fix step | after fix step |
|---|---|---|
| spacetraders | ~5.0s | ~3.3s (~35% faster) |
| github | ~42s | ~19.5s (~54% faster) |

Spacetraders fix count: 3315 → 2410. The remaining unused-import fixes come from `collectSchemasUnderSchema` walking transitively (e.g. `ship.dart` importing `ship_cargo_item.dart` even though only `ShipCargo` is used in the body). Addressing those would need a non-recursive walk or class-name body filter — left for a separate change.

## Test plan

- [x] `dart analyze` clean (only pre-existing long-line warnings in `render_tree.dart:626/628`)
- [x] `dart test` — 226 tests pass
- [x] `gen_tests/types` golden regenerated cleanly; `gen_tests/tests` test passes
- [x] Manually verified no regressions running generator on spacetraders + github specs; subsequent `dart fix` is a no-op (idempotent)