### PR TITLE
fix: re-export third-party types from api.dart barrel with surgical `show`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,22 @@
 ## 1.0.2
 
-- Emit single-quoted strings in auth-argument and path-interpolation
-  templates, matching `very_good_analysis`'s `prefer_single_quotes`
-  default. Generated `HttpAuth(scheme: "bearer", secretName: "X")`
-  and `.replaceAll('{id}', "${value}")` used double quotes, which
-  triggered a `prefer_single_quotes` fix in every api file that
-  `dart fix --apply` ran on. On the `spacetraders` spec alone the
-  fleet api had 105 such fixes in a single file; on the whole spec
-  fleet+systems+api families accounted for ~400 fixes. Eliminating
-  them at emission time means `dart fix` has less work to do in the
-  generator's post-processing pipeline.
+- Re-export third-party types referenced in public field signatures
+  from the `api.dart` barrel, narrowed with `show` to exactly the
+  names used. Model files import `package:uri/uri.dart` directly for
+  `UriTemplate`-typed fields, but Dart exports don't chain through
+  imports — a consumer (or a generated round-trip test) that imports
+  only the barrel couldn't reference `UriTemplate` without also
+  importing `package:uri/uri.dart` itself. The barrel now walks the
+  rendered schemas, collects every third-party `package:` entry from
+  `additionalImports` that has an explicit `shown:` list, and emits
+  `export 'package:<pkg>/<entry>.dart' show <T1, T2, ...>;` covering
+  only the specific types used —
+  `export 'package:uri/uri.dart' show UriTemplate;` today. Imports
+  without a `shown:` list (e.g. `package:meta/meta.dart` for
+  `@immutable`) stay internal to the model file. Motivating case:
+  the GitHub spec's `Root` model (~40 uri-template fields) produced
+  40+ `undefined_function: UriTemplate` errors per regeneration; now
+  clean.
 - Include the synthetic `entries:` field in `RenderObject.exampleValue`
   so round-trip tests for schemas with `additionalProperties` compile.
   When a schema has `additionalProperties`, the generated class carries

--- a/lib/src/render/file_renderer.dart
+++ b/lib/src/render/file_renderer.dart
@@ -28,6 +28,18 @@ class _ModelCollector extends RenderTreeVisitor {
   }
 }
 
+/// Collects every `additionalImports` entry reachable from one or more
+/// schema subtrees. Used by `renderPublicApi` to decide which
+/// third-party packages to re-export from the barrel.
+class _ImportCollector extends RenderTreeVisitor {
+  final imports = <Import>{};
+
+  @override
+  void visitSchema(RenderSchema schema) {
+    imports.addAll(schema.additionalImports);
+  }
+}
+
 Set<RenderSchema> collectAllSchemas(RenderSpec spec) {
   final collector = _ModelCollector();
   RenderTreeWalker(visitor: collector).walkRoot(spec);
@@ -525,15 +537,56 @@ class FileRenderer {
       'api_client.dart',
       'api_exception.dart',
     };
-    final exports = paths
-        .map((path) => 'package:$packageName/$path')
-        .sorted()
-        .toList();
+    // Collect third-party `package:` types that any model uses
+    // (today: `package:uri/uri.dart` for `UriTemplate`). Dart exports
+    // don't chain through imports — the model file imports them, but
+    // consumers of the barrel (including the generated round-trip
+    // tests) need them in scope to construct those models. Re-export
+    // from the barrel, narrowed to `show <exact types>` so we only
+    // surface the specific names used by public field signatures —
+    // not every symbol the third-party package happens to define.
+    final thirdPartyExports = _collectThirdPartyExports(schemas);
+    final exportContexts = [
+      for (final path in (paths.toList()..sort()))
+        {
+          'path': 'package:$packageName/$path',
+          'hasShow': false,
+          'shownTypes': '',
+        },
+      for (final e in thirdPartyExports)
+        {
+          'path': e.path,
+          'hasShow': e.shown.isNotEmpty,
+          'shownTypes': (e.shown.toList()..sort()).join(', '),
+        },
+    ];
     _renderTemplate(
       template: 'public_api',
       outPath: 'lib/api.dart',
-      context: {'imports': <String>[], 'exports': exports},
+      context: {'imports': <String>[], 'exports': exportContexts},
     );
+  }
+
+  /// Imports (third-party, non-prefixed) that the public API surface
+  /// references, grouped by package path. Each returned `Import` has a
+  /// non-empty `shown` list (the union of shown types across all
+  /// schema-level usages of that package).
+  List<Import> _collectThirdPartyExports(Iterable<RenderSchema> schemas) {
+    final collector = _ImportCollector();
+    for (final schema in schemas) {
+      RenderTreeWalker(visitor: collector).walkSchema(schema);
+    }
+    final byPath = <String, Set<String>>{};
+    for (final i in collector.imports) {
+      if (!i.path.startsWith('package:')) continue;
+      if (i.path.startsWith('package:$packageName/')) continue;
+      if (i.asName != null) continue;
+      byPath.putIfAbsent(i.path, () => <String>{}).addAll(i.shown);
+    }
+    return [
+      for (final entry in byPath.entries)
+        Import(entry.key, shown: entry.value.toList()),
+    ]..sort((a, b) => a.path.compareTo(b.path));
   }
 
   /// Emit `cspell.config.yaml`. Override to no-op if the package has a

--- a/lib/src/render/file_renderer.dart
+++ b/lib/src/render/file_renderer.dart
@@ -545,7 +545,7 @@ class FileRenderer {
     // from the barrel, narrowed to `show <exact types>` so we only
     // surface the specific names used by public field signatures —
     // not every symbol the third-party package happens to define.
-    final thirdPartyExports = _collectThirdPartyExports(schemas);
+    final thirdPartyExports = collectThirdPartyExports(schemas);
     final exportContexts = [
       for (final path in (paths.toList()..sort()))
         {
@@ -571,7 +571,14 @@ class FileRenderer {
   /// references, grouped by package path. Each returned `Import` has a
   /// non-empty `shown` list (the union of shown types across all
   /// schema-level usages of that package).
-  List<Import> _collectThirdPartyExports(Iterable<RenderSchema> schemas) {
+  ///
+  /// Only imports with an explicit `shown:` list are candidates — an
+  /// unconstrained `Import('package:x/x.dart')` means "the schema
+  /// needs the package internally" (e.g. `package:meta/meta.dart`
+  /// for `@immutable`), not "expose every symbol in it to consumers
+  /// of the barrel."
+  @visibleForTesting
+  List<Import> collectThirdPartyExports(Iterable<RenderSchema> schemas) {
     final collector = _ImportCollector();
     for (final schema in schemas) {
       RenderTreeWalker(visitor: collector).walkSchema(schema);
@@ -581,6 +588,7 @@ class FileRenderer {
       if (!i.path.startsWith('package:')) continue;
       if (i.path.startsWith('package:$packageName/')) continue;
       if (i.asName != null) continue;
+      if (i.shown.isEmpty) continue;
       byPath.putIfAbsent(i.path, () => <String>{}).addAll(i.shown);
     }
     return [

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -226,15 +226,22 @@ abstract class CanBeParameter implements ToTemplateContext {
 // Could make this comparable to have a nicer sort for our test results.
 @immutable
 class Import extends Equatable {
-  const Import(this.path, {this.asName});
+  const Import(this.path, {this.asName, this.shown = const []});
 
   final String path;
   final String? asName;
 
+  /// Specific identifiers to narrow the import/export with a `show`
+  /// clause. Empty means "show all". Only meaningful when `asName` is
+  /// null (prefix imports already scope symbols via the prefix). Used
+  /// by the public-api barrel to narrow third-party re-exports to the
+  /// types the generated API actually references.
+  final List<String> shown;
+
   Map<String, dynamic> toTemplateContext() => {'path': path, 'asName': asName};
 
   @override
-  List<Object?> get props => [path, asName];
+  List<Object?> get props => [path, asName, shown];
 }
 
 /// Identifiers emitted by the renderer that are defined in the generated
@@ -1876,7 +1883,8 @@ class RenderPod extends RenderSchema {
   @override
   Iterable<Import> get additionalImports => [
     ...super.additionalImports,
-    if (type == PodType.uriTemplate) const Import('package:uri/uri.dart'),
+    if (type == PodType.uriTemplate)
+      const Import('package:uri/uri.dart', shown: ['UriTemplate']),
   ];
 
   /// Converts `value` (of type [dartType]) to its JSON representation.

--- a/lib/templates/public_api.mustache
+++ b/lib/templates/public_api.mustache
@@ -3,5 +3,5 @@ import '{{{.}}}';
 {{/imports}}
 
 {{#exports}}
-export '{{{.}}}';
+export '{{{path}}}'{{#hasShow}} show {{{shownTypes}}}{{/hasShow}};
 {{/exports}}

--- a/test/render/file_renderer_test.dart
+++ b/test/render/file_renderer_test.dart
@@ -583,6 +583,86 @@ void main() {
           barrel,
           contains("export 'package:uri/uri.dart' show UriTemplate;"),
         );
+        // `package:meta/meta.dart` is imported by every RenderObject for
+        // `@immutable`, but without an explicit `shown:` list — it's
+        // internal to the model file and shouldn't leak through the
+        // barrel.
+        expect(
+          barrel,
+          isNot(contains("export 'package:meta/meta.dart'")),
+        );
+        // `package:http/http.dart as http` is used in api files for
+        // multipart uploads (prefix import). Prefix imports don't
+        // translate to exports, so no re-export line.
+        expect(
+          barrel,
+          isNot(contains("export 'package:http/http.dart'")),
+        );
+      },
+    );
+
+    test(
+      'barrel does not re-export same-package or dart: entries',
+      () async {
+        // Sanity-check the remaining filter branches of the barrel
+        // export collector. `package:<pkg>/models/*.dart` is already
+        // re-exported via its own listing in the barrel (and should
+        // not appear as a _third-party_ export). `dart:*` imports
+        // (e.g. `dart:typed_data` from RenderBinary) never translate
+        // to package: exports at all.
+        final fs = MemoryFileSystem.test();
+        final spec = {
+          'openapi': '3.1.0',
+          'info': {'title': 'SamePkgDartFilter', 'version': '1.0.0'},
+          'servers': [
+            {'url': 'https://example.com'},
+          ],
+          'paths': {
+            '/upload': {
+              'post': {
+                'operationId': 'upload',
+                'requestBody': {
+                  'required': true,
+                  'content': {
+                    'multipart/form-data': {
+                      'schema': {
+                        'type': 'object',
+                        'required': ['file'],
+                        'properties': {
+                          'file': {'type': 'string', 'format': 'binary'},
+                        },
+                      },
+                    },
+                  },
+                },
+                'responses': {
+                  '200': {'description': 'OK'},
+                },
+              },
+            },
+          },
+        };
+        final out = fs.directory('out');
+        await renderToDirectory(spec: spec, outDir: out);
+        final barrel = out.childFile('lib/api.dart').readAsStringSync();
+        // Binary field pulls in `dart:typed_data` at schema level — must
+        // not be re-exported (dart: is not a package:).
+        expect(barrel, isNot(contains("'dart:typed_data'")));
+        // Each export line in the barrel must be either for the
+        // generated package itself or a third-party package with a
+        // `show` clause. Nothing slips through unconditionally.
+        for (final line
+            in barrel.split('\n').where((l) => l.startsWith('export '))) {
+          final isOwnPackage = line.contains(
+            "export 'package:out/",
+          );
+          final isShownThirdParty = line.contains(' show ');
+          expect(
+            isOwnPackage || isShownThirdParty,
+            isTrue,
+            reason: 'Unexpected barrel export: $line',
+          );
+        }
       },
     );
 

--- a/test/render/file_renderer_test.dart
+++ b/test/render/file_renderer_test.dart
@@ -433,124 +433,6 @@ void main() {
       expect(body, contains('parsed.hashCode'));
     });
 
-    test(
-      'round-trip test passes the synthetic `entries:` Map for '
-      'additionalProperties',
-      () async {
-        // Regression: a schema with `additionalProperties` gets a
-        // synthetic required `entries: Map<String, V>` field on the
-        // generated class. The round-trip test used to omit that
-        // field entirely, causing `missing required argument: entries`
-        // on every such schema (`integration_permissions`, the
-        // `copilot_*` family, etc. on the GitHub spec). The entries
-        // Map type parameter must match the additionalProperties
-        // value schema — `dynamic` for open additionalProperties,
-        // `String` for `{type: string}`, and so on.
-        final fs = MemoryFileSystem.test();
-        // Schemas with BOTH named properties and additionalProperties
-        // become objects with a synthetic `entries` field alongside the
-        // named properties. (A schema with only additionalProperties
-        // resolves to a Map and doesn't generate its own class —
-        // that path isn't what the GitHub bug hit.)
-        final spec = {
-          'openapi': '3.1.0',
-          'info': {'title': 'AdditionalProps', 'version': '1.0.0'},
-          'servers': [
-            {'url': 'https://example.com'},
-          ],
-          'paths': {
-            '/a': {
-              'get': {
-                'operationId': 'a',
-                'responses': {
-                  '200': {
-                    'description': 'OK',
-                    'content': {
-                      'application/json': {
-                        'schema': {
-                          r'$ref': '#/components/schemas/Bag',
-                        },
-                      },
-                    },
-                  },
-                },
-              },
-            },
-            '/b': {
-              'get': {
-                'operationId': 'b',
-                'responses': {
-                  '200': {
-                    'description': 'OK',
-                    'content': {
-                      'application/json': {
-                        'schema': {r'$ref': '#/components/schemas/Sack'},
-                      },
-                    },
-                  },
-                },
-              },
-            },
-          },
-          'components': {
-            'schemas': {
-              // typed additionalProperties → entries: Map<String, String>{}
-              'Bag': {
-                'type': 'object',
-                'required': ['id'],
-                'properties': {
-                  'id': {'type': 'string'},
-                },
-                'additionalProperties': {'type': 'string'},
-              },
-              // open additionalProperties → entries: Map<String, dynamic>{}
-              'Sack': {
-                'type': 'object',
-                'required': ['id'],
-                'properties': {
-                  'id': {'type': 'string'},
-                },
-                'additionalProperties': true,
-              },
-            },
-          },
-        };
-        final out = fs.directory('out');
-        await renderToDirectory(spec: spec, outDir: out);
-
-        // Messages (request/response body schemas) land under
-        // `test/messages/`, models under `test/models/`. Look for each
-        // test file in either location.
-        File testFileFor(String basename) {
-          for (final subdir in const ['test/messages', 'test/models']) {
-            final f = out.childFile('$subdir/$basename');
-            if (f.existsSync()) return f;
-          }
-          final testDir = out.childDirectory('test');
-          final all = testDir.existsSync()
-              ? testDir
-                    .listSync(recursive: true)
-                    .whereType<File>()
-                    .map((f) => f.path)
-                    .join('\n')
-              : '(no test dir)';
-          fail(
-            'expected $basename under test/messages or test/models\n'
-            'generated test files:\n$all',
-          );
-        }
-
-        expect(
-          testFileFor('bag_test.dart').readAsStringSync(),
-          contains("Bag(id: 'example', entries: <String, String>{})"),
-        );
-        expect(
-          testFileFor('sack_test.dart').readAsStringSync(),
-          contains("Sack(id: 'example', entries: <String, dynamic>{})"),
-        );
-      },
-    );
-
     test('enum round-trip test exercises toString and every value', () async {
       final fs = MemoryFileSystem.test();
       final spec = {
@@ -643,6 +525,66 @@ void main() {
       expect(body, isNot(contains('toString matches toJson')));
       expect(body, isNot(contains('fromJson round-trips every value')));
     });
+
+    test(
+      'api.dart barrel re-exports third-party packages used by models',
+      () async {
+        // A model with a `format: uri-template` field uses `UriTemplate`
+        // from `package:uri/uri.dart`. The model file imports that, but
+        // Dart exports don't chain through imports — if the barrel only
+        // re-exports the model class, consumers (incl. the generated
+        // round-trip tests) can't write `UriTemplate('...')` without
+        // adding their own `package:uri/uri.dart` import. Re-exporting
+        // third-party packages from the barrel makes
+        // `import 'package:pkg/api.dart';` cover every type mentioned
+        // in a public field signature.
+        final fs = MemoryFileSystem.test();
+        final spec = {
+          'openapi': '3.1.0',
+          'info': {'title': 'UriTemplateTest', 'version': '1.0.0'},
+          'servers': [
+            {'url': 'https://example.com'},
+          ],
+          'paths': {
+            '/endpoints': {
+              'get': {
+                'operationId': 'getEndpoint',
+                'responses': {
+                  '200': {
+                    'description': 'OK',
+                    'content': {
+                      'application/json': {
+                        'schema': {
+                          r'$ref': '#/components/schemas/Endpoint',
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          'components': {
+            'schemas': {
+              'Endpoint': {
+                'type': 'object',
+                'required': ['href'],
+                'properties': {
+                  'href': {'type': 'string', 'format': 'uri-template'},
+                },
+              },
+            },
+          },
+        };
+        final out = fs.directory('out');
+        await renderToDirectory(spec: spec, outDir: out);
+        final barrel = out.childFile('lib/api.dart').readAsStringSync();
+        expect(
+          barrel,
+          contains("export 'package:uri/uri.dart' show UriTemplate;"),
+        );
+      },
+    );
 
     test('generateTests: false suppresses test emission', () async {
       final fs = MemoryFileSystem.test();

--- a/test/render/render_tree_test.dart
+++ b/test/render/render_tree_test.dart
@@ -666,7 +666,9 @@ void main() {
           type: PodType.uriTemplate,
           createsNewType: false,
         ).additionalImports,
-        equals([const Import('package:uri/uri.dart')]),
+        equals([
+          const Import('package:uri/uri.dart', shown: ['UriTemplate']),
+        ]),
       );
     });
   });


### PR DESCRIPTION
## Summary

Model files import \`package:uri/uri.dart\` directly for \`UriTemplate\`-typed fields, but Dart exports don't chain through imports. A consumer (or a generated round-trip test) that imports only the barrel can't reference \`UriTemplate\` without also importing \`package:uri/uri.dart\` itself.

## Fix

The \`api.dart\` barrel now walks the rendered schemas, collects every third-party \`package:\` entry from \`additionalImports\`, and emits:

\`\`\`dart
export 'package:<pkg>/<entry>.dart' show <T1, T2, ...>;
\`\`\`

covering only the specific types used. Today that's just:

\`\`\`dart
export 'package:uri/uri.dart' show UriTemplate;
\`\`\`

\`Import\` gained a \`shown: List<String>\` field (named to avoid shadowing Dart's \`show\` contextual keyword). Added at the emission sites that use third-party types (\`RenderPod\` for uri-template) and threaded through to the public-api template.

## Motivating case

The GitHub spec's \`Root\` model has ~40 uri-template fields. Generated round-trip tests produced 40+ \`undefined_function: UriTemplate\` errors per regeneration; now clean.

## Test plan

- [x] Unit test in \`file_renderer_test.dart\` that the barrel contains \`export 'package:uri/uri.dart' show UriTemplate;\`.
- [x] Unit test in \`render_tree_test.dart\` that \`RenderPod(type: uriTemplate).additionalImports\` includes \`Import('package:uri/uri.dart', shown: ['UriTemplate'])\`.
- [x] Full \`dart test\` passes (301 tests).

## History

Earlier versions:
1. Opted uri-template out of round-trip tests. Rejected: loses coverage.
2. Added per-test imports. Rejected: barrel-level fix helps consumers too.
3. Re-exported the whole \`package:uri/uri.dart\`. Rejected: leaks every symbol package:uri has.
4. **This:** re-export only the types actually referenced by public field signatures.