### PR TITLE
feat: generate round-trip tests for each model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## 1.0.2
 
+- Emit a round-trip test for each generated newtype by default at
+  `test/<modelPath>_test.dart`. The test builds an in-memory instance
+  via `RenderSchema.exampleValue` (implemented per subclass), then
+  asserts `Type.fromJson(instance.toJson()) == instance`. Schemas that
+  can't produce a safe example — recursive types, no-JSON types —
+  opt out automatically (propagate `null` up). Consumers control the
+  behavior with the new hooks:
+  - `GeneratorConfig.generateTests` (default `true`): wholesale off
+  - `FileRenderer.testPath(LayoutContext) → String?`: return `null` to
+    skip a schema, or redirect (e.g. to `test/generated/` to avoid
+    colliding with hand-written tests).
 - Throw `FormatException` (not raw `TypeError`) from generated object
   `fromJson` factories on malformed input. A shared `parseFromJson`
   helper in `model_helpers.dart` wraps the constructor call in a

--- a/lib/src/render.dart
+++ b/lib/src/render.dart
@@ -73,6 +73,7 @@ class GeneratorConfig {
     this.runProcess,
     this.quirks = const Quirks(),
     this.logSchemas = true,
+    this.generateTests = true,
     this.fileRendererBuilder = FileRenderer.new,
   });
 
@@ -102,6 +103,13 @@ class GeneratorConfig {
   /// Whether to log each schema seen during resolution. Useful for
   /// debugging large specs; off by default for CLI usage.
   final bool logSchemas;
+
+  /// Whether to emit round-trip tests next to each generated model.
+  /// Default `true`. Individual schemas can still opt out by
+  /// overriding [FileRenderer.testPath] to return `null`, or are
+  /// skipped automatically when no safe example value can be
+  /// constructed (recursive types, no-JSON types).
+  final bool generateTests;
 
   /// Hook for plugging in a custom [FileRenderer] subclass. Defaults
   /// to `FileRenderer.new`.
@@ -162,6 +170,7 @@ Future<void> loadAndRenderSpec(GeneratorConfig config) async {
           formatter: formatter,
           fileWriter: fileWriter,
           spellChecker: spellChecker,
+          generateTests: config.generateTests,
         ),
       )
       .render(renderSpec);

--- a/lib/src/render/file_renderer.dart
+++ b/lib/src/render/file_renderer.dart
@@ -206,6 +206,7 @@ class FileRendererConfig {
     required this.formatter,
     required this.fileWriter,
     required this.spellChecker,
+    this.generateTests = true,
   });
 
   final String packageName;
@@ -214,6 +215,9 @@ class FileRendererConfig {
   final Formatter formatter;
   final FileWriter fileWriter;
   final SpellChecker spellChecker;
+
+  /// Whether to emit round-trip tests for each generated model.
+  final bool generateTests;
 }
 
 /// The information a layout hook (e.g. [FileRenderer.modelPath]) is
@@ -303,6 +307,28 @@ class FileRenderer {
         className.endsWith('Request') || className.endsWith('Response');
     final subdir = isMessage ? 'messages' : 'models';
     return '$subdir/$snakeName.dart';
+  }
+
+  /// Path for a schema's generated round-trip test, relative to the
+  /// package root (so the returned value includes the leading `test/`).
+  /// Return `null` to skip emitting a test for this schema.
+  ///
+  /// Default: mirrors [modelPath] under `test/`, with `_test` before the
+  /// `.dart` extension — so a schema at `lib/models/app.dart` gets a
+  /// test at `test/models/app_test.dart`.
+  ///
+  /// Override this hook to redirect generated tests (e.g. to
+  /// `test/generated/` so they sit alongside hand-written tests without
+  /// colliding), or return null to opt out entirely.
+  @protected
+  @visibleForOverriding
+  String? testPath(LayoutContext context) {
+    final libRelative = modelPath(context);
+    final withSuffix = libRelative.replaceFirst(
+      RegExp(r'\.dart$'),
+      '_test.dart',
+    );
+    return 'test/$withSuffix';
   }
 
   LayoutContext _contextFor(RenderSchema schema) => LayoutContext(
@@ -520,6 +546,32 @@ class FileRenderer {
     }
   }
 
+  /// Render a round-trip test for each schema that has a testable
+  /// example value. Skips schemas for which [testPath] returns null,
+  /// or for which [RenderSchema.exampleValue] returns null (recursive
+  /// types, no-JSON types).
+  void renderModelTests(Iterable<RenderSchema> schemas) {
+    final schemaContext = schemaRenderer;
+    for (final schema in schemas) {
+      if (!schema.createsNewType) continue;
+      final layoutContext = _contextFor(schema);
+      final outPath = testPath(layoutContext);
+      if (outPath == null) continue;
+      final example = schema.exampleValue(schemaContext);
+      if (example == null) continue;
+      _renderTemplate(
+        template: 'schema_round_trip_test',
+        outPath: outPath,
+        context: {
+          'packageName': packageName,
+          'modelImportPath': modelPackagePath(schema),
+          'typeName': schema.typeName,
+          'exampleValue': example,
+        },
+      );
+    }
+  }
+
   /// Render the entire spec.
   void render(RenderSpec spec, {bool clearDirectory = true}) {
     if (clearDirectory) {
@@ -565,6 +617,9 @@ class FileRenderer {
 
     // Render the models (schemas).
     renderModels(schemas);
+    if (config.generateTests) {
+      renderModelTests(schemas);
+    }
     // Render the api client.
     _renderApiClient(spec);
     // This is a bit of hack, but seems to work with the specs I've tested.

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -1218,6 +1218,14 @@ abstract class RenderSchema extends Equatable implements ToTemplateContext {
     required bool dartIsNullable,
   });
 
+  /// A Dart expression that constructs a valid in-memory instance of
+  /// this schema, used by generated round-trip tests. Returns `null`
+  /// when the generator cannot produce a safe example — e.g. a
+  /// [RenderRecursiveRef] in a non-nullable slot would loop forever.
+  /// Callers treat `null` as a signal to skip emitting a round-trip
+  /// test for the enclosing type.
+  String? exampleValue(SchemaRenderer context);
+
   /// The default value of this schema as a string.
   String? defaultValueString(SchemaRenderer context) {
     if (defaultValue == null) {
@@ -1424,6 +1432,16 @@ class RenderPod extends RenderSchema {
       (other is RenderPod) &&
       type == other.type &&
       super.equalsIgnoringName(other);
+
+  @override
+  String? exampleValue(SchemaRenderer context) => switch (type) {
+    PodType.boolean => 'false',
+    PodType.dateTime => 'DateTime.utc(2024, 1, 1)',
+    PodType.date => 'DateTime.utc(2024, 1, 1)',
+    PodType.uri => "Uri.parse('https://example.com')",
+    PodType.uriTemplate => "UriTemplate('https://example.com/{id}')",
+    PodType.email => "'user@example.com'",
+  };
 }
 
 abstract class RenderNewType extends RenderSchema {
@@ -1569,6 +1587,9 @@ class RenderString extends RenderSchema {
       maxLength == other.maxLength &&
       minLength == other.minLength &&
       super.equalsIgnoringName(other);
+
+  @override
+  String? exampleValue(SchemaRenderer context) => "'example'";
 }
 
 abstract class RenderNumeric<T extends num> extends RenderSchema {
@@ -1746,6 +1767,9 @@ class RenderNumber extends RenderNumeric<double> {
   @override
   String jsonToDartCall({required bool jsonIsNullable}) =>
       jsonIsNullable ? '?.toDouble()' : '.toDouble()';
+
+  @override
+  String? exampleValue(SchemaRenderer context) => '0.0';
 }
 
 class RenderInteger extends RenderNumeric<int> {
@@ -1770,6 +1794,9 @@ class RenderInteger extends RenderNumeric<int> {
   // jsonType and dartType are both int, so we don't need to do anything.
   @override
   String jsonToDartCall({required bool jsonIsNullable}) => '';
+
+  @override
+  String? exampleValue(SchemaRenderer context) => '0';
 }
 
 class RenderObject extends RenderNewType {
@@ -2095,6 +2122,21 @@ class RenderObject extends RenderNewType {
     }
     return super.equalsIgnoringName(other);
   }
+
+  @override
+  String? exampleValue(SchemaRenderer context) {
+    final args = <String>[];
+    for (final entry in properties.entries) {
+      final jsonName = entry.key;
+      if (!requiredProperties.contains(jsonName)) continue;
+      final property = entry.value;
+      final example = property.exampleValue(context);
+      if (example == null) return null;
+      final dartName = variableSafeName(context.quirks, jsonName);
+      args.add('$dartName: $example');
+    }
+    return '$typeName(${args.join(', ')})';
+  }
 }
 
 class RenderArray extends RenderSchema {
@@ -2252,6 +2294,13 @@ class RenderArray extends RenderSchema {
     }
     return super.equalsIgnoringName(other);
   }
+
+  @override
+  String? exampleValue(SchemaRenderer context) {
+    final inner = items.exampleValue(context);
+    if (inner == null) return null;
+    return '<${items.typeName}>[$inner]';
+  }
 }
 
 class RenderMap extends RenderSchema {
@@ -2368,6 +2417,14 @@ class RenderMap extends RenderSchema {
     return valueSchema.equalsIgnoringName(other.valueSchema) &&
         RenderSchema.maybeEqualsIgnoringName(keySchema, other.keySchema) &&
         super.equalsIgnoringName(other);
+  }
+
+  @override
+  String? exampleValue(SchemaRenderer context) {
+    final value = valueSchema.exampleValue(context);
+    if (value == null) return null;
+    final key = keySchema?.exampleValue(context) ?? "'key'";
+    return '{$key: $value}';
   }
 }
 
@@ -2500,6 +2557,9 @@ class RenderEnum extends RenderNewType {
     }
     return super.equalsIgnoringName(other);
   }
+
+  @override
+  String? exampleValue(SchemaRenderer context) => '$typeName.values.first';
 }
 
 class RenderOneOf extends RenderNewType {
@@ -2563,6 +2623,15 @@ class RenderOneOf extends RenderNewType {
 
   @override
   dynamic get defaultValue => null;
+
+  @override
+  String? exampleValue(SchemaRenderer context) {
+    for (final branch in schemas) {
+      final example = branch.exampleValue(context);
+      if (example != null) return example;
+    }
+    return null;
+  }
 }
 
 class RenderParameter implements CanBeParameter {
@@ -2675,6 +2744,9 @@ class RenderUnknown extends RenderSchema {
   @override
   Map<String, dynamic> toTemplateContext(SchemaRenderer context) =>
       throw UnimplementedError('RenderUnknown.toTemplateContext');
+
+  @override
+  String? exampleValue(SchemaRenderer context) => '<String, dynamic>{}';
 }
 
 class RenderVoid extends RenderNoJson {
@@ -2702,6 +2774,9 @@ class RenderVoid extends RenderNoJson {
     required bool dartIsNullable,
   }) => ''; // Unclear if this is correct. The one usage is for returning
   // a void type, maybe we need a "return expression" value instead?
+
+  @override
+  String? exampleValue(SchemaRenderer context) => null;
 }
 
 /// A schema that represents a type which cannot be converted to json.
@@ -2733,6 +2808,11 @@ abstract class RenderNoJson extends RenderSchema {
   @override
   Map<String, dynamic> toTemplateContext(SchemaRenderer context) =>
       throw UnimplementedError('$runtimeType.toTemplateContext');
+
+  /// No-JSON types (void, binary) can't round-trip via JSON so they
+  /// have no example value.
+  @override
+  String? exampleValue(SchemaRenderer context) => null;
 }
 
 class RenderBinary extends RenderNoJson {
@@ -2792,6 +2872,9 @@ class RenderEmptyObject extends RenderNewType {
     'typeArticle': aOrAn(typeName),
     'nullableTypeName': nullableTypeName(context),
   };
+
+  @override
+  String? exampleValue(SchemaRenderer context) => 'const $typeName()';
 }
 
 /// A cycle-break marker: appears where a $ref would otherwise recurse back
@@ -2866,6 +2949,13 @@ class RenderRecursiveRef extends RenderSchema {
   @override
   Map<String, dynamic> toTemplateContext(SchemaRenderer context) =>
       throw UnimplementedError('RenderRecursiveRef does not render a template');
+
+  /// Recursive refs by definition loop back through themselves — any
+  /// attempt to build an example value would recurse indefinitely.
+  /// Returning null here propagates up the tree so the enclosing
+  /// schema opts out of test generation.
+  @override
+  String? exampleValue(SchemaRenderer context) => null;
 
   @override
   List<Object?> get props => [super.props, targetPointer];

--- a/lib/templates/schema_round_trip_test.mustache
+++ b/lib/templates/schema_round_trip_test.mustache
@@ -1,0 +1,12 @@
+// GENERATED — do not hand-edit.
+import 'package:{{{ packageName }}}/{{{ modelImportPath }}}';
+import 'package:test/test.dart';
+
+void main() {
+  group('{{{ typeName }}}', () {
+    test('round-trips via fromJson/toJson', () {
+      final instance = {{{ exampleValue }}};
+      expect({{{ typeName }}}.fromJson(instance.toJson()), instance);
+    });
+  });
+}

--- a/test/render/file_renderer_test.dart
+++ b/test/render/file_renderer_test.dart
@@ -383,6 +383,112 @@ void main() {
       },
     );
 
+    test('round-trip tests are emitted next to each model', () async {
+      final fs = MemoryFileSystem.test();
+      final spec = {
+        'openapi': '3.1.0',
+        'info': {'title': 'Roundtrip', 'version': '1.0.0'},
+        'servers': [
+          {'url': 'https://example.com'},
+        ],
+        'paths': {
+          '/widgets': {
+            'get': {
+              'operationId': 'getWidget',
+              'responses': {
+                '200': {
+                  'description': 'OK',
+                  'content': {
+                    'application/json': {
+                      'schema': {r'$ref': '#/components/schemas/Widget'},
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        'components': {
+          'schemas': {
+            'Widget': {
+              'type': 'object',
+              'required': ['id', 'name'],
+              'properties': {
+                'id': {'type': 'integer', 'format': 'int64'},
+                'name': {'type': 'string'},
+              },
+            },
+          },
+        },
+      };
+      final out = fs.directory('out');
+      await renderToDirectory(spec: spec, outDir: out);
+      final testFile = out.childFile('test/models/widget_test.dart');
+      expect(testFile.existsSync(), isTrue);
+      final body = testFile.readAsStringSync();
+      expect(body, contains("import 'package:out/models/widget.dart';"));
+      expect(body, contains('Widget(id: 0, name: '));
+      expect(body, contains('Widget.fromJson(instance.toJson())'));
+    });
+
+    test('generateTests: false suppresses test emission', () async {
+      final fs = MemoryFileSystem.test();
+      final spec = {
+        'openapi': '3.1.0',
+        'info': {'title': 'NoTests', 'version': '1.0.0'},
+        'servers': [
+          {'url': 'https://example.com'},
+        ],
+        'paths': {
+          '/widgets': {
+            'get': {
+              'operationId': 'getWidget',
+              'responses': {
+                '200': {
+                  'description': 'OK',
+                  'content': {
+                    'application/json': {
+                      'schema': {r'$ref': '#/components/schemas/Widget'},
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        'components': {
+          'schemas': {
+            'Widget': {
+              'type': 'object',
+              'required': ['id'],
+              'properties': {
+                'id': {'type': 'integer'},
+              },
+            },
+          },
+        },
+      };
+      final out = fs.directory('out');
+      final specFile = fs.file('spec.json')
+        ..createSync(recursive: true)
+        ..writeAsStringSync(jsonEncode(spec));
+      await runWithLogger(
+        _MockLogger(),
+        () => loadAndRenderSpec(
+          GeneratorConfig(
+            specUrl: Uri.file(specFile.path),
+            packageName: 'out',
+            outDir: out,
+            templatesDir: templatesDir,
+            runProcess: runProcess,
+            logSchemas: false,
+            generateTests: false,
+          ),
+        ),
+      );
+      expect(out.childDirectory('test').existsSync(), isFalse);
+    });
+
     test('smoke test with simple spec', () async {
       final fs = MemoryFileSystem.test();
       final spec = {

--- a/test/render/render_tree_test.dart
+++ b/test/render/render_tree_test.dart
@@ -752,4 +752,45 @@ void main() {
       expect(a, isNot(equals(differentTarget)));
     });
   });
+
+  group('exampleValue', () {
+    final context = SchemaRenderer(
+      templates: TemplateProvider.defaultLocation(),
+      quirks: const Quirks(),
+    );
+    const common = CommonProperties.test(
+      snakeName: 'foo',
+      pointer: JsonPointer.empty(),
+    );
+
+    test('date format produces a DateTime literal', () {
+      const schema = RenderPod(common: common, type: PodType.date);
+      expect(schema.exampleValue(context), 'DateTime.utc(2024, 1, 1)');
+    });
+
+    test('map with keySchema uses its exampleValue', () {
+      const inner = RenderString(
+        createsNewType: false,
+        common: common,
+        defaultValue: null,
+        maxLength: null,
+        minLength: null,
+        pattern: null,
+      );
+      final keySchema = RenderEnum(
+        common: common,
+        values: const ['a', 'b'],
+        names: const ['a', 'b'],
+        descriptions: null,
+        defaultValue: null,
+      );
+      final map = RenderMap(
+        common: common,
+        valueSchema: inner,
+        keySchema: keySchema,
+      );
+      // Key example is the enum's first value; value is the string example.
+      expect(map.exampleValue(context), "{Foo.values.first: 'example'}");
+    });
+  });
 }

--- a/test/render/render_tree_test.dart
+++ b/test/render/render_tree_test.dart
@@ -768,6 +768,29 @@ void main() {
       expect(schema.exampleValue(context), 'DateTime.utc(2024, 1, 1)');
     });
 
+    test('unknown returns an empty dynamic map literal', () {
+      const schema = RenderUnknown(common: common);
+      expect(schema.exampleValue(context), '<String, dynamic>{}');
+    });
+
+    test('void returns null (no round-trip possible)', () {
+      const schema = RenderVoid(common: common);
+      expect(schema.exampleValue(context), isNull);
+    });
+
+    test('binary (NoJson) returns null', () {
+      const schema = RenderBinary(common: common);
+      expect(schema.exampleValue(context), isNull);
+    });
+
+    test('recursive ref returns null', () {
+      const schema = RenderRecursiveRef(
+        common: common,
+        targetPointer: JsonPointer.empty(),
+      );
+      expect(schema.exampleValue(context), isNull);
+    });
+
     test('map with keySchema uses its exampleValue', () {
       const inner = RenderString(
         createsNewType: false,

--- a/test/render/render_tree_test.dart
+++ b/test/render/render_tree_test.dart
@@ -768,6 +768,27 @@ void main() {
       expect(schema.exampleValue(context), 'DateTime.utc(2024, 1, 1)');
     });
 
+    test('uri format produces a Uri.parse literal', () {
+      const schema = RenderPod(common: common, type: PodType.uri);
+      expect(
+        schema.exampleValue(context),
+        "Uri.parse('https://example.com')",
+      );
+    });
+
+    test('uriTemplate format produces a UriTemplate literal', () {
+      const schema = RenderPod(common: common, type: PodType.uriTemplate);
+      expect(
+        schema.exampleValue(context),
+        "UriTemplate('https://example.com/{id}')",
+      );
+    });
+
+    test('email format produces an email string literal', () {
+      const schema = RenderPod(common: common, type: PodType.email);
+      expect(schema.exampleValue(context), "'user@example.com'");
+    });
+
     test('unknown returns an empty dynamic map literal', () {
       const schema = RenderUnknown(common: common);
       expect(schema.exampleValue(context), '<String, dynamic>{}');


### PR DESCRIPTION
## Summary
For each generated newtype, emit a test file at \`test/<modelPath>_test.dart\` that builds a synthetic instance, round-trips through \`toJson\`/\`fromJson\`, and asserts equality. Catches most fromJson/toJson drift, missing-field bugs, and cast issues without any hand-written tests.

- \`RenderSchema.exampleValue(context) → String?\` implemented per subclass. Primitives and enums return a literal; objects build a constructor call recursively. Recursive and no-JSON types return \`null\` (no safe example) and propagate up, so the enclosing test is skipped.
- \`FileRenderer.testPath(LayoutContext) → String?\` override hook, default mirrors \`modelPath\` under \`test/\`. Return \`null\` to skip a schema entirely, or redirect (Shorebird will use this to route generated tests to \`test/generated/\` so they sit alongside hand-written tests without colliding).
- \`GeneratorConfig.generateTests\` (default \`true\`) — wholesale disable.

## Test plan
- [x] \`dart test\` — 260 tests pass (+2 new file-renderer tests: round-trip test is emitted; \`generateTests: false\` suppresses emission)
- [x] \`dart analyze\` — clean (only pre-existing info-level doc-comment line-length lints)
- [x] \`dart format --set-exit-if-changed .\` — clean