### PR TITLE
feat: support path-item-level parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.4
+
+- Support path-item-level `parameters`. Parameters declared on a path
+  item now apply to every operation on that path; operation-level
+  parameters still override by (name, in). Previously path-item-level
+  parameters were silently dropped.
+
 ## 1.0.3
 
 - Fix `Future<void>` endpoints so a successful empty body (e.g. 204

--- a/lib/src/parse/spec.dart
+++ b/lib/src/parse/spec.dart
@@ -484,7 +484,7 @@ class PathItem extends Equatable implements HasPointer {
     required this.operations,
     required this.summary,
     required this.description,
-    // required this.parameters,
+    this.parameters = const [],
   });
 
   /// Where this path item is located in the spec.
@@ -503,8 +503,10 @@ class PathItem extends Equatable implements HasPointer {
   /// The default description for all operations in this path.
   final String? description;
 
-  /// Parameters available to all operations in this path.
-  // final List<Parameter> parameters;
+  /// Parameters applicable to all operations in this path.
+  /// Operation-level parameters with the same name + location override
+  /// these at the operation level.
+  final List<RefOr<Parameter>> parameters;
 
   @override
   List<Object?> get props => [
@@ -512,7 +514,7 @@ class PathItem extends Equatable implements HasPointer {
     operations,
     summary,
     description,
-    // parameters,
+    parameters,
   ];
 }
 

--- a/lib/src/parse/spec.dart
+++ b/lib/src/parse/spec.dart
@@ -484,7 +484,7 @@ class PathItem extends Equatable implements HasPointer {
     required this.operations,
     required this.summary,
     required this.description,
-    this.parameters = const [],
+    required this.parameters,
   });
 
   /// Where this path item is located in the spec.

--- a/lib/src/parse/visitor.dart
+++ b/lib/src/parse/visitor.dart
@@ -44,9 +44,9 @@ class SpecWalker {
 
   void walkPathItem(PathItem pathItem) {
     visitor.visitPathItem(pathItem);
-    // for (final parameter in pathItem.parameters) {
-    //   _parameter(parameter);
-    // }
+    for (final parameter in pathItem.parameters) {
+      _refOr(parameter);
+    }
     for (final operation in pathItem.operations.values) {
       _operation(operation);
     }

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -839,13 +839,12 @@ PathItem parsePathItem({
   //   return RefOr<PathItem>.ref(ref);
   // }
   final summary = _optional<String>(pathItemJson, 'summary');
-  _ignored<List<dynamic>>(pathItemJson, 'parameters');
-  // final parameters = _mapOptionalList(
-  //   pathItemJson,
-  //   'parameters',
-  //   (child, index) => parseParameterOrRef(
-  //  child.addSnakeName('parameter$index')),
-  // );
+  final parameters = _mapOptionalList(
+    pathItemJson,
+    'parameters',
+    (child, index) =>
+        parseParameterOrRef(child.addSnakeName('parameter$index')),
+  );
 
   final description = _optional<String>(pathItemJson, 'description');
   final operations = _parseOperations(pathItemJson, path);
@@ -856,7 +855,7 @@ PathItem parsePathItem({
     path: path,
     summary: summary,
     description: description,
-    // parameters: parameters,
+    parameters: parameters,
     operations: operations,
   );
 }

--- a/lib/src/resolver.dart
+++ b/lib/src/resolver.dart
@@ -456,6 +456,7 @@ ResolvedOperation resolveOperation({
   required Method method,
   required Operation operation,
   required ResolveContext context,
+  List<ResolvedParameter> pathItemParameters = const [],
 }) {
   final requestBody = _resolveRequestBody(operation.requestBody, context);
   final responses = _resolveResponses(operation.responses, context);
@@ -484,21 +485,48 @@ ResolvedOperation resolveOperation({
     path: path,
     requestBody: requestBody,
     responses: responses,
-    parameters: _resolveParameters(operation.parameters, context),
+    parameters: _mergeParameters(
+      pathItemParameters,
+      _resolveParameters(operation.parameters, context),
+    ),
     securityRequirements: securityRequirements,
   );
+}
+
+/// Merges path-item-level parameters with operation-level parameters.
+///
+/// OpenAPI 3.x uniqueness for a parameter is (name, in). Operation-level
+/// parameters override path-item-level parameters with the same key; any
+/// remaining path-item-level parameters are kept in their original order
+/// ahead of operation-only parameters.
+List<ResolvedParameter> _mergeParameters(
+  List<ResolvedParameter> pathItemParameters,
+  List<ResolvedParameter> operationParameters,
+) {
+  if (pathItemParameters.isEmpty) return operationParameters;
+  String key(ResolvedParameter p) => '${p.inLocation.name}:${p.name}';
+  final operationKeys = operationParameters.map(key).toSet();
+  return [
+    ...pathItemParameters.where((p) => !operationKeys.contains(key(p))),
+    ...operationParameters,
+  ];
 }
 
 List<ResolvedOperation> _resolveOperations(
   PathItem pathItem,
   ResolveContext context,
 ) {
+  final pathItemParameters = _resolveParameters(
+    pathItem.parameters,
+    context,
+  );
   return pathItem.operations.entries.map((entry) {
     return resolveOperation(
       path: pathItem.path,
       method: entry.key,
       operation: entry.value,
       context: context,
+      pathItemParameters: pathItemParameters,
     );
   }).toList();
 }

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -630,6 +630,41 @@ void main() {
       );
     });
 
+    test('path-item-level parameters are parsed', () {
+      final json = {
+        'openapi': '3.1.0',
+        'info': {'title': 'Space Traders API', 'version': '1.0.0'},
+        'servers': [
+          {'url': 'https://api.spacetraders.io/v2'},
+        ],
+        'paths': {
+          '/users/{id}': {
+            'parameters': [
+              {
+                'name': 'id',
+                'in': 'path',
+                'schema': {'type': 'string'},
+                'required': true,
+              },
+            ],
+            'get': {
+              'summary': 'Get user',
+              'responses': {
+                '200': {'description': 'OK'},
+              },
+            },
+          },
+        },
+      };
+      final spec = parseOpenApi(json);
+      final pathItem = spec.paths['/users/{id}'];
+      expect(pathItem.parameters, hasLength(1));
+      final parameter = pathItem.parameters.first.object!;
+      expect(parameter.name, 'id');
+      expect(parameter.inLocation, ParameterLocation.path);
+      expect(parameter.isRequired, isTrue);
+    });
+
     test('path parameters must be required', () {
       final json = {
         'openapi': '3.1.0',

--- a/test/resolver_test.dart
+++ b/test/resolver_test.dart
@@ -170,6 +170,94 @@ void main() {
       );
     });
 
+    test('path-item-level parameters apply to every operation', () {
+      final json = {
+        'openapi': '3.1.0',
+        'info': {'title': 'Space Traders API', 'version': '1.0.0'},
+        'servers': [
+          {'url': 'https://api.spacetraders.io/v2'},
+        ],
+        'paths': {
+          '/users/{id}': {
+            'parameters': [
+              {
+                'name': 'id',
+                'in': 'path',
+                'schema': {'type': 'string'},
+                'required': true,
+              },
+            ],
+            'get': {
+              'operationId': 'getUser',
+              'summary': 'Get user',
+              'responses': {
+                '200': {'description': 'OK'},
+              },
+            },
+            'delete': {
+              'operationId': 'deleteUser',
+              'summary': 'Delete user',
+              'responses': {
+                '200': {'description': 'OK'},
+              },
+            },
+          },
+        },
+      };
+      final spec = parseAndResolveTestSpec(json);
+      final operations = spec.paths.first.operations;
+      expect(operations, hasLength(2));
+      for (final op in operations) {
+        expect(op.parameters, hasLength(1));
+        expect(op.parameters.first.name, 'id');
+        expect(op.parameters.first.inLocation, ParameterLocation.path);
+      }
+    });
+
+    test('operation parameter overrides path-item parameter with same '
+        '(name, in)', () {
+      final json = {
+        'openapi': '3.1.0',
+        'info': {'title': 'Space Traders API', 'version': '1.0.0'},
+        'servers': [
+          {'url': 'https://api.spacetraders.io/v2'},
+        ],
+        'paths': {
+          '/users/{id}': {
+            'parameters': [
+              {
+                'name': 'id',
+                'in': 'path',
+                'description': 'shared id',
+                'schema': {'type': 'string'},
+                'required': true,
+              },
+            ],
+            'get': {
+              'summary': 'Get user',
+              'parameters': [
+                {
+                  'name': 'id',
+                  'in': 'path',
+                  'description': 'get-specific id',
+                  'schema': {'type': 'integer'},
+                  'required': true,
+                },
+              ],
+              'responses': {
+                '200': {'description': 'OK'},
+              },
+            },
+          },
+        },
+      };
+      final spec = parseAndResolveTestSpec(json);
+      final params = spec.paths.first.operations.first.parameters;
+      expect(params, hasLength(1));
+      expect(params.first.description, 'get-specific id');
+      expect(params.first.schema, isA<ResolvedInteger>());
+    });
+
     test('allOf only supports objects', () {
       final json = {
         'allOf': [


### PR DESCRIPTION
## Summary
- OpenAPI lets you declare `parameters` on a path item, and those parameters apply to every operation under that path (with operation-level parameters overriding by `(name, in)`). Common idiom — e.g. `/apps/{appId}` with `appId` declared once on the path item and inherited by GET/PATCH/DELETE.
- Previously `parsePathItem` called `_ignored('parameters')` and the `PathItem.parameters` field was commented out, so these parameters were silently dropped. A generated method like `deleteApp()` would take no arguments and hit a literal `/apps/{appId}` URL.

## What changed
- `PathItem.parameters` is a real field again (was commented out alongside a TODO).
- `parsePathItem` parses the list via the existing `parseParameterOrRef`.
- `SpecWalker.walkPathItem` walks them, so component `$ref`s register correctly.
- `resolveOperation` takes a new optional `pathItemParameters` argument; `_resolveOperations` resolves the path-item list once per path item and merges it into each operation. Operation-level parameters override by `(name, in)` (OpenAPI 3.1 semantics).
- New tests cover parsing, inheritance across operations, and override.

## Test plan
- [x] `dart test` — all pass
- [x] `dart analyze` — clean
- [x] Regenerated a spec with path-item-level parameters; generated API methods now take the path param as a positional arg and substitute it into the URL.