### PR TITLE
fix: export Api and RenderSpec so FileRenderer hooks are usable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
   to no-op, while still regenerating models/messages/tests from the
   spec. Previously these were private `_render*` methods, so the only
   way to opt out was to overwrite the files after each regeneration.
+- Export `Api` and `RenderSpec` from `package:space_gen/space_gen.dart`
+  so subclasses of `FileRenderer` can actually spell the parameter
+  types of the new override hooks (`renderApis`, `renderClient`,
+  `renderPublicApi`, `renderApiClient`). Shipped with the hooks in
+  `1.0.2` but initially forgotten, breaking every attempt to override.
 - Escape reserved words in generated API method parameter names. A
   spec with a parameter literally named `with`/`try`/`case`/... now
   emits `required String with_` (matching `dartParameterName`) instead

--- a/lib/space_gen.dart
+++ b/lib/space_gen.dart
@@ -12,4 +12,4 @@ export 'src/render.dart'
 // of the exported surface.
 export 'src/render/file_renderer.dart'
     show FileRenderer, FileRendererConfig, LayoutContext;
-export 'src/render/render_tree.dart' show RenderSchema;
+export 'src/render/render_tree.dart' show Api, RenderSchema, RenderSpec;


### PR DESCRIPTION
## Summary
- Add `Api` and `RenderSpec` to the `package:space_gen/space_gen.dart` public exports so subclasses of `FileRenderer` can spell the parameter types of the override hooks added in #90.

Without this fix, every attempt to override `renderApis` / `renderClient` / `renderPublicApi` / `renderApiClient` fails at compile time with \`Type 'Api' not found.\`. Caught while wiring the hooks into \`shorebird_code_push_protocol\`'s \`tool/gen.dart\`.

## Test plan
- [x] \`dart analyze\`
- [x] \`dart test\`