### PR TITLE
fix: escape reserved words in generated API method parameter names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## 1.0.2
 
+- Escape reserved words in generated API method parameter names. A
+  spec with a parameter literally named `with`/`try`/`case`/... now
+  emits `required String with_` (matching `dartParameterName`) instead
+  of the uncompilable `required String with`. `RenderParameter`'s
+  template context was using raw `lowercaseCamelFromSnake(name)` while
+  every other call site went through `variableSafeName`, producing a
+  name mismatch and invalid Dart.
 - Honor the "named → newtype" invariant for pod schemas, and wire up
   more string formats. A top-level named schema whose body is a string
   or boolean pod (`type: string, format: date-time | uri | uri-template

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -2759,7 +2759,10 @@ class RenderParameter implements CanBeParameter {
   Map<String, dynamic> toTemplateContext(SchemaRenderer context) {
     final isNullable = !isRequired;
     final specName = name;
-    final dartName = lowercaseCamelFromSnake(name);
+    // Must match dartParameterName (used elsewhere for the same parameter,
+    // e.g. validation calls) — and importantly, avoid reserved words so a
+    // spec with a parameter like `with`/`try`/`case` compiles.
+    final dartName = dartParameterName(context.quirks);
     final jsonName = name;
     return {
       'parameter_description': createDocCommentFromParts(

--- a/test/render/render_tree_test.dart
+++ b/test/render/render_tree_test.dart
@@ -80,6 +80,34 @@ void main() {
       );
       expect(parameter.dartParameterName(quirks), 'aB');
     });
+
+    test('reserved-word parameter name is escaped in template context', () {
+      // A spec with a parameter literally named `with` (or `try`/`case`/
+      // ...) previously emitted `required String with` in the generated
+      // signature — uncompilable. `dartName` in the template context must
+      // match what `dartParameterName` returns so reserved words are
+      // escaped consistently across call sites.
+      final context = SchemaRenderer(
+        templates: TemplateProvider.defaultLocation(),
+      );
+      const common = CommonProperties.test(
+        snakeName: 'with',
+        pointer: JsonPointer.empty(),
+      );
+      const parameter = RenderParameter(
+        description: 'Foo',
+        name: 'with',
+        type: RenderUnknown(common: common),
+        isRequired: true,
+        isDeprecated: false,
+        inLocation: ParameterLocation.query,
+      );
+      final ctx = parameter.toTemplateContext(context);
+      expect(ctx['dartName'], 'with_');
+      // The spec (`name`) and JSON key keep the original reserved word.
+      expect(ctx['name'], 'with');
+      expect(ctx['bracketedName'], '{with}');
+    });
   });
 
   group('createDocComment', () {
@@ -883,9 +911,9 @@ void main() {
     );
 
     RenderPod pod(PodType type, {bool createsNewType = false}) => RenderPod(
-      common: CommonProperties.test(
+      common: const CommonProperties.test(
         snakeName: 'foo_bar',
-        pointer: const JsonPointer.empty(),
+        pointer: JsonPointer.empty(),
       ),
       type: type,
       createsNewType: createsNewType,


### PR DESCRIPTION
## Summary

- A spec with an API parameter literally named `with`/`try`/`case`/... was emitting `required String with` (and similar) in the generated method signature — uncompilable Dart. `RenderParameter.toTemplateContext` was computing `dartName` as `lowercaseCamelFromSnake(name)` directly, bypassing the `avoidReservedWord` escape that `dartParameterName` (used everywhere else for the same parameter) applies. On top of producing invalid Dart, the two call sites for the same parameter disagreed on the identifier — declaration vs. `validationStatements`.
- Route the template-context `dartName` through `dartParameterName` so all references agree and reserved words are escaped (`with` → `with_`).

This is the last remaining item from #52.

## Test plan

- [x] `dart test` — 281 passed (new test: reserved-word parameter name emits `with_` in template context, keeps `with` as the JSON key / path placeholder)
- [x] `dart analyze` — no new issues (two pre-existing info-level doc-comment line-length warnings unchanged)
- [x] `dart format --set-exit-if-changed .` — clean
- [x] `dart run tool/gen_tests.dart` — regenerates cleanly
- [ ] CI green