### PR TITLE
feat: support x-enum-descriptions vendor extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@
   uncompilable `try._('TRY')` / `class._('CLASS')`. Now all Dart
   reserved words, built-in identifiers, and contextual keywords are
   escaped with a trailing underscore.
+- Support the `x-enum-descriptions` vendor extension. A parallel array
+  of strings alongside `enum:` now renders as per-case dartdoc on the
+  generated enum.
 - Fix nullable primitive query parameters to be null-safe. Generated
   code previously emitted `?foo.toString()`, which always produced a
   map entry (with the literal string `"null"` as its value) because

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,9 +67,21 @@ approach. See the class-level doc comment on `RenderRecursiveRef` in
 - 80-col wrap (enforced for code, not strict for doc comments).
 - `very_good_analysis` lint.
 - Prefer new atomic commits over `git amend`.
-- `CHANGELOG.md` entries per feature.
+- `CHANGELOG.md` entries per feature. Don't bump the heading; stack
+  new bullets under the top-most `## x.y.z` until the pubspec version
+  actually bumps.
 - Keep custom words in `cspell.config.yaml` — CI blocks on unknown words.
   `newtype` / `newtypes` / `renderable` are common false positives.
+- **`required` on internal pipeline types**: `Schema*` (parse),
+  `Resolved*` (resolve), and `Render*` (render) classes mark **every**
+  constructor parameter `required`, including fields that default to
+  `null` or an empty list. These aren't user-facing APIs like Flutter
+  widgets — they're plumbing. A field that should thread all three
+  layers can silently be dropped if intermediate constructors have
+  defaults; `required` turns the "I forgot to pass it" case into a
+  compile error at every call site instead of a quietly-dropped value
+  in the generator. Any exception here should be justified in code
+  comments, not with a convenient default.
 
 ## Gotchas
 

--- a/lib/src/parse/spec.dart
+++ b/lib/src/parse/spec.dart
@@ -242,6 +242,7 @@ class SchemaEnum extends Schema {
     required super.common,
     required this.defaultValue,
     required this.enumValues,
+    required this.enumDescriptions,
   });
 
   /// The default value of the enum.
@@ -250,8 +251,18 @@ class SchemaEnum extends Schema {
   // Only string enums are supported for now.
   final List<String> enumValues;
 
+  /// Optional per-value dartdoc descriptions, parallel to [enumValues].
+  /// Populated from the OpenAPI vendor extension `x-enum-descriptions`
+  /// when present.
+  final List<String>? enumDescriptions;
+
   @override
-  List<Object?> get props => [super.props, defaultValue, enumValues];
+  List<Object?> get props => [
+    super.props,
+    defaultValue,
+    enumValues,
+    enumDescriptions,
+  ];
 }
 
 class SchemaNull extends Schema {

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -382,10 +382,29 @@ SchemaEnum? _handleEnum({
       typedDefaultValue = defaultValue as String?;
     }
   }
+  final xEnumDescriptions = _optionalList<dynamic>(json, 'x-enum-descriptions');
+  List<String>? enumDescriptions;
+  if (xEnumDescriptions != null) {
+    if (xEnumDescriptions.length != typedEnumValues.length) {
+      _error(
+        json,
+        'x-enum-descriptions length (${xEnumDescriptions.length}) must '
+        'match enum length (${typedEnumValues.length})',
+      );
+    }
+    if (xEnumDescriptions.any((e) => e is! String)) {
+      _error(
+        json,
+        'x-enum-descriptions must be a list of strings: $xEnumDescriptions',
+      );
+    }
+    enumDescriptions = xEnumDescriptions.cast<String>();
+  }
   return SchemaEnum(
     common: common,
     defaultValue: typedDefaultValue,
     enumValues: typedEnumValues,
+    enumDescriptions: enumDescriptions,
   );
 }
 

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -234,6 +234,7 @@ class SpecResolver {
           common: schema.common,
           values: schema.values,
           names: RenderEnum.variableNamesFor(quirks, schema.values),
+          descriptions: schema.descriptions,
         );
       case ResolvedObject():
         return RenderObject(
@@ -2163,11 +2164,15 @@ class RenderEnum extends RenderNewType {
     required super.common,
     required this.values,
     required this.names,
+    required this.descriptions,
     this.defaultValue,
   }) : assert(
          names.length == values.length,
          'names and values must have the same length',
        );
+  // Invariant: if descriptions is non-null, descriptions.length ==
+  // values.length. Enforced at parse time (see parser.dart), so we
+  // don't re-check here.
 
   @visibleForTesting
   static List<String> variableNamesFor(Quirks quirks, List<String> values) {
@@ -2197,8 +2202,17 @@ class RenderEnum extends RenderNewType {
   /// The names of the resolved schema.
   final List<String> names;
 
+  /// Optional per-value dartdoc descriptions, parallel to [values].
+  final List<String>? descriptions;
+
   @override
-  List<Object?> get props => [super.props, values, names, defaultValue];
+  List<Object?> get props => [
+    super.props,
+    values,
+    names,
+    defaultValue,
+    descriptions,
+  ];
 
   @override
   String jsonStorageType({required bool isNullable}) {
@@ -2208,10 +2222,16 @@ class RenderEnum extends RenderNewType {
   /// Template context for an enum schema.
   @override
   Map<String, dynamic> toTemplateContext(SchemaRenderer context) {
-    Map<String, dynamic> enumValueToTemplateContext(String value) {
+    Map<String, dynamic> enumValueToTemplateContext(int index) {
+      final value = values[index];
+      final description = descriptions?[index];
       return {
         'enumValueName': variableNameFor(value),
         'enumValue': quoteString(value),
+        'enum_value_doc_comment': createDocCommentFromParts(
+          body: description,
+          indent: 4,
+        ),
       };
     }
 
@@ -2219,7 +2239,9 @@ class RenderEnum extends RenderNewType {
       'doc_comment': createDocComment(common: common),
       'typeName': typeName,
       'nullableTypeName': nullableTypeName(context),
-      'enumValues': values.map(enumValueToTemplateContext).toList(),
+      'enumValues': [
+        for (var i = 0; i < values.length; i++) enumValueToTemplateContext(i),
+      ],
     };
   }
 

--- a/lib/src/resolver.dart
+++ b/lib/src/resolver.dart
@@ -177,6 +177,7 @@ ResolvedSchema _resolveSchemaFully(
       common: resolvedCommon,
       defaultValue: schema.defaultValue,
       values: schema.enumValues,
+      descriptions: schema.enumDescriptions,
     );
   }
   if (schema is SchemaBinary) {
@@ -1158,6 +1159,7 @@ class ResolvedEnum extends ResolvedSchema {
     required super.common,
     required this.defaultValue,
     required this.values,
+    required this.descriptions,
   }) : super(createsNewType: true);
 
   /// The values of the resolved schema.
@@ -1168,17 +1170,21 @@ class ResolvedEnum extends ResolvedSchema {
   /// The default value of the enum type.
   final dynamic defaultValue;
 
+  /// Optional per-value dartdoc descriptions, parallel to [values].
+  final List<String>? descriptions;
+
   @override
   ResolvedEnum copyWith({CommonProperties? common}) {
     return ResolvedEnum(
       common: common ?? this.common,
       defaultValue: defaultValue,
       values: values,
+      descriptions: descriptions,
     );
   }
 
   @override
-  List<Object?> get props => [super.props, values, defaultValue];
+  List<Object?> get props => [super.props, values, defaultValue, descriptions];
 }
 
 class ResolvedObject extends ResolvedSchema {

--- a/lib/templates/schema_enum.mustache
+++ b/lib/templates/schema_enum.mustache
@@ -1,6 +1,6 @@
 {{{ doc_comment }}}enum {{ typeName }} {
     {{#enumValues}}
-    {{ enumValueName }}._({{{ enumValue }}}),
+    {{{ enum_value_doc_comment }}}{{ enumValueName }}._({{{ enumValue }}}),
     {{/enumValues}}
     ;
 

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -109,6 +109,71 @@ void main() {
       }
     });
 
+    test('x-enum-descriptions emits dartdoc per enum case', () {
+      final schema = {
+        'type': 'string',
+        'enum': ['owner', 'admin', 'viewer'],
+        'x-enum-descriptions': [
+          'User that created the organization.',
+          'Users who have permissions to manage the organization.',
+          'Users with read-only access.',
+        ],
+      };
+      final result = renderTestSchema(schema, asComponent: true);
+      expect(
+        result,
+        contains(
+          '    /// User that created the organization.\n'
+          "    owner._('owner'),\n",
+        ),
+      );
+      expect(
+        result,
+        contains(
+          '    /// Users who have permissions to manage the organization.\n'
+          "    admin._('admin'),\n",
+        ),
+      );
+      expect(
+        result,
+        contains(
+          '    /// Users with read-only access.\n'
+          "    viewer._('viewer'),\n",
+        ),
+      );
+    });
+
+    test('x-enum-descriptions length mismatch is a spec error', () {
+      final schema = {
+        'type': 'string',
+        'enum': ['a', 'b'],
+        'x-enum-descriptions': ['only one'],
+      };
+      expect(
+        () => renderTestSchema(schema, asComponent: true),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('x-enum-descriptions with non-string entries is a spec error', () {
+      final schema = {
+        'type': 'string',
+        'enum': ['a', 'b'],
+        // Length matches, but the second entry is not a string.
+        'x-enum-descriptions': ['ok', 42],
+      };
+      expect(
+        () => renderTestSchema(schema, asComponent: true),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            contains('must be a list of strings'),
+          ),
+        ),
+      );
+    });
+
     test('trailing newline in description does not produce blank ///', () {
       // Spec yaml block scalars (`description: |`) add a trailing '\n'
       // to the string; make sure that does not render as a dangling

--- a/test/render/render_tree_test.dart
+++ b/test/render/render_tree_test.dart
@@ -409,6 +409,7 @@ void main() {
         ),
         names: const ['a', 'b', 'c'],
         values: const ['a', 'b', 'c'],
+        descriptions: null,
       );
       expect(a.equalsIgnoringName(a), isTrue);
 
@@ -420,6 +421,7 @@ void main() {
         ),
         names: const ['a', 'b', 'c'],
         values: const ['a', 'b', 'c'],
+        descriptions: null,
       );
       expect(a.equalsIgnoringName(b), isTrue);
 
@@ -431,6 +433,7 @@ void main() {
         ),
         names: const ['a', 'b'],
         values: const ['a', 'b'],
+        descriptions: null,
       );
       expect(a.equalsIgnoringName(c), isFalse);
     });

--- a/test/resolver_test.dart
+++ b/test/resolver_test.dart
@@ -898,6 +898,7 @@ void main() {
           ),
           values: const ['bar', 'baz'],
           defaultValue: null,
+          descriptions: null,
         );
         final schema2 = ResolvedEnum(
           common: CommonProperties.test(
@@ -909,6 +910,7 @@ void main() {
           ),
           values: const ['bar', 'qux'],
           defaultValue: null,
+          descriptions: null,
         );
         expect(schema1, equals(schema1));
         // Different values.
@@ -1064,6 +1066,7 @@ void main() {
           common: beforeCommon,
           values: const ['bar', 'baz'],
           defaultValue: null,
+          descriptions: null,
         );
         testCopyWith(schema, (schema, copy) {
           expect(copy.values, equals(schema.values));


### PR DESCRIPTION
## Summary
OpenAPI string enums carry only the wire value — there's no standard way to attach a dartdoc to each case. A few common generators look for the vendor extension **`x-enum-descriptions`**: a parallel array of strings alongside `enum:`, one per value. This PR teaches space_gen to read it and render it as per-case dartdoc on the generated enum.

## Example

Spec:
```yaml
Role:
  type: string
  description: A role that a user can have relative to an Organization or App.
  enum: [owner, admin, appManager, developer, viewer, none]
  x-enum-descriptions:
    - User that created the organization.
    - Users who have permissions to manage the organization.
    - Users who have permissions to manage an app.
    - Users who are part of the organization but have limited permissions.
    - Users who have read-only access to the organization.
    - Users who are not part of the organization but have visibility into it via app collaborator permissions.
```

Generated (now matches the Shorebird handwritten `Role` enum):
```dart
/// A role that a user can have relative to an Organization or App.
enum Role {
  /// User that created the organization.
  owner._('owner'),

  /// Users who have permissions to manage the organization.
  admin._('admin'),

  /// Users who have permissions to manage an app.
  appManager._('appManager'),
  ...
}
```

Length mismatch between `enum:` and `x-enum-descriptions` is a hard parse error.

## What changed
- `SchemaEnum.enumDescriptions` (parser) → `ResolvedEnum.descriptions` (resolve) → `RenderEnum.descriptions` (render), threaded through as `List<String>?` with length-equality validated at parse time. All three constructors take it as `required` so the value can't silently be dropped at an intermediate layer.
- `schema_enum.mustache`: emit `{{{ enum_value_doc_comment }}}` before each enum case.
- **`CLAUDE.md`**: added a convention note explaining *why* `required` is the default on internal pipeline types (parse/resolve/render). That came up while reviewing this PR — worth codifying.
- New tests: golden-output + error-path coverage for `x-enum-descriptions`.

## Test plan
- [x] `dart test` — all pass
- [x] `dart analyze` — clean (pre-existing infos only)
- [x] Added `x-enum-descriptions` to the Shorebird `codepush.yaml` fixture; regenerated `role.dart` is byte-for-byte close to the handwritten version.