### PR TITLE
feat: prune unused helpers from generated model_helpers.dart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## 1.0.2
 
+- Prune unused helpers from the generated `lib/model_helpers.dart`.
+  Previously every generated package shipped all nine runtime helpers
+  (`maybeParseDateTime`, `maybeParseDate`, `maybeParseUri`,
+  `maybeParseUriTemplate`, `parseFromJson`, `listsEqual`, `mapsEqual`,
+  `listHash`, `mapHash`) plus the `package:collection` / `package:uri`
+  imports, even when no generated code referenced them. The file
+  renderer now aggregates `SchemaUsage`/`ApiUsage` across every
+  rendered file and emits only the helpers actually called — and
+  skips writing `model_helpers.dart` entirely when the spec uses
+  none. Consumers running coverage on generated code see fewer
+  uncovered lines.
 - Generated round-trip tests now assert the `fromJson` rejection
   contract where applicable. A new `RenderSchema.invalidJsonExample`
   hook returns a guaranteed-invalid JSON payload — implemented for

--- a/gen_tests/types/lib/model_helpers.dart
+++ b/gen_tests/types/lib/model_helpers.dart
@@ -1,38 +1,4 @@
 import 'package:collection/collection.dart';
-import 'package:uri/uri.dart';
-
-/// Parse a nullable string as a DateTime.
-DateTime? maybeParseDateTime(String? value) {
-  if (value == null) {
-    return null;
-  }
-  return DateTime.parse(value);
-}
-
-/// Parse a nullable RFC 3339 full-date string (`YYYY-MM-DD`) as a DateTime.
-/// Time and timezone components are zero.
-DateTime? maybeParseDate(String? value) {
-  if (value == null) {
-    return null;
-  }
-  return DateTime.parse(value);
-}
-
-/// Parse a nullable string as a Uri.
-Uri? maybeParseUri(String? value) {
-  if (value == null) {
-    return null;
-  }
-  return Uri.parse(value);
-}
-
-/// Parse a nullable string as a UriTemplate.
-UriTemplate? maybeParseUriTemplate(String? value) {
-  if (value == null) {
-    return null;
-  }
-  return UriTemplate(value);
-}
 
 /// Runs [build] to construct a `fromJson`-parsed value of type [T],
 /// converting any `TypeError` (e.g. an unexpected null or a cast

--- a/lib/src/render/file_renderer.dart
+++ b/lib/src/render/file_renderer.dart
@@ -477,13 +477,40 @@ class FileRenderer {
     );
   }
 
-  /// Emit `lib/model_helpers.dart` (the shared runtime helpers used by
-  /// generated `fromJson`/`toJson`/`hashCode`). Most consumers want this.
+  /// The aggregate set of `model_helpers.dart` identifiers referenced by
+  /// every generated file emitted so far. Populated as a side effect of
+  /// [renderModels] and [renderApis]; consumed by [renderModelHelpers]
+  /// to prune helpers that nothing imports.
+  ///
+  /// A subclass that replaces those emit hooks without calling `super`
+  /// and that still writes files referencing model helpers is
+  /// responsible for adding those names here. The default flow does
+  /// this automatically.
+  @protected
+  final Set<String> usedModelHelpers = {};
+
+  /// Emit `lib/model_helpers.dart` containing only the helpers that any
+  /// other generated file actually references (per [usedModelHelpers]).
+  /// Called after [renderModels] and [renderApis] so the aggregate is
+  /// complete.
   @protected
   void renderModelHelpers() {
+    if (usedModelHelpers.isEmpty) return;
     _renderTemplate(
       template: 'model_helpers',
       outPath: 'lib/model_helpers.dart',
+      context: {
+        for (final h in ModelHelpers.all) h: usedModelHelpers.contains(h),
+        'needsCollectionImport': const {
+          ModelHelpers.listsEqual,
+          ModelHelpers.mapsEqual,
+          ModelHelpers.listHash,
+          ModelHelpers.mapHash,
+        }.any(usedModelHelpers.contains),
+        'needsUriPackageImport': usedModelHelpers.contains(
+          ModelHelpers.maybeParseUriTemplate,
+        ),
+      },
     );
   }
 
@@ -563,6 +590,7 @@ class FileRenderer {
     final rendered = <Api>[];
     for (final api in apis) {
       final renderedApi = schemaRenderer.renderApi(api);
+      usedModelHelpers.addAll(renderedApi.usage.modelHelpers);
       final imports = importsForApi(api, renderedApi.usage);
       final importsContext = imports
           .sortedBy((i) => i.path)
@@ -627,6 +655,7 @@ class FileRenderer {
   void renderModels(Iterable<RenderSchema> schemas) {
     for (final schema in schemas) {
       final rendered = schemaRenderer.renderSchema(schema);
+      usedModelHelpers.addAll(rendered.usage.modelHelpers);
       final imports = importsForModel(schema, rendered.usage);
       final importsContext = imports
           .sortedBy((i) => i.path)

--- a/lib/src/render/schema_renderer.dart
+++ b/lib/src/render/schema_renderer.dart
@@ -3,7 +3,8 @@ import 'package:space_gen/src/render/render_tree.dart';
 import 'package:space_gen/src/render/templates.dart';
 
 /// Which imports a rendered schema body needs beyond the schemas it
-/// references.
+/// references, plus which `model_helpers.dart` helpers the body calls
+/// (used to prune unused helpers from the shared file).
 ///
 /// Today we derive this from the rendered body via substring checks. The
 /// long-term plan is for the rendering pipeline in render_tree.dart to
@@ -12,19 +13,27 @@ import 'package:space_gen/src/render/templates.dart';
 class SchemaUsage {
   const SchemaUsage({
     this.usesMetaAnnotations = false,
-    this.usesModelHelpers = false,
+    this.modelHelpers = const {},
   });
 
   /// Derives usage by inspecting a rendered body.
   factory SchemaUsage.fromBody(String body) {
     return SchemaUsage(
       usesMetaAnnotations: body.contains('@immutable'),
-      usesModelHelpers: ModelHelpers.all.any(body.contains),
+      modelHelpers: {
+        for (final h in ModelHelpers.all)
+          if (body.contains(h)) h,
+      },
     );
   }
 
   final bool usesMetaAnnotations;
-  final bool usesModelHelpers;
+
+  /// The set of `model_helpers.dart` identifiers referenced by the
+  /// rendered body. A subset of [ModelHelpers.all].
+  final Set<String> modelHelpers;
+
+  bool get usesModelHelpers => modelHelpers.isNotEmpty;
 
   /// Imports required by the body itself. Package-local imports are
   /// resolved against [packageName].
@@ -37,16 +46,28 @@ class SchemaUsage {
 }
 
 /// Which imports a rendered api body needs beyond the schemas it
-/// references.
+/// references, plus which `model_helpers.dart` helpers the body calls.
 class ApiUsage {
-  const ApiUsage();
+  const ApiUsage({this.modelHelpers = const {}});
 
-  // No conditional fields yet; body kept to match the SchemaUsage shape
-  // so a future refactor can populate them without changing callers.
-  // ignore: avoid_unused_constructor_parameters
-  factory ApiUsage.fromBody(String body) => const ApiUsage();
+  factory ApiUsage.fromBody(String body) => ApiUsage(
+    modelHelpers: {
+      for (final h in ModelHelpers.all)
+        if (body.contains(h)) h,
+    },
+  );
 
-  Iterable<Import> importsFor(String packageName) => const [];
+  /// The set of `model_helpers.dart` identifiers referenced by the
+  /// rendered body. A subset of [ModelHelpers.all].
+  final Set<String> modelHelpers;
+
+  bool get usesModelHelpers => modelHelpers.isNotEmpty;
+
+  Iterable<Import> importsFor(String packageName) sync* {
+    if (usesModelHelpers) {
+      yield Import('package:$packageName/model_helpers.dart');
+    }
+  }
 }
 
 /// A rendered schema body paired with the usage of that body.

--- a/lib/templates/model_helpers.mustache
+++ b/lib/templates/model_helpers.mustache
@@ -1,6 +1,11 @@
+{{#needsCollectionImport}}
 import 'package:collection/collection.dart';
+{{/needsCollectionImport}}
+{{#needsUriPackageImport}}
 import 'package:uri/uri.dart';
+{{/needsUriPackageImport}}
 
+{{#maybeParseDateTime}}
 /// Parse a nullable string as a DateTime.
 DateTime? maybeParseDateTime(String? value) {
   if (value == null) {
@@ -8,7 +13,9 @@ DateTime? maybeParseDateTime(String? value) {
   }
   return DateTime.parse(value);
 }
+{{/maybeParseDateTime}}
 
+{{#maybeParseDate}}
 /// Parse a nullable RFC 3339 full-date string (`YYYY-MM-DD`) as a DateTime.
 /// Time and timezone components are zero.
 DateTime? maybeParseDate(String? value) {
@@ -17,7 +24,9 @@ DateTime? maybeParseDate(String? value) {
   }
   return DateTime.parse(value);
 }
+{{/maybeParseDate}}
 
+{{#maybeParseUri}}
 /// Parse a nullable string as a Uri.
 Uri? maybeParseUri(String? value) {
   if (value == null) {
@@ -25,7 +34,9 @@ Uri? maybeParseUri(String? value) {
   }
   return Uri.parse(value);
 }
+{{/maybeParseUri}}
 
+{{#maybeParseUriTemplate}}
 /// Parse a nullable string as a UriTemplate.
 UriTemplate? maybeParseUriTemplate(String? value) {
   if (value == null) {
@@ -33,7 +44,9 @@ UriTemplate? maybeParseUriTemplate(String? value) {
   }
   return UriTemplate(value);
 }
+{{/maybeParseUriTemplate}}
 
+{{#parseFromJson}}
 /// Runs [build] to construct a `fromJson`-parsed value of type [T],
 /// converting any `TypeError` (e.g. an unexpected null or a cast
 /// failure on a required field) into a `FormatException` that names
@@ -51,19 +64,25 @@ T parseFromJson<T>(
     throw FormatException('Failed to parse $className from JSON: $error', json);
   }
 }
+{{/parseFromJson}}
 
+{{#listsEqual}}
 /// Check if two nullable lists are deeply equal.
 bool listsEqual<T>(List<T>? a, List<T>? b) {
   final deepEquals = const DeepCollectionEquality().equals;
   return deepEquals(a, b);
 }
+{{/listsEqual}}
 
+{{#mapsEqual}}
 /// Check if two nullable maps are deeply equal.
 bool mapsEqual<K, V>(Map<K, V>? a, Map<K, V>? b) {
   final deepEquals = const DeepCollectionEquality().equals;
   return deepEquals(a, b);
 }
+{{/mapsEqual}}
 
+{{#listHash}}
 /// A deep hash of a nullable list — consistent with [listsEqual].
 /// Two lists that compare equal under [listsEqual] produce the same
 /// hash. Null hashes to 0.
@@ -71,7 +90,9 @@ int listHash<T>(List<T>? list) {
   if (list == null) return 0;
   return const DeepCollectionEquality().hash(list);
 }
+{{/listHash}}
 
+{{#mapHash}}
 /// A deep hash of a nullable map — consistent with [mapsEqual].
 /// Two maps that compare equal under [mapsEqual] produce the same
 /// hash. Null hashes to 0.
@@ -79,3 +100,4 @@ int mapHash<K, V>(Map<K, V>? map) {
   if (map == null) return 0;
   return const DeepCollectionEquality().hash(map);
 }
+{{/mapHash}}

--- a/test/render/file_renderer_test.dart
+++ b/test/render/file_renderer_test.dart
@@ -520,7 +520,8 @@ void main() {
           'api_client.dart',
           'auth.dart',
           'client.dart',
-          'model_helpers.dart',
+          // model_helpers.dart is omitted because this spec has no
+          // schemas and thus no helpers are referenced.
         ]),
       );
 
@@ -625,6 +626,118 @@ void main() {
           'account_role.dart',
         ]),
       );
+    });
+
+    test('model_helpers.dart only includes helpers that are used', () async {
+      // This spec has strings only — `parseFromJson` is the only helper
+      // any generated file references. The date / uri / list / map
+      // helpers should be pruned out.
+      final fs = MemoryFileSystem.test();
+      final spec = {
+        'openapi': '3.1.0',
+        'info': {'title': 'Test API', 'version': '1.0.0'},
+        'servers': [
+          {'url': 'https://example.com'},
+        ],
+        'paths': {
+          '/thing': {
+            'get': {
+              'operationId': 'get-thing',
+              'responses': {
+                '200': {
+                  'description': 'OK',
+                  'content': {
+                    'application/json': {
+                      'schema': {r'$ref': '#/components/schemas/Thing'},
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        'components': {
+          'schemas': {
+            'Thing': {
+              'type': 'object',
+              'properties': {
+                'name': {'type': 'string'},
+              },
+              'required': ['name'],
+            },
+          },
+        },
+      };
+      final out = fs.directory('out');
+      await renderToDirectory(spec: spec, outDir: out);
+      final helpers = out
+          .childFile('lib/model_helpers.dart')
+          .readAsStringSync();
+      expect(helpers, contains('parseFromJson'));
+      expect(helpers, isNot(contains('maybeParseDateTime')));
+      expect(helpers, isNot(contains('maybeParseUri')));
+      expect(helpers, isNot(contains('listsEqual')));
+      expect(helpers, isNot(contains('mapsEqual')));
+      expect(helpers, isNot(contains('listHash')));
+      expect(helpers, isNot(contains('mapHash')));
+      expect(helpers, isNot(contains("import 'package:collection")));
+      expect(helpers, isNot(contains("import 'package:uri/uri.dart")));
+    });
+
+    test('model_helpers.dart includes collection helpers for list/map '
+        'properties', () async {
+      final fs = MemoryFileSystem.test();
+      final spec = {
+        'openapi': '3.1.0',
+        'info': {'title': 'Test API', 'version': '1.0.0'},
+        'servers': [
+          {'url': 'https://example.com'},
+        ],
+        'paths': {
+          '/thing': {
+            'get': {
+              'operationId': 'get-thing',
+              'responses': {
+                '200': {
+                  'description': 'OK',
+                  'content': {
+                    'application/json': {
+                      'schema': {r'$ref': '#/components/schemas/Thing'},
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        'components': {
+          'schemas': {
+            'Thing': {
+              'type': 'object',
+              'properties': {
+                'tags': {
+                  'type': 'array',
+                  'items': {'type': 'string'},
+                },
+                'createdAt': {'type': 'string', 'format': 'date-time'},
+              },
+              'required': ['tags', 'createdAt'],
+            },
+          },
+        },
+      };
+      final out = fs.directory('out');
+      await renderToDirectory(spec: spec, outDir: out);
+      final helpers = out
+          .childFile('lib/model_helpers.dart')
+          .readAsStringSync();
+      expect(helpers, contains('parseFromJson'));
+      expect(helpers, contains('listsEqual'));
+      expect(helpers, contains('listHash'));
+      expect(helpers, contains("import 'package:collection/collection.dart"));
+      // `createdAt` is required (non-nullable json), so DateTime.parse is
+      // inlined at the call site — `maybeParseDateTime` stays pruned.
+      expect(helpers, isNot(contains('maybeParseDateTime')));
     });
 
     test('with request body', () async {
@@ -2042,7 +2155,7 @@ void main() {
         schema,
         const SchemaUsage(
           usesMetaAnnotations: true,
-          usesModelHelpers: true,
+          modelHelpers: {ModelHelpers.parseFromJson},
         ),
       );
       expect(imports, {


### PR DESCRIPTION
## Summary

- Aggregate `SchemaUsage`/`ApiUsage` across every rendered file and emit only the `model_helpers.dart` helpers actually referenced. Previously all 9 helpers shipped unconditionally, even when no generated code used them.
- Skip writing `model_helpers.dart` entirely when the spec uses none of them.
- Gate `package:collection` and `package:uri` imports on the subset of helpers that need them, so a pruned file drops those imports too.

Motivation: consumers running coverage on generated code reported the unused helpers as uncovered. Generated `lib/model_helpers.dart` for the `types` gen_test drops from 81 → 48 lines as a result.

## Test plan

- [x] `dart analyze` — clean (2 pre-existing line-length infos on unrelated code)
- [x] `dart test` — all 281 tests pass, including two new tests:
  - `model_helpers.dart only includes helpers that are used` — spec with only string schemas emits only `parseFromJson`.
  - `model_helpers.dart includes collection helpers for list/map properties` — spec with array property emits `listsEqual`/`listHash` plus `package:collection` import.
- [x] `dart run tool/gen_tests.dart` — generated `types` package still compiles and its round-trip tests pass.