### PR TITLE
docs: add example/ with petstore spec and usage walkthrough

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,54 @@
+# space_gen example
+
+A tiny OpenAPI 3.1 spec for a pet store, plus the command to generate a
+Dart client package from it.
+
+## The spec
+
+[`petstore.yaml`](petstore.yaml) defines two operations — `listPets` and
+`getPet` — and a `Pet` model with a `PetStatus` enum. It's intentionally
+small so the generated output is easy to skim.
+
+## Generating a client
+
+From this directory:
+
+```sh
+dart pub global activate space_gen
+space_gen -i petstore.yaml -o petstore_api
+```
+
+Or, without a global install:
+
+```sh
+dart run space_gen -i petstore.yaml -o petstore_api
+```
+
+`space_gen` writes a full Dart package into `petstore_api/`, including:
+
+- `lib/api/default_api.dart` — a `DefaultApi` class with `listPets()` and
+  `getPet()` methods.
+- `lib/models/pet.dart` and `lib/models/pet_status.dart` — immutable
+  model classes with `fromJson` / `toJson` and a real Dart enum.
+- `lib/api_client.dart`, `lib/api_exception.dart` — the shared runtime.
+- `lib/api.dart` — a barrel that re-exports the APIs, models, and
+  runtime for consumers.
+- `test/models/` — round-trip tests for each model.
+- `pubspec.yaml`, `analysis_options.yaml` — ready to `dart pub get`.
+
+## Using the generated client
+
+```dart
+import 'package:petstore_api/api.dart';
+
+Future<void> main() async {
+  final api = DefaultApi(ApiClient());
+  final pets = await api.listPets();
+  for (final pet in pets) {
+    print('${pet.id}: ${pet.name} (${pet.status.name})');
+  }
+}
+```
+
+See the top-level [README](../README.md) for the full list of supported
+OpenAPI features and configuration flags.

--- a/example/petstore.yaml
+++ b/example/petstore.yaml
@@ -1,0 +1,56 @@
+openapi: 3.1.0
+info:
+  title: Petstore
+  version: 1.0.0
+servers:
+  - url: https://petstore.example.com
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      summary: List all pets
+      responses:
+        '200':
+          description: A list of pets.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+  /pets/{petId}:
+    get:
+      operationId: getPet
+      summary: Fetch a single pet by id
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: The requested pet.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+components:
+  schemas:
+    Pet:
+      type: object
+      required: [id, name, status]
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string
+        status:
+          $ref: '#/components/schemas/PetStatus'
+    PetStatus:
+      type: string
+      enum: [available, pending, sold]


### PR DESCRIPTION
## Summary

- Adds `example/petstore.yaml` — a minimal OpenAPI 3.1 spec (two
  operations, a `Pet` model, a `PetStatus` enum).
- Adds `example/README.md` — walks through the CLI invocation, the
  generated package layout (verified by actually running `space_gen` on
  the spec), and a small usage snippet.
- Motivation: pub.dev's package scoring rewards having an `example/`
  directory. This is the simplest shape that satisfies it for a CLI
  generator — no Dart code in `example/`, so no lint surface.

## Test plan

- [x] `dart analyze example/` — no issues
- [x] `dart run space_gen -i example/petstore.yaml -o /tmp/petstore_api` generates the layout described in the README