### PR TITLE
fix: allow pod schemas (uuid/date/...) as path parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@
   crashed the resolver with "Path parameters must be strings or
   integers". All pod types serialize to a single string via their
   `toJson` — which is the expression interpolated into the URL path —
-  so they're legal path parameters. Hit while triaging the WatchCrunch
-  OpenAPI spec.
+  so they're legal path parameters. Found while running the generator
+  against a third-party OpenAPI spec that uses UUID path parameters
+  throughout.
 - Honor `security: []` on an operation as an explicit override of the
   global security requirement (public endpoint), rather than silently
   inheriting from the spec-level `security`. Previously the parser

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## 1.0.2
 
+- Allow pod schemas (`format: uuid`, `date`, `date-time`, `email`, `uri`,
+  `uri-template`, `boolean`) as path parameters. Previously
+  `_canBePathParameter` only accepted `ResolvedString`, `ResolvedInteger`,
+  `ResolvedEnum`, and recursive `ResolvedOneOf`, so a common pattern like
+  `/resources/{id}` with `id` declared as `type: string, format: uuid`
+  crashed the resolver with "Path parameters must be strings or
+  integers". All pod types serialize to a single string via their
+  `toJson` — which is the expression interpolated into the URL path —
+  so they're legal path parameters. Hit while triaging the WatchCrunch
+  OpenAPI spec.
 - Honor `security: []` on an operation as an explicit override of the
   global security requirement (public endpoint), rather than silently
   inheriting from the spec-level `security`. Previously the parser

--- a/lib/src/resolver.dart
+++ b/lib/src/resolver.dart
@@ -390,6 +390,14 @@ bool _canBePathParameter(ResolvedSchema schema) {
   if (schema is ResolvedString || schema is ResolvedInteger) {
     return true;
   }
+  // Pod types (uuid, email, date, date-time, uri, uri-template, boolean) all
+  // serialize to a single string on the wire via their `toJson` — which is
+  // the expression interpolated into the URL path — so they're legal path
+  // parameters. Without this, common patterns like `format: uuid` on a
+  // `/things/{id}` path crash the resolver.
+  if (schema is ResolvedPod) {
+    return true;
+  }
   if (schema is ResolvedOneOf) {
     return schema.schemas.every(_canBePathParameter);
   }

--- a/test/resolver_test.dart
+++ b/test/resolver_test.dart
@@ -90,7 +90,7 @@ void main() {
     });
 
     test('path parameters can be pod types (uuid/date/date-time/etc)', () {
-      // Repro for the watchcrunch spec: a `/resource/{id}` path where `id` is
+      // A common real-world pattern: a `/resource/{id}` path where `id` is
       // declared as `type: string, format: uuid`. Previously this crashed
       // the resolver ("Path parameters must be strings or integers") because
       // pod types aren't `ResolvedString`.

--- a/test/resolver_test.dart
+++ b/test/resolver_test.dart
@@ -89,6 +89,55 @@ void main() {
       );
     });
 
+    test('path parameters can be pod types (uuid/date/date-time/etc)', () {
+      // Repro for the watchcrunch spec: a `/resource/{id}` path where `id` is
+      // declared as `type: string, format: uuid`. Previously this crashed
+      // the resolver ("Path parameters must be strings or integers") because
+      // pod types aren't `ResolvedString`.
+      Map<String, dynamic> specWithPodPathParam(String format) => {
+        'openapi': '3.1.0',
+        'info': {'title': 'T', 'version': '1.0.0'},
+        'servers': [
+          {'url': 'https://example.com'},
+        ],
+        'paths': {
+          '/things/{id}': {
+            'get': {
+              'summary': 'Get thing',
+              'parameters': [
+                {
+                  'name': 'id',
+                  'in': 'path',
+                  'required': true,
+                  'schema': {'type': 'string', 'format': format},
+                },
+              ],
+              'responses': {
+                '200': {'description': 'OK'},
+              },
+            },
+          },
+        },
+      };
+
+      for (final format in [
+        'uuid',
+        'date',
+        'date-time',
+        'email',
+        'uri',
+        'uri-template',
+      ]) {
+        final spec = parseAndResolveTestSpec(specWithPodPathParam(format));
+        final param = spec.paths.first.operations.first.parameters.first;
+        expect(
+          param.schema,
+          isA<ResolvedPod>(),
+          reason: 'format: $format should resolve to a ResolvedPod',
+        );
+      }
+    });
+
     test('path parameters can be oneOf of strings or integers', () {
       final json = {
         'openapi': '3.1.0',


### PR DESCRIPTION
## Summary

`_canBePathParameter` in `resolver.dart` previously only accepted `ResolvedString`, `ResolvedInteger`, `ResolvedEnum`, and recursive `ResolvedOneOf`. A common real-world pattern like

```yaml
/resources/{id}:
  parameters:
    - name: id
      in: path
      schema: { type: string, format: uuid }
```

crashed with `FormatException: Path parameters must be strings or integers` because `format: uuid` resolves to a `ResolvedPod`, not a `ResolvedString`.

All pod types (`uuid`, `date`, `date-time`, `email`, `uri`, `uri-template`, `boolean`) serialize to a single string via their `toJson` expression — which is exactly what gets interpolated into the URL path at `render_tree.dart:781` (`.replaceAll('{foo}', "\${foo.toJson()}")`). So they're legal path parameters.

## Motivating case

Found while triaging the WatchCrunch OpenAPI spec, which uses UUID path params throughout (`/notification/{notification}` where `notification` is `type: string, format: uuid`). Previously the whole generation aborted on the first such parameter.

With this fix, WatchCrunch gets past the resolver — it now hits a different, unrelated bug downstream (`ResolvedNull` unhandled in render), which I'll file separately.

## Test plan

- [x] New `test/resolver_test.dart` case exercises each of the six string pod formats as a path param schema and asserts the resolved parameter carries a `ResolvedPod`.
- [x] Full `dart test` passes.
- [x] gen_tests regenerate clean (no spec in the suite uses pod path params, so no golden changes).