### PR TITLE
feat: support propertyNames for typed Map<Enum, V> keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,12 @@
 - Fix `RenderArray.defaultValueString` to return `null` when the
   schema has no default (previously crashed casting `null as List`
   once `allListsDefaultToEmpty` was off).
+- Honour the JSON Schema 2020-12 / OpenAPI 3.1 `propertyNames`
+  keyword on map-shaped schemas. When `propertyNames` resolves to a
+  named string enum, the generated field becomes `Map<EnumKey, V>`
+  with the enum's `fromJson`/`toJson` round-tripping each key at the
+  boundary. Handwritten `Map<ReleasePlatform, ReleaseStatus>` can now
+  be expressed spec-compliantly without a vendor extension.
 - Fix nullable primitive query parameters to be null-safe. Generated
   code previously emitted `?foo.toString()`, which always produced a
   map entry (with the literal string `"null"` as its value) because

--- a/lib/src/parse/spec.dart
+++ b/lib/src/parse/spec.dart
@@ -225,12 +225,24 @@ abstract class SchemaObjectBase extends Schema {
 /// Map isn't a type in the spec, but rather inferred by having
 /// additionalProperties and no other properties.
 class SchemaMap extends Schema {
-  const SchemaMap({required super.common, required this.valueSchema});
+  const SchemaMap({
+    required super.common,
+    required this.valueSchema,
+    required this.keySchema,
+  });
 
   final SchemaRef valueSchema;
 
+  /// Optional typed key schema, from the OpenAPI 3.1 / JSON Schema
+  /// 2020-12 `propertyNames` keyword. Non-null when the spec declared
+  /// `propertyNames` on a map-shaped object. OpenAPI JSON objects
+  /// always have string keys on the wire; this lets the generated
+  /// Dart use a richer key type (currently only string enums) with
+  /// automatic encode/decode at the boundary.
+  final SchemaRef? keySchema;
+
   @override
-  List<Object?> get props => [super.props, valueSchema];
+  List<Object?> get props => [super.props, valueSchema, keySchema];
 }
 
 class SchemaBinary extends Schema {

--- a/lib/src/parse/visitor.dart
+++ b/lib/src/parse/visitor.dart
@@ -132,8 +132,10 @@ class SpecWalker {
         _maybeRefOr(schema.additionalProperties);
       case SchemaArray():
         _maybeRefOr(schema.items);
-      case SchemaEnum():
       case SchemaMap():
+        _maybeRefOr(schema.valueSchema);
+        _maybeRefOr(schema.keySchema);
+      case SchemaEnum():
       case SchemaUnknown():
       case SchemaPod():
       case SchemaInteger():

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -677,7 +677,19 @@ Schema _createCorrectSchemaSubtype(MapContext json) {
     if (additionalPropertiesSchema == null) {
       return SchemaUnknown(common: common);
     }
-    return SchemaMap(common: common, valueSchema: additionalPropertiesSchema);
+    // Optional: JSON Schema 2020-12 / OpenAPI 3.1 `propertyNames`
+    // constrains the keys of this map-shaped object to values that
+    // conform to the given schema. When that schema is (or resolves
+    // to) a string enum, we use it as the Dart map key type.
+    final propertyNamesJson = _optionalMap(json, 'propertyNames');
+    final keySchema = propertyNamesJson == null
+        ? null
+        : parseSchemaOrRef(propertyNamesJson);
+    return SchemaMap(
+      common: common,
+      valueSchema: additionalPropertiesSchema,
+      keySchema: keySchema,
+    );
   }
   // The difference between an empty object and an unknown object is subtle
   // and probably not correct.  GitHub has an explicitly empty object, which is

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -329,9 +329,13 @@ class SpecResolver {
           schemas: schema.schemas.map(toRenderSchema).toList(),
         );
       case ResolvedMap():
+        final keyEnum = schema.keySchema;
         return RenderMap(
           common: schema.common,
           valueSchema: toRenderSchema(schema.valueSchema),
+          keySchema: keyEnum == null
+              ? null
+              : toRenderSchema(keyEnum) as RenderEnum,
         );
       case ResolvedEmptyObject():
         return RenderEmptyObject(common: schema.common);
@@ -2071,19 +2075,31 @@ class RenderMap extends RenderSchema {
   const RenderMap({
     required super.common,
     required this.valueSchema,
+    required this.keySchema,
     this.defaultValue,
   }) : super(createsNewType: false);
 
   final RenderSchema valueSchema;
 
+  /// Optional typed key schema. JSON always uses string keys on the wire;
+  /// when non-null the generated Dart uses this enum as the map key and
+  /// the enum's `fromJson`/`toJson` round-trips each key at the boundary.
+  final RenderEnum? keySchema;
+
   @override
   final dynamic defaultValue;
 
   @override
-  List<Object?> get props => [super.props, valueSchema, defaultValue];
+  List<Object?> get props => [
+    super.props,
+    valueSchema,
+    keySchema,
+    defaultValue,
+  ];
 
   @override
-  bool get shouldCallToJson => valueSchema.shouldCallToJson;
+  bool get shouldCallToJson =>
+      keySchema != null || valueSchema.shouldCallToJson;
 
   @override
   bool get defaultCanConstConstruct {
@@ -2097,7 +2113,10 @@ class RenderMap extends RenderSchema {
   }
 
   @override
-  String get typeName => 'Map<String, ${valueSchema.typeName}>';
+  String get typeName {
+    final keyType = keySchema?.typeName ?? 'String';
+    return 'Map<$keyType, ${valueSchema.typeName}>';
+  }
 
   @override
   String equalsExpression(String name, SchemaRenderer context) =>
@@ -2113,17 +2132,19 @@ class RenderMap extends RenderSchema {
     SchemaRenderer context, {
     required bool dartIsNullable,
   }) {
-    // Nothing to do if the value schema is only json types.
-    if (!valueSchema.shouldCallToJson) {
+    // Nothing to do if both key and value are json types.
+    if (keySchema == null && !valueSchema.shouldCallToJson) {
       return dartName;
     }
+    final keyToJson = keySchema == null ? 'key' : 'key.toJson()';
     final valueToJson = valueSchema.toJsonExpression(
       'value',
       context,
       dartIsNullable: false,
     );
     final callMap = dartIsNullable ? '?.map' : '.map';
-    return '$dartName$callMap((key, value) => MapEntry(key, $valueToJson))';
+    return '$dartName$callMap((key, value) => '
+        'MapEntry($keyToJson, $valueToJson))';
   }
 
   @override
@@ -2136,6 +2157,9 @@ class RenderMap extends RenderSchema {
     // We could probably do a smaller cast if the value schema is only json
     // types.
     final jsonType = jsonStorageType(isNullable: jsonIsNullable);
+    final keyFromJson = keySchema == null
+        ? 'key'
+        : '${keySchema!.typeName}.fromJson(key)';
     final valueFromJson = valueSchema.fromJsonExpression(
       'value',
       context,
@@ -2146,7 +2170,7 @@ class RenderMap extends RenderSchema {
     // Should this have a leading ? to skip the key on null?
     final callMap = jsonIsNullable ? '?.map' : '.map';
     return '($jsonValue as $jsonType)$callMap((key, value) => '
-        'MapEntry(key, $valueFromJson))';
+        'MapEntry($keyFromJson, $valueFromJson))';
   }
 
   @override
@@ -2159,6 +2183,7 @@ class RenderMap extends RenderSchema {
       return false;
     }
     return valueSchema.equalsIgnoringName(other.valueSchema) &&
+        RenderSchema.maybeEqualsIgnoringName(keySchema, other.keySchema) &&
         super.equalsIgnoringName(other);
   }
 }

--- a/lib/src/render/tree_visitor.dart
+++ b/lib/src/render/tree_visitor.dart
@@ -42,6 +42,8 @@ class RenderTreeWalker {
         }
       case RenderMap():
         walkSchema(schema.valueSchema);
+        final keySchema = schema.keySchema;
+        if (keySchema != null) walkSchema(keySchema);
       case RenderRecursiveRef():
       case RenderEnum():
       case RenderString():

--- a/lib/src/resolver.dart
+++ b/lib/src/resolver.dart
@@ -317,9 +317,20 @@ ResolvedSchema _resolveSchemaFully(
     );
   }
   if (schema is SchemaMap) {
+    final keyRef = schema.keySchema;
+    final keySchema = keyRef == null ? null : resolveSchemaRef(keyRef, context);
+    if (keySchema != null && keySchema is! ResolvedEnum) {
+      _error(
+        'propertyNames must resolve to a string enum for a map-typed '
+        r'schema. Either use a $ref to a named string enum or an inline '
+        'string enum. Got: ${keySchema.runtimeType}',
+        schema.pointer,
+      );
+    }
     return ResolvedMap(
       common: resolvedCommon,
       valueSchema: resolveSchemaRef(schema.valueSchema, context),
+      keySchema: keySchema as ResolvedEnum?,
       createsNewType: createsNewType,
     );
   }
@@ -1315,16 +1326,21 @@ class ResolvedMap extends ResolvedSchema {
   const ResolvedMap({
     required super.common,
     required this.valueSchema,
+    required this.keySchema,
     required super.createsNewType,
   });
 
   final ResolvedSchema valueSchema;
+
+  /// Optional typed key schema. Must resolve to a string enum.
+  final ResolvedEnum? keySchema;
 
   @override
   ResolvedMap copyWith({CommonProperties? common}) {
     return ResolvedMap(
       common: common ?? this.common,
       valueSchema: valueSchema,
+      keySchema: keySchema,
       createsNewType: createsNewType,
     );
   }

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -109,6 +109,66 @@ void main() {
       }
     });
 
+    test('propertyNames with ref to a string enum gives a typed map key', () {
+      final schemas = <String, Map<String, dynamic>>{
+        'Platform': {
+          'type': 'string',
+          'enum': ['android', 'ios'],
+        },
+        'Status': {
+          'type': 'string',
+          'enum': ['draft', 'active'],
+        },
+        'R': {
+          'type': 'object',
+          'required': ['statuses'],
+          'properties': {
+            'statuses': {
+              'type': 'object',
+              'additionalProperties': {
+                r'$ref': '#/components/schemas/Status',
+              },
+              'propertyNames': {
+                r'$ref': '#/components/schemas/Platform',
+              },
+            },
+          },
+        },
+      };
+      final rendered = renderTestSchemas(
+        schemas,
+        specUrl: Uri.parse('file:///spec.yaml'),
+      );
+      final r = rendered['R']!;
+      expect(r, contains('final Map<Platform, Status> statuses;'));
+      expect(r, contains('MapEntry(Platform.fromJson(key), Status.fromJson'));
+      expect(r, contains('MapEntry(key.toJson(), value.toJson())'));
+    });
+
+    test('propertyNames without an enum ref is a spec error', () {
+      final schema = {
+        'type': 'object',
+        'required': ['statuses'],
+        'properties': {
+          'statuses': {
+            'type': 'object',
+            'additionalProperties': {'type': 'string'},
+            'propertyNames': {'type': 'string'},
+          },
+        },
+      };
+      expect(
+        () => renderTestSchema(schema, asComponent: true),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            contains('must resolve to a string enum'),
+          ),
+        ),
+      );
+    });
+
     test('x-enum-descriptions emits dartdoc per enum case', () {
       final schema = {
         'type': 'string',

--- a/test/render/render_tree_test.dart
+++ b/test/render/render_tree_test.dart
@@ -504,6 +504,50 @@ void main() {
       );
       expect(a.equalsIgnoringName(c), isFalse);
     });
+
+    test('RenderMap keySchema participates in equality', () {
+      const boolValue = RenderPod(
+        common: CommonProperties.test(
+          snakeName: 'v',
+          pointer: JsonPointer.empty(),
+          description: 'v',
+        ),
+        type: PodType.boolean,
+      );
+      final enumKey = RenderEnum(
+        common: const CommonProperties.test(
+          snakeName: 'platform',
+          pointer: JsonPointer.empty(),
+          description: 'Platform',
+        ),
+        values: const ['android', 'ios'],
+        names: const ['android', 'ios'],
+        descriptions: null,
+      );
+      const noKey = RenderMap(
+        common: CommonProperties.test(
+          snakeName: 'a',
+          pointer: JsonPointer.empty(),
+          description: 'm',
+        ),
+        valueSchema: boolValue,
+        keySchema: null,
+      );
+      final withKey = RenderMap(
+        common: const CommonProperties.test(
+          snakeName: 'a',
+          pointer: JsonPointer.empty(),
+          description: 'm',
+        ),
+        valueSchema: boolValue,
+        keySchema: enumKey,
+      );
+      expect(noKey.equalsIgnoringName(noKey), isTrue);
+      expect(withKey.equalsIgnoringName(withKey), isTrue);
+      // Different keySchema (null vs enum) => not equal.
+      expect(noKey.equalsIgnoringName(withKey), isFalse);
+      expect(withKey.equalsIgnoringName(noKey), isFalse);
+    });
   });
 
   group('additionalImports', () {

--- a/test/resolver_test.dart
+++ b/test/resolver_test.dart
@@ -1184,6 +1184,7 @@ void main() {
             common: beforeCommon,
             type: PodType.boolean,
           ),
+          keySchema: null,
         );
         testCopyWith(schema, (schema, copy) {
           expect(copy.valueSchema, equals(schema.valueSchema));


### PR DESCRIPTION
## Summary
OpenAPI's `additionalProperties` lets you type the *values* of a free-form object-as-map, but JSON always uses string keys on the wire. There's no way to express a richer Dart-side key type with only `additionalProperties` — so a handwritten `Map<ReleasePlatform, ReleaseStatus>` had to become `Map<String, ReleaseStatus>` once it round-tripped through the generator.

JSON Schema 2020-12 (which OpenAPI 3.1 extends) already has the standard answer: **`propertyNames`** constrains the keys of an object to values that match a schema. When `propertyNames` resolves to a named string enum, we can use that enum as the Dart map key type:

```yaml
platform_statuses:
  type: object
  propertyNames:
    $ref: "#/components/schemas/ReleasePlatform"
  additionalProperties:
    $ref: "#/components/schemas/ReleaseStatus"
```

becomes

```dart
final Map<ReleasePlatform, ReleaseStatus> platformStatuses;
// ...
factory Foo.fromJson(Map<String, dynamic> json) => Foo(
  platformStatuses: (json['platform_statuses'] as Map<String, dynamic>).map(
    (k, v) => MapEntry(
      ReleasePlatform.fromJson(k),
      ReleaseStatus.fromJson(v as String),
    ),
  ),
);
// toJson emits `key.toJson()` back to a String.
```

with the enum's `fromJson`/`toJson` round-tripping each key at the boundary. **No vendor extension** — any spec reader that honours `propertyNames` will pick up the same semantic.

## What changed
- New field `keySchema` on `SchemaMap` / `ResolvedMap` / `RenderMap`, all `required` per the pipeline-type convention in `CLAUDE.md`.
- `RenderTreeWalker` walks the key schema so the generated file picks up the import for the enum class.
- Resolver hard-errors if `propertyNames` doesn't resolve to a `ResolvedEnum` — error message points users at the right fix.
- New tests cover the happy path (round-trip rendering) and the error path.

## Previous revision
Earlier revisions of this PR used a custom `x-dart-map-key` vendor extension. Switched to `propertyNames` since it's the spec-standard way to say the same thing — discussed in the PR thread.

## Test plan
- [x] `dart test` — all pass
- [x] `dart analyze` — clean (pre-existing info unrelated)
- [x] Round-tripped a real-world use case (Shorebird's `Release.platformStatuses`) through this and got byte-identical output to the handwritten version.