### PR TITLE
fix: null-safe cast for nullable Map<String, T> fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,13 @@
 - Support the `x-enum-descriptions` vendor extension. A parallel array
   of strings alongside `enum:` now renders as per-case dartdoc on the
   generated enum.
+- Fix `RenderMap.jsonStorageType` to honour `isNullable`. Previously a
+  nullable map field emitted
+  `(json[key] as Map<String, dynamic>)?.map(...)` — the cast crashed
+  when the key was missing/null (`type 'Null' is not a subtype of type
+  'Map<String, dynamic>'`). Now emits
+  `(json[key] as Map<String, dynamic>?)?.map(...)` so the null-aware
+  `?.map` chain actually has a nullable receiver.
 - Fix nullable primitive query parameters to be null-safe. Generated
   code previously emitted `?foo.toString()`, which always produced a
   map entry (with the literal string `"null"` as its value) because

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -2101,7 +2101,8 @@ class RenderMap extends RenderSchema {
       '${ModelHelpers.mapsEqual}(this.$name, other.$name)';
 
   @override
-  String jsonStorageType({required bool isNullable}) => 'Map<String, dynamic>';
+  String jsonStorageType({required bool isNullable}) =>
+      isNullable ? 'Map<String, dynamic>?' : 'Map<String, dynamic>';
 
   @override
   String toJsonExpression(

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -801,7 +801,7 @@ void main() {
         '    factory Test.fromJson(Map<String, dynamic>\n'
         '        json) {\n'
         '        return Test(\n'
-        "            map: (json['map'] as Map<String, dynamic>)?.map((key, value) => MapEntry(key, value as String)),\n"
+        "            map: (json['map'] as Map<String, dynamic>?)?.map((key, value) => MapEntry(key, value as String)),\n"
         '        );\n'
         '    }\n'
         '\n'
@@ -895,15 +895,15 @@ void main() {
         '    factory Test.fromJson(Map<String, dynamic>\n'
         '        json) {\n'
         '        return Test(\n'
-        "            mString: (json['m_string'] as Map<String, dynamic>)?.map((key, value) => MapEntry(key, value as String)),\n"
-        "            mInt: (json['m_int'] as Map<String, dynamic>)?.map((key, value) => MapEntry(key, (value as int))),\n"
-        "            mNumber: (json['m_number'] as Map<String, dynamic>)?.map((key, value) => MapEntry(key, (value as num).toDouble())),\n"
-        "            mBoolean: (json['m_boolean'] as Map<String, dynamic>)?.map((key, value) => MapEntry(key, value as bool)),\n"
-        "            mDateTime: (json['m_date_time'] as Map<String, dynamic>)?.map((key, value) => MapEntry(key, DateTime.parse(value as String))),\n"
-        "            mUri: (json['m_uri'] as Map<String, dynamic>)?.map((key, value) => MapEntry(key, Uri.parse(value as String))),\n"
-        "            mMapOfString: (json['m_map_of_string'] as Map<String, dynamic>)?.map((key, value) => MapEntry(key, (value as Map<String, dynamic>).map((key, value) => MapEntry(key, value as String)))),\n"
-        "            mEnum: (json['m_enum'] as Map<String, dynamic>)?.map((key, value) => MapEntry(key, TestMEnum.fromJson(value as String))),\n"
-        "            mUnknown: (json['m_unknown'] as Map<String, dynamic>)?.map((key, value) => MapEntry(key, value)),\n"
+        "            mString: (json['m_string'] as Map<String, dynamic>?)?.map((key, value) => MapEntry(key, value as String)),\n"
+        "            mInt: (json['m_int'] as Map<String, dynamic>?)?.map((key, value) => MapEntry(key, (value as int))),\n"
+        "            mNumber: (json['m_number'] as Map<String, dynamic>?)?.map((key, value) => MapEntry(key, (value as num).toDouble())),\n"
+        "            mBoolean: (json['m_boolean'] as Map<String, dynamic>?)?.map((key, value) => MapEntry(key, value as bool)),\n"
+        "            mDateTime: (json['m_date_time'] as Map<String, dynamic>?)?.map((key, value) => MapEntry(key, DateTime.parse(value as String))),\n"
+        "            mUri: (json['m_uri'] as Map<String, dynamic>?)?.map((key, value) => MapEntry(key, Uri.parse(value as String))),\n"
+        "            mMapOfString: (json['m_map_of_string'] as Map<String, dynamic>?)?.map((key, value) => MapEntry(key, (value as Map<String, dynamic>).map((key, value) => MapEntry(key, value as String)))),\n"
+        "            mEnum: (json['m_enum'] as Map<String, dynamic>?)?.map((key, value) => MapEntry(key, TestMEnum.fromJson(value as String))),\n"
+        "            mUnknown: (json['m_unknown'] as Map<String, dynamic>?)?.map((key, value) => MapEntry(key, value)),\n"
         '        );\n'
         '    }\n'
         '\n'


### PR DESCRIPTION
## Summary
`RenderMap.jsonStorageType` hard-coded `'Map<String, dynamic>'` regardless of the `isNullable` parameter. A nullable map field then generated:

```dart
metadata: (json['metadata'] as Map<String, dynamic>).map(...)
```

which crashes at runtime when the key is missing:

```
type 'Null' is not a subtype of type 'Map<String, dynamic>' in type cast
```

The `.map()` call was already null-aware (`?.map`) — the **receiver cast** was the buggy part. Honour `isNullable` so the cast becomes `as Map<String, dynamic>?`, letting the already-null-aware `?.map` chain return `null` cleanly.

## Example

Before:
```dart
metadata: (json['metadata'] as Map<String, dynamic>)?.map(MapEntry.new),
```

After:
```dart
metadata: (json['metadata'] as Map<String, dynamic>?)?.map(MapEntry.new),
```

## Test plan
- [x] Updated the existing map-type golden tests in `render_schema_test.dart` to match.
- [x] `dart test` — all pass
- [x] `dart analyze` — clean

Hit in the wild while generating the Shorebird `UpdateReleaseRequest.metadata` field, which was nullable; the old cast blew up trying to deserialize an `UpdateReleaseRequest` that didn't include metadata.