### PR TITLE
feat: cover toString and every enum value in generated round-trip tests

### DIFF
--- a/lib/src/render/file_renderer.dart
+++ b/lib/src/render/file_renderer.dart
@@ -694,6 +694,7 @@ class FileRenderer {
           'typeName': schema.typeName,
           'exampleValue': example,
           'invalidJsonExample': invalidJson,
+          'isEnum': schema is RenderEnum,
         },
       );
     }

--- a/lib/templates/schema_round_trip_test.mustache
+++ b/lib/templates/schema_round_trip_test.mustache
@@ -23,5 +23,19 @@ void main() {
       );
     });
 {{/invalidJsonExample}}
+{{#isEnum}}
+
+    test('toString matches toJson for every value', () {
+      for (final value in {{{ typeName }}}.values) {
+        expect(value.toString(), equals(value.toJson()));
+      }
+    });
+
+    test('fromJson round-trips every value', () {
+      for (final value in {{{ typeName }}}.values) {
+        expect({{{ typeName }}}.fromJson(value.toJson()), equals(value));
+      }
+    });
+{{/isEnum}}
   });
 }

--- a/test/render/file_renderer_test.dart
+++ b/test/render/file_renderer_test.dart
@@ -433,6 +433,99 @@ void main() {
       expect(body, contains('parsed.hashCode'));
     });
 
+    test('enum round-trip test exercises toString and every value', () async {
+      final fs = MemoryFileSystem.test();
+      final spec = {
+        'openapi': '3.1.0',
+        'info': {'title': 'EnumRoundtrip', 'version': '1.0.0'},
+        'servers': [
+          {'url': 'https://example.com'},
+        ],
+        'paths': {
+          '/roles': {
+            'get': {
+              'operationId': 'getRole',
+              'responses': {
+                '200': {
+                  'description': 'OK',
+                  'content': {
+                    'application/json': {
+                      'schema': {r'$ref': '#/components/schemas/Role'},
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        'components': {
+          'schemas': {
+            'Role': {
+              'type': 'string',
+              'enum': ['admin', 'user'],
+            },
+          },
+        },
+      };
+      final out = fs.directory('out');
+      await renderToDirectory(spec: spec, outDir: out);
+      final testFile = out.childFile('test/models/role_test.dart');
+      expect(testFile.existsSync(), isTrue);
+      final body = testFile.readAsStringSync();
+      // Object schemas don't get these blocks; enums do.
+      expect(body, contains('toString matches toJson for every value'));
+      expect(body, contains('fromJson round-trips every value'));
+      expect(body, contains('for (final value in Role.values)'));
+      expect(body, contains('value.toString()'));
+      expect(body, contains('Role.fromJson(value.toJson())'));
+    });
+
+    test('non-enum round-trip test omits the enum-only assertions', () async {
+      final fs = MemoryFileSystem.test();
+      final spec = {
+        'openapi': '3.1.0',
+        'info': {'title': 'NoEnumExtras', 'version': '1.0.0'},
+        'servers': [
+          {'url': 'https://example.com'},
+        ],
+        'paths': {
+          '/widgets': {
+            'get': {
+              'operationId': 'getWidget',
+              'responses': {
+                '200': {
+                  'description': 'OK',
+                  'content': {
+                    'application/json': {
+                      'schema': {r'$ref': '#/components/schemas/Widget'},
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        'components': {
+          'schemas': {
+            'Widget': {
+              'type': 'object',
+              'required': ['id'],
+              'properties': {
+                'id': {'type': 'integer'},
+              },
+            },
+          },
+        },
+      };
+      final out = fs.directory('out');
+      await renderToDirectory(spec: spec, outDir: out);
+      final body = out
+          .childFile('test/models/widget_test.dart')
+          .readAsStringSync();
+      expect(body, isNot(contains('toString matches toJson')));
+      expect(body, isNot(contains('fromJson round-trips every value')));
+    });
+
     test('generateTests: false suppresses test emission', () async {
       final fs = MemoryFileSystem.test();
       final spec = {


### PR DESCRIPTION
## Summary

The round-trip test template only exercised `exampleValue`, which for enums is `values.first`. That left the `toString()` override and every non-first enum value uncovered.

Add an `isEnum`-conditional block that iterates `values`, asserting:
- `toString() == toJson()` for each variant (covers the override).
- `fromJson(value.toJson()) == value` for each variant (covers all enum values, not just the first).

## Diff shape

```mustache
{{#isEnum}}

    test('toString matches toJson for every value', () {
      for (final value in {{{ typeName }}}.values) {
        expect(value.toString(), equals(value.toJson()));
      }
    });

    test('fromJson round-trips every value', () {
      for (final value in {{{ typeName }}}.values) {
        expect({{{ typeName }}}.fromJson(value.toJson()), equals(value));
      }
    });
{{/isEnum}}
```

`isEnum` is wired in `file_renderer.dart::renderModelTests` as `schema is RenderEnum`. Object/oneOf/etc. schemas get an empty conditional and behave exactly as before.

## Test plan

- [x] `dart test` — 295 pass (was 292; +3 here).
- [x] New positive + negative coverage in `test/render/file_renderer_test.dart`:
  - Role (enum) gets both new test bodies.
  - Widget (object) does not.
- [x] End-to-end validated against `shorebird_code_push_protocol`: regenerated with this branch as a path override; only the 5 enum test files diff, and all 216 generated-package tests pass.