### PR TITLE
feat: split schemas into lib/models and lib/messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## 1.0.2
 
+- **Breaking:** Schemas are now emitted to `lib/models/<name>.dart` or
+  `lib/messages/<name>.dart` (split by name suffix: classes whose name
+  ends in `Request` or `Response` go to `messages/`) instead of a flat
+  `lib/model/` directory. Matches the conventional layout of
+  hand-written Dart packages (models as domain primitives, messages as
+  request/response DTOs). The old flat `lib/model/` layout is still
+  produced by `Quirks.openapi()` via the new `flatModelDir` quirk, so
+  generators targeting OpenAPI Generator compatibility see no change.
+  The previous `lib/model/` directory is also wiped when regenerating,
+  so stale files from the old layout don't linger after an upgrade.
+
 - Emit only the imports a rendered model/api body actually needs: drop
   unconditional `dart:convert`, `dart:io`, `package:meta/meta.dart`, and
   `model_helpers.dart` from models; gate `meta` and `model_helpers` on

--- a/lib/src/quirks.dart
+++ b/lib/src/quirks.dart
@@ -6,6 +6,7 @@ class Quirks {
     this.allListsDefaultToEmpty = false,
     this.nonNullableDefaultValues = false,
     this.screamingCapsEnums = false,
+    this.flatModelDir = false,
   });
 
   const Quirks.openapi()
@@ -15,6 +16,7 @@ class Quirks {
         nonNullableDefaultValues: true,
         allListsDefaultToEmpty: true,
         screamingCapsEnums: true,
+        flatModelDir: true,
       );
 
   /// Use "dynamic" instead of "Map\<String, dynamic\>" for passing to fromJson
@@ -36,8 +38,10 @@ class Quirks {
   /// OpenAPI uses SCREAMING_CAPS for enum values, but that's not Dart style.
   final bool screamingCapsEnums;
 
-  // Potential future quirks:
-
-  /// OpenAPI flattens everything into the top level `lib` folder.
-  // final bool doNotUseSrcPaths;
+  /// Emit all schemas into a single flat `lib/model/` directory, matching
+  /// the layout OpenAPI Generator produces. Off by default: schemas are
+  /// split into `lib/models/` (domain models) and `lib/messages/`
+  /// (classes whose name ends in `Request`/`Response`), which better
+  /// matches hand-written Dart packaging.
+  final bool flatModelDir;
 }

--- a/lib/src/render/file_renderer.dart
+++ b/lib/src/render/file_renderer.dart
@@ -241,24 +241,35 @@ class FileRenderer {
     return 'api/${api.fileName}.dart';
   }
 
-  static String modelFilePath(RenderSchema schema) {
-    // openapi generator does not use /src/ in the path.
-    return 'lib/model/${schema.snakeName}.dart';
+  /// Subdirectory under `lib/` a schema renders into.
+  ///
+  /// Default: classes whose Dart name ends in `Request` or `Response`
+  /// are treated as message DTOs and land under `messages/`; everything
+  /// else is a domain model and lands under `models/`.
+  ///
+  /// With [Quirks.flatModelDir] on (implied by `Quirks.openapi()`),
+  /// everything lands in a single flat `model/` directory for
+  /// compatibility with OpenAPI Generator's output layout.
+  String _modelSubdir(RenderSchema schema) {
+    if (quirks.flatModelDir) return 'model';
+    final className = schema.typeName;
+    final isMessage =
+        className.endsWith('Request') || className.endsWith('Response');
+    return isMessage ? 'messages' : 'models';
   }
 
-  static String modelPackagePath(RenderSchema schema) {
-    return 'model/${schema.snakeName}.dart';
+  String modelFilePath(RenderSchema schema) {
+    return 'lib/${_modelSubdir(schema)}/${schema.snakeName}.dart';
+  }
+
+  String modelPackagePath(RenderSchema schema) {
+    return '${_modelSubdir(schema)}/${schema.snakeName}.dart';
   }
 
   String modelPackageImport(FileRenderer context, RenderSchema schema) {
-    return 'package:${context.packageName}/model/${schema.snakeName}.dart';
+    return 'package:${context.packageName}/'
+        '${context._modelSubdir(schema)}/${schema.snakeName}.dart';
   }
-
-  // String packageImport(_Context context) {
-  //   final name = p.basenameWithoutExtension(ref!);
-  //   final snakeName = snakeFromCamel(name);
-  //   return 'package:${context.packageName}/model/$snakeName.dart';
-  // }
 
   /// Render a template.
   void _renderTemplate({
@@ -464,7 +475,15 @@ class FileRenderer {
       // Only delete the directories we make to handle the case of changing
       // directory structure or adding/removing files.
       // All other files we make can be overwritten.
-      final dirs = {p.join('lib', 'api'), p.join('lib', 'model')};
+      final dirs = {
+        p.join('lib', 'api'),
+        // Previous output layouts we might inherit from — clear so stale
+        // files from an earlier layout don't linger.
+        p.join('lib', 'model'),
+        // Current layout.
+        p.join('lib', 'models'),
+        p.join('lib', 'messages'),
+      };
       for (final dirName in dirs) {
         final path = p.join(fileWriter.outDir.path, dirName);
         final dir = fileWriter.fs.directory(path);

--- a/test/render/file_renderer_test.dart
+++ b/test/render/file_renderer_test.dart
@@ -56,6 +56,45 @@ class _HasFiles extends CustomMatcher {
 
 Matcher hasFiles(List<String> files) => _HasFiles(files);
 
+/// Matches the union of files emitted under `lib/models/` and
+/// `lib/messages/`, applied to the package root directory. Use this
+/// when a test just cares "these schema files were generated" and
+/// doesn't need to pin which of the two subdirectories each landed in.
+class _HasGeneratedSchemaFiles extends CustomMatcher {
+  _HasGeneratedSchemaFiles(List<String> files)
+    : super(
+        'has generated schema files (models + messages)',
+        'files',
+        unorderedEquals(files),
+      );
+
+  @override
+  Object? featureValueOf(dynamic actual) {
+    final out = actual as Directory;
+    final names = <String>[];
+    for (final subdir in const ['lib/models', 'lib/messages']) {
+      final dir = out.childDirectory(subdir);
+      if (!dir.existsSync()) continue;
+      names.addAll(
+        dir.listSync().whereType<File>().map((e) => e.path.split('/').last),
+      );
+    }
+    return names;
+  }
+}
+
+Matcher hasGeneratedSchemaFiles(List<String> files) =>
+    _HasGeneratedSchemaFiles(files);
+
+/// True when any generated model or message file has been emitted under
+/// the package root.
+bool hasGeneratedSchemaDirs(Directory out) {
+  for (final subdir in const ['lib/models', 'lib/messages']) {
+    if (out.childDirectory(subdir).existsSync()) return true;
+  }
+  return false;
+}
+
 void main() {
   group('loadAndRenderSpec', () {
     const localFs = LocalFileSystem();
@@ -267,8 +306,8 @@ void main() {
       );
       expect(out.childDirectory('lib/api'), hasFiles(['default_api.dart']));
       expect(
-        out.childDirectory('lib/model'),
-        hasFiles([
+        out,
+        hasGeneratedSchemaFiles([
           'get_user200_response.dart',
           'account.dart',
           'account_role.dart',
@@ -372,8 +411,8 @@ void main() {
       expect(outFile('lib/api_client.dart'), exists);
       expect(apiFile('fleet_api.dart'), exists);
       expect(
-        out.childDirectory('lib/model'),
-        hasFiles([
+        out,
+        hasGeneratedSchemaFiles([
           'purchase_cargo_request.dart',
           'purchase_cargo201_response.dart',
           'purchase_cargo201_response_data.dart',
@@ -438,8 +477,12 @@ void main() {
 
       await renderToDirectory(spec: spec, outDir: out);
       expect(
-        out.childDirectory('lib/model'),
-        hasFiles(['get_user200_response.dart', 'user.dart', 'multiplier.dart']),
+        out,
+        hasGeneratedSchemaFiles([
+          'get_user200_response.dart',
+          'user.dart',
+          'multiplier.dart',
+        ]),
       );
     });
 
@@ -499,8 +542,11 @@ void main() {
       final out = fs.directory('spacetraders');
 
       await renderToDirectory(spec: spec, outDir: out);
-      expect(out.childFile('lib/model/get_user200_response.dart'), exists);
-      expect(out.childFile('lib/model/user.dart'), exists);
+      expect(
+        out.childFile('lib/messages/get_user200_response.dart'),
+        exists,
+      );
+      expect(out.childFile('lib/models/user.dart'), exists);
     });
 
     test('with additionalProperties', () async {
@@ -538,8 +584,8 @@ void main() {
       final out = fs.directory('spacetraders');
 
       await renderToDirectory(spec: spec, outDir: out);
-      // No model files are needed for the Map.
-      expect(out.childDirectory('lib/model').existsSync(), isFalse);
+      // No schema files are needed for the Map.
+      expect(hasGeneratedSchemaDirs(out), isFalse);
     });
 
     test('with inner types', () async {
@@ -591,8 +637,8 @@ void main() {
 
       await renderToDirectory(spec: spec, outDir: out);
       expect(
-        out.childDirectory('lib/model'),
-        hasFiles([
+        out,
+        hasGeneratedSchemaFiles([
           'get_my_factions200_response.dart',
           'get_my_factions200_response_data_inner.dart',
         ]),
@@ -644,8 +690,8 @@ void main() {
 
       await renderToDirectory(spec: spec, outDir: out);
       expect(
-        out.childDirectory('lib/model'),
-        hasFiles(['purchase_cargo_request.dart']),
+        out,
+        hasGeneratedSchemaFiles(['purchase_cargo_request.dart']),
       );
       expect(out.childFile('lib/api/default_api.dart'), exists);
     });
@@ -732,8 +778,8 @@ void main() {
 
       await renderToDirectory(spec: spec, outDir: out);
       expect(
-        out.childDirectory('lib/model'),
-        hasFiles(['get_user200_response.dart']),
+        out,
+        hasGeneratedSchemaFiles(['get_user200_response.dart']),
       );
     });
 
@@ -788,8 +834,8 @@ void main() {
       await renderToDirectory(spec: spec, outDir: out);
       expect(out.childFile('lib/api/default_api.dart'), exists);
       expect(
-        out.childDirectory('lib/model'),
-        hasFiles(['get_my_ships200_response.dart']),
+        out,
+        hasGeneratedSchemaFiles(['get_my_ships200_response.dart']),
       );
     });
 
@@ -857,7 +903,7 @@ void main() {
 
       await renderToDirectory(spec: spec, outDir: out);
       expect(out.childFile('lib/api/default_api.dart'), exists);
-      expect(out.childDirectory('lib/model'), isNot(exists));
+      expect(hasGeneratedSchemaDirs(out), isFalse);
     });
 
     test(
@@ -899,8 +945,8 @@ void main() {
         await renderToDirectory(spec: spec, outDir: out);
         expect(out.childFile('lib/api/default_api.dart'), exists);
         expect(
-          out.childDirectory('lib/model'),
-          hasFiles(['users200_response.dart']),
+          out,
+          hasGeneratedSchemaFiles(['users200_response.dart']),
         );
       },
     );
@@ -942,8 +988,8 @@ void main() {
       await renderToDirectory(spec: spec, outDir: out);
       expect(out.childFile('lib/api/default_api.dart'), exists);
       expect(
-        out.childDirectory('lib/model'),
-        hasFiles(['users_response.dart']),
+        out,
+        hasGeneratedSchemaFiles(['users_response.dart']),
       );
     });
     test('empty object creates new file', () async {
@@ -985,7 +1031,7 @@ void main() {
       final out = fs.directory('spacetraders');
 
       await renderToDirectory(spec: spec, outDir: out);
-      expect(out.childFile('lib/model/empty_object.dart'), exists);
+      expect(out.childFile('lib/models/empty_object.dart'), exists);
     });
 
     test('tag with kebab case', () async {
@@ -1078,11 +1124,10 @@ void main() {
       final out = fs.directory('spacetraders');
 
       await renderToDirectory(spec: spec, outDir: out);
-      final modelDir = out.childDirectory('lib/model');
       // TODO(eseidel): This is wrong. We shouldn't render the nested objects.
       expect(
-        modelDir,
-        hasFiles([
+        out,
+        hasGeneratedSchemaFiles([
           'workflow_usage.dart',
           'workflow_usage_billable.dart',
           'workflow_usage_billable_u_b_u_n_t_u.dart',
@@ -1149,8 +1194,8 @@ void main() {
 
       await renderToDirectory(spec: spec, outDir: out);
       expect(
-        out.childDirectory('lib/model'),
-        hasFiles([
+        out,
+        hasGeneratedSchemaFiles([
           'users200_response.dart',
           'user.dart',
           'user_role.dart',
@@ -1212,8 +1257,8 @@ void main() {
       final logger = _MockLogger();
       await renderToDirectory(spec: spec, outDir: out, logger: logger);
       expect(
-        out.childDirectory('lib/model'),
-        hasFiles([
+        out,
+        hasGeneratedSchemaFiles([
           'users200_response.dart',
           'user.dart',
           'user_role.dart',
@@ -1263,9 +1308,9 @@ void main() {
       await renderToDirectory(spec: spec, outDir: out);
 
       // Only one file for Node — the cycle-break refs don't emit their own.
-      expect(out.childDirectory('lib/model'), hasFiles(['node.dart']));
+      expect(out, hasGeneratedSchemaFiles(['node.dart']));
 
-      final node = out.childFile('lib/model/node.dart').readAsStringSync();
+      final node = out.childFile('lib/models/node.dart').readAsStringSync();
       // Recursive fields typed as Node?.
       expect(node, contains('final Node? left;'));
       expect(node, contains('final Node? right;'));
@@ -1324,16 +1369,16 @@ void main() {
       await renderToDirectory(spec: spec, outDir: out);
 
       expect(
-        out.childDirectory('lib/model'),
-        hasFiles(['foo.dart', 'bar.dart']),
+        out,
+        hasGeneratedSchemaFiles(['foo.dart', 'bar.dart']),
       );
-      final foo = out.childFile('lib/model/foo.dart').readAsStringSync();
-      final bar = out.childFile('lib/model/bar.dart').readAsStringSync();
+      final foo = out.childFile('lib/models/foo.dart').readAsStringSync();
+      final bar = out.childFile('lib/models/bar.dart').readAsStringSync();
       // Each file references the other's class and imports its model file.
       expect(foo, contains('final Bar? bar;'));
-      expect(foo, contains("import 'package:mutual/model/bar.dart'"));
+      expect(foo, contains("import 'package:mutual/models/bar.dart'"));
       expect(bar, contains('final Foo? foo;'));
-      expect(bar, contains("import 'package:mutual/model/foo.dart'"));
+      expect(bar, contains("import 'package:mutual/models/foo.dart'"));
     });
   });
 


### PR DESCRIPTION
## Summary
Emit generated schemas to one of two sibling subdirectories under `lib/` instead of a flat `lib/model/`:

```
lib/
  models/      domain primitives — everything not suffixed Request/Response
  messages/    request + response DTOs (class name ends in Request or Response)
```

Matches the conventional layout of hand-written Dart protocol packages, where domain models live separately from the request/response DTOs that carry them over the wire. Classification is by a simple Dart-class-name suffix heuristic — works well for the specs I've checked; `ErrorResponse` goes to `messages/` because its Dart class name ends in `Response`, which is arguably the correct home for an error DTO.

## Layout after this PR

**Default** (plain `Quirks()`):
```
lib/
  api.dart, api_client.dart, api_exception.dart, auth.dart, client.dart
  model_helpers.dart
  api/<tag>_api.dart
  models/<snake_name>.dart
  messages/<snake_name>.dart
```

**`Quirks.openapi()`** (opt-in via `--openapi`):
```
lib/
  …
  model/<snake_name>.dart    ← flat, openapi-generator-compatible
```

## Breaking change

Callers that imported generated files by path — `package:foo/model/bar.dart` — will break. Fix by switching to `package:foo/models/bar.dart` or `package:foo/messages/bar.dart`, or opt into `Quirks.openapi()` (which sets the new `flatModelDir` flag) to keep the old layout.

The output-directory cleanup wipes both the new dirs and the old `lib/model/`, so upgrading generators doesn't leave stale files from the previous layout.

## What changed
- `Quirks`: new `flatModelDir` flag. Default `false`; `Quirks.openapi()` sets `true`.
- `FileRenderer`: a single `_modelSubdir` method decides `models/` / `messages/` / `model/`. Path helpers (`modelFilePath`, `modelPackagePath`, `modelPackageImport`) route through it.
- `FileRenderer.render`: cleanup step removes the new dirs *and* the old `lib/model/`.
- Tests: existing tests updated; new `hasGeneratedSchemaFiles` matcher iterates both dirs so callers can assert the generated set without pinning which of the two each file lives in.

## Test plan
- [x] `dart test` — all pass
- [x] `dart analyze` — clean
- [x] Regenerated the Shorebird CodePush protocol spec against this branch: generated output has `lib/models/` with 18 files (domain models + enums), `lib/messages/` with 27 files (Request/Response DTOs), matching the hand-written Shorebird layout.