### PR TITLE
feat(tests): round-trip via maybeFromJson + assert hashCode

### DIFF
--- a/lib/templates/schema_round_trip_test.mustache
+++ b/lib/templates/schema_round_trip_test.mustache
@@ -4,9 +4,15 @@ import 'package:test/test.dart';
 
 void main() {
   group('{{{ typeName }}}', () {
-    test('round-trips via fromJson/toJson', () {
+    test('round-trips via maybeFromJson/toJson', () {
       final instance = {{{ exampleValue }}};
-      expect({{{ typeName }}}.fromJson(instance.toJson()), instance);
+      final parsed = {{{ typeName }}}.maybeFromJson(instance.toJson())!;
+      expect(parsed, equals(instance));
+      expect(parsed.hashCode, equals(instance.hashCode));
+    });
+
+    test('maybeFromJson returns null on null input', () {
+      expect({{{ typeName }}}.maybeFromJson(null), isNull);
     });
   });
 }

--- a/test/render/file_renderer_test.dart
+++ b/test/render/file_renderer_test.dart
@@ -428,7 +428,9 @@ void main() {
       final body = testFile.readAsStringSync();
       expect(body, contains("import 'package:out/out.dart';"));
       expect(body, contains('Widget(id: 0, name: '));
-      expect(body, contains('Widget.fromJson(instance.toJson())'));
+      expect(body, contains('Widget.maybeFromJson(instance.toJson())'));
+      expect(body, contains('Widget.maybeFromJson(null)'));
+      expect(body, contains('parsed.hashCode'));
     });
 
     test('generateTests: false suppresses test emission', () async {


### PR DESCRIPTION
## Summary
Two small upgrades to the generated round-trip test:

- Call \`Type.maybeFromJson(instance.toJson())!\` instead of \`Type.fromJson(...)\`. Exercises the nullable-input branch and its delegation to \`fromJson\` in one shot.
- Assert \`parsed.hashCode == instance.hashCode\` alongside \`parsed == instance\` to catch any drift between the generated \`==\` and \`hashCode\` overrides.
- Add a second test case: \`Type.maybeFromJson(null)\` returns \`null\`.

## Test plan
- [x] \`dart test\` — 269 tests pass
- [x] \`dart analyze\` / \`dart format --set-exit-if-changed .\` — clean