### PR TITLE
feat: support OpenAPI range status codes (NXX)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## 1.0.2
 
+- Accept OpenAPI range status code keys (`1XX`/`2XX`/`3XX`/`4XX`/`5XX`)
+  in response maps. Previously the parser rejected them with "Invalid
+  response code". Range responses are stored separately from
+  specific-code responses at each pipeline layer. `2XX` ranges feed the
+  return-type determination — an operation declaring `2XX: { schema: X }`
+  with no explicit 200 now generates `Future<X>` instead of
+  `Future<void>`. Range schemas are walked for emission so the referenced
+  types are generated like any other response.
 - Generate a typed error body on generated API methods whose operation
   declares a `default:` response. `ApiException` is now generic
   (`ApiException<T>`): when the operation has a default response schema,

--- a/lib/src/parse/spec.dart
+++ b/lib/src/parse/spec.dart
@@ -541,6 +541,30 @@ class PathItem extends Equatable implements HasPointer {
   ];
 }
 
+/// An HTTP status code range declared as `NXX` in OpenAPI. Finite
+/// domain — OpenAPI only allows `1XX`..`5XX`.
+enum StatusCodeRange {
+  /// `1XX` — Informational (100–199).
+  informational(100),
+
+  /// `2XX` — Successful (200–299).
+  success(200),
+
+  /// `3XX` — Redirection (300–399).
+  redirect(300),
+
+  /// `4XX` — Client error (400–499).
+  clientError(400),
+
+  /// `5XX` — Server error (500–599).
+  serverError(500);
+
+  const StatusCodeRange(this.startCode);
+
+  /// The first status code covered by this range (100, 200, 300, 400, 500).
+  final int startCode;
+}
+
 /// A map of response codes to responses.
 /// https://spec.openapis.org/oas/v3.1.0#responses-object
 @immutable
@@ -555,9 +579,8 @@ class Responses extends Equatable implements Parseable {
   /// The responses of this endpoint, keyed by exact status code.
   final Map<int, RefOr<Response>> responses;
 
-  /// The responses of this endpoint, keyed by range (`1XX`..`5XX`). The
-  /// key is the range start (100, 200, 300, 400, or 500).
-  final Map<int, RefOr<Response>> rangeResponses;
+  /// The responses of this endpoint, keyed by range (`1XX`..`5XX`).
+  final Map<StatusCodeRange, RefOr<Response>> rangeResponses;
 
   /// The `default:` response — catches any status code not explicitly
   /// enumerated in [responses] or matched by [rangeResponses].

--- a/lib/src/parse/spec.dart
+++ b/lib/src/parse/spec.dart
@@ -546,22 +546,32 @@ class PathItem extends Equatable implements HasPointer {
 @immutable
 class Responses extends Equatable implements Parseable {
   /// Create a new responses object.
-  const Responses({required this.responses, required this.defaultResponse});
+  const Responses({
+    required this.responses,
+    required this.rangeResponses,
+    required this.defaultResponse,
+  });
 
-  /// The responses of this endpoint.
+  /// The responses of this endpoint, keyed by exact status code.
   final Map<int, RefOr<Response>> responses;
 
+  /// The responses of this endpoint, keyed by range (`1XX`..`5XX`). The
+  /// key is the range start (100, 200, 300, 400, or 500).
+  final Map<int, RefOr<Response>> rangeResponses;
+
   /// The `default:` response — catches any status code not explicitly
-  /// enumerated in [responses]. https://spec.openapis.org/oas/v3.1.0#responses-object
+  /// enumerated in [responses] or matched by [rangeResponses].
+  /// https://spec.openapis.org/oas/v3.1.0#responses-object
   final RefOr<Response>? defaultResponse;
 
   /// Whether this endpoint has any responses.
-  bool get isEmpty => responses.isEmpty && defaultResponse == null;
+  bool get isEmpty =>
+      responses.isEmpty && rangeResponses.isEmpty && defaultResponse == null;
 
   RefOr<Response>? operator [](int code) => responses[code];
 
   @override
-  List<Object?> get props => [responses, defaultResponse];
+  List<Object?> get props => [responses, rangeResponses, defaultResponse];
 }
 
 /// A response from an endpoint.

--- a/lib/src/parse/visitor.dart
+++ b/lib/src/parse/visitor.dart
@@ -57,6 +57,9 @@ class SpecWalker {
     for (final response in operation.responses.responses.values) {
       _refOr(response);
     }
+    for (final response in operation.responses.rangeResponses.values) {
+      _refOr(response);
+    }
     _maybeRefOr(operation.responses.defaultResponse);
     for (final parameter in operation.parameters) {
       _refOr(parameter);

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -949,8 +949,18 @@ Response _parseResponse(MapContext responseJson) {
 }
 
 /// Matches a range status code like `2XX`, `4XX`, etc. Capturing group 1
-/// is the first digit (1-5).
+/// is the leading digit (1-5).
 final _rangeCodeRegex = RegExp(r'^([1-5])XX$');
+
+/// Maps the leading digit of an `NXX` range to the corresponding
+/// [StatusCodeRange] variant.
+const Map<int, StatusCodeRange> _rangesByLeadingDigit = {
+  1: StatusCodeRange.informational,
+  2: StatusCodeRange.success,
+  3: StatusCodeRange.redirect,
+  4: StatusCodeRange.clientError,
+  5: StatusCodeRange.serverError,
+};
 
 Responses parseResponses(MapContext responsesJson) {
   final responseCodes = responsesJson.keys.toList();
@@ -963,15 +973,15 @@ Responses parseResponses(MapContext responsesJson) {
   }
 
   final responses = <int, RefOr<Response>>{};
-  final rangeResponses = <int, RefOr<Response>>{};
+  final rangeResponses = <StatusCodeRange, RefOr<Response>>{};
   for (final responseCode in responseCodes) {
     final responseJson = responsesJson
         .childAsMap(responseCode)
         .addSnakeName(responseCode);
     final rangeMatch = _rangeCodeRegex.firstMatch(responseCode);
     if (rangeMatch != null) {
-      final rangeStart = int.parse(rangeMatch.group(1)!) * 100;
-      rangeResponses[rangeStart] = parseResponseOrRef(responseJson);
+      final range = _rangesByLeadingDigit[int.parse(rangeMatch.group(1)!)]!;
+      rangeResponses[range] = parseResponseOrRef(responseJson);
       continue;
     }
     final responseCodeInt = int.tryParse(responseCode);

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -948,6 +948,10 @@ Response _parseResponse(MapContext responseJson) {
   );
 }
 
+/// Matches a range status code like `2XX`, `4XX`, etc. Capturing group 1
+/// is the first digit (1-5).
+final _rangeCodeRegex = RegExp(r'^([1-5])XX$');
+
 Responses parseResponses(MapContext responsesJson) {
   final responseCodes = responsesJson.keys.toList();
 
@@ -959,10 +963,17 @@ Responses parseResponses(MapContext responsesJson) {
   }
 
   final responses = <int, RefOr<Response>>{};
+  final rangeResponses = <int, RefOr<Response>>{};
   for (final responseCode in responseCodes) {
     final responseJson = responsesJson
         .childAsMap(responseCode)
         .addSnakeName(responseCode);
+    final rangeMatch = _rangeCodeRegex.firstMatch(responseCode);
+    if (rangeMatch != null) {
+      final rangeStart = int.parse(rangeMatch.group(1)!) * 100;
+      rangeResponses[rangeStart] = parseResponseOrRef(responseJson);
+      continue;
+    }
     final responseCodeInt = int.tryParse(responseCode);
     if (responseCodeInt == null) {
       _error(responsesJson, 'Invalid response code: $responseCode');
@@ -970,7 +981,11 @@ Responses parseResponses(MapContext responsesJson) {
     responses[responseCodeInt] = parseResponseOrRef(responseJson);
   }
   _warnUnused(responsesJson);
-  return Responses(responses: responses, defaultResponse: defaultResponse);
+  return Responses(
+    responses: responses,
+    rangeResponses: rangeResponses,
+    defaultResponse: defaultResponse,
+  );
 }
 
 Map<String, RefOr<T>> _parseComponent<T extends Parseable>(

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -1,6 +1,7 @@
 import 'package:collection/collection.dart';
 import 'package:equatable/equatable.dart';
 import 'package:meta/meta.dart';
+import 'package:space_gen/src/parse/spec.dart' show StatusCodeRange;
 import 'package:space_gen/src/quirks.dart';
 // Any code that depends on SchemaRenderer probably should be moved out
 // of this file and into the schema_renderer.dart file.
@@ -428,7 +429,7 @@ class SpecResolver {
           .where((e) => e.statusCode >= 200 && e.statusCode < 300)
           .map((e) => e.content),
       ...operation.rangeResponses
-          .where((e) => e.rangeStart == 200)
+          .where((e) => e.range == StatusCodeRange.success)
           .map((e) => e.content),
     ];
     if (successfulContent.isEmpty) {
@@ -466,7 +467,7 @@ class SpecResolver {
 
   RenderRangeResponse toRenderRangeResponse(ResolvedRangeResponse response) {
     return RenderRangeResponse(
-      rangeStart: response.rangeStart,
+      range: response.range,
       description: response.description,
       content: toRenderSchema(response.content),
     );
@@ -887,10 +888,9 @@ class RenderOperation {
   final List<RenderResponse> responses;
 
   /// The range (`NXX`) responses of the resolved operation, if any.
-  /// Each entry's `rangeStart` is the first status code of the range
-  /// (100, 200, 300, 400, or 500). 2XX ranges feed the return-type
-  /// determination on the operation method; their schemas are walked
-  /// for import/emission like any other response.
+  /// `2XX` ranges feed the return-type determination on the operation
+  /// method; all range schemas are walked for import/emission like any
+  /// other response.
   final List<RenderRangeResponse> rangeResponses;
 
   /// The `default:` (catch-all) response, if the operation declares one.
@@ -1048,17 +1048,17 @@ class RenderResponse {
 }
 
 /// A range (`NXX`) response on an operation. Shares the description +
-/// content shape with [RenderResponse] but its "status code" is the
-/// range start (100/200/300/400/500) rather than an exact code.
+/// content shape with [RenderResponse] but is keyed by a
+/// [StatusCodeRange] rather than an exact code.
 class RenderRangeResponse {
   const RenderRangeResponse({
-    required this.rangeStart,
+    required this.range,
     required this.description,
     required this.content,
   });
 
-  /// The first status code of the range: 100, 200, 300, 400, or 500.
-  final int rangeStart;
+  /// Which `NXX` range this response covers.
+  final StatusCodeRange range;
 
   /// The description of the resolved range response.
   final String description;

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -421,12 +421,17 @@ class SpecResolver {
   }
 
   RenderSchema _determineReturnType(ResolvedOperation operation) {
-    final responses = operation.responses;
     // Figure out how many different successful responses there are.
-    final successful = responses.where(
-      (e) => e.statusCode >= 200 && e.statusCode < 300,
-    );
-    if (successful.isEmpty) {
+    // Successful = explicit 2xx codes plus the `2XX` range if declared.
+    final successfulContent = [
+      ...operation.responses
+          .where((e) => e.statusCode >= 200 && e.statusCode < 300)
+          .map((e) => e.content),
+      ...operation.rangeResponses
+          .where((e) => e.rangeStart == 200)
+          .map((e) => e.content),
+    ];
+    if (successfulContent.isEmpty) {
       return RenderVoid(
         common: CommonProperties.empty(
           snakeName: '${operation.snakeName}_response',
@@ -434,12 +439,10 @@ class SpecResolver {
         ),
       );
     }
-    if (successful.length == 1) {
-      return toRenderSchema(successful.first.content);
+    if (successfulContent.length == 1) {
+      return toRenderSchema(successfulContent.first);
     }
-    final renderSchemas = successful
-        .expand((e) => [toRenderSchema(e.content)])
-        .toList();
+    final renderSchemas = successfulContent.map(toRenderSchema).toList();
     // We don't implement hashCode/equals but rather equalsIgnoringName
     final distinctSchemas = <RenderSchema>{};
     for (final schema in renderSchemas) {
@@ -461,6 +464,14 @@ class SpecResolver {
     return distinctSchemas.first;
   }
 
+  RenderRangeResponse toRenderRangeResponse(ResolvedRangeResponse response) {
+    return RenderRangeResponse(
+      rangeStart: response.rangeStart,
+      description: response.description,
+      content: toRenderSchema(response.content),
+    );
+  }
+
   RenderOperation toRenderOperation(ResolvedOperation operation) {
     final returnType = _determineReturnType(operation);
     final resolvedDefault = operation.defaultResponse;
@@ -480,6 +491,9 @@ class SpecResolver {
       tags: operation.tags,
       parameters: operation.parameters.map(toRenderParameter).toList(),
       responses: operation.responses.map(toRenderResponse).toList(),
+      rangeResponses: operation.rangeResponses
+          .map(toRenderRangeResponse)
+          .toList(),
       defaultResponse: defaultResponse,
       requestBody: toRenderRequestBody(operation.requestBody),
       returnType: returnType,
@@ -840,6 +854,7 @@ class RenderOperation {
     required this.parameters,
     required this.requestBody,
     required this.responses,
+    required this.rangeResponses,
     required this.defaultResponse,
     required this.returnType,
     required this.tags,
@@ -866,9 +881,17 @@ class RenderOperation {
   final RenderRequestBody? requestBody;
 
   /// The responses of the resolved operation. Only contains responses
-  /// keyed by a specific status code — the `default:` response (if any)
-  /// is on [defaultResponse].
+  /// keyed by a specific status code — range (`NXX`) responses are on
+  /// [rangeResponses] and the `default:` response (if any) is on
+  /// [defaultResponse].
   final List<RenderResponse> responses;
+
+  /// The range (`NXX`) responses of the resolved operation, if any.
+  /// Each entry's `rangeStart` is the first status code of the range
+  /// (100, 200, 300, 400, or 500). 2XX ranges feed the return-type
+  /// determination on the operation method; their schemas are walked
+  /// for import/emission like any other response.
+  final List<RenderRangeResponse> rangeResponses;
 
   /// The `default:` (catch-all) response, if the operation declares one.
   /// Its schema is walked for import/emission like any other response,
@@ -1020,6 +1043,27 @@ class RenderResponse {
   final String description;
 
   /// The resolved content of the resolved response.
+  /// We only support json, so we only need a single content.
+  final RenderSchema content;
+}
+
+/// A range (`NXX`) response on an operation. Shares the description +
+/// content shape with [RenderResponse] but its "status code" is the
+/// range start (100/200/300/400/500) rather than an exact code.
+class RenderRangeResponse {
+  const RenderRangeResponse({
+    required this.rangeStart,
+    required this.description,
+    required this.content,
+  });
+
+  /// The first status code of the range: 100, 200, 300, 400, or 500.
+  final int rangeStart;
+
+  /// The description of the resolved range response.
+  final String description;
+
+  /// The resolved content of the resolved range response.
   /// We only support json, so we only need a single content.
   final RenderSchema content;
 }

--- a/lib/src/render/tree_visitor.dart
+++ b/lib/src/render/tree_visitor.dart
@@ -8,6 +8,7 @@ class RenderTreeVisitor {
   void visitParameter(RenderParameter parameter) {}
   void visitRequestBody(RenderRequestBody requestBody) {}
   void visitResponse(RenderResponse response) {}
+  void visitRangeResponse(RenderRangeResponse response) {}
   void visitDefaultResponse(RenderDefaultResponse response) {}
 }
 
@@ -82,6 +83,9 @@ class RenderTreeWalker {
     for (final response in operation.responses) {
       walkResponse(response);
     }
+    for (final response in operation.rangeResponses) {
+      walkRangeResponse(response);
+    }
     final defaultResponse = operation.defaultResponse;
     if (defaultResponse != null) {
       walkDefaultResponse(defaultResponse);
@@ -99,6 +103,11 @@ class RenderTreeWalker {
 
   void walkResponse(RenderResponse response) {
     visitor.visitResponse(response);
+    walkSchema(response.content);
+  }
+
+  void walkRangeResponse(RenderRangeResponse response) {
+    visitor.visitRangeResponse(response);
     walkSchema(response.content);
   }
 

--- a/lib/src/resolver.dart
+++ b/lib/src/resolver.dart
@@ -594,14 +594,14 @@ List<ResolvedResponse> _resolveResponses(
 }
 
 List<ResolvedRangeResponse> _resolveRangeResponses(
-  Map<int, RefOr<Response>> rangeResponses,
+  Map<StatusCodeRange, RefOr<Response>> rangeResponses,
   ResolveContext context,
 ) {
   return rangeResponses.entries.map((entry) {
-    final rangeStart = entry.key;
+    final range = entry.key;
     final response = context._resolve(entry.value);
     return ResolvedRangeResponse(
-      rangeStart: rangeStart,
+      range: range,
       description: response.description,
       content: _resolveContent(response, context),
     );
@@ -937,9 +937,7 @@ class ResolvedOperation {
   /// [defaultResponse].
   final List<ResolvedResponse> responses;
 
-  /// The range (`NXX`) responses of the resolved operation, if any. Each
-  /// entry's `rangeStart` is the first code in the range (100, 200, 300,
-  /// 400, or 500).
+  /// The range (`NXX`) responses of the resolved operation, if any.
   final List<ResolvedRangeResponse> rangeResponses;
 
   /// The `default:` (catch-all) response, if the operation declares one.
@@ -977,17 +975,17 @@ class ResolvedResponse {
 }
 
 /// A range (`NXX`) response on an operation. Shares the description +
-/// content shape with [ResolvedResponse] but its "status code" is the
-/// range start (100/200/300/400/500) rather than an exact code.
+/// content shape with [ResolvedResponse] but is keyed by a
+/// [StatusCodeRange] rather than an exact code.
 class ResolvedRangeResponse {
   const ResolvedRangeResponse({
-    required this.rangeStart,
+    required this.range,
     required this.description,
     required this.content,
   });
 
-  /// The first status code of the range: 100, 200, 300, 400, or 500.
-  final int rangeStart;
+  /// Which `NXX` range this response covers.
+  final StatusCodeRange range;
 
   /// The description of the resolved range response.
   final String description;

--- a/lib/src/resolver.dart
+++ b/lib/src/resolver.dart
@@ -472,6 +472,10 @@ ResolvedOperation resolveOperation({
 }) {
   final requestBody = _resolveRequestBody(operation.requestBody, context);
   final responses = _resolveResponses(operation.responses, context);
+  final rangeResponses = _resolveRangeResponses(
+    operation.responses.rangeResponses,
+    context,
+  );
   final defaultResponse = _resolveDefaultResponse(
     operation.responses.defaultResponse,
     context,
@@ -501,6 +505,7 @@ ResolvedOperation resolveOperation({
     path: path,
     requestBody: requestBody,
     responses: responses,
+    rangeResponses: rangeResponses,
     defaultResponse: defaultResponse,
     parameters: _mergeParameters(
       pathItemParameters,
@@ -582,6 +587,21 @@ List<ResolvedResponse> _resolveResponses(
 
     return ResolvedResponse(
       statusCode: statusCode,
+      description: response.description,
+      content: _resolveContent(response, context),
+    );
+  }).toList();
+}
+
+List<ResolvedRangeResponse> _resolveRangeResponses(
+  Map<int, RefOr<Response>> rangeResponses,
+  ResolveContext context,
+) {
+  return rangeResponses.entries.map((entry) {
+    final rangeStart = entry.key;
+    final response = context._resolve(entry.value);
+    return ResolvedRangeResponse(
+      rangeStart: rangeStart,
       description: response.description,
       content: _resolveContent(response, context),
     );
@@ -884,6 +904,7 @@ class ResolvedOperation {
     required this.snakeName,
     required this.requestBody,
     required this.responses,
+    required this.rangeResponses,
     required this.defaultResponse,
     required this.tags,
     required this.summary,
@@ -911,9 +932,15 @@ class ResolvedOperation {
   final ResolvedRequestBody? requestBody;
 
   /// The responses of the resolved operation. Only contains responses
-  /// keyed by a specific status code — the `default:` response (if any)
-  /// is on [defaultResponse].
+  /// keyed by a specific status code — range (`NXX`) responses are on
+  /// [rangeResponses] and the `default:` response (if any) is on
+  /// [defaultResponse].
   final List<ResolvedResponse> responses;
+
+  /// The range (`NXX`) responses of the resolved operation, if any. Each
+  /// entry's `rangeStart` is the first code in the range (100, 200, 300,
+  /// 400, or 500).
+  final List<ResolvedRangeResponse> rangeResponses;
 
   /// The `default:` (catch-all) response, if the operation declares one.
   final ResolvedDefaultResponse? defaultResponse;
@@ -945,6 +972,27 @@ class ResolvedResponse {
   final String description;
 
   /// The resolved content of the resolved response.
+  /// We only support json, so we only need a single content.
+  final ResolvedSchema content;
+}
+
+/// A range (`NXX`) response on an operation. Shares the description +
+/// content shape with [ResolvedResponse] but its "status code" is the
+/// range start (100/200/300/400/500) rather than an exact code.
+class ResolvedRangeResponse {
+  const ResolvedRangeResponse({
+    required this.rangeStart,
+    required this.description,
+    required this.content,
+  });
+
+  /// The first status code of the range: 100, 200, 300, 400, or 500.
+  final int rangeStart;
+
+  /// The description of the resolved range response.
+  final String description;
+
+  /// The resolved content of the resolved range response.
   /// We only support json, so we only need a single content.
   final ResolvedSchema content;
 }

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -735,7 +735,7 @@ void main() {
           ),
         );
       });
-      test('only integers and default are supported as response codes', () {
+      test('integers, NXX ranges, and default are supported response keys', () {
         final json = {
           'openapi': '3.1.0',
           'info': {'title': 'Space Traders API', 'version': '1.0.0'},
@@ -766,6 +766,42 @@ void main() {
           ),
         );
       });
+      test('NXX range responses are parsed', () {
+        final json = {
+          'openapi': '3.1.0',
+          'info': {'title': 'Space Traders API', 'version': '1.0.0'},
+          'servers': [
+            {'url': 'https://api.spacetraders.io/v2'},
+          ],
+          'paths': {
+            '/users': {
+              'get': {
+                'responses': {
+                  '200': {'description': 'OK'},
+                  '2XX': {'description': 'Success'},
+                  '4XX': {'description': 'Client error'},
+                  '5XX': {'description': 'Server error'},
+                },
+              },
+            },
+          },
+        };
+        final spec = parseOpenApi(json);
+        final responses =
+            spec.paths['/users'].operations[Method.get]!.responses;
+        expect(responses[200], isNotNull);
+        expect(responses.rangeResponses.keys, containsAll([200, 400, 500]));
+        expect(responses.rangeResponses[200]!.object!.description, 'Success');
+        expect(
+          responses.rangeResponses[400]!.object!.description,
+          'Client error',
+        );
+        expect(
+          responses.rangeResponses[500]!.object!.description,
+          'Server error',
+        );
+      });
+
       test('default response is parsed', () {
         final json = {
           'openapi': '3.1.0',

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -790,14 +790,25 @@ void main() {
         final responses =
             spec.paths['/users'].operations[Method.get]!.responses;
         expect(responses[200], isNotNull);
-        expect(responses.rangeResponses.keys, containsAll([200, 400, 500]));
-        expect(responses.rangeResponses[200]!.object!.description, 'Success');
         expect(
-          responses.rangeResponses[400]!.object!.description,
+          responses.rangeResponses.keys,
+          containsAll([
+            StatusCodeRange.success,
+            StatusCodeRange.clientError,
+            StatusCodeRange.serverError,
+          ]),
+        );
+        final byRange = responses.rangeResponses;
+        expect(
+          byRange[StatusCodeRange.success]!.object!.description,
+          'Success',
+        );
+        expect(
+          byRange[StatusCodeRange.clientError]!.object!.description,
           'Client error',
         );
         expect(
-          responses.rangeResponses[500]!.object!.description,
+          byRange[StatusCodeRange.serverError]!.object!.description,
           'Server error',
         );
       });

--- a/test/render/file_renderer_test.dart
+++ b/test/render/file_renderer_test.dart
@@ -1715,6 +1715,7 @@ void main() {
               ],
               requestBody: null,
               responses: <RenderResponse>[],
+              rangeResponses: <RenderRangeResponse>[],
               defaultResponse: null,
               securityRequirements: <ResolvedSecurityRequirement>[],
             ),

--- a/test/render/file_renderer_test.dart
+++ b/test/render/file_renderer_test.dart
@@ -255,6 +255,68 @@ void main() {
       },
     );
 
+    test(
+      'NXX range response schema is emitted even when no specific status '
+      'code references it',
+      () async {
+        final fs = MemoryFileSystem.test();
+        final spec = {
+          'openapi': '3.1.0',
+          'info': {'title': 'Range', 'version': '1.0.0'},
+          'servers': [
+            {'url': 'https://example.com'},
+          ],
+          'paths': {
+            '/widgets': {
+              'get': {
+                'operationId': 'getWidget',
+                'responses': {
+                  '200': {
+                    'description': 'OK',
+                    'content': {
+                      'application/json': {
+                        'schema': {r'$ref': '#/components/schemas/Widget'},
+                      },
+                    },
+                  },
+                  '5XX': {
+                    'description': 'Server error',
+                    'content': {
+                      'application/json': {
+                        'schema': {r'$ref': '#/components/schemas/Error'},
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          'components': {
+            'schemas': {
+              'Widget': {
+                'type': 'object',
+                'properties': {
+                  'name': {'type': 'string'},
+                },
+              },
+              'Error': {
+                'type': 'object',
+                'properties': {
+                  'message': {'type': 'string'},
+                },
+              },
+            },
+          },
+        };
+        final out = fs.directory('out');
+        await renderToDirectory(spec: spec, outDir: out);
+        // `Error` is only referenced by `5XX:` — if the renderer didn't
+        // walk range responses it would be tree-shaken.
+        expect(out.childFile('lib/models/widget.dart').existsSync(), isTrue);
+        expect(out.childFile('lib/models/error.dart').existsSync(), isTrue);
+      },
+    );
+
     test('smoke test with simple spec', () async {
       final fs = MemoryFileSystem.test();
       final spec = {

--- a/test/render/render_operation_test.dart
+++ b/test/render/render_operation_test.dart
@@ -1021,6 +1021,38 @@ void main() {
     });
   });
 
+  group('range (NXX) responses', () {
+    test('2XX schema drives return type when no explicit 2xx code', () {
+      final json = {
+        'summary': 'Get widgets',
+        'operationId': 'getWidgets',
+        'responses': {
+          '2XX': {
+            'description': 'Success',
+            'content': {
+              'application/json': {
+                'schema': {
+                  'type': 'object',
+                  'properties': {
+                    'id': {'type': 'string'},
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+      final result = renderTestOperation(
+        path: '/widgets',
+        operationJson: json,
+        serverUrl: Uri.parse('https://example.com'),
+      );
+      // Assert on the return type line rather than the whole output —
+      // the interesting bit is that the 2XX schema won.
+      expect(result, contains('Future<GetWidgets2XXResponse> getWidgets('));
+    });
+  });
+
   group('default response (typed error body)', () {
     test('emits ApiException<ErrorType> with parsed body', () {
       final json = {

--- a/test/resolver_test.dart
+++ b/test/resolver_test.dart
@@ -1,5 +1,6 @@
 import 'package:mocktail/mocktail.dart';
 import 'package:space_gen/src/logger.dart';
+import 'package:space_gen/src/parse/spec.dart' show StatusCodeRange;
 import 'package:space_gen/src/parser.dart';
 import 'package:space_gen/src/resolver.dart';
 import 'package:space_gen/src/types.dart';
@@ -742,9 +743,9 @@ void main() {
       final spec = parseAndResolveTestSpec(json);
       final op = spec.paths.first.operations.first;
       expect(op.rangeResponses, hasLength(2));
-      final byStart = {for (final r in op.rangeResponses) r.rangeStart: r};
+      final byRange = {for (final r in op.rangeResponses) r.range: r};
       expect(
-        byStart[200],
+        byRange[StatusCodeRange.success],
         isA<ResolvedRangeResponse>().having(
           (r) => r.description,
           'description',
@@ -752,7 +753,7 @@ void main() {
         ),
       );
       expect(
-        byStart[500],
+        byRange[StatusCodeRange.serverError],
         isA<ResolvedRangeResponse>().having(
           (r) => r.description,
           'description',

--- a/test/resolver_test.dart
+++ b/test/resolver_test.dart
@@ -700,6 +700,67 @@ void main() {
       );
     });
 
+    test('NXX range responses are resolved', () {
+      final json = {
+        'openapi': '3.1.0',
+        'info': {'title': 'Range', 'version': '1.0.0'},
+        'servers': [
+          {'url': 'https://example.com'},
+        ],
+        'paths': {
+          '/widgets': {
+            'get': {
+              'operationId': 'getWidget',
+              'responses': {
+                '2XX': {
+                  'description': 'Success',
+                  'content': {
+                    'application/json': {
+                      'schema': {r'$ref': '#/components/schemas/Widget'},
+                    },
+                  },
+                },
+                '5XX': {
+                  'description': 'Server error',
+                  'content': {
+                    'application/json': {
+                      'schema': {r'$ref': '#/components/schemas/Error'},
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        'components': {
+          'schemas': {
+            'Widget': {'type': 'object'},
+            'Error': {'type': 'object'},
+          },
+        },
+      };
+      final spec = parseAndResolveTestSpec(json);
+      final op = spec.paths.first.operations.first;
+      expect(op.rangeResponses, hasLength(2));
+      final byStart = {for (final r in op.rangeResponses) r.rangeStart: r};
+      expect(
+        byStart[200],
+        isA<ResolvedRangeResponse>().having(
+          (r) => r.description,
+          'description',
+          'Success',
+        ),
+      );
+      expect(
+        byStart[500],
+        isA<ResolvedRangeResponse>().having(
+          (r) => r.description,
+          'description',
+          'Server error',
+        ),
+      );
+    });
+
     test('default response is resolved and referenced schema is emitted', () {
       final json = {
         'openapi': '3.1.0',


### PR DESCRIPTION
## Summary
Stacked on #75 — please review/merge that first.

- Parser accepts `1XX`/`2XX`/`3XX`/`4XX`/`5XX` response keys (previously rejected as "Invalid response code").
- Range responses thread through the pipeline on separate fields (`rangeResponses` on `Responses`, `ResolvedOperation`, `RenderOperation`), keyed by range start (100/200/300/400/500).
- Tree walker walks range responses so referenced schemas are emitted.
- `_determineReturnType` unions explicit 2xx responses with the `2XX` range — an op declaring only `2XX: { schema: X }` now generates `Future<X>`.
- Range 4XX/5XX responses are carried through but not yet consumed by typed error handling; follow-up PR.

## Test plan
- [x] \`dart test\` — 250 tests pass (+3 new: parser accepts NXX, resolver propagates, render uses 2XX schema when no explicit 200)
- [x] \`dart analyze\` — clean (pre-existing info-level doc-comment line-length lints only)
- [x] \`dart format --set-exit-if-changed .\` — clean