### PR TITLE
fix: allow 204 No Content on Future<void> endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.0.3
+
+- Fix `Future<void>` endpoints so a successful empty body (e.g. 204
+  No Content) returns normally. Generated methods previously fell
+  through to `throw ApiException.unhandled(...)` whenever the body
+  was empty, which meant every successful DELETE/PATCH on a 204 route
+  threw.
+
 ## 1.0.2
 
 - Emit only the imports a rendered model/api body actually needs: drop

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -658,6 +658,7 @@ class Endpoint implements ToTemplateContext {
 
     final responseSchema = operation.returnType;
     final returnType = responseSchema.typeName;
+    final isVoidReturn = responseSchema is RenderVoid;
     final responseFromJson = responseSchema.fromJsonExpression(
       'jsonDecode(response.body)',
       context,
@@ -726,6 +727,7 @@ class Endpoint implements ToTemplateContext {
       'headerParameters': toTemplateContexts(headerParameters),
       'requestBody': requestBody?.toTemplateContext(context),
       'returnType': returnType,
+      'isVoidReturn': isVoidReturn,
       'responseFromJson': responseFromJson,
       'validationStatements': validationStatementsString,
       'authArgument': authArgumentString,

--- a/lib/templates/api.mustache
+++ b/lib/templates/api.mustache
@@ -43,12 +43,14 @@
         if (response.statusCode >= HttpStatus.badRequest) {
             throw ApiException(response.statusCode, response.body.toString());
         }
+{{^isVoidReturn}}
 
         if (response.body.isNotEmpty) {
             return {{{ responseFromJson }}};
         }
 
         throw ApiException.unhandled(response.statusCode);
+{{/isVoidReturn}}
     }
     {{/endpoints}}
 }

--- a/test/render/render_operation_test.dart
+++ b/test/render/render_operation_test.dart
@@ -73,12 +73,6 @@ void main() {
         '        if (response.statusCode >= HttpStatus.badRequest) {\n'
         '            throw ApiException(response.statusCode, response.body.toString());\n'
         '        }\n'
-        '\n'
-        '        if (response.body.isNotEmpty) {\n'
-        '            return ;\n'
-        '        }\n'
-        '\n'
-        '        throw ApiException.unhandled(response.statusCode);\n'
         '    }\n'
         '}\n',
       );
@@ -127,12 +121,6 @@ void main() {
         '        if (response.statusCode >= HttpStatus.badRequest) {\n'
         '            throw ApiException(response.statusCode, response.body.toString());\n'
         '        }\n'
-        '\n'
-        '        if (response.body.isNotEmpty) {\n'
-        '            return ;\n'
-        '        }\n'
-        '\n'
-        '        throw ApiException.unhandled(response.statusCode);\n'
         '    }\n'
         '}\n',
       );
@@ -398,12 +386,6 @@ void main() {
         '        if (response.statusCode >= HttpStatus.badRequest) {\n'
         '            throw ApiException(response.statusCode, response.body.toString());\n'
         '        }\n'
-        '\n'
-        '        if (response.body.isNotEmpty) {\n'
-        '            return ;\n'
-        '        }\n'
-        '\n'
-        '        throw ApiException.unhandled(response.statusCode);\n'
         '    }\n'
         '}\n',
       );
@@ -455,12 +437,6 @@ void main() {
         '        if (response.statusCode >= HttpStatus.badRequest) {\n'
         '            throw ApiException(response.statusCode, response.body.toString());\n'
         '        }\n'
-        '\n'
-        '        if (response.body.isNotEmpty) {\n'
-        '            return ;\n'
-        '        }\n'
-        '\n'
-        '        throw ApiException.unhandled(response.statusCode);\n'
         '    }\n'
         '}\n',
       );
@@ -519,12 +495,6 @@ void main() {
         '        if (response.statusCode >= HttpStatus.badRequest) {\n'
         '            throw ApiException(response.statusCode, response.body.toString());\n'
         '        }\n'
-        '\n'
-        '        if (response.body.isNotEmpty) {\n'
-        '            return ;\n'
-        '        }\n'
-        '\n'
-        '        throw ApiException.unhandled(response.statusCode);\n'
         '    }\n'
         '}\n',
       );
@@ -580,12 +550,6 @@ void main() {
         '        if (response.statusCode >= HttpStatus.badRequest) {\n'
         '            throw ApiException(response.statusCode, response.body.toString());\n'
         '        }\n'
-        '\n'
-        '        if (response.body.isNotEmpty) {\n'
-        '            return ;\n'
-        '        }\n'
-        '\n'
-        '        throw ApiException.unhandled(response.statusCode);\n'
         '    }\n'
         '}\n',
       );
@@ -682,12 +646,6 @@ void main() {
         '        if (response.statusCode >= HttpStatus.badRequest) {\n'
         '            throw ApiException(response.statusCode, response.body.toString());\n'
         '        }\n'
-        '\n'
-        '        if (response.body.isNotEmpty) {\n'
-        '            return ;\n'
-        '        }\n'
-        '\n'
-        '        throw ApiException.unhandled(response.statusCode);\n'
         '    }\n'
         '}\n',
       );
@@ -741,12 +699,6 @@ void main() {
           '        if (response.statusCode >= HttpStatus.badRequest) {\n'
           '            throw ApiException(response.statusCode, response.body.toString());\n'
           '        }\n'
-          '\n'
-          '        if (response.body.isNotEmpty) {\n'
-          '            return ;\n'
-          '        }\n'
-          '\n'
-          '        throw ApiException.unhandled(response.statusCode);\n'
           '    }\n'
           '}\n',
         );
@@ -810,6 +762,28 @@ void main() {
         '    }\n'
         '}\n',
       );
+    });
+
+    test('void return omits body/unhandled branch (allows 204)', () {
+      final json = {
+        'summary': 'Delete user',
+        'operationId': 'deleteUser',
+        'tags': ['users'],
+        'responses': {
+          '204': {'description': 'No content'},
+        },
+      };
+      final result = renderTestOperation(
+        path: '/users/{id}',
+        operationJson: json,
+        serverUrl: Uri.parse('https://api.spacetraders.io/v2'),
+      );
+      // Generated `Future<void>` methods should not contain the
+      // `response.body.isNotEmpty` guard or the `ApiException.unhandled`
+      // fallback — otherwise every successful 204 would throw.
+      expect(result, contains('Future<void> deleteUser'));
+      expect(result, isNot(contains('response.body.isNotEmpty')));
+      expect(result, isNot(contains('ApiException.unhandled')));
     });
 
     test('remove prefix', () {

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -1948,12 +1948,6 @@ void main() {
           '        if (response.statusCode >= HttpStatus.badRequest) {\n'
           '            throw ApiException(response.statusCode, response.body.toString());\n'
           '        }\n'
-          '\n'
-          '        if (response.body.isNotEmpty) {\n'
-          '            return ;\n'
-          '        }\n'
-          '\n'
-          '        throw ApiException.unhandled(response.statusCode);\n'
           '    }\n'
           '}\n',
         );
@@ -2032,12 +2026,6 @@ void main() {
         '        if (response.statusCode >= HttpStatus.badRequest) {\n'
         '            throw ApiException(response.statusCode, response.body.toString());\n'
         '        }\n'
-        '\n'
-        '        if (response.body.isNotEmpty) {\n'
-        '            return ;\n'
-        '        }\n'
-        '\n'
-        '        throw ApiException.unhandled(response.statusCode);\n'
         '    }\n'
         '}\n',
       );


### PR DESCRIPTION
## Summary
Generated `Future<void>` methods unconditionally emitted:

```dart
if (response.body.isNotEmpty) { return; }
throw ApiException.unhandled(response.statusCode);
```

…so every successful empty-body response (e.g. DELETE/PATCH returning 204) fell through to the unhandled throw. Any spec with a void endpoint on a 2xx-with-no-body contract was broken at runtime on success.

For `Future<void>`, skip the body-check / unhandled-throw block entirely — the `statusCode >= 400` check above it already rejects errors, and a 2xx with an empty body is exactly what a void endpoint expects.

## What changed
- `render_tree.dart`: added `isVoidReturn` to the endpoint template context.
- `api.mustache`: gated the `body.isNotEmpty` / `throw unhandled` block behind `{{^isVoidReturn}}`.
- Updated 9 existing golden-string tests whose `Future<void>` expected-output now no longer contains that block.
- New regression test: for a 204-only void endpoint, assert the generated method does **not** contain `response.body.isNotEmpty` or `ApiException.unhandled`.

Non-void endpoints are unchanged (verified by the untouched non-void tests).

## Test plan
- [x] `dart test` — all pass
- [x] `dart analyze` — clean (pre-existing infos unrelated)
- [x] Regenerated sample spec; void-returning methods now end after the error check.