### PR TITLE
feat: assert FormatException contract in generated round-trip tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## 1.0.2
 
+- Generated round-trip tests now assert the `fromJson` rejection
+  contract where applicable. A new `RenderSchema.invalidJsonExample`
+  hook returns a guaranteed-invalid JSON payload — implemented for
+  enums (unknown string), objects with required properties (empty
+  map, which fails the type cast inside `parseFromJson`), and
+  `date`/`date-time` pods (unparseable string). When non-null, the
+  `schema_round_trip_test` template emits an extra
+  `throwsFormatException` test. No-op pods (string / email / uuid /
+  boolean / uri / uri-template) and objects with no required fields
+  get no negative test because any input is valid for them.
 - Resolve external `$ref`s at generation time. A spec that refs
   schemas/responses/parameters/request-bodies/headers in another file
   (`$ref: 'shared.yaml#/components/schemas/Foo'`) now loads that file

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -11,6 +11,7 @@ words:
   - cooldown
   - petstore
   - parseable
+  - unparseable
   - renderable
   - Seidel
   - mocktail

--- a/gen_tests/types.json
+++ b/gen_tests/types.json
@@ -35,6 +35,9 @@
                                         },
                                         "widget": {
                                             "$ref": "#/components/schemas/Widget"
+                                        },
+                                        "status": {
+                                            "$ref": "#/components/schemas/Status"
                                         }
                                     },
                                     "required": [
@@ -42,7 +45,8 @@
                                         "email",
                                         "uuid",
                                         "timestamp",
-                                        "widget"
+                                        "widget",
+                                        "status"
                                     ]
                                 }
                             }
@@ -69,6 +73,10 @@
             "Timestamp": {
                 "type": "string",
                 "format": "date-time"
+            },
+            "Status": {
+                "type": "string",
+                "enum": ["active", "inactive", "pending"]
             },
             "Widget": {
                 "type": "object",

--- a/gen_tests/types/lib/api.dart
+++ b/gen_tests/types/lib/api.dart
@@ -3,6 +3,7 @@ export 'package:types/api_client.dart';
 export 'package:types/api_exception.dart';
 export 'package:types/model/date_type.dart';
 export 'package:types/model/email_type.dart';
+export 'package:types/model/status.dart';
 export 'package:types/model/timestamp.dart';
 export 'package:types/model/types200_response.dart';
 export 'package:types/model/uuid_type.dart';

--- a/gen_tests/types/lib/model/status.dart
+++ b/gen_tests/types/lib/model/status.dart
@@ -1,0 +1,35 @@
+enum Status {
+  active._('active'),
+  inactive._('inactive'),
+  pending._('pending');
+
+  const Status._(this.value);
+
+  /// Creates a Status from a json string.
+  factory Status.fromJson(String json) {
+    return Status.values.firstWhere(
+      (value) => value.value == json,
+      orElse: () => throw FormatException('Unknown Status value: $json'),
+    );
+  }
+
+  /// Convenience to create a nullable type from a nullable json object.
+  /// Useful when parsing optional fields.
+  static Status? maybeFromJson(String? json) {
+    if (json == null) {
+      return null;
+    }
+    return Status.fromJson(json);
+  }
+
+  /// The value of the enum, as a string.  This is the exact value
+  /// from the OpenAPI spec and will be used for network transport.
+  final String value;
+
+  /// Converts the enum to a json string.
+  String toJson() => value;
+
+  /// Returns the string value of the enum.
+  @override
+  String toString() => value;
+}

--- a/gen_tests/types/lib/model/types200_response.dart
+++ b/gen_tests/types/lib/model/types200_response.dart
@@ -1,5 +1,6 @@
 import 'package:types/model/date_type.dart';
 import 'package:types/model/email_type.dart';
+import 'package:types/model/status.dart';
 import 'package:types/model/timestamp.dart';
 import 'package:types/model/uuid_type.dart';
 import 'package:types/model/widget.dart';
@@ -12,6 +13,7 @@ class Types200Response {
     required this.uuid,
     required this.timestamp,
     required this.widget,
+    required this.status,
   });
 
   /// Converts a `Map<String, dynamic>` to a [Types200Response].
@@ -26,6 +28,7 @@ class Types200Response {
         uuid: UuidType.fromJson(json['uuid'] as String),
         timestamp: Timestamp.fromJson(json['timestamp'] as String),
         widget: Widget.fromJson(json['widget'] as Map<String, dynamic>),
+        status: Status.fromJson(json['status'] as String),
       ),
     );
   }
@@ -47,6 +50,7 @@ class Types200Response {
   /// Smoke-test object to exercise list/map fields through the generated
   /// round-trip test — catches hashCode-vs-== drift on collections.
   Widget widget;
+  Status status;
 
   /// Converts a [Types200Response] to a `Map<String, dynamic>`.
   Map<String, dynamic> toJson() {
@@ -56,6 +60,7 @@ class Types200Response {
       'uuid': uuid.toJson(),
       'timestamp': timestamp.toJson(),
       'widget': widget.toJson(),
+      'status': status.toJson(),
     };
   }
 
@@ -66,6 +71,7 @@ class Types200Response {
     uuid,
     timestamp,
     widget,
+    status,
   ]);
 
   @override
@@ -76,6 +82,7 @@ class Types200Response {
         email == other.email &&
         uuid == other.uuid &&
         timestamp == other.timestamp &&
-        widget == other.widget;
+        widget == other.widget &&
+        status == other.status;
   }
 }

--- a/gen_tests/types/test/model/date_type_test.dart
+++ b/gen_tests/types/test/model/date_type_test.dart
@@ -14,5 +14,12 @@ void main() {
     test('maybeFromJson returns null on null input', () {
       expect(DateType.maybeFromJson(null), isNull);
     });
+
+    test('maybeFromJson throws FormatException on invalid input', () {
+      expect(
+        () => DateType.maybeFromJson('not a date'),
+        throwsFormatException,
+      );
+    });
   });
 }

--- a/gen_tests/types/test/model/status_test.dart
+++ b/gen_tests/types/test/model/status_test.dart
@@ -3,25 +3,21 @@ import 'package:test/test.dart';
 import 'package:types/api.dart';
 
 void main() {
-  group('Widget', () {
+  group('Status', () {
     test('round-trips via maybeFromJson/toJson', () {
-      final instance = Widget(
-        id: 0,
-        tags: <String>['example'],
-        attributes: {'key': 'example'},
-      );
-      final parsed = Widget.maybeFromJson(instance.toJson())!;
+      final instance = Status.values.first;
+      final parsed = Status.maybeFromJson(instance.toJson())!;
       expect(parsed, equals(instance));
       expect(parsed.hashCode, equals(instance.hashCode));
     });
 
     test('maybeFromJson returns null on null input', () {
-      expect(Widget.maybeFromJson(null), isNull);
+      expect(Status.maybeFromJson(null), isNull);
     });
 
     test('maybeFromJson throws FormatException on invalid input', () {
       expect(
-        () => Widget.maybeFromJson(<String, dynamic>{}),
+        () => Status.maybeFromJson('__invalid_enum_value__'),
         throwsFormatException,
       );
     });

--- a/gen_tests/types/test/model/timestamp_test.dart
+++ b/gen_tests/types/test/model/timestamp_test.dart
@@ -14,5 +14,12 @@ void main() {
     test('maybeFromJson returns null on null input', () {
       expect(Timestamp.maybeFromJson(null), isNull);
     });
+
+    test('maybeFromJson throws FormatException on invalid input', () {
+      expect(
+        () => Timestamp.maybeFromJson('not a date'),
+        throwsFormatException,
+      );
+    });
   });
 }

--- a/gen_tests/types/test/model/types200_response_test.dart
+++ b/gen_tests/types/test/model/types200_response_test.dart
@@ -15,6 +15,7 @@ void main() {
           tags: <String>['example'],
           attributes: {'key': 'example'},
         ),
+        status: Status.values.first,
       );
       final parsed = Types200Response.maybeFromJson(instance.toJson())!;
       expect(parsed, equals(instance));
@@ -23,6 +24,13 @@ void main() {
 
     test('maybeFromJson returns null on null input', () {
       expect(Types200Response.maybeFromJson(null), isNull);
+    });
+
+    test('maybeFromJson throws FormatException on invalid input', () {
+      expect(
+        () => Types200Response.maybeFromJson(<String, dynamic>{}),
+        throwsFormatException,
+      );
     });
   });
 }

--- a/lib/src/render/file_renderer.dart
+++ b/lib/src/render/file_renderer.dart
@@ -655,6 +655,7 @@ class FileRenderer {
       if (outPath == null) continue;
       final example = schema.exampleValue(schemaContext);
       if (example == null) continue;
+      final invalidJson = schema.invalidJsonExample(schemaContext);
       _renderTemplate(
         template: 'schema_round_trip_test',
         outPath: outPath,
@@ -663,6 +664,7 @@ class FileRenderer {
           'barrelImportPath': testBarrelImport(),
           'typeName': schema.typeName,
           'exampleValue': example,
+          'invalidJsonExample': invalidJson,
         },
       );
     }

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -1241,6 +1241,15 @@ abstract class RenderSchema extends Equatable implements ToTemplateContext {
   /// test for the enclosing type.
   String? exampleValue(SchemaRenderer context);
 
+  /// A Dart expression of type [jsonStorageType] that is guaranteed to
+  /// fail this schema's `fromJson`/`maybeFromJson` with a
+  /// `FormatException`. Used by generated tests to lock in the parse
+  /// contract at the type boundary. Returns `null` when no such input
+  /// exists (e.g. a string newtype that accepts any string) or when
+  /// the rejection path isn't through `FormatException` — callers skip
+  /// emitting the negative test for those.
+  String? invalidJsonExample(SchemaRenderer context) => null;
+
   /// The default value of this schema as a string.
   String? defaultValueString(SchemaRenderer context) {
     if (defaultValue == null) {
@@ -1518,6 +1527,16 @@ class RenderPod extends RenderSchema {
     };
     return createsNewType ? '$typeName($raw)' : raw;
   }
+
+  /// Only date/dateTime pods parse through `DateTime.parse`, which
+  /// rejects garbage with FormatException. Uri.parse is famously
+  /// lenient; UriTemplate accepts most strings; string/bool/email/uuid
+  /// pods don't validate at all — so no guaranteed-invalid input.
+  @override
+  String? invalidJsonExample(SchemaRenderer context) => switch (type) {
+    PodType.dateTime || PodType.date => "'not a date'",
+    _ => null,
+  };
 }
 
 abstract class RenderNewType extends RenderSchema {
@@ -2217,6 +2236,14 @@ class RenderObject extends RenderNewType {
     }
     return '$typeName(${args.join(', ')})';
   }
+
+  /// Empty map: any required property will fail its type cast inside
+  /// `parseFromJson`, which rewraps the TypeError as FormatException.
+  /// When there are no required properties, `{}` is a valid instance
+  /// and we have no guaranteed-invalid input.
+  @override
+  String? invalidJsonExample(SchemaRenderer context) =>
+      requiredProperties.isEmpty ? null : '<String, dynamic>{}';
 }
 
 class RenderArray extends RenderSchema {
@@ -2646,6 +2673,10 @@ class RenderEnum extends RenderNewType {
 
   @override
   String? exampleValue(SchemaRenderer context) => '$typeName.values.first';
+
+  @override
+  String? invalidJsonExample(SchemaRenderer context) =>
+      "'__invalid_enum_value__'";
 }
 
 class RenderOneOf extends RenderNewType {

--- a/lib/templates/schema_round_trip_test.mustache
+++ b/lib/templates/schema_round_trip_test.mustache
@@ -14,5 +14,14 @@ void main() {
     test('maybeFromJson returns null on null input', () {
       expect({{{ typeName }}}.maybeFromJson(null), isNull);
     });
+{{#invalidJsonExample}}
+
+    test('maybeFromJson throws FormatException on invalid input', () {
+      expect(
+        () => {{{ typeName }}}.maybeFromJson({{{ invalidJsonExample }}}),
+        throwsFormatException,
+      );
+    });
+{{/invalidJsonExample}}
   });
 }


### PR DESCRIPTION
## Summary

- Adds `RenderSchema.invalidJsonExample(SchemaRenderer)` parallel to `exampleValue`. Non-null implementations: `RenderEnum` (unknown string), `RenderObject` with required properties (empty map — `parseFromJson` wraps the cast `TypeError` as `FormatException`), and `RenderPod` for `date` / `date-time` (unparseable string hits `DateTime.parse`).
- When the hook returns non-null, the generated round-trip test picks up an extra `throwsFormatException` check. No-op pods (`string` / `email` / `uuid` / `boolean` / `uri` / `uri-template`) and objects with no required fields get no negative test because any input is valid for them.
- Adds a `Status` enum to `gen_tests/types.json` so the new enum path is exercised end-to-end by the CI run that executes `dart test` inside `gen_tests/types`.

`toString` is intentionally not tested uniformly — only `RenderEnum` overrides it; everyone else inherits `Object.toString`, which isn't ours to assert.

## Test plan

- [x] `dart test` — all 281 unit tests pass.
- [x] `dart run tool/gen_tests.dart` regenerates `gen_tests/types/` cleanly.
- [x] `cd gen_tests/types && dart test` — 19/19 generated tests pass, including 4 new `throwsFormatException` tests (DateType, Timestamp, Widget, Types200Response, Status).
- [x] EmailType / UuidType correctly emit no invalid-input test.
- [x] `dart analyze` — no new issues (only pre-existing long-line infos in unrelated doc comments).