### PR TITLE
feat: emit per-field dartdoc from schema property description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@
   item now apply to every operation on that path; operation-level
   parameters still override by (name, in). Previously path-item-level
   parameters were silently dropped.
+- Emit per-field dartdoc from schema property `description`. Previously
+  the class-level description was rendered but property-level
+  descriptions were dropped.
+- Trim trailing whitespace off doc-comment text so YAML block-scalar
+  descriptions (`description: |`) no longer render a dangling `///`
+  line before the class or field they document.
 - Fix nullable primitive query parameters to be null-safe. Generated
   code previously emitted `?foo.toString()`, which always produced a
   map entry (with the literal string `"null"` as its value) because

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -15,3 +15,4 @@ words:
   - Seidel
   - mocktail
   - pubspec
+  - dartdoc

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -82,7 +82,9 @@ Iterable<String> wrapLines({
 Iterable<String> wrapDocComment(String value, {int indent = 0}) {
   final prefix = '${' ' * indent}/// ';
   final wrapWidth = 80 - prefix.length;
-  final lines = value.split('\n');
+  // Trim trailing whitespace so a YAML block-scalar description (which
+  // carries a trailing newline) does not render as a dangling `///` line.
+  final lines = value.trimRight().split('\n');
   return wrapLines(
     lines: lines,
     maxWidth: wrapWidth,
@@ -1751,6 +1753,10 @@ class RenderObject extends RenderNewType {
     return {
       'dartName': dartName,
       'jsonName': quoteString(jsonName),
+      'property_doc_comment': createDocComment(
+        common: property.common,
+        indent: 4,
+      ),
       'argumentLine': argumentLine(
         jsonName,
         property,

--- a/lib/templates/schema_object.mustache
+++ b/lib/templates/schema_object.mustache
@@ -34,7 +34,7 @@ class {{ typeName }} {
         return {{ typeName }}.fromJson(json);
     }
 
-    {{#properties}}{{{ storageTypeDeclaration }}}{{ dartName }};
+    {{#properties}}{{{ property_doc_comment }}}{{{ storageTypeDeclaration }}}{{ dartName }};
     {{/properties}}
     {{#hasAdditionalProperties}}
     final Map<String, {{{ valueSchema }}}> {{additionalPropertiesName}};

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -1,6 +1,8 @@
 // We don't have a good way to shorten the literal strings from the
 // expected generated code, so ignoring 80c for now.
 // ignore_for_file: lines_longer_than_80_chars
+import 'dart:convert';
+
 import 'package:mocktail/mocktail.dart';
 import 'package:space_gen/src/logger.dart';
 import 'package:space_gen/src/render.dart';
@@ -63,6 +65,94 @@ void main() {
         '}\n',
       );
     });
+    test('property description emits dartdoc on the field', () {
+      final schema = {
+        'type': 'object',
+        'required': ['id'],
+        'properties': {
+          'id': {
+            'type': 'string',
+            'description': 'The ID of the thing.',
+          },
+        },
+      };
+      final result = renderTestSchema(schema);
+      // The property's description should appear as dartdoc immediately
+      // before the field declaration.
+      expect(
+        result,
+        contains('/// The ID of the thing.\n    final String id;'),
+      );
+    });
+
+    test('long property description wraps to 80 cols at 4-space indent', () {
+      final schema = {
+        'type': 'object',
+        'required': ['id'],
+        'properties': {
+          'id': {
+            'type': 'string',
+            'description':
+                'A quite long property description that must be wrapped '
+                'across multiple lines so that it does not exceed the '
+                'eighty-column limit applied to the generated code.',
+          },
+        },
+      };
+      final result = renderTestSchema(schema);
+      for (final line in const LineSplitter().convert(result)) {
+        if (line.trimLeft().startsWith('///')) {
+          expect(line.length, lessThanOrEqualTo(80), reason: 'line: "$line"');
+          // Field-level dartdoc should be indented with 4 spaces.
+          expect(line, startsWith('    /// '), reason: 'line: "$line"');
+        }
+      }
+    });
+
+    test('trailing newline in description does not produce blank ///', () {
+      // Spec yaml block scalars (`description: |`) add a trailing '\n'
+      // to the string; make sure that does not render as a dangling
+      // `///` line before the field declaration.
+      final schema = {
+        'type': 'object',
+        'required': ['id'],
+        'properties': {
+          'id': {
+            'type': 'string',
+            'description': 'Trailing newline.\n',
+          },
+        },
+      };
+      final result = renderTestSchema(schema);
+      expect(
+        result,
+        contains('/// Trailing newline.\n    final String id;'),
+      );
+      expect(result, isNot(contains('///\n    final String id;')));
+    });
+
+    test('multi-line property description preserves paragraph breaks', () {
+      final schema = {
+        'type': 'object',
+        'required': ['id'],
+        'properties': {
+          'id': {
+            'type': 'string',
+            'description': 'First line.\nSecond line.',
+          },
+        },
+      };
+      final result = renderTestSchema(schema);
+      expect(
+        result,
+        contains(
+          '    /// First line.\n'
+          '    /// Second line.\n'
+          '    final String id;',
+        ),
+      );
+    });
+
     test('datetime', () {
       final schema = {
         'type': 'object',


### PR DESCRIPTION
## Summary
Generated model classes had class-level dartdoc (from a schema's `description`) but their fields had none, even when the spec gave each property a description. Handwritten Dart typically carries dartdoc on every field; generated code should too.

## Before

```dart
class App {
  const App({required this.id, required this.displayName});
  ...
  final String id;
  final String displayName;
}
```

## After

```dart
class App {
  const App({required this.id, required this.displayName});
  ...
  /// The ID of the app.
  final String id;

  /// The display name of the app.
  final String displayName;
}
```

## What changed
- `render_tree.dart`: added `property_doc_comment` to the property template context, built via the existing `createDocComment(common: property.common, indent: 4)` used elsewhere.
- `schema_object.mustache`: emit `{{{ property_doc_comment }}}` before each `final ...` property declaration.
- New test asserts that a property with a `description` in the spec produces `/// The ID of the thing.\n    final String id;`.

## Test plan
- [x] `dart test` — all pass
- [x] `dart analyze` — clean (pre-existing infos unrelated)
- [x] Regenerated the codepush sample; every field now carries its description as dartdoc, matching the handwritten `shorebird_code_push_protocol` style.