### PR TITLE
fix(tests): import the package barrel in generated round-trip tests

### DIFF
--- a/lib/templates/schema_round_trip_test.mustache
+++ b/lib/templates/schema_round_trip_test.mustache
@@ -1,5 +1,5 @@
 // GENERATED — do not hand-edit.
-import 'package:{{{ packageName }}}/{{{ modelImportPath }}}';
+import 'package:{{{ packageName }}}/{{{ packageName }}}.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/test/render/file_renderer_test.dart
+++ b/test/render/file_renderer_test.dart
@@ -426,7 +426,7 @@ void main() {
       final testFile = out.childFile('test/models/widget_test.dart');
       expect(testFile.existsSync(), isTrue);
       final body = testFile.readAsStringSync();
-      expect(body, contains("import 'package:out/models/widget.dart';"));
+      expect(body, contains("import 'package:out/out.dart';"));
       expect(body, contains('Widget(id: 0, name: '));
       expect(body, contains('Widget.fromJson(instance.toJson())'));
     });

--- a/test/render/render_tree_test.dart
+++ b/test/render/render_tree_test.dart
@@ -756,7 +756,6 @@ void main() {
   group('exampleValue', () {
     final context = SchemaRenderer(
       templates: TemplateProvider.defaultLocation(),
-      quirks: const Quirks(),
     );
     const common = CommonProperties.test(
       snakeName: 'foo',
@@ -826,7 +825,6 @@ void main() {
         values: const ['a', 'b'],
         names: const ['a', 'b'],
         descriptions: null,
-        defaultValue: null,
       );
       final map = RenderMap(
         common: common,


### PR DESCRIPTION
## Summary
Generated round-trip tests reference nested types via \`exampleValue\` (e.g. \`GetAppsResponse\` constructs its \`apps\` field with \`<AppMetadata>[...]\`). The previous template imported only the specific model file, so any nested-type reference failed to resolve.

Switch to importing \`package:<packageName>/<packageName>.dart\` — the public barrel already re-exports every generated type.

## Test plan
- [x] \`dart test\` — 269 tests pass
- [x] Verified against Shorebird's regenerated protocol: all generated tests import the barrel and compile cleanly
- [x] \`dart analyze\` / \`dart format\` — clean (pre-existing info-level lints only)