### PR TITLE
chore: emit Shorebird protocol under lib/src/ via gen_shorebird

### DIFF
--- a/tool/gen_shorebird.dart
+++ b/tool/gen_shorebird.dart
@@ -2,10 +2,11 @@
 //
 // Plugs a custom [FileRenderer] into the standard [runCli] shell.
 // This matches Shorebird's hand-written
-// `shorebird_code_push_protocol` package layout: request/response
-// DTOs owned by a single operation nest under a per-operation
-// directory, domain models land in `lib/models/`, shared messages
-// stay flat.
+// `shorebird_code_push_protocol` package layout: everything lives
+// under `lib/src/` (Dart-package convention for internal files),
+// request/response DTOs owned by a single operation nest under a
+// per-operation directory, domain models land in `lib/src/models/`,
+// shared messages stay flat in `lib/src/messages/`.
 //
 // Treat the space_gen extension surface used here (`runCli`,
 // `FileRendererBuilder`, the `@protected` hooks on `FileRenderer`)
@@ -25,12 +26,12 @@ class ShorebirdFileRenderer extends FileRenderer {
     final className = context.schema.typeName;
     final isMessage =
         className.endsWith('Request') || className.endsWith('Response');
-    if (!isMessage) return 'models/$snakeName.dart';
+    if (!isMessage) return 'src/models/$snakeName.dart';
     final base = _messageBaseName(snakeName);
     if (context.operationSnakeNames.contains(base)) {
-      return 'messages/$base/$snakeName.dart';
+      return 'src/messages/$base/$snakeName.dart';
     }
-    return 'messages/$snakeName.dart';
+    return 'src/messages/$snakeName.dart';
   }
 
   /// Strip a trailing `_request`/`_response` (and any HTTP status code


### PR DESCRIPTION
## Summary
\`ShorebirdFileRenderer.modelPath\` returned paths like \`models/foo.dart\` and \`messages/bar_request.dart\`, but Shorebird's handwritten \`shorebird_code_push_protocol\` keeps everything under \`lib/src/\` per Dart convention. Regenerating required a post-processing sed to rewrite the imports (\`package:.../models/\` → \`package:.../src/models/\`).

Just prefix the returned paths with \`src/\` so a clean regen produces the final layout with no manual fixups. Doc comment updated to match.

## Test plan
- [x] \`dart test\` — 255 tests pass (no behavior change for non-Shorebird consumers)
- [x] \`dart analyze\` — clean (only pre-existing info-level lints in render_tree.dart)
- [x] \`dart format --set-exit-if-changed .\` — clean
- [x] Verified: regenerating against latest codepush.yaml produces zero diff against the current shorebird_code_push_protocol tree on PR #3696, vs. a sed-fix dance without this change.