### PR TITLE
feat: top-level named pod schemas render as extension-type newtypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## 1.0.2
 
+- Honor the "named → newtype" invariant for pod schemas, and wire up
+  more string formats. A top-level named schema whose body is a string
+  or boolean pod (`type: string, format: date-time | uri | uri-template
+  | email | uuid | date`, or `type: boolean`) now renders as an
+  extension-type newtype wrapping its Dart type — previously, named
+  `format: date-time` schemas silently inlined as raw `DateTime` at
+  every reference, losing the wrapper. Inline fields continue to use
+  the raw Dart type. `format: email` / `uuid` now map to a
+  `String`-backed pod; `format: date` maps to a `DateTime` with
+  `YYYY-MM-DD` JSON serialization via a new `maybeParseDate` helper;
+  `format: time` is accepted without warning and falls through to
+  `SchemaString` (no Dart type equivalent).
 - Fix generated `hashCode` to be consistent with `==` on list/map
   fields. Two instances with the same list/map contents now hash to
   the same value — matching the `listsEqual`/`mapsEqual`-based `==`

--- a/gen_tests/tests/test/types_test.dart
+++ b/gen_tests/tests/test/types_test.dart
@@ -3,25 +3,26 @@ import 'package:types/api.dart';
 
 void main() {
   group('Date', () {
-    test('DateType', () async {
-      final date = DateType('2021-01-01');
-      expect(date.toJson(), '2021-01-01');
+    test('DateType wraps DateTime and serializes to YYYY-MM-DD', () {
+      final date = DateType(DateTime(2021, 1, 15));
+      expect(date.toJson(), '2021-01-15');
       expect(DateType.maybeFromJson(null), isNull);
 
-      // TODO(eseidel): Date should validate the date string.
-      expect(DateType.fromJson('not a date'), isA<String>());
-      expect(DateType.fromJson('01-01-2021'), isA<String>());
+      // Round-trip through fromJson.
+      final parsed = DateType.fromJson('2021-01-15');
+      expect(parsed.value, DateTime.parse('2021-01-15'));
+      expect(parsed.toJson(), '2021-01-15');
     });
   });
   group('Email', () {
-    test('EmailType', () async {
+    test('EmailType wraps String and is a no-op on toJson', () {
       final email = EmailType('test@example.com');
       expect(email.toJson(), 'test@example.com');
       expect(EmailType.maybeFromJson(null), isNull);
 
       // TODO(eseidel): Email should validate the email string.
-      expect(EmailType.fromJson('not an email'), isA<String>());
-      expect(EmailType.fromJson('test@example'), isA<String>());
+      expect(EmailType.fromJson('not an email').value, isA<String>());
+      expect(EmailType.fromJson('test@example').value, isA<String>());
     });
   });
 }

--- a/gen_tests/types.json
+++ b/gen_tests/types.json
@@ -27,11 +27,23 @@
                                         "email": {
                                             "$ref": "#/components/schemas/EmailType"
                                         },
+                                        "uuid": {
+                                            "$ref": "#/components/schemas/UuidType"
+                                        },
+                                        "timestamp": {
+                                            "$ref": "#/components/schemas/Timestamp"
+                                        },
                                         "widget": {
                                             "$ref": "#/components/schemas/Widget"
                                         }
                                     },
-                                    "required": ["date", "email", "widget"]
+                                    "required": [
+                                        "date",
+                                        "email",
+                                        "uuid",
+                                        "timestamp",
+                                        "widget"
+                                    ]
                                 }
                             }
                         }
@@ -49,6 +61,14 @@
             "EmailType": {
                 "type": "string",
                 "format": "email"
+            },
+            "UuidType": {
+                "type": "string",
+                "format": "uuid"
+            },
+            "Timestamp": {
+                "type": "string",
+                "format": "date-time"
             },
             "Widget": {
                 "type": "object",

--- a/gen_tests/types/lib/api.dart
+++ b/gen_tests/types/lib/api.dart
@@ -3,5 +3,7 @@ export 'package:types/api_client.dart';
 export 'package:types/api_exception.dart';
 export 'package:types/model/date_type.dart';
 export 'package:types/model/email_type.dart';
+export 'package:types/model/timestamp.dart';
 export 'package:types/model/types200_response.dart';
+export 'package:types/model/uuid_type.dart';
 export 'package:types/model/widget.dart';

--- a/gen_tests/types/lib/model/date_type.dart
+++ b/gen_tests/types/lib/model/date_type.dart
@@ -1,7 +1,7 @@
-extension type const DateType._(String value) {
+extension type const DateType._(DateTime value) {
   const DateType(this.value);
 
-  factory DateType.fromJson(String json) => DateType(json);
+  factory DateType.fromJson(String json) => DateType(DateTime.parse(json));
 
   /// Convenience to create a nullable type from a nullable json object.
   /// Useful when parsing optional fields.
@@ -12,5 +12,5 @@ extension type const DateType._(String value) {
     return DateType.fromJson(json);
   }
 
-  String toJson() => value;
+  String toJson() => value.toIso8601String().substring(0, 10);
 }

--- a/gen_tests/types/lib/model/timestamp.dart
+++ b/gen_tests/types/lib/model/timestamp.dart
@@ -1,0 +1,16 @@
+extension type const Timestamp._(DateTime value) {
+  const Timestamp(this.value);
+
+  factory Timestamp.fromJson(String json) => Timestamp(DateTime.parse(json));
+
+  /// Convenience to create a nullable type from a nullable json object.
+  /// Useful when parsing optional fields.
+  static Timestamp? maybeFromJson(String? json) {
+    if (json == null) {
+      return null;
+    }
+    return Timestamp.fromJson(json);
+  }
+
+  String toJson() => value.toIso8601String();
+}

--- a/gen_tests/types/lib/model/types200_response.dart
+++ b/gen_tests/types/lib/model/types200_response.dart
@@ -1,5 +1,7 @@
 import 'package:types/model/date_type.dart';
 import 'package:types/model/email_type.dart';
+import 'package:types/model/timestamp.dart';
+import 'package:types/model/uuid_type.dart';
 import 'package:types/model/widget.dart';
 import 'package:types/model_helpers.dart';
 
@@ -7,6 +9,8 @@ class Types200Response {
   Types200Response({
     required this.date,
     required this.email,
+    required this.uuid,
+    required this.timestamp,
     required this.widget,
   });
 
@@ -19,6 +23,8 @@ class Types200Response {
       () => Types200Response(
         date: DateType.fromJson(json['date'] as String),
         email: EmailType.fromJson(json['email'] as String),
+        uuid: UuidType.fromJson(json['uuid'] as String),
+        timestamp: Timestamp.fromJson(json['timestamp'] as String),
         widget: Widget.fromJson(json['widget'] as Map<String, dynamic>),
       ),
     );
@@ -35,6 +41,8 @@ class Types200Response {
 
   DateType date;
   EmailType email;
+  UuidType uuid;
+  Timestamp timestamp;
 
   /// Smoke-test object to exercise list/map fields through the generated
   /// round-trip test — catches hashCode-vs-== drift on collections.
@@ -45,6 +53,8 @@ class Types200Response {
     return {
       'date': date.toJson(),
       'email': email.toJson(),
+      'uuid': uuid.toJson(),
+      'timestamp': timestamp.toJson(),
       'widget': widget.toJson(),
     };
   }
@@ -53,6 +63,8 @@ class Types200Response {
   int get hashCode => Object.hashAll([
     date,
     email,
+    uuid,
+    timestamp,
     widget,
   ]);
 
@@ -62,6 +74,8 @@ class Types200Response {
     return other is Types200Response &&
         date == other.date &&
         email == other.email &&
+        uuid == other.uuid &&
+        timestamp == other.timestamp &&
         widget == other.widget;
   }
 }

--- a/gen_tests/types/lib/model/uuid_type.dart
+++ b/gen_tests/types/lib/model/uuid_type.dart
@@ -1,0 +1,16 @@
+extension type const UuidType._(String value) {
+  const UuidType(this.value);
+
+  factory UuidType.fromJson(String json) => UuidType(json);
+
+  /// Convenience to create a nullable type from a nullable json object.
+  /// Useful when parsing optional fields.
+  static UuidType? maybeFromJson(String? json) {
+    if (json == null) {
+      return null;
+    }
+    return UuidType.fromJson(json);
+  }
+
+  String toJson() => value;
+}

--- a/gen_tests/types/lib/model_helpers.dart
+++ b/gen_tests/types/lib/model_helpers.dart
@@ -9,6 +9,15 @@ DateTime? maybeParseDateTime(String? value) {
   return DateTime.parse(value);
 }
 
+/// Parse a nullable RFC 3339 full-date string (`YYYY-MM-DD`) as a DateTime.
+/// Time and timezone components are zero.
+DateTime? maybeParseDate(String? value) {
+  if (value == null) {
+    return null;
+  }
+  return DateTime.parse(value);
+}
+
 /// Parse a nullable string as a Uri.
 Uri? maybeParseUri(String? value) {
   if (value == null) {

--- a/gen_tests/types/test/model/email_type_test.dart
+++ b/gen_tests/types/test/model/email_type_test.dart
@@ -5,7 +5,7 @@ import 'package:types/api.dart';
 void main() {
   group('EmailType', () {
     test('round-trips via maybeFromJson/toJson', () {
-      const instance = EmailType('example');
+      const instance = EmailType('user@example.com');
       final parsed = EmailType.maybeFromJson(instance.toJson())!;
       expect(parsed, equals(instance));
       expect(parsed.hashCode, equals(instance.hashCode));

--- a/gen_tests/types/test/model/timestamp_test.dart
+++ b/gen_tests/types/test/model/timestamp_test.dart
@@ -3,16 +3,16 @@ import 'package:test/test.dart';
 import 'package:types/api.dart';
 
 void main() {
-  group('DateType', () {
+  group('Timestamp', () {
     test('round-trips via maybeFromJson/toJson', () {
-      final instance = DateType(DateTime(2024));
-      final parsed = DateType.maybeFromJson(instance.toJson())!;
+      final instance = Timestamp(DateTime.utc(2024));
+      final parsed = Timestamp.maybeFromJson(instance.toJson())!;
       expect(parsed, equals(instance));
       expect(parsed.hashCode, equals(instance.hashCode));
     });
 
     test('maybeFromJson returns null on null input', () {
-      expect(DateType.maybeFromJson(null), isNull);
+      expect(Timestamp.maybeFromJson(null), isNull);
     });
   });
 }

--- a/gen_tests/types/test/model/types200_response_test.dart
+++ b/gen_tests/types/test/model/types200_response_test.dart
@@ -6,8 +6,10 @@ void main() {
   group('Types200Response', () {
     test('round-trips via maybeFromJson/toJson', () {
       final instance = Types200Response(
-        date: const DateType('example'),
-        email: const EmailType('example'),
+        date: DateType(DateTime(2024)),
+        email: const EmailType('user@example.com'),
+        uuid: const UuidType('00000000-0000-0000-0000-000000000000'),
+        timestamp: Timestamp(DateTime.utc(2024)),
         widget: Widget(
           id: 0,
           tags: <String>['example'],

--- a/gen_tests/types/test/model/uuid_type_test.dart
+++ b/gen_tests/types/test/model/uuid_type_test.dart
@@ -3,16 +3,16 @@ import 'package:test/test.dart';
 import 'package:types/api.dart';
 
 void main() {
-  group('DateType', () {
+  group('UuidType', () {
     test('round-trips via maybeFromJson/toJson', () {
-      final instance = DateType(DateTime(2024));
-      final parsed = DateType.maybeFromJson(instance.toJson())!;
+      const instance = UuidType('00000000-0000-0000-0000-000000000000');
+      final parsed = UuidType.maybeFromJson(instance.toJson())!;
       expect(parsed, equals(instance));
       expect(parsed.hashCode, equals(instance.hashCode));
     });
 
     test('maybeFromJson returns null on null input', () {
-      expect(DateType.maybeFromJson(null), isNull);
+      expect(UuidType.maybeFromJson(null), isNull);
     });
   });
 }

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -473,7 +473,16 @@ TypeAndFormat parseTypeAndFormat(MapContext json) {
       return null;
     }
     final expectedFormats = {
-      'string': {'binary', 'date-time', 'uri', 'uri-template', 'email', 'date'},
+      'string': {
+        'binary',
+        'date-time',
+        'uri',
+        'uri-template',
+        'email',
+        'uuid',
+        'date',
+        'time',
+      },
     };
     final expected = expectedFormats[type];
     if (expected == null || !expected.contains(format)) {
@@ -506,6 +515,19 @@ TypeAndFormat parseTypeAndFormat(MapContext json) {
       if (format == 'uri-template') {
         return PodType.uriTemplate;
       }
+      if (format == 'email') {
+        return PodType.email;
+      }
+      if (format == 'uuid') {
+        return PodType.uuid;
+      }
+      if (format == 'date') {
+        return PodType.date;
+      }
+      // 'time' (RFC 3339 partial-time, e.g. 14:30:00) has no clean Dart
+      // type — DateTime requires a date. Leave it as a plain string so
+      // top-level named schemas become String-backed extension-type
+      // newtypes.
     }
     return null;
   }

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -243,6 +243,7 @@ class Import extends Equatable {
 /// and by [SchemaUsage] to decide whether to import `model_helpers.dart`.
 abstract final class ModelHelpers {
   static const maybeParseDateTime = 'maybeParseDateTime';
+  static const maybeParseDate = 'maybeParseDate';
   static const maybeParseUri = 'maybeParseUri';
   static const maybeParseUriTemplate = 'maybeParseUriTemplate';
   static const listsEqual = 'listsEqual';
@@ -253,6 +254,7 @@ abstract final class ModelHelpers {
 
   static const List<String> all = [
     maybeParseDateTime,
+    maybeParseDate,
     maybeParseUri,
     maybeParseUriTemplate,
     listsEqual,
@@ -302,6 +304,7 @@ class SpecResolver {
         return RenderPod(
           common: schema.common,
           type: schema.type,
+          createsNewType: schema.createsNewType,
           defaultValue: schema.defaultValue,
         );
       case ResolvedString():
@@ -1279,13 +1282,21 @@ abstract class RenderSchema extends Equatable implements ToTemplateContext {
   String toString() => '$runtimeType(snakeName: $snakeName, pointer: $pointer)';
 }
 
-// Plain old data types (string, number, boolean)
+// Plain old data types (string, number, boolean) plus string formats that
+// map to specific Dart types (DateTime, Uri, UriTemplate) or are known
+// string subsets (email, uuid).
+//
+// When [createsNewType] is true this is a top-level named schema and
+// renders to its own file as an extension type wrapping [dartType]. When
+// false the schema is inline and uses [dartType] directly at the use
+// site.
 class RenderPod extends RenderSchema {
   const RenderPod({
     required super.common,
     required this.type,
+    required super.createsNewType,
     this.defaultValue,
-  }) : super(createsNewType: false);
+  });
 
   /// The type of the resolved schema.
   final PodType type;
@@ -1299,47 +1310,47 @@ class RenderPod extends RenderSchema {
       return true;
     }
     return switch (type) {
-      // Bool is already a json type.
-      PodType.boolean => false,
-      // These require serialization to a string.
+      // Already json-native: no conversion at the use site.
+      PodType.boolean || PodType.email || PodType.uuid => false,
+      // Need serialization to a string.
       PodType.dateTime ||
       PodType.uri ||
       PodType.uriTemplate ||
-      PodType.email ||
       PodType.date => true,
     };
   }
 
   @override
   bool get defaultCanConstConstruct {
+    // Newtype defaults wrap dartType in a constructor call; const-ness
+    // depends on whether the wrapped expression is const.
     return switch (type) {
       PodType.dateTime ||
       PodType.uri ||
       PodType.uriTemplate ||
-      PodType.email ||
       PodType.date => false,
-      PodType.boolean => true,
+      PodType.boolean || PodType.email || PodType.uuid => true,
     };
   }
 
   @override
   List<Object?> get props => [super.props, type, defaultValue];
 
+  /// The Dart type that represents this pod at the use site (when inline)
+  /// or that the newtype wraps (when a newtype).
+  String get dartType => switch (type) {
+    PodType.boolean => 'bool',
+    PodType.dateTime => 'DateTime',
+    PodType.uri => 'Uri',
+    PodType.uriTemplate => 'UriTemplate',
+    // email and uuid are String subsets.
+    PodType.email => 'String',
+    PodType.uuid => 'String',
+    PodType.date => 'DateTime',
+  };
+
   @override
-  String get typeName {
-    // TODO(eseidel): Make RenderPod extensible.
-    // Right now we have this hard-coded list, but we should make it possible
-    // to register generators for various format types, e.g.
-    // https://spec.openapis.org/registry/format/ has many we don't implement.
-    return switch (type) {
-      PodType.boolean => 'bool',
-      PodType.dateTime => 'DateTime',
-      PodType.uri => 'Uri',
-      PodType.uriTemplate => 'UriTemplate',
-      PodType.email => 'String', // Could create a new type for this.
-      PodType.date => 'DateTime',
-    };
-  }
+  String get typeName => createsNewType ? camelFromSnake(snakeName) : dartType;
 
   @override
   String jsonStorageType({required bool isNullable}) {
@@ -1348,6 +1359,7 @@ class RenderPod extends RenderSchema {
       PodType.uri ||
       PodType.uriTemplate ||
       PodType.email ||
+      PodType.uuid ||
       PodType.date => isNullable ? 'String?' : 'String',
       PodType.boolean => isNullable ? 'bool?' : 'bool',
     };
@@ -1359,15 +1371,16 @@ class RenderPod extends RenderSchema {
     if (defaultValue == null) {
       return null;
     }
-    return switch (type) {
+    final raw = switch (type) {
       PodType.dateTime ||
       PodType.date => 'DateTime.parse(${quoteString(defaultValue as String)})',
       PodType.uri => 'Uri.parse(${quoteString(defaultValue as String)})',
       PodType.uriTemplate =>
         'UriTemplate(${quoteString(defaultValue as String)})',
-      PodType.email => quoteString(defaultValue as String),
+      PodType.email || PodType.uuid => quoteString(defaultValue as String),
       PodType.boolean => defaultValue.toString(),
     };
+    return createsNewType ? '$typeName($raw)' : raw;
   }
 
   @override
@@ -1376,21 +1389,42 @@ class RenderPod extends RenderSchema {
     if (type == PodType.uriTemplate) const Import('package:uri/uri.dart'),
   ];
 
+  /// Converts `value` (of type [dartType]) to its JSON representation.
+  /// Used both at the inline use site and inside the newtype's toJson.
+  String _valueToJsonBody(String name, {required bool nameIsNullable}) {
+    final nameCall = nameIsNullable ? '$name?' : name;
+    return switch (type) {
+      PodType.dateTime => '$nameCall.toIso8601String()',
+      // Full-date: YYYY-MM-DD, the first 10 chars of ISO-8601.
+      PodType.date => '$nameCall.toIso8601String().substring(0, 10)',
+      PodType.uri => '$nameCall.toString()',
+      PodType.uriTemplate => '$nameCall.toString()',
+      // String- and bool-backed types: no conversion; `name` already
+      // has the correct nullable/non-nullable type.
+      PodType.email || PodType.uuid || PodType.boolean => name,
+    };
+  }
+
+  /// Converts `json` (of type jsonStorageType) to [dartType]. Used inside
+  /// the newtype's fromJson factory body and (non-nullable only) at the
+  /// inline use site.
+  String _jsonToValueBody(String jsonName) => switch (type) {
+    PodType.dateTime || PodType.date => 'DateTime.parse($jsonName)',
+    PodType.uri => 'Uri.parse($jsonName)',
+    PodType.uriTemplate => 'UriTemplate($jsonName)',
+    PodType.email || PodType.uuid || PodType.boolean => jsonName,
+  };
+
   @override
   String toJsonExpression(
     String dartName,
     SchemaRenderer context, {
     required bool dartIsNullable,
   }) {
-    final nameCall = dartIsNullable ? '$dartName?' : dartName;
-    return switch (type) {
-      PodType.dateTime => '$nameCall.toIso8601String()',
-      PodType.uri => '$nameCall.toString()',
-      PodType.uriTemplate => '$nameCall.toString()',
-      PodType.email => nameCall,
-      PodType.date => '$nameCall.toRfc3339FullDate()',
-      PodType.boolean => dartName,
-    };
+    if (createsNewType) {
+      return dartIsNullable ? '$dartName?.toJson()' : '$dartName.toJson()';
+    }
+    return _valueToJsonBody(dartName, nameIsNullable: dartIsNullable);
   }
 
   @override
@@ -1407,15 +1441,24 @@ class RenderPod extends RenderSchema {
       dartIsNullable: dartIsNullable,
     );
     final castedValue = '$jsonValue as $jsonType';
+
+    if (createsNewType) {
+      final jsonMethod = jsonIsNullable ? 'maybeFromJson' : 'fromJson';
+      return '$typeName.$jsonMethod($castedValue)$orDefault';
+    }
+
+    // Inline: convert json String -> Dart value at the use site. For
+    // nullable values we call a helper (so the expression remains a
+    // single nullable-aware expression), for non-nullable we inline.
     switch (type) {
-      case PodType.date:
-        if (jsonIsNullable) {
-          return 'maybeParseDate($castedValue)$orDefault';
-        }
-        return 'DateTime.parse($castedValue)';
       case PodType.dateTime:
         if (jsonIsNullable) {
           return '${ModelHelpers.maybeParseDateTime}($castedValue)$orDefault';
+        }
+        return 'DateTime.parse($castedValue)';
+      case PodType.date:
+        if (jsonIsNullable) {
+          return '${ModelHelpers.maybeParseDate}($castedValue)$orDefault';
         }
         return 'DateTime.parse($castedValue)';
       case PodType.uri:
@@ -1429,15 +1472,29 @@ class RenderPod extends RenderSchema {
           return '$call$orDefault';
         }
         return 'UriTemplate($castedValue)';
-      case PodType.boolean || PodType.email:
+      case PodType.boolean || PodType.email || PodType.uuid:
         // 'as' has higher precedence than '??' so no parens are needed.
         return '$castedValue$orDefault';
     }
   }
 
   @override
-  Map<String, dynamic> toTemplateContext(SchemaRenderer context) =>
-      throw UnimplementedError('RenderPod.toTemplateContext');
+  Map<String, dynamic> toTemplateContext(SchemaRenderer context) {
+    if (!createsNewType) {
+      throw StateError(
+        '$runtimeType.toTemplateContext called for non-new type: $this',
+      );
+    }
+    return {
+      'doc_comment': createDocComment(common: common),
+      'typeName': typeName,
+      'nullableTypeName': nullableTypeName(context),
+      'dartType': dartType,
+      'jsonType': jsonStorageType(isNullable: false),
+      'fromJsonBody': _jsonToValueBody('json'),
+      'toJsonBody': _valueToJsonBody('value', nameIsNullable: false),
+    };
+  }
 
   @override
   bool equalsIgnoringName(RenderSchema other) =>
@@ -1450,10 +1507,14 @@ class RenderPod extends RenderSchema {
     final raw = switch (type) {
       PodType.boolean => 'false',
       PodType.dateTime => 'DateTime.utc(2024, 1, 1)',
-      PodType.date => 'DateTime.utc(2024, 1, 1)',
+      // Local (not UTC) so `value.toIso8601String().substring(0, 10)`
+      // round-trips back through `DateTime.parse` (which returns a
+      // local DateTime).
+      PodType.date => 'DateTime(2024, 1, 1)',
       PodType.uri => "Uri.parse('https://example.com')",
       PodType.uriTemplate => "UriTemplate('https://example.com/{id}')",
       PodType.email => "'user@example.com'",
+      PodType.uuid => "'00000000-0000-0000-0000-000000000000'",
     };
     return createsNewType ? '$typeName($raw)' : raw;
   }

--- a/lib/src/render/schema_renderer.dart
+++ b/lib/src/render/schema_renderer.dart
@@ -88,6 +88,7 @@ class SchemaRenderer {
       RenderObject() => 'schema_object',
       RenderString() => 'schema_string_newtype',
       RenderInteger() || RenderNumber() => 'schema_number_newtype',
+      RenderPod() => 'schema_pod_newtype',
       RenderOneOf() => 'schema_one_of',
       RenderEmptyObject() => 'schema_empty_object',
       RenderSchema() => throw StateError('No code to render $schema'),

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -100,7 +100,7 @@ enum MimeType {
   final String value;
 }
 
-enum PodType { boolean, dateTime, uri, uriTemplate, email, date }
+enum PodType { boolean, dateTime, uri, uriTemplate, email, uuid, date }
 
 /// Properties that are common to all schemas and across
 /// parsing, resolution and rendering.  This just saves a lot of boilerplate.

--- a/lib/templates/model_helpers.mustache
+++ b/lib/templates/model_helpers.mustache
@@ -9,6 +9,15 @@ DateTime? maybeParseDateTime(String? value) {
   return DateTime.parse(value);
 }
 
+/// Parse a nullable RFC 3339 full-date string (`YYYY-MM-DD`) as a DateTime.
+/// Time and timezone components are zero.
+DateTime? maybeParseDate(String? value) {
+  if (value == null) {
+    return null;
+  }
+  return DateTime.parse(value);
+}
+
 /// Parse a nullable string as a Uri.
 Uri? maybeParseUri(String? value) {
   if (value == null) {

--- a/lib/templates/schema_pod_newtype.mustache
+++ b/lib/templates/schema_pod_newtype.mustache
@@ -1,0 +1,16 @@
+{{{ doc_comment }}}extension type const {{{ typeName }}}._({{{ dartType }}} value) {
+    const {{ typeName }}(this.value);
+
+    factory {{ typeName }}.fromJson({{{ jsonType }}} json) => {{ typeName }}({{{ fromJsonBody }}});
+
+    /// Convenience to create a nullable type from a nullable json object.
+    /// Useful when parsing optional fields.
+    static {{ nullableTypeName }} maybeFromJson({{{ jsonType }}}? json) {
+        if (json == null) {
+            return null;
+        }
+        return {{ typeName }}.fromJson(json);
+    }
+
+    {{{ jsonType }}} toJson() => {{{ toJsonBody }}};
+}

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -31,6 +31,13 @@ void main() {
       expect(parse('string', format: 'binary'), isNull);
       expect(parse('string', format: 'date-time'), PodType.dateTime);
       expect(parse('string', format: 'uri'), PodType.uri);
+      expect(parse('string', format: 'uri-template'), PodType.uriTemplate);
+      expect(parse('string', format: 'email'), PodType.email);
+      expect(parse('string', format: 'uuid'), PodType.uuid);
+      expect(parse('string', format: 'date'), PodType.date);
+      // 'time' is accepted (no warning) but has no Dart equivalent, so
+      // it falls through to SchemaString.
+      expect(parse('string', format: 'time'), isNull);
       expect(parse('string', format: 'foo', expectLogs: true), isNull);
       verify(() => logger.warn('Unknown string format: foo in #/')).called(1);
       expect(parse('number'), isNull);

--- a/test/render/render_tree_test.dart
+++ b/test/render/render_tree_test.dart
@@ -876,4 +876,212 @@ void main() {
       expect(map.exampleValue(context), "{Foo.values.first: 'example'}");
     });
   });
+
+  group('RenderPod newtype', () {
+    final context = SchemaRenderer(
+      templates: TemplateProvider.defaultLocation(),
+    );
+
+    RenderPod pod(PodType type, {bool createsNewType = false}) => RenderPod(
+      common: CommonProperties.test(
+        snakeName: 'foo_bar',
+        pointer: const JsonPointer.empty(),
+      ),
+      type: type,
+      createsNewType: createsNewType,
+    );
+
+    test('typeName is the class name when a newtype, else the Dart type', () {
+      expect(pod(PodType.dateTime).typeName, 'DateTime');
+      expect(pod(PodType.email).typeName, 'String');
+      expect(pod(PodType.uuid).typeName, 'String');
+      expect(pod(PodType.date).typeName, 'DateTime');
+      expect(pod(PodType.boolean).typeName, 'bool');
+      expect(pod(PodType.uri).typeName, 'Uri');
+      expect(pod(PodType.uriTemplate).typeName, 'UriTemplate');
+
+      expect(pod(PodType.dateTime, createsNewType: true).typeName, 'FooBar');
+      expect(pod(PodType.email, createsNewType: true).typeName, 'FooBar');
+      expect(pod(PodType.date, createsNewType: true).typeName, 'FooBar');
+    });
+
+    test('dartType is the underlying Dart type regardless of newtype', () {
+      expect(pod(PodType.dateTime).dartType, 'DateTime');
+      expect(pod(PodType.dateTime, createsNewType: true).dartType, 'DateTime');
+      expect(pod(PodType.email).dartType, 'String');
+      expect(pod(PodType.uuid).dartType, 'String');
+      expect(pod(PodType.date).dartType, 'DateTime');
+    });
+
+    test('toJsonExpression delegates to .toJson() when a newtype', () {
+      final schema = pod(PodType.dateTime, createsNewType: true);
+      expect(
+        schema.toJsonExpression('x', context, dartIsNullable: false),
+        'x.toJson()',
+      );
+      expect(
+        schema.toJsonExpression('x', context, dartIsNullable: true),
+        'x?.toJson()',
+      );
+    });
+
+    test('toJsonExpression is inline for pod types when not a newtype', () {
+      expect(
+        pod(PodType.dateTime).toJsonExpression(
+          'x',
+          context,
+          dartIsNullable: false,
+        ),
+        'x.toIso8601String()',
+      );
+      expect(
+        pod(PodType.date).toJsonExpression(
+          'x',
+          context,
+          dartIsNullable: true,
+        ),
+        'x?.toIso8601String().substring(0, 10)',
+      );
+      // email and uuid are Strings; no conversion, just pass dartName.
+      expect(
+        pod(PodType.email).toJsonExpression(
+          'x',
+          context,
+          dartIsNullable: true,
+        ),
+        'x',
+      );
+      expect(
+        pod(PodType.uuid).toJsonExpression(
+          'x',
+          context,
+          dartIsNullable: true,
+        ),
+        'x',
+      );
+    });
+
+    test('fromJsonExpression delegates to fromJson/maybeFromJson '
+        'when a newtype', () {
+      final schema = pod(PodType.date, createsNewType: true);
+      expect(
+        schema.fromJsonExpression(
+          "json['d']",
+          context,
+          jsonIsNullable: false,
+          dartIsNullable: false,
+        ),
+        "FooBar.fromJson(json['d'] as String)",
+      );
+      expect(
+        schema.fromJsonExpression(
+          "json['d']",
+          context,
+          jsonIsNullable: true,
+          dartIsNullable: true,
+        ),
+        "FooBar.maybeFromJson(json['d'] as String?)",
+      );
+    });
+
+    test('fromJsonExpression inline routes nullable date/uuid correctly', () {
+      expect(
+        pod(PodType.date).fromJsonExpression(
+          "json['d']",
+          context,
+          jsonIsNullable: true,
+          dartIsNullable: true,
+        ),
+        "maybeParseDate(json['d'] as String?)",
+      );
+      expect(
+        pod(PodType.date).fromJsonExpression(
+          "json['d']",
+          context,
+          jsonIsNullable: false,
+          dartIsNullable: false,
+        ),
+        "DateTime.parse(json['d'] as String)",
+      );
+      expect(
+        pod(PodType.uuid).fromJsonExpression(
+          "json['u']",
+          context,
+          jsonIsNullable: false,
+          dartIsNullable: false,
+        ),
+        "json['u'] as String",
+      );
+    });
+
+    test('toTemplateContext throws for non-newtype', () {
+      expect(
+        () => pod(PodType.email).toTemplateContext(context),
+        throwsStateError,
+      );
+    });
+
+    test('toTemplateContext exposes the fields the newtype template reads', () {
+      final ctx = pod(
+        PodType.date,
+        createsNewType: true,
+      ).toTemplateContext(context);
+      expect(ctx['typeName'], 'FooBar');
+      expect(ctx['dartType'], 'DateTime');
+      expect(ctx['jsonType'], 'String');
+      expect(ctx['fromJsonBody'], 'DateTime.parse(json)');
+      expect(ctx['toJsonBody'], 'value.toIso8601String().substring(0, 10)');
+
+      final emailCtx = pod(
+        PodType.email,
+        createsNewType: true,
+      ).toTemplateContext(context);
+      expect(emailCtx['dartType'], 'String');
+      expect(emailCtx['fromJsonBody'], 'json');
+      expect(emailCtx['toJsonBody'], 'value');
+    });
+
+    test(
+      'shouldCallToJson: inline pods need conversion iff non-json-native',
+      () {
+        expect(pod(PodType.dateTime).shouldCallToJson, isTrue);
+        expect(pod(PodType.date).shouldCallToJson, isTrue);
+        expect(pod(PodType.uri).shouldCallToJson, isTrue);
+        expect(pod(PodType.uriTemplate).shouldCallToJson, isTrue);
+        expect(pod(PodType.boolean).shouldCallToJson, isFalse);
+        expect(pod(PodType.email).shouldCallToJson, isFalse);
+        expect(pod(PodType.uuid).shouldCallToJson, isFalse);
+        // Newtypes always serialize through .toJson() regardless of the
+        // underlying Dart type.
+        expect(
+          pod(PodType.boolean, createsNewType: true).shouldCallToJson,
+          isTrue,
+        );
+      },
+    );
+
+    test('defaultValueString wraps in typeName constructor when a newtype', () {
+      const newtypeBool = RenderPod(
+        common: CommonProperties.test(
+          snakeName: 'flag',
+          pointer: JsonPointer.empty(),
+        ),
+        type: PodType.boolean,
+        createsNewType: true,
+        defaultValue: true,
+      );
+      expect(newtypeBool.defaultValueString(context), 'Flag(true)');
+
+      const inlineEmail = RenderPod(
+        common: CommonProperties.test(
+          snakeName: 'e',
+          pointer: JsonPointer.empty(),
+        ),
+        type: PodType.email,
+        createsNewType: false,
+        defaultValue: 'a@b.c',
+      );
+      expect(inlineEmail.defaultValueString(context), "'a@b.c'");
+    });
+  });
 }

--- a/test/render/render_tree_test.dart
+++ b/test/render/render_tree_test.dart
@@ -201,6 +201,7 @@ void main() {
               description: 'Foo',
             ),
             type: PodType.boolean,
+            createsNewType: false,
           ),
         },
       );
@@ -220,6 +221,7 @@ void main() {
             description: 'Foo',
           ),
           type: PodType.boolean,
+          createsNewType: false,
         ),
       );
       expect(a.equalsIgnoringName(e), isFalse);
@@ -249,6 +251,7 @@ void main() {
             description: 'Foo',
           ),
           type: PodType.dateTime,
+          createsNewType: false,
         ),
       );
       expect(e.equalsIgnoringName(g), isFalse);
@@ -267,6 +270,7 @@ void main() {
               description: 'Foo',
             ),
             type: PodType.boolean,
+            createsNewType: false,
           ),
         },
       );
@@ -381,6 +385,7 @@ void main() {
             description: 'Foo',
           ),
           type: PodType.boolean,
+          createsNewType: false,
         ),
       );
       expect(a.equalsIgnoringName(a), isTrue);
@@ -398,6 +403,7 @@ void main() {
             description: 'Foo',
           ),
           type: PodType.boolean,
+          createsNewType: false,
         ),
       );
       expect(a.equalsIgnoringName(b), isTrue);
@@ -415,6 +421,7 @@ void main() {
             description: 'Foo',
           ),
           type: PodType.dateTime,
+          createsNewType: false,
         ),
       );
       expect(a.equalsIgnoringName(c), isFalse);
@@ -473,6 +480,7 @@ void main() {
               description: 'Foo',
             ),
             type: PodType.boolean,
+            createsNewType: false,
           ),
         ],
       );
@@ -492,6 +500,7 @@ void main() {
               description: 'Foo',
             ),
             type: PodType.boolean,
+            createsNewType: false,
           ),
         ],
       );
@@ -511,6 +520,7 @@ void main() {
               description: 'Foo',
             ),
             type: PodType.boolean,
+            createsNewType: false,
           ),
           RenderPod(
             common: CommonProperties.test(
@@ -519,6 +529,7 @@ void main() {
               description: 'Foo',
             ),
             type: PodType.boolean,
+            createsNewType: false,
           ),
         ],
       );
@@ -533,6 +544,7 @@ void main() {
           description: 'v',
         ),
         type: PodType.boolean,
+        createsNewType: false,
       );
       final enumKey = RenderEnum(
         common: const CommonProperties.test(
@@ -622,6 +634,7 @@ void main() {
             description: 'Foo',
           ),
           type: PodType.uriTemplate,
+          createsNewType: false,
         ).additionalImports,
         equals([const Import('package:uri/uri.dart')]),
       );
@@ -762,13 +775,21 @@ void main() {
       pointer: JsonPointer.empty(),
     );
 
-    test('date format produces a DateTime literal', () {
-      const schema = RenderPod(common: common, type: PodType.date);
-      expect(schema.exampleValue(context), 'DateTime.utc(2024, 1, 1)');
+    test('date format produces a local DateTime literal', () {
+      const schema = RenderPod(
+        common: common,
+        type: PodType.date,
+        createsNewType: false,
+      );
+      expect(schema.exampleValue(context), 'DateTime(2024, 1, 1)');
     });
 
     test('uri format produces a Uri.parse literal', () {
-      const schema = RenderPod(common: common, type: PodType.uri);
+      const schema = RenderPod(
+        common: common,
+        type: PodType.uri,
+        createsNewType: false,
+      );
       expect(
         schema.exampleValue(context),
         "Uri.parse('https://example.com')",
@@ -776,7 +797,11 @@ void main() {
     });
 
     test('uriTemplate format produces a UriTemplate literal', () {
-      const schema = RenderPod(common: common, type: PodType.uriTemplate);
+      const schema = RenderPod(
+        common: common,
+        type: PodType.uriTemplate,
+        createsNewType: false,
+      );
       expect(
         schema.exampleValue(context),
         "UriTemplate('https://example.com/{id}')",
@@ -784,8 +809,24 @@ void main() {
     });
 
     test('email format produces an email string literal', () {
-      const schema = RenderPod(common: common, type: PodType.email);
+      const schema = RenderPod(
+        common: common,
+        type: PodType.email,
+        createsNewType: false,
+      );
       expect(schema.exampleValue(context), "'user@example.com'");
+    });
+
+    test('uuid format produces a uuid string literal', () {
+      const schema = RenderPod(
+        common: common,
+        type: PodType.uuid,
+        createsNewType: false,
+      );
+      expect(
+        schema.exampleValue(context),
+        "'00000000-0000-0000-0000-000000000000'",
+      );
     });
 
     test('unknown returns an empty dynamic map literal', () {


### PR DESCRIPTION
## Summary

- Enforce the "named → newtype" invariant for pod schemas. A top-level named `{ type: string, format: date-time }` (or `boolean`, `uri`, `uri-template`, `email`, `uuid`, `date`) now generates as an `extension type` wrapping its Dart type, same as named `SchemaString`/`SchemaInteger`. Previously, `RenderPod` hardcoded `createsNewType: false`, so these silently inlined as raw `DateTime` (etc.) everywhere, losing the name.
- Finish wiring the string formats that PR #58 started: `format: email` / `uuid` / `date` now map to dedicated `PodType`s (String-backed for email/uuid; `DateTime` + `YYYY-MM-DD` serialization for date). Accept `format: time` without warning and leave it as plain String.
- Fix latent bugs in the previously-dead `PodType.email`/`PodType.date` render paths: nullable `email` toJson produced invalid Dart (`$name?` alone); date referenced a non-existent `.toRfc3339FullDate()`; `maybeParseDate` was called but never defined. All cleaned up and a real `maybeParseDate` helper landed in `model_helpers.dart`.

## Test plan

- [x] `dart test` — 270 passed
- [x] `dart analyze` — no new issues (the two pre-existing info-level doc-comment line-length warnings are unchanged)
- [x] `dart format --set-exit-if-changed .` — clean
- [x] `dart run tool/gen_tests.dart` — regenerates the `types` fixture cleanly; hand-written `types_test.dart` and auto-generated round-trip tests all green
- [x] `gen_tests/types` now exercises `Timestamp` (`format: date-time`), `DateType` (`format: date`), `EmailType` (`format: email`), and `UuidType` (`format: uuid`) as named top-level schemas — each generates as a distinct extension-type newtype and round-trips through the auto-generated tests
- [ ] CI green