### PR TITLE
ci: auto-publish to pub.dev on tag push

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,18 @@
+name: Publish to pub.dev
+
+# Triggered when a `vX.Y.Z` (or `vX.Y.Z-prerelease`) tag is pushed.
+# pub.dev's "Automated publishing from GitHub Actions" must be enabled
+# for the package via Admin → Automated publishing on pub.dev/packages/space_gen,
+# pointing at this repository and the same tag pattern.
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
+
+jobs:
+  publish:
+    # `id-token: write` lets the runner mint an OIDC token that pub.dev
+    # accepts in lieu of an API key — no long-lived secret stored here.
+    permissions:
+      id-token: write
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/publish.yaml` triggered on `v[0-9]+.[0-9]+.[0-9]+*` tag pushes.
- Uses `dart-lang/setup-dart/.github/workflows/publish.yml@v1` (the canonical reusable workflow for pure Dart packages) with OIDC auth — no API token stored in repo secrets.
- Mirrors the pattern from `shorebirdtech/updater`'s `publish.yaml`, adapted for Dart instead of Flutter (we don't need `subosito/flutter-action`).

## One-time pub.dev configuration

After merge, this needs the matching pub.dev side enabled:
- pub.dev/packages/space_gen → Admin → Automated publishing → enable Publishing from GitHub Actions
- Repository: `eseidel/space_gen`
- Tag pattern: `v{{version}}` (matches the `v[0-9]+.[0-9]+.[0-9]+*` glob the workflow listens on)

Without this pub.dev side, the OIDC-authenticated `dart pub publish -f` from the runner gets rejected.

## v1.1.0 caveat

The workflow won't retroactively publish `v1.1.0` (the tag was pushed before the workflow existed). For 1.1.0, run `dart pub publish` manually once. Subsequent tags will fire the workflow.

## Test plan

- [x] YAML parses (the reusable workflow + permissions block matches the canonical pattern).
- [ ] After merge: enable pub.dev side, then verify the next release tag triggers a successful publish.