### PR TITLE
fix: opt out of round-trip test for oneOf/anyOf sealed classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 ## 1.0.2
 
+- Skip round-trip test generation for schemas whose type is (or
+  transitively contains a required) `oneOf` / `anyOf`. The
+  `schema_one_of.mustache` template emits a sealed class with no
+  concrete subclasses and an `UnimplementedError`-throwing `fromJson`,
+  so there's no Dart value of the sealed type that can be constructed
+  at compile time. Previously `RenderOneOf.exampleValue` returned the
+  first branch's own example (e.g. a raw `'example'` String for
+  `oneOf: [string, integer]`), which didn't type-check against the
+  enclosing sealed-class field and produced errors like `String can't
+  be assigned to IssuesCreateRequestTitle` — ~85 of the 156 broken
+  tests in the generated GitHub client. Returning `null` propagates
+  through `RenderObject.exampleValue` so the round-trip test is
+  skipped for any schema that transitively depends on a oneOf/anyOf.
+  Real coverage here is blocked on discriminator-aware subclass
+  emission (#99); today's coverage was fake.
 - Render `type: null` properties as `dynamic` instead of crashing.
   OpenAPI 3.1 / JSON Schema 2020-12 allows a property schema to be
   `{"type": "null"}`, meaning "the only legal value is `null`"; the

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -3232,10 +3232,21 @@ class RenderOneOf extends RenderNewType {
 
   @override
   String? exampleValue(SchemaRenderer context) {
-    for (final branch in schemas) {
-      final example = branch.exampleValue(context);
-      if (example != null) return example;
-    }
+    // A oneOf / anyOf currently renders as a sealed class with no
+    // subclasses (the template at `schema_one_of.mustache` emits only
+    // the base class and an `UnimplementedError`-throwing fromJson).
+    // There is therefore no Dart value of the sealed type that can be
+    // constructed at compile time — returning a branch's own example
+    // doesn't type-check against the enclosing field, which produces
+    // errors like `String can't be assigned to IssuesCreateRequestTitle`
+    // in the generated round-trip tests.
+    //
+    // Opting out via `null` propagates through the containing object,
+    // which skips the round-trip test for it entirely. We lose
+    // coverage for every schema that transitively depends on a
+    // oneOf/anyOf, but today's coverage is fake anyway — the tests
+    // don't compile. Restoring real coverage requires real
+    // discriminator-aware subclass emission (#99).
     return null;
   }
 }

--- a/test/render/render_tree_test.dart
+++ b/test/render/render_tree_test.dart
@@ -882,6 +882,33 @@ void main() {
       expect(schema.exampleValue(context), isNull);
     });
 
+    test('oneOf returns null (sealed class, no constructable subtype)', () {
+      // `schema_one_of.mustache` emits a sealed class with no
+      // concrete subclasses and an `UnimplementedError`-throwing
+      // fromJson, so there's no way to construct a value of the
+      // sealed type. Returning a branch example would type-check
+      // against the branch but not the enclosing field, producing
+      // errors like `String can't be assigned to
+      // IssuesCreateRequestTitle` in generated round-trip tests. Opt
+      // out via `null` so the test is skipped.
+      const schema = RenderOneOf(
+        common: common,
+        schemas: [
+          RenderPod(
+            common: common,
+            type: PodType.email,
+            createsNewType: false,
+          ),
+          RenderPod(
+            common: common,
+            type: PodType.uuid,
+            createsNewType: false,
+          ),
+        ],
+      );
+      expect(schema.exampleValue(context), isNull);
+    });
+
     test('map with keySchema uses its exampleValue', () {
       const inner = RenderString(
         createsNewType: false,


### PR DESCRIPTION
## Summary

\`schema_one_of.mustache\` emits a sealed class with no concrete subclasses and an \`UnimplementedError\`-throwing \`fromJson\` — there is no Dart value of the sealed type that can be constructed at compile time. Previously \`RenderOneOf.exampleValue\` returned the first branch's own example (e.g. \`'example'\` String for \`oneOf: [string, integer]\`), which didn't type-check against the enclosing sealed-class field and produced errors like:

\`\`\`
error - test/messages/issues_create_request_test.dart:8:51 - The argument type 'String' can't be assigned to the parameter type 'IssuesCreateRequestTitle'.
\`\`\`

## Fix

\`RenderOneOf.exampleValue\` now returns \`null\`. That propagates through \`RenderObject.exampleValue\` so any schema that transitively depends on a required oneOf/anyOf has its round-trip test skipped. Real coverage here is blocked on discriminator-aware subclass emission (#99) — today's "coverage" was fake because the tests didn't compile.

\`RenderAnyOf\` maps to \`RenderOneOf\` at render-tree conversion time (\`resolver.dart\` → \`toRenderSchema\`) so this covers anyOf too.

## Motivating case

Of 156 broken tests in the generated GitHub client, ~85 go away after this change:

- 50 \`argument_type_not_assignable\` (wrong branch in oneOf example)
- 35 \`undefined_method\` (toJson on List/Map from a oneOf \`variants\` test)

Remaining errors after this PR alone are in separate patterns (additionalProperties + uriTemplate), each filed as its own PR.

## Test plan

- [x] Unit test in \`test/render/render_tree_test.dart\` that \`RenderOneOf.exampleValue\` returns null.
- [x] Full \`dart test\` passes (299 tests).
- [x] No gen_tests/ fixture — fix lives entirely in \`render_tree.dart\` and is covered by the unit test.