### PR TITLE
feat: declare space_gen executable in pubspec

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,6 +6,9 @@ repository: https://github.com/eseidel/space_gen
 environment:
   sdk: ^3.8.0
 
+executables:
+  space_gen:
+
 dependencies:
   args: ^2.4.2
   collection: ^1.19.1


### PR DESCRIPTION
## Summary

- Adds an `executables:` section to `pubspec.yaml` so `dart pub global activate space_gen` installs a `space_gen` command directly on PATH, and pub.dev surfaces the binary on the package page.
- Empty value defaults to `bin/space_gen.dart`, which is already what we ship — no code changes.

Closes #111.

## Test plan

- [x] `dart pub get` still resolves
- [ ] After merge: `dart pub global activate space_gen` exposes `space_gen` on PATH without needing `dart pub global run`