### PR TITLE
feat: parse default responses and emit their referenced schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## 1.0.2
 
+- Parse OpenAPI `default:` responses instead of silently ignoring them.
+  A default response is stored on `Responses.defaultResponse` at the
+  parse layer, threads through the resolver and render tree as a
+  separate field (the numeric-status-keyed responses are unchanged),
+  and is walked by the render-tree walker so its referenced schema is
+  always emitted — no more tree-shaking a type whose only reference is
+  through `default:`. The generated API method still throws an untyped
+  `ApiException` on non-2xx; using the default response's schema as a
+  typed error body is a separate follow-up.
 - **Experimental:** expose a small customization surface for callers
   with their own layout conventions. `loadAndRenderSpec` now takes a
   single `GeneratorConfig` value (replacing 8 individual named

--- a/lib/src/parse/spec.dart
+++ b/lib/src/parse/spec.dart
@@ -546,20 +546,22 @@ class PathItem extends Equatable implements HasPointer {
 @immutable
 class Responses extends Equatable implements Parseable {
   /// Create a new responses object.
-  const Responses({required this.responses});
+  const Responses({required this.responses, required this.defaultResponse});
 
   /// The responses of this endpoint.
   final Map<int, RefOr<Response>> responses;
 
-  // default is not yet supported.
+  /// The `default:` response — catches any status code not explicitly
+  /// enumerated in [responses]. https://spec.openapis.org/oas/v3.1.0#responses-object
+  final RefOr<Response>? defaultResponse;
 
   /// Whether this endpoint has any responses.
-  bool get isEmpty => responses.isEmpty;
+  bool get isEmpty => responses.isEmpty && defaultResponse == null;
 
   RefOr<Response>? operator [](int code) => responses[code];
 
   @override
-  List<Object?> get props => [responses];
+  List<Object?> get props => [responses, defaultResponse];
 }
 
 /// A response from an endpoint.

--- a/lib/src/parse/visitor.dart
+++ b/lib/src/parse/visitor.dart
@@ -57,6 +57,7 @@ class SpecWalker {
     for (final response in operation.responses.responses.values) {
       _refOr(response);
     }
+    _maybeRefOr(operation.responses.defaultResponse);
     for (final parameter in operation.parameters) {
       _refOr(parameter);
     }

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -951,9 +951,12 @@ Response _parseResponse(MapContext responseJson) {
 Responses parseResponses(MapContext responsesJson) {
   final responseCodes = responsesJson.keys.toList();
 
-  // We don't yet support default responses.
-  _ignored<Map<String, dynamic>>(responsesJson, 'default');
-  responseCodes.remove('default');
+  RefOr<Response>? defaultResponse;
+  if (responseCodes.remove('default')) {
+    defaultResponse = parseResponseOrRef(
+      responsesJson.childAsMap('default').addSnakeName('default'),
+    );
+  }
 
   final responses = <int, RefOr<Response>>{};
   for (final responseCode in responseCodes) {
@@ -967,7 +970,7 @@ Responses parseResponses(MapContext responsesJson) {
     responses[responseCodeInt] = parseResponseOrRef(responseJson);
   }
   _warnUnused(responsesJson);
-  return Responses(responses: responses);
+  return Responses(responses: responses, defaultResponse: defaultResponse);
 }
 
 Map<String, RefOr<T>> _parseComponent<T extends Parseable>(

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -423,8 +423,10 @@ class SpecResolver {
   RenderSchema _determineReturnType(ResolvedOperation operation) {
     final responses = operation.responses;
     // Figure out how many different successful responses there are.
+    // `responses` here never contains the default (catch-all), so
+    // statusCode is always non-null.
     final successful = responses.where(
-      (e) => e.statusCode >= 200 && e.statusCode < 300,
+      (e) => e.statusCode! >= 200 && e.statusCode! < 300,
     );
     if (successful.isEmpty) {
       return RenderVoid(
@@ -463,6 +465,9 @@ class SpecResolver {
 
   RenderOperation toRenderOperation(ResolvedOperation operation) {
     final returnType = _determineReturnType(operation);
+    final defaultResponse = operation.defaultResponse == null
+        ? null
+        : toRenderResponse(operation.defaultResponse!);
     return RenderOperation(
       pointer: operation.pointer,
       snakeName: operation.snakeName,
@@ -473,6 +478,7 @@ class SpecResolver {
       tags: operation.tags,
       parameters: operation.parameters.map(toRenderParameter).toList(),
       responses: operation.responses.map(toRenderResponse).toList(),
+      defaultResponse: defaultResponse,
       requestBody: toRenderRequestBody(operation.requestBody),
       returnType: returnType,
       securityRequirements: operation.securityRequirements,
@@ -819,6 +825,7 @@ class RenderOperation {
     required this.parameters,
     required this.requestBody,
     required this.responses,
+    required this.defaultResponse,
     required this.returnType,
     required this.tags,
     required this.summary,
@@ -843,8 +850,16 @@ class RenderOperation {
   /// The request body of the resolved operation.
   final RenderRequestBody? requestBody;
 
-  /// The responses of the resolved operation.
+  /// The responses of the resolved operation. Only contains responses
+  /// keyed by a specific status code — the `default:` response (if any)
+  /// is on [defaultResponse].
   final List<RenderResponse> responses;
+
+  /// The `default:` (catch-all) response, if the operation declares one.
+  /// Its schema is walked for import/emission like any other response,
+  /// so the referenced type is always generated even when no specific
+  /// 4xx/5xx status code also references it.
+  final RenderResponse? defaultResponse;
 
   /// The return type of the resolved operation.
   final RenderSchema returnType;
@@ -983,8 +998,9 @@ class RenderResponse {
     required this.content,
   });
 
-  /// The status code of the resolved response.
-  final int statusCode;
+  /// The status code of the resolved response, or null if this is
+  /// the `default:` (catch-all) response.
+  final int? statusCode;
 
   /// The description of the resolved response.
   final String description;

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -423,10 +423,9 @@ class SpecResolver {
   RenderSchema _determineReturnType(ResolvedOperation operation) {
     final responses = operation.responses;
     // Figure out how many different successful responses there are.
-    final successful = responses.where((e) {
-      final code = e.statusCode;
-      return code != null && code >= 200 && code < 300;
-    });
+    final successful = responses.where(
+      (e) => e.statusCode >= 200 && e.statusCode < 300,
+    );
     if (successful.isEmpty) {
       return RenderVoid(
         common: CommonProperties.empty(
@@ -467,7 +466,10 @@ class SpecResolver {
     final resolvedDefault = operation.defaultResponse;
     final defaultResponse = resolvedDefault == null
         ? null
-        : toRenderResponse(resolvedDefault);
+        : RenderDefaultResponse(
+            description: resolvedDefault.description,
+            content: toRenderSchema(resolvedDefault.content),
+          );
     return RenderOperation(
       pointer: operation.pointer,
       snakeName: operation.snakeName,
@@ -859,7 +861,7 @@ class RenderOperation {
   /// Its schema is walked for import/emission like any other response,
   /// so the referenced type is always generated even when no specific
   /// 4xx/5xx status code also references it.
-  final RenderResponse? defaultResponse;
+  final RenderDefaultResponse? defaultResponse;
 
   /// The return type of the resolved operation.
   final RenderSchema returnType;
@@ -998,14 +1000,30 @@ class RenderResponse {
     required this.content,
   });
 
-  /// The status code of the resolved response, or null if this is
-  /// the `default:` (catch-all) response.
-  final int? statusCode;
+  /// The status code of the resolved response.
+  final int statusCode;
 
   /// The description of the resolved response.
   final String description;
 
   /// The resolved content of the resolved response.
+  /// We only support json, so we only need a single content.
+  final RenderSchema content;
+}
+
+/// The `default:` (catch-all) response on an operation. Shares the
+/// description + content shape with [RenderResponse] but carries no
+/// status code.
+class RenderDefaultResponse {
+  const RenderDefaultResponse({
+    required this.description,
+    required this.content,
+  });
+
+  /// The description of the resolved default response.
+  final String description;
+
+  /// The resolved content of the resolved default response.
   /// We only support json, so we only need a single content.
   final RenderSchema content;
 }

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -423,11 +423,10 @@ class SpecResolver {
   RenderSchema _determineReturnType(ResolvedOperation operation) {
     final responses = operation.responses;
     // Figure out how many different successful responses there are.
-    // `responses` here never contains the default (catch-all), so
-    // statusCode is always non-null.
-    final successful = responses.where(
-      (e) => e.statusCode! >= 200 && e.statusCode! < 300,
-    );
+    final successful = responses.where((e) {
+      final code = e.statusCode;
+      return code != null && code >= 200 && code < 300;
+    });
     if (successful.isEmpty) {
       return RenderVoid(
         common: CommonProperties.empty(
@@ -465,9 +464,10 @@ class SpecResolver {
 
   RenderOperation toRenderOperation(ResolvedOperation operation) {
     final returnType = _determineReturnType(operation);
-    final defaultResponse = operation.defaultResponse == null
+    final resolvedDefault = operation.defaultResponse;
+    final defaultResponse = resolvedDefault == null
         ? null
-        : toRenderResponse(operation.defaultResponse!);
+        : toRenderResponse(resolvedDefault);
     return RenderOperation(
       pointer: operation.pointer,
       snakeName: operation.snakeName,

--- a/lib/src/render/tree_visitor.dart
+++ b/lib/src/render/tree_visitor.dart
@@ -81,6 +81,10 @@ class RenderTreeWalker {
     for (final response in operation.responses) {
       walkResponse(response);
     }
+    final defaultResponse = operation.defaultResponse;
+    if (defaultResponse != null) {
+      walkResponse(defaultResponse);
+    }
     for (final parameter in operation.parameters) {
       walkParameter(parameter);
     }

--- a/lib/src/render/tree_visitor.dart
+++ b/lib/src/render/tree_visitor.dart
@@ -8,6 +8,7 @@ class RenderTreeVisitor {
   void visitParameter(RenderParameter parameter) {}
   void visitRequestBody(RenderRequestBody requestBody) {}
   void visitResponse(RenderResponse response) {}
+  void visitDefaultResponse(RenderDefaultResponse response) {}
 }
 
 class RenderTreeWalker {
@@ -83,7 +84,7 @@ class RenderTreeWalker {
     }
     final defaultResponse = operation.defaultResponse;
     if (defaultResponse != null) {
-      walkResponse(defaultResponse);
+      walkDefaultResponse(defaultResponse);
     }
     for (final parameter in operation.parameters) {
       walkParameter(parameter);
@@ -98,6 +99,11 @@ class RenderTreeWalker {
 
   void walkResponse(RenderResponse response) {
     visitor.visitResponse(response);
+    walkSchema(response.content);
+  }
+
+  void walkDefaultResponse(RenderDefaultResponse response) {
+    visitor.visitDefaultResponse(response);
     walkSchema(response.content);
   }
 }

--- a/lib/src/resolver.dart
+++ b/lib/src/resolver.dart
@@ -472,6 +472,10 @@ ResolvedOperation resolveOperation({
 }) {
   final requestBody = _resolveRequestBody(operation.requestBody, context);
   final responses = _resolveResponses(operation.responses, context);
+  final defaultResponse = _resolveDefaultResponse(
+    operation.responses.defaultResponse,
+    context,
+  );
 
   // Need to resolve any local security requirements, or otherwise fall back to
   // the global security requirements.
@@ -497,6 +501,7 @@ ResolvedOperation resolveOperation({
     path: path,
     requestBody: requestBody,
     responses: responses,
+    defaultResponse: defaultResponse,
     parameters: _mergeParameters(
       pathItemParameters,
       _resolveParameters(operation.parameters, context),
@@ -581,6 +586,19 @@ List<ResolvedResponse> _resolveResponses(
       content: _resolveContent(response, context),
     );
   }).toList();
+}
+
+ResolvedResponse? _resolveDefaultResponse(
+  RefOr<Response>? ref,
+  ResolveContext context,
+) {
+  if (ref == null) return null;
+  final response = context._resolve(ref);
+  return ResolvedResponse(
+    statusCode: null,
+    description: response.description,
+    content: _resolveContent(response, context),
+  );
 }
 
 class RegistryBuilder extends Visitor {
@@ -867,6 +885,7 @@ class ResolvedOperation {
     required this.snakeName,
     required this.requestBody,
     required this.responses,
+    required this.defaultResponse,
     required this.tags,
     required this.summary,
     required this.description,
@@ -892,8 +911,13 @@ class ResolvedOperation {
   /// The request body of the resolved operation.
   final ResolvedRequestBody? requestBody;
 
-  /// The responses of the resolved operation.
+  /// The responses of the resolved operation. Only contains responses
+  /// keyed by a specific status code — the `default:` response (if any)
+  /// is on [defaultResponse].
   final List<ResolvedResponse> responses;
+
+  /// The `default:` (catch-all) response, if the operation declares one.
+  final ResolvedResponse? defaultResponse;
 
   /// The tags of the resolved operation.
   final List<String> tags;
@@ -915,8 +939,9 @@ class ResolvedResponse {
     required this.content,
   });
 
-  /// The status code of the resolved response.
-  final int statusCode;
+  /// The status code of the resolved response, or null if this is
+  /// the `default:` (catch-all) response.
+  final int? statusCode;
 
   /// The description of the resolved response.
   final String description;

--- a/lib/src/resolver.dart
+++ b/lib/src/resolver.dart
@@ -588,14 +588,13 @@ List<ResolvedResponse> _resolveResponses(
   }).toList();
 }
 
-ResolvedResponse? _resolveDefaultResponse(
+ResolvedDefaultResponse? _resolveDefaultResponse(
   RefOr<Response>? ref,
   ResolveContext context,
 ) {
   if (ref == null) return null;
   final response = context._resolve(ref);
-  return ResolvedResponse(
-    statusCode: null,
+  return ResolvedDefaultResponse(
     description: response.description,
     content: _resolveContent(response, context),
   );
@@ -917,7 +916,7 @@ class ResolvedOperation {
   final List<ResolvedResponse> responses;
 
   /// The `default:` (catch-all) response, if the operation declares one.
-  final ResolvedResponse? defaultResponse;
+  final ResolvedDefaultResponse? defaultResponse;
 
   /// The tags of the resolved operation.
   final List<String> tags;
@@ -939,14 +938,30 @@ class ResolvedResponse {
     required this.content,
   });
 
-  /// The status code of the resolved response, or null if this is
-  /// the `default:` (catch-all) response.
-  final int? statusCode;
+  /// The status code of the resolved response.
+  final int statusCode;
 
   /// The description of the resolved response.
   final String description;
 
   /// The resolved content of the resolved response.
+  /// We only support json, so we only need a single content.
+  final ResolvedSchema content;
+}
+
+/// The `default:` (catch-all) response on an operation. Shares the
+/// description + content shape with [ResolvedResponse] but carries no
+/// status code.
+class ResolvedDefaultResponse {
+  const ResolvedDefaultResponse({
+    required this.description,
+    required this.content,
+  });
+
+  /// The description of the resolved default response.
+  final String description;
+
+  /// The resolved content of the resolved default response.
   /// We only support json, so we only need a single content.
   final ResolvedSchema content;
 }

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -766,7 +766,7 @@ void main() {
           ),
         );
       });
-      test('default response is not supported', () {
+      test('default response is parsed', () {
         final json = {
           'openapi': '3.1.0',
           'info': {'title': 'Space Traders API', 'version': '1.0.0'},
@@ -784,12 +784,12 @@ void main() {
             },
           },
         };
-        final logger = _MockLogger();
-        final spec = runWithLogger(logger, () => parseOpenApi(json));
-        expect(
-          spec.paths['/users'].operations[Method.get]!.responses[200],
-          isNull,
-        );
+        final spec = parseOpenApi(json);
+        final responses =
+            spec.paths['/users'].operations[Method.get]!.responses;
+        expect(responses[201], isNotNull);
+        expect(responses.defaultResponse, isNotNull);
+        expect(responses.defaultResponse!.object!.description, 'Default');
       });
 
       test('responses are required', () {

--- a/test/render/file_renderer_test.dart
+++ b/test/render/file_renderer_test.dart
@@ -192,6 +192,69 @@ void main() {
       );
     });
 
+    test(
+      'default response schema is emitted even when no explicit status '
+      'code references it',
+      () async {
+        final fs = MemoryFileSystem.test();
+        final spec = {
+          'openapi': '3.1.0',
+          'info': {'title': 'Default', 'version': '1.0.0'},
+          'servers': [
+            {'url': 'https://example.com'},
+          ],
+          'paths': {
+            '/widgets': {
+              'get': {
+                'operationId': 'getWidget',
+                'responses': {
+                  '200': {
+                    'description': 'OK',
+                    'content': {
+                      'application/json': {
+                        'schema': {r'$ref': '#/components/schemas/Widget'},
+                      },
+                    },
+                  },
+                  'default': {
+                    'description': 'Error',
+                    'content': {
+                      'application/json': {
+                        'schema': {r'$ref': '#/components/schemas/Error'},
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          'components': {
+            'schemas': {
+              'Widget': {
+                'type': 'object',
+                'properties': {
+                  'name': {'type': 'string'},
+                },
+              },
+              'Error': {
+                'type': 'object',
+                'properties': {
+                  'message': {'type': 'string'},
+                },
+              },
+            },
+          },
+        };
+        final out = fs.directory('out');
+        await renderToDirectory(spec: spec, outDir: out);
+        // The `Error` schema is only referenced by `default:` — if the
+        // renderer didn't walk default responses, it would be tree-shaken
+        // and no file would be written for it.
+        expect(out.childFile('lib/models/widget.dart').existsSync(), isTrue);
+        expect(out.childFile('lib/models/error.dart').existsSync(), isTrue);
+      },
+    );
+
     test('smoke test with simple spec', () async {
       final fs = MemoryFileSystem.test();
       final spec = {
@@ -1652,6 +1715,7 @@ void main() {
               ],
               requestBody: null,
               responses: <RenderResponse>[],
+              defaultResponse: null,
               securityRequirements: <ResolvedSecurityRequirement>[],
             ),
             serverUrl: Uri.parse('https://api.spacetraders.io/v2'),

--- a/test/resolver_test.dart
+++ b/test/resolver_test.dart
@@ -751,10 +751,10 @@ void main() {
       };
       final spec = parseAndResolveTestSpec(json);
       final op = spec.paths.first.operations.first;
-      expect(op.defaultResponse, isNotNull);
-      expect(op.defaultResponse!.statusCode, isNull);
-      expect(op.defaultResponse!.description, 'Error');
-      expect(op.defaultResponse!.content, isA<ResolvedObject>());
+      final defaultResponse = op.defaultResponse;
+      expect(defaultResponse, isNotNull);
+      expect(defaultResponse!.description, 'Error');
+      expect(defaultResponse.content, isA<ResolvedObject>());
     });
 
     test('mutual recursion: A -> b: B -> a: A', () {

--- a/test/resolver_test.dart
+++ b/test/resolver_test.dart
@@ -700,6 +700,63 @@ void main() {
       );
     });
 
+    test('default response is resolved and referenced schema is emitted', () {
+      final json = {
+        'openapi': '3.1.0',
+        'info': {'title': 'Default', 'version': '1.0.0'},
+        'servers': [
+          {'url': 'https://example.com'},
+        ],
+        'paths': {
+          '/widgets': {
+            'get': {
+              'operationId': 'getWidget',
+              'responses': {
+                '200': {
+                  'description': 'OK',
+                  'content': {
+                    'application/json': {
+                      'schema': {r'$ref': '#/components/schemas/Widget'},
+                    },
+                  },
+                },
+                'default': {
+                  'description': 'Error',
+                  'content': {
+                    'application/json': {
+                      'schema': {r'$ref': '#/components/schemas/Error'},
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        'components': {
+          'schemas': {
+            'Widget': {
+              'type': 'object',
+              'properties': {
+                'name': {'type': 'string'},
+              },
+            },
+            'Error': {
+              'type': 'object',
+              'properties': {
+                'message': {'type': 'string'},
+              },
+            },
+          },
+        },
+      };
+      final spec = parseAndResolveTestSpec(json);
+      final op = spec.paths.first.operations.first;
+      expect(op.defaultResponse, isNotNull);
+      expect(op.defaultResponse!.statusCode, isNull);
+      expect(op.defaultResponse!.description, 'Error');
+      expect(op.defaultResponse!.content, isA<ResolvedObject>());
+    });
+
     test('mutual recursion: A -> b: B -> a: A', () {
       final json = {
         'openapi': '3.1.0',


### PR DESCRIPTION
## Summary
- Parse OpenAPI `default:` responses instead of silently ignoring them. Threads through parser → resolver → render tree → render-tree walker so the referenced schema is always emitted.
- Fixes the case where a shared error schema (referenced only by `default:`) would be tree-shaken out of the generated output.
- Generated API methods still throw untyped `ApiException` on non-2xx — using the default schema as a typed error body is a separate follow-up.

## Test plan
- [x] `dart test` — 246 tests pass (was 244; +2 new tests for default-response parsing/resolving + emission)
- [x] `dart analyze` — no new issues (only pre-existing info-level doc-comment line-length warnings)
- [x] `dart format --set-exit-if-changed .` — clean