### PR TITLE
fix: pass synthetic entries Map in example for additionalProperties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## 1.0.2
 
+- Include the synthetic `entries:` field in `RenderObject.exampleValue`
+  so round-trip tests for schemas with `additionalProperties` compile.
+  When a schema has `additionalProperties`, the generated class carries
+  a required `entries: Map<String, V>` field alongside the named
+  properties — but the exampleValue generator iterated only
+  `properties` and produced a constructor call missing the required
+  `entries` argument, yielding `missing_required_argument` errors for
+  every such schema. The value type on the emitted Map literal matches
+  the `additionalProperties.typeName` — `dynamic` for open
+  additionalProperties, `String` for `{type: string}`, etc. Hit by
+  `integration_permissions` and the `copilot_*` family on the GitHub
+  spec.
 - Skip round-trip test generation for schemas whose type is (or
   transitively contains a required) `oneOf` / `anyOf`. The
   `schema_one_of.mustache` template emits a sealed class with no

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -2723,6 +2723,19 @@ class RenderObject extends RenderNewType {
       final dartName = variableSafeName(context.quirks, jsonName);
       args.add('$dartName: $example');
     }
+    // When the schema has `additionalProperties`, the generated class
+    // carries a synthetic required `entries` Map field whose value type
+    // matches `additionalProperties.typeName` (`dynamic` for open
+    // additionalProperties, or the specific type for
+    // `additionalProperties: { type: string }` etc). Without this
+    // the round-trip test emits a missing-required-arg error for
+    // every schema that uses additionalProperties — `copilot_*`,
+    // `integration_permissions`, and the `checks_create_request_one_of_*`
+    // family on the GitHub spec all hit this.
+    final additional = additionalProperties;
+    if (additional != null) {
+      args.add('entries: <String, ${additional.typeName}>{}');
+    }
     return '$typeName(${args.join(', ')})';
   }
 

--- a/test/render/file_renderer_test.dart
+++ b/test/render/file_renderer_test.dart
@@ -433,6 +433,124 @@ void main() {
       expect(body, contains('parsed.hashCode'));
     });
 
+    test(
+      'round-trip test passes the synthetic `entries:` Map for '
+      'additionalProperties',
+      () async {
+        // Regression: a schema with `additionalProperties` gets a
+        // synthetic required `entries: Map<String, V>` field on the
+        // generated class. The round-trip test used to omit that
+        // field entirely, causing `missing required argument: entries`
+        // on every such schema (`integration_permissions`, the
+        // `copilot_*` family, etc. on the GitHub spec). The entries
+        // Map type parameter must match the additionalProperties
+        // value schema — `dynamic` for open additionalProperties,
+        // `String` for `{type: string}`, and so on.
+        final fs = MemoryFileSystem.test();
+        // Schemas with BOTH named properties and additionalProperties
+        // become objects with a synthetic `entries` field alongside the
+        // named properties. (A schema with only additionalProperties
+        // resolves to a Map and doesn't generate its own class —
+        // that path isn't what the GitHub bug hit.)
+        final spec = {
+          'openapi': '3.1.0',
+          'info': {'title': 'AdditionalProps', 'version': '1.0.0'},
+          'servers': [
+            {'url': 'https://example.com'},
+          ],
+          'paths': {
+            '/a': {
+              'get': {
+                'operationId': 'a',
+                'responses': {
+                  '200': {
+                    'description': 'OK',
+                    'content': {
+                      'application/json': {
+                        'schema': {
+                          r'$ref': '#/components/schemas/Bag',
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            '/b': {
+              'get': {
+                'operationId': 'b',
+                'responses': {
+                  '200': {
+                    'description': 'OK',
+                    'content': {
+                      'application/json': {
+                        'schema': {r'$ref': '#/components/schemas/Sack'},
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          'components': {
+            'schemas': {
+              // typed additionalProperties → entries: Map<String, String>{}
+              'Bag': {
+                'type': 'object',
+                'required': ['id'],
+                'properties': {
+                  'id': {'type': 'string'},
+                },
+                'additionalProperties': {'type': 'string'},
+              },
+              // open additionalProperties → entries: Map<String, dynamic>{}
+              'Sack': {
+                'type': 'object',
+                'required': ['id'],
+                'properties': {
+                  'id': {'type': 'string'},
+                },
+                'additionalProperties': true,
+              },
+            },
+          },
+        };
+        final out = fs.directory('out');
+        await renderToDirectory(spec: spec, outDir: out);
+
+        // Messages (request/response body schemas) land under
+        // `test/messages/`, models under `test/models/`. Look for each
+        // test file in either location.
+        File testFileFor(String basename) {
+          for (final subdir in const ['test/messages', 'test/models']) {
+            final f = out.childFile('$subdir/$basename');
+            if (f.existsSync()) return f;
+          }
+          final testDir = out.childDirectory('test');
+          final all = testDir.existsSync()
+              ? testDir
+                    .listSync(recursive: true)
+                    .whereType<File>()
+                    .map((f) => f.path)
+                    .join('\n')
+              : '(no test dir)';
+          fail(
+            'expected $basename under test/messages or test/models\n'
+            'generated test files:\n$all',
+          );
+        }
+
+        expect(
+          testFileFor('bag_test.dart').readAsStringSync(),
+          contains("Bag(id: 'example', entries: <String, String>{})"),
+        );
+        expect(
+          testFileFor('sack_test.dart').readAsStringSync(),
+          contains("Sack(id: 'example', entries: <String, dynamic>{})"),
+        );
+      },
+    );
+
     test('enum round-trip test exercises toString and every value', () async {
       final fs = MemoryFileSystem.test();
       final spec = {


### PR DESCRIPTION
## Summary

When a schema has \`additionalProperties\`, the generated class carries a required synthetic \`entries: Map<String, V>\` field alongside the named properties. \`RenderObject.exampleValue\` iterated only \`properties.entries\` and produced a constructor call missing the required \`entries\` argument:

\`\`\`
error: The named parameter 'entries' is required, but there's no corresponding argument
\`\`\`

## Fix

Add an explicit \`entries: <String, V>{}\` argument to the constructor call when \`additionalProperties != null\`. The value type \`V\` matches \`additionalProperties.typeName\` — \`dynamic\` for open \`additionalProperties: true\`, \`String\` for \`additionalProperties: { type: string }\`, and so on.

## Motivating case

GitHub spec: \`integration_permissions\`, \`copilot_organization_details\`, \`copilot_ide_chat\`, \`copilot_usage_metrics_day\`, \`copilot_ide_code_completions\`, and the other \`copilot_*\` models. ~12 of the remaining errors after #109 and #110.

## Test plan

- [x] Unit test in \`file_renderer_test.dart\` that exercises both \`additionalProperties: true\` and \`additionalProperties: {type: string}\` against the full generator pipeline and asserts the emitted test file includes \`entries: <String, ?>{}\` with the right value type.
- [x] Full \`dart test\` passes (301 tests).