### PR TITLE
feat: typed ApiException body from 4XX/5XX range responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## 1.0.2
 
+- Extend typed error bodies to `4XX`/`5XX` range responses. Previously
+  only `default:` contributed to `ApiException<T>`. Now the generator
+  collects error schemas from `default:`, `4XX:`, and `5XX:`,
+  deduplicates by structural equality, and emits the typed throw when exactly one
+  distinct error schema remains (the common case — most specs alias
+  every error to a single `ErrorResponse`). When the error schemas
+  disagree across those slots, the generator falls back to untyped
+  `ApiException<Object?>` rather than lying about what callers will
+  catch.
 - Accept OpenAPI range status code keys (`1XX`/`2XX`/`3XX`/`4XX`/`5XX`)
   in response maps. Previously the parser rejected them with "Invalid
   response code". Range responses are stored separately from

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -727,10 +727,34 @@ class Endpoint implements ToTemplateContext {
       dartIsNullable: false,
     );
 
-    final defaultResponse = operation.defaultResponse;
-    final hasErrorType = defaultResponse != null;
-    final errorType = defaultResponse?.content.typeName;
-    final errorFromJson = defaultResponse?.content.fromJsonExpression(
+    // Collect error-body schemas from `default:`, `4XX:`, and `5XX:` and
+    // deduplicate by structural equality. When they all resolve to the same
+    // schema (the common case — most specs alias every error to a single
+    // `ErrorResponse`), emit a typed `ApiException<ErrorType>` throw.
+    // When they disagree, fall back to untyped — picking one would lie
+    // to callers about what they'll actually catch.
+    final errorSchemas = <RenderSchema>[
+      ?operation.defaultResponse?.content,
+      ...operation.rangeResponses
+          .where(
+            (e) =>
+                e.range == StatusCodeRange.clientError ||
+                e.range == StatusCodeRange.serverError,
+          )
+          .map((e) => e.content),
+    ];
+    final distinctErrorSchemas = <RenderSchema>[];
+    for (final schema in errorSchemas) {
+      if (!distinctErrorSchemas.any((e) => e.equalsIgnoringName(schema))) {
+        distinctErrorSchemas.add(schema);
+      }
+    }
+    final errorSchema = distinctErrorSchemas.length == 1
+        ? distinctErrorSchemas.first
+        : null;
+    final hasErrorType = errorSchema != null;
+    final errorType = errorSchema?.typeName;
+    final errorFromJson = errorSchema?.fromJsonExpression(
       'jsonDecode(response.body)',
       context,
       jsonIsNullable: false,

--- a/test/render/render_operation_test.dart
+++ b/test/render/render_operation_test.dart
@@ -1108,5 +1108,127 @@ void main() {
         '}\n',
       );
     });
+
+    test('4XX range alone drives the typed error body', () {
+      final json = {
+        'summary': 'Get widgets',
+        'operationId': 'getWidgets',
+        'responses': {
+          '200': {'description': 'OK'},
+          '4XX': {
+            'description': 'Client error',
+            'content': {
+              'application/json': {
+                'schema': {
+                  'type': 'object',
+                  'properties': {
+                    'reason': {'type': 'string'},
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+      final result = renderTestOperation(
+        path: '/widgets',
+        operationJson: json,
+        serverUrl: Uri.parse('https://example.com'),
+      );
+      expect(result, contains('throw ApiException<GetWidgets4XXResponse>('));
+      expect(result, contains('body: GetWidgets4XXResponse.fromJson'));
+    });
+
+    test(
+      'default + 4XX with identical inline schemas still typed',
+      () {
+        final errorSchema = {
+          'type': 'object',
+          'properties': {
+            'message': {'type': 'string'},
+          },
+        };
+        final json = {
+          'summary': 'Get widgets',
+          'operationId': 'getWidgets',
+          'responses': {
+            '200': {'description': 'OK'},
+            '4XX': {
+              'description': 'Client error',
+              'content': {
+                'application/json': {'schema': errorSchema},
+              },
+            },
+            'default': {
+              'description': 'Error',
+              'content': {
+                'application/json': {'schema': errorSchema},
+              },
+            },
+          },
+        };
+        final result = renderTestOperation(
+          path: '/widgets',
+          operationJson: json,
+          serverUrl: Uri.parse('https://example.com'),
+        );
+        // Both default and 4XX are structurally the same inline schema;
+        // deduplication collapses them so the typed throw still fires.
+        expect(result, contains('throw ApiException<'));
+        expect(result, isNot(contains('throw ApiException<Object?>')));
+      },
+    );
+
+    test(
+      'default + 4XX with different schemas falls back to untyped',
+      () {
+        final json = {
+          'summary': 'Get widgets',
+          'operationId': 'getWidgets',
+          'responses': {
+            '200': {'description': 'OK'},
+            '4XX': {
+              'description': 'Client error',
+              'content': {
+                'application/json': {
+                  'schema': {
+                    'type': 'object',
+                    'properties': {
+                      'reason': {'type': 'string'},
+                    },
+                  },
+                },
+              },
+            },
+            'default': {
+              'description': 'Error',
+              'content': {
+                'application/json': {
+                  'schema': {
+                    'type': 'object',
+                    'properties': {
+                      'message': {'type': 'string'},
+                    },
+                  },
+                },
+              },
+            },
+          },
+        };
+        final result = renderTestOperation(
+          path: '/widgets',
+          operationJson: json,
+          serverUrl: Uri.parse('https://example.com'),
+        );
+        // Schemas disagree — fall back to untyped throw.
+        expect(
+          result,
+          contains(
+            'throw ApiException<Object?>(response.statusCode, '
+            'response.body.toString());',
+          ),
+        );
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary
Stacked on #76. Extends #75's typed-error work from \`default:\` to also consider \`4XX:\`/\`5XX:\` range responses.

- Collects error schemas from {default, 4XX, 5XX}, dedupes structurally.
- If exactly one distinct schema: \`throw ApiException<ErrorType>(code, raw, body: ErrorType.fromJson(...))\`.
- If schemas disagree: honest fallback to untyped \`ApiException<Object?>\`.
- Common case — a single shared \`ErrorResponse\` aliased to every slot — Just Works.

## Test plan
- [x] \`dart test\` — 254 tests pass (+3 new: 4XX alone drives the error type; default + 4XX with identical schemas stays typed; default + 4XX with different schemas falls back to untyped)
- [x] \`dart analyze\` — clean (pre-existing info-level doc-comment line-length lints on render_tree only)
- [x] \`dart format --set-exit-if-changed .\` — clean