### PR TITLE
feat: pick grammatically correct a/an in generated doc comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 1.0.2
 
+- Pick grammatically correct `a`/`an` in generated `fromJson`/`toJson`
+  dartdoc (`/// Converts a \`Map<String, dynamic>\` to an [App].` instead
+  of `… a [App].`). Class names starting with A/E/I/O get "an"; U is
+  excluded since `User`/`Uniform`/`Unique` start with a consonant sound.
 - Extend typed error bodies to `4XX`/`5XX` range responses. Previously
   only `default:` contributed to `ApiException<T>`. Now the generator
   collects error schemas from `default:`, `4XX:`, and `5XX:`,

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -80,6 +80,19 @@ Iterable<String> wrapLines({
   });
 }
 
+/// Picks "a" or "an" for [word], biased for programming class names.
+/// Returns "an" when [word] starts with A/E/I/O, "a" otherwise — `U`
+/// is *not* treated as a vowel here because the dominant class-name
+/// U-words (`User`, `Uniform`, `Unique`) start with a consonant "yoo"
+/// sound. Misses edge cases like `Upload` (vowel sound, should be
+/// "an") and `FBI` (acronym, should be "an") but those are rare in
+/// class names.
+@visibleForTesting
+String aOrAn(String word) {
+  if (word.isEmpty) return 'a';
+  return 'aeioAEIO'.contains(word[0]) ? 'an' : 'a';
+}
+
 Iterable<String> wrapDocComment(String value, {int indent = 0}) {
   final prefix = '${' ' * indent}/// ';
   final wrapWidth = 80 - prefix.length;
@@ -1992,9 +2005,11 @@ class RenderObject extends RenderNewType {
         indent: 4,
       ),
       'from_json_doc_comment':
-          '/// Converts a `Map<String, dynamic>` to a [$typeName].\n    ',
+          '/// Converts a `Map<String, dynamic>` to ${aOrAn(typeName)} '
+          '[$typeName].\n    ',
       'to_json_doc_comment':
-          '/// Converts a [$typeName] to a `Map<String, dynamic>`.\n    ',
+          '/// Converts ${aOrAn(typeName)} [$typeName] to a '
+          '`Map<String, dynamic>`.\n    ',
       'typeName': typeName,
       'nullableTypeName': nullableTypeName(context),
       'hasProperties': hasProperties,
@@ -2770,6 +2785,7 @@ class RenderEmptyObject extends RenderNewType {
   Map<String, dynamic> toTemplateContext(SchemaRenderer context) => {
     'doc_comment': createDocComment(common: common),
     'typeName': typeName,
+    'typeArticle': aOrAn(typeName),
     'nullableTypeName': nullableTypeName(context),
   };
 }

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -80,17 +80,19 @@ Iterable<String> wrapLines({
   });
 }
 
+/// Letters a/e/i/o treated as "an"-taking; `u` is excluded because the
+/// dominant class-name U-words (`User`, `Uniform`, `Unique`) start with
+/// a consonant "yoo" sound.
+const _anTakingInitials = {'a', 'e', 'i', 'o', 'A', 'E', 'I', 'O'};
+
 /// Picks "a" or "an" for [word], biased for programming class names.
-/// Returns "an" when [word] starts with A/E/I/O, "a" otherwise — `U`
-/// is *not* treated as a vowel here because the dominant class-name
-/// U-words (`User`, `Uniform`, `Unique`) start with a consonant "yoo"
-/// sound. Misses edge cases like `Upload` (vowel sound, should be
-/// "an") and `FBI` (acronym, should be "an") but those are rare in
-/// class names.
+/// Returns "an" when [word] starts with A/E/I/O, "a" otherwise. Misses
+/// edge cases like `Upload` (vowel sound, should be "an") and `FBI`
+/// (acronym, should be "an"), but those are rare in class names.
 @visibleForTesting
 String aOrAn(String word) {
   if (word.isEmpty) return 'a';
-  return 'aeioAEIO'.contains(word[0]) ? 'an' : 'a';
+  return _anTakingInitials.contains(word[0]) ? 'an' : 'a';
 }
 
 Iterable<String> wrapDocComment(String value, {int indent = 0}) {

--- a/lib/templates/schema_empty_object.mustache
+++ b/lib/templates/schema_empty_object.mustache
@@ -2,7 +2,7 @@
 class {{ typeName }} {
     const {{ typeName }}();
 
-    /// Converts a `Map<String, dynamic>` to a [{{ typeName }}].
+    /// Converts a `Map<String, dynamic>` to {{ typeArticle }} [{{ typeName }}].
     factory {{ typeName }}.fromJson(Map<String, dynamic> _) {
         return const {{ typeName }}();
     }

--- a/test/render/render_tree_test.dart
+++ b/test/render/render_tree_test.dart
@@ -14,6 +14,26 @@ class _Collector extends RenderTreeVisitor {
 }
 
 void main() {
+  group('aOrAn', () {
+    test('common class names', () {
+      expect(aOrAn('Apple'), 'an');
+      expect(aOrAn('Egg'), 'an');
+      expect(aOrAn('Item'), 'an');
+      expect(aOrAn('Order'), 'an');
+      expect(aOrAn('User'), 'a');
+      expect(aOrAn('Upload'), 'a');
+      expect(aOrAn('Map'), 'a');
+      expect(aOrAn('Customer'), 'a');
+    });
+    test('empty word defaults to a', () {
+      expect(aOrAn(''), 'a');
+    });
+    test('lowercase first letter', () {
+      expect(aOrAn('apple'), 'an');
+      expect(aOrAn('user'), 'a');
+    });
+  });
+
   group('variableSafeName', () {
     test('basic', () {
       const quirks = Quirks();


### PR DESCRIPTION
## Summary
Generated object classes emit \`/// Converts a \\\`Map<String, dynamic>\\\` to a [ClassName].\` doc comments. For classes whose name starts with a vowel (\`App\`, \`Error\`, \`Item\`, \`Order\`), \"a\" reads wrong — should be \"an\".

- New \`aOrAn(word)\` helper picks \"an\" for A/E/I/O-starting words, \"a\" otherwise.
- \`U\` deliberately excluded — \`User\`/\`Uniform\`/\`Unique\` all start with a \"yoo\" consonant sound where \"an User\" sounds wrong. Doc comment notes the exception.
- Wired through the two emission sites: the inline doc strings in \`SchemaObject\`/\`SchemaEmptyObject\` template context, and the \`schema_empty_object.mustache\` template (now uses \`{{ typeArticle }}\`).
- Misses \`Upload\` (should be \"an\") and acronyms like \`FBI\`. Rare in class names.

## Test plan
- [x] \`dart test\` — 258 tests pass (+3 new for \`aOrAn\`)
- [x] \`dart analyze\` — clean (only pre-existing info-level doc-comment line-length lints)
- [x] \`dart format --set-exit-if-changed .\` — clean