### PR TITLE
refactor: make allListsDefaultToEmpty an openapi-only quirk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,15 @@
   'Map<String, dynamic>'`). Now emits
   `(json[key] as Map<String, dynamic>?)?.map(...)` so the null-aware
   `?.map` chain actually has a nullable receiver.
+- **Breaking:** `Quirks().allListsDefaultToEmpty` now defaults to
+  `false`. The "nullable lists default to `const []`" behavior was
+  really an OpenAPI convention and is now only on via
+  `Quirks.openapi()`. Callers using the plain default who relied on
+  the old behavior should opt in explicitly:
+  `Quirks(allListsDefaultToEmpty: true)`.
+- Fix `RenderArray.defaultValueString` to return `null` when the
+  schema has no default (previously crashed casting `null as List`
+  once `allListsDefaultToEmpty` was off).
 - Fix nullable primitive query parameters to be null-safe. Generated
   code previously emitted `?foo.toString()`, which always produced a
   map entry (with the literal string `"null"` as its value) because

--- a/lib/src/quirks.dart
+++ b/lib/src/quirks.dart
@@ -3,8 +3,7 @@ class Quirks {
   const Quirks({
     this.dynamicJson = false,
     this.mutableModels = false,
-    // Avoiding ever having List? seems reasonable so we default to true.
-    this.allListsDefaultToEmpty = true,
+    this.allListsDefaultToEmpty = false,
     this.nonNullableDefaultValues = false,
     this.screamingCapsEnums = false,
   });

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -1978,6 +1978,9 @@ class RenderArray extends RenderSchema {
 
   @override
   String? defaultValueString(SchemaRenderer context) {
+    if (defaultValue == null) {
+      return null;
+    }
     final listDefault = defaultValue as List;
     if (listDefault.isEmpty) {
       // Type annotation is not needed for empty lists.

--- a/test/render/render_operation_test.dart
+++ b/test/render/render_operation_test.dart
@@ -459,14 +459,16 @@ void main() {
           '200': {'description': 'OK'},
         },
       };
-      const quirks = Quirks();
-      // If this expectation changes, set an explicit quirks for renderOperation
-      expect(quirks.allListsDefaultToEmpty, isTrue);
+      // allListsDefaultToEmpty is an openapi-only quirk; the plain
+      // Quirks() default no longer turns it on.
+      const quirks = Quirks(allListsDefaultToEmpty: true);
+      expect(const Quirks().allListsDefaultToEmpty, isFalse);
+      expect(const Quirks.openapi().allListsDefaultToEmpty, isTrue);
       final result = renderTestOperation(
         path: '/users',
         operationJson: json,
         serverUrl: Uri.parse('https://api.spacetraders.io/v2'),
-        // Using default quirks.
+        quirks: quirks,
       );
       expect(
         result,

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -1018,7 +1018,10 @@ void main() {
           'a_unknown': {'type': 'array', 'items': <String, dynamic>{}},
         },
       };
-      final result = renderTestSchema(schema);
+      final result = renderTestSchema(
+        schema,
+        quirks: const Quirks(allListsDefaultToEmpty: true),
+      );
       expect(
         result,
         '@immutable\n'


### PR DESCRIPTION
## Summary
The `Quirks.allListsDefaultToEmpty` flag defaults nullable list fields to `const []`. That erases the distinction between 'absent' and 'empty' on the wire — a handwritten Dart protocol that wants to round-trip `foo: null` as literally null can't, because `toJson` always emits `[]`.

This is really an OpenAPI convention, not a general-purpose default. Flip the plain `Quirks()` default to `false`; `Quirks.openapi()` keeps it at `true` so the OpenAPI preset is unchanged.

## Breaking change

If your generator invocation relied on the old default, opt in:

```dart
const quirks = Quirks(allListsDefaultToEmpty: true);
```

## What changed
- `lib/src/quirks.dart`: `Quirks()` now defaults `allListsDefaultToEmpty` to `false`. `Quirks.openapi()` continues to set it to `true`, unchanged.
- `lib/src/render/render_tree.dart`: `RenderArray.defaultValueString` now returns `null` when the schema has no default, instead of crashing on `null as List`. This path was unreachable before because the quirk guaranteed a default for every list.
- Two existing tests that exercised the old default were updated to pass `Quirks(allListsDefaultToEmpty: true)` so their expectations stay valid.

## Test plan
- [x] `dart test` — all pass
- [x] `dart analyze` — clean
- [x] Hit in the wild while generating the Shorebird `PatchCheckResponse.rolledBackPatchNumbers` field — with the new default, `toJson()` emits the same `null` semantics as the handwritten protocol.