### PR TITLE
feat: throw FormatException from object fromJson on malformed input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## 1.0.2
 
+- Throw `FormatException` (not raw `TypeError`) from generated object
+  `fromJson` factories on malformed input. A shared `parseFromJson`
+  helper in `model_helpers.dart` wraps the constructor call in a
+  try/catch that converts `TypeError` (which extends `Error`, so routes
+  that do `on Exception catch` were dropping it and returning 500) into
+  a `FormatException` that caller code can handle cleanly as
+  "malformed request body". Generated factories are one line:
+  `return parseFromJson('App', json, () => App(id: json['id'] as String, ...));`.
 - Pick grammatically correct `a`/`an` in generated `fromJson`/`toJson`
   dartdoc (`/// Converts a \`Map<String, dynamic>\` to an [App].` instead
   of `… a [App].`). Class names starting with A/E/I/O get "an"; U is

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -247,6 +247,7 @@ abstract final class ModelHelpers {
   static const maybeParseUriTemplate = 'maybeParseUriTemplate';
   static const listsEqual = 'listsEqual';
   static const mapsEqual = 'mapsEqual';
+  static const parseFromJson = 'parseFromJson';
 
   static const List<String> all = [
     maybeParseDateTime,
@@ -254,6 +255,7 @@ abstract final class ModelHelpers {
     maybeParseUriTemplate,
     listsEqual,
     mapsEqual,
+    parseFromJson,
   ];
 }
 

--- a/lib/templates/model_helpers.mustache
+++ b/lib/templates/model_helpers.mustache
@@ -25,6 +25,24 @@ UriTemplate? maybeParseUriTemplate(String? value) {
   return UriTemplate(value);
 }
 
+/// Runs [build] to construct a `fromJson`-parsed value of type [T],
+/// converting any `TypeError` (e.g. an unexpected null or a cast
+/// failure on a required field) into a `FormatException` that names
+/// the class and includes the offending JSON. Generated `fromJson`
+/// factories delegate to this so callers that catch `Exception`
+/// treat malformed bodies as a parse error, not a crash.
+T parseFromJson<T>(
+  String className,
+  Map<String, dynamic> json,
+  T Function() build,
+) {
+  try {
+    return build();
+  } on TypeError catch (error) {
+    throw FormatException('Failed to parse $className from JSON: $error', json);
+  }
+}
+
 /// Check if two nullable lists are deeply equal.
 bool listsEqual<T>(List<T>? a, List<T>? b) {
   final deepEquals = const DeepCollectionEquality().equals;

--- a/lib/templates/schema_object.mustache
+++ b/lib/templates/schema_object.mustache
@@ -15,14 +15,14 @@ class {{ typeName }} {
     {{^castFromJsonArg}}
         json) {
     {{/castFromJsonArg}}
-        return {{ typeName }}(
+        return parseFromJson('{{ typeName }}', json, () => {{ typeName }}(
             {{#properties}}
             {{ dartName }}: {{{ fromJson }}},
             {{/properties}}
             {{#hasAdditionalProperties}}
             {{additionalPropertiesName}}: json.map((key, value) => MapEntry(key, {{{ valueFromJson }}})),
             {{/hasAdditionalProperties}}
-        );
+        ));
     }
 
     /// Convenience to create a nullable type from a nullable json object.

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -30,9 +30,9 @@ void main() {
         '    /// Converts a `Map<String, dynamic>` to a [Test].\n'
         '    factory Test.fromJson(Map<String, dynamic>\n'
         '        json) {\n'
-        '        return Test(\n'
+        "        return parseFromJson('Test', json, () => Test(\n"
         "            foo: json['foo'],\n"
-        '        );\n'
+        '        ));\n'
         '    }\n'
         '\n'
         '    /// Convenience to create a nullable type from a nullable json object.\n'
@@ -304,9 +304,9 @@ void main() {
         '    /// Converts a `Map<String, dynamic>` to a [Test].\n'
         '    factory Test.fromJson(Map<String, dynamic>\n'
         '        json) {\n'
-        '        return Test(\n'
+        "        return parseFromJson('Test', json, () => Test(\n"
         "            foo: maybeParseDateTime(json['foo'] as String?),\n"
-        '        );\n'
+        '        ));\n'
         '    }\n'
         '\n'
         '    /// Convenience to create a nullable type from a nullable json object.\n'
@@ -367,9 +367,9 @@ void main() {
           '    /// Converts a `Map<String, dynamic>` to a [Test].\n'
           '    factory Test.fromJson(Map<String, dynamic>\n'
           '        json) {\n'
-          '        return Test(\n'
+          "        return parseFromJson('Test', json, () => Test(\n"
           "            foo: maybeParseUri(json['foo'] as String?),\n"
-          '        );\n'
+          '        ));\n'
           '    }\n'
           '\n'
           '    /// Convenience to create a nullable type from a nullable json object.\n'
@@ -426,9 +426,9 @@ void main() {
           '    /// Converts a `Map<String, dynamic>` to a [Test].\n'
           '    factory Test.fromJson(Map<String, dynamic>\n'
           '        json) {\n'
-          '        return Test(\n'
+          "        return parseFromJson('Test', json, () => Test(\n"
           "            foo: Uri.parse(json['foo'] as String),\n"
-          '        );\n'
+          '        ));\n'
           '    }\n'
           '\n'
           '    /// Convenience to create a nullable type from a nullable json object.\n'
@@ -490,9 +490,9 @@ void main() {
           '    /// Converts a `Map<String, dynamic>` to a [Test].\n'
           '    factory Test.fromJson(Map<String, dynamic>\n'
           '        json) {\n'
-          '        return Test(\n'
+          "        return parseFromJson('Test', json, () => Test(\n"
           "            foo: maybeParseUriTemplate(json['foo'] as String?),\n"
-          '        );\n'
+          '        ));\n'
           '    }\n'
           '\n'
           '    /// Convenience to create a nullable type from a nullable json object.\n'
@@ -549,9 +549,9 @@ void main() {
           '    /// Converts a `Map<String, dynamic>` to a [Test].\n'
           '    factory Test.fromJson(Map<String, dynamic>\n'
           '        json) {\n'
-          '        return Test(\n'
+          "        return parseFromJson('Test', json, () => Test(\n"
           "            foo: UriTemplate(json['foo'] as String),\n"
-          '        );\n'
+          '        ));\n'
           '    }\n'
           '\n'
           '    /// Convenience to create a nullable type from a nullable json object.\n'
@@ -619,10 +619,10 @@ void main() {
         '    /// Converts a `Map<String, dynamic>` to a [Test].\n'
         '    factory Test.fromJson(Map<String, dynamic>\n'
         '        json) {\n'
-        '        return Test(\n'
+        "        return parseFromJson('Test', json, () => Test(\n"
         "            foo: json['foo'] as String?,\n"
         "            bar: (json['bar'] as num?)?.toDouble(),\n"
-        '        );\n'
+        '        ));\n'
         '    }\n'
         '\n'
         '    /// Convenience to create a nullable type from a nullable json object.\n'
@@ -815,9 +815,9 @@ void main() {
           '    /// Converts a `Map<String, dynamic>` to a [User].\n'
           '    factory User.fromJson(Map<String, dynamic>\n'
           '        json) {\n'
-          '        return User(\n'
+          "        return parseFromJson('User', json, () => User(\n"
           "            foo: Value.maybeFromJson(json['foo'] as Map<String, dynamic>?),\n"
-          '        );\n'
+          '        ));\n'
           '    }\n'
           '\n'
           '    /// Convenience to create a nullable type from a nullable json object.\n'
@@ -877,9 +877,9 @@ void main() {
         '    /// Converts a `Map<String, dynamic>` to a [Test].\n'
         '    factory Test.fromJson(Map<String, dynamic>\n'
         '        json) {\n'
-        '        return Test(\n'
+        "        return parseFromJson('Test', json, () => Test(\n"
         "            map: (json['map'] as Map<String, dynamic>?)?.map((key, value) => MapEntry(key, value as String)),\n"
-        '        );\n'
+        '        ));\n'
         '    }\n'
         '\n'
         '    /// Convenience to create a nullable type from a nullable json object.\n'
@@ -973,7 +973,7 @@ void main() {
         '    /// Converts a `Map<String, dynamic>` to a [Test].\n'
         '    factory Test.fromJson(Map<String, dynamic>\n'
         '        json) {\n'
-        '        return Test(\n'
+        "        return parseFromJson('Test', json, () => Test(\n"
         "            mString: (json['m_string'] as Map<String, dynamic>?)?.map((key, value) => MapEntry(key, value as String)),\n"
         "            mInt: (json['m_int'] as Map<String, dynamic>?)?.map((key, value) => MapEntry(key, (value as int))),\n"
         "            mNumber: (json['m_number'] as Map<String, dynamic>?)?.map((key, value) => MapEntry(key, (value as num).toDouble())),\n"
@@ -983,7 +983,7 @@ void main() {
         "            mMapOfString: (json['m_map_of_string'] as Map<String, dynamic>?)?.map((key, value) => MapEntry(key, (value as Map<String, dynamic>).map((key, value) => MapEntry(key, value as String)))),\n"
         "            mEnum: (json['m_enum'] as Map<String, dynamic>?)?.map((key, value) => MapEntry(key, TestMEnum.fromJson(value as String))),\n"
         "            mUnknown: (json['m_unknown'] as Map<String, dynamic>?)?.map((key, value) => MapEntry(key, value)),\n"
-        '        );\n'
+        '        ));\n'
         '    }\n'
         '\n'
         '    /// Convenience to create a nullable type from a nullable json object.\n'
@@ -1114,7 +1114,7 @@ void main() {
         '    /// Converts a `Map<String, dynamic>` to a [Test].\n'
         '    factory Test.fromJson(Map<String, dynamic>\n'
         '        json) {\n'
-        '        return Test(\n'
+        "        return parseFromJson('Test', json, () => Test(\n"
         "            aString: (json['a_string'] as List?)?.cast<String>(),\n"
         "            aInt: (json['a_int'] as List?)?.cast<int>(),\n"
         "            aNumber: (json['a_number'] as List?)?.cast<double>(),\n"
@@ -1124,7 +1124,7 @@ void main() {
         "            aArrayOfString: (json['a_array_of_string'] as List?)?.cast<List<String>>(),\n"
         "            aEnum: (json['a_enum'] as List?)?.map<TestAEnumInner>((e) => TestAEnumInner.fromJson(e as String)).toList(),\n"
         "            aUnknown: (json['a_unknown'] as List?)?.cast<dynamic>(),\n"
-        '        );\n'
+        '        ));\n'
         '    }\n'
         '\n'
         '    /// Convenience to create a nullable type from a nullable json object.\n'
@@ -1242,9 +1242,9 @@ void main() {
         '    /// Converts a `Map<String, dynamic>` to a [Test].\n'
         '    factory Test.fromJson(Map<String, dynamic>\n'
         '        json) {\n'
-        '        return Test(\n'
+        "        return parseFromJson('Test', json, () => Test(\n"
         '            a: const TestA(),\n'
-        '        );\n'
+        '        ));\n'
         '    }\n'
         '\n'
         '    /// Convenience to create a nullable type from a nullable json object.\n'
@@ -1304,9 +1304,9 @@ void main() {
         '    /// Converts a `Map<String, dynamic>` to a [Test].\n'
         '    factory Test.fromJson(Map<String, dynamic>\n'
         '        json) {\n'
-        '        return Test(\n'
+        "        return parseFromJson('Test', json, () => Test(\n"
         "            a: (json['a'] as List?)?.cast<String>(),\n"
-        '        );\n'
+        '        ));\n'
         '    }\n'
         '\n'
         '    /// Convenience to create a nullable type from a nullable json object.\n'
@@ -1417,7 +1417,7 @@ void main() {
         '    /// Converts a `Map<String, dynamic>` to a [Test].\n'
         '    factory Test.fromJson(Map<String, dynamic>\n'
         '        json) {\n'
-        '        return Test(\n'
+        "        return parseFromJson('Test', json, () => Test(\n"
         "            fooBar: json['foo-bar'] as String?,\n"
         "            notPrivate: json['_not_private'] as String?,\n"
         "            barBaz: json['bar baz'] as String?,\n"
@@ -1426,7 +1426,7 @@ void main() {
         "            minus1: json['-1'] as String?,\n"
         "            dont: json['don't'] as String?,\n"
         "            default_: json['default'] as String?,\n"
-        '        );\n'
+        '        ));\n'
         '    }\n'
         '\n'
         '    /// Convenience to create a nullable type from a nullable json object.\n'
@@ -1624,9 +1624,9 @@ void main() {
           '    /// Converts a `Map<String, dynamic>` to a [Test].\n'
           '    factory Test.fromJson(Map<String, dynamic>\n'
           '        json) {\n'
-          '        return Test(\n'
+          "        return parseFromJson('Test', json, () => Test(\n"
           "            a: (json['a'] as num?)?.toDouble(),\n"
-          '        );\n'
+          '        ));\n'
           '    }\n'
           '\n'
           '    /// Convenience to create a nullable type from a nullable json object.\n'
@@ -1705,9 +1705,9 @@ void main() {
           '    /// Converts a `Map<String, dynamic>` to a [Test].\n'
           '    factory Test.fromJson(Map<String, dynamic>\n'
           '        json) {\n'
-          '        return Test(\n'
+          "        return parseFromJson('Test', json, () => Test(\n"
           "            a: (json['a'] as int?),\n"
-          '        );\n'
+          '        ));\n'
           '    }\n'
           '\n'
           '    /// Convenience to create a nullable type from a nullable json object.\n'
@@ -1846,10 +1846,10 @@ void main() {
           '    /// Converts a `Map<String, dynamic>` to a [Test].\n'
           '    factory Test.fromJson(Map<String, dynamic>\n'
           '        json) {\n'
-          '        return Test(\n'
+          "        return parseFromJson('Test', json, () => Test(\n"
           "            a: json['a'] as String?,\n"
           "            b: json['b'] as String?,\n"
-          '        );\n'
+          '        ));\n'
           '    }\n'
           '\n'
           '    /// Convenience to create a nullable type from a nullable json object.\n'
@@ -1913,9 +1913,9 @@ void main() {
           '    /// Converts a `Map<String, dynamic>` to a [Test].\n'
           '    factory Test.fromJson(Map<String, dynamic>\n'
           '        json) {\n'
-          '        return Test(\n'
+          "        return parseFromJson('Test', json, () => Test(\n"
           "            a: json['a'] as String?,\n"
-          '        );\n'
+          '        ));\n'
           '    }\n'
           '\n'
           '    /// Convenience to create a nullable type from a nullable json object.\n'
@@ -1978,12 +1978,12 @@ void main() {
           '    /// Converts a `Map<String, dynamic>` to a [Test].\n'
           '    factory Test.fromJson(Map<String, dynamic>\n'
           '        json) {\n'
-          '        return Test(\n'
+          "        return parseFromJson('Test', json, () => Test(\n"
           "            reqNull: json['req_null'] as String?,\n"
           "            optNull: json['opt_null'] as String?,\n"
           "            req: json['req'] as String,\n"
           "            opt: json['opt'] as String?,\n"
-          '        );\n'
+          '        ));\n'
           '    }\n'
           '\n'
           '    /// Convenience to create a nullable type from a nullable json object.\n'
@@ -2083,9 +2083,9 @@ void main() {
           '    /// Converts a `Map<String, dynamic>` to a [Test].\n'
           '    factory Test.fromJson(Map<String, dynamic>\n'
           '        json) {\n'
-          '        return Test(\n'
+          "        return parseFromJson('Test', json, () => Test(\n"
           "            a: TestA.maybeFromJson(json['a'] as Map<String, dynamic>),\n"
-          '        );\n'
+          '        ));\n'
           '    }\n'
           '\n'
           '    /// Convenience to create a nullable type from a nullable json object.\n'


### PR DESCRIPTION
## Summary
Generated object \`fromJson\` factories now throw \`FormatException\` (not raw \`TypeError\`) when the JSON is malformed — wrong field type, missing required key, etc. \`FormatException\` extends \`Exception\`, so standard HTTP-route patterns like \`on Exception catch (e) { return 400; }\` now actually catch parse failures instead of letting them propagate as 500s.

Mechanism: wrap the return expression in a \`try { ... } on TypeError catch (error) { throw FormatException('Failed to parse X from JSON: \$error', json); }\`. No consumer-API change besides the thrown type.

## Test plan
- [x] \`dart test\` — 258 tests pass (20 expected-output tests updated to include the new try/catch)
- [x] \`dart analyze\` — clean (only pre-existing info-level lints)
- [x] \`dart format --set-exit-if-changed .\` — clean