### PR TITLE
fix: normalize dotted schema names in toSnakeCase

### DIFF
--- a/lib/src/string.dart
+++ b/lib/src/string.dart
@@ -26,7 +26,10 @@ String toSnakeCase(String unknown) {
   // like "Payment Methods" or "Seller Account" arrive here verbatim
   // and would otherwise survive into generated class/file names as
   // `Payment MethodsApi`, which isn't valid Dart.
-  final normalized = unknown.replaceAll(RegExp(r'\s+'), '_');
+  // Dots get the same treatment: .NET-style specs declare schemas under
+  // dotted namespace keys like `.App.Features.Order.Enums.Foo`, which
+  // would otherwise land in generated code verbatim and fail to parse.
+  final normalized = unknown.replaceAll(RegExp(r'[\s.]+'), '_');
   // Try to convert any UpperCase to snake_case.
   final lowered = snakeFromCamel(normalized);
   // Then convert any kebab-case to snake_case.
@@ -34,7 +37,11 @@ String toSnakeCase(String unknown) {
   // "Payment Methods" → "Payment_Methods" → snakeFromCamel splits at
   // each uppercase, producing "payment__methods". Collapse the double
   // underscore (and any others the input introduced) to a single one.
-  return snake.replaceAll(RegExp('_+'), '_');
+  final collapsed = snake.replaceAll(RegExp('_+'), '_');
+  // A leading dot (`.App.Features.X`) normalizes to a leading underscore;
+  // strip it so snake names don't start with `_` (which makes generated
+  // file/identifier names private and reads as noise).
+  return collapsed.startsWith('_') ? collapsed.substring(1) : collapsed;
 }
 
 /// Convert kebab-case to snake_case.

--- a/test/string_test.dart
+++ b/test/string_test.dart
@@ -24,6 +24,14 @@ void main() {
     expect(toSnakeCase('Four More Words Here'), 'four_more_words_here');
     expect(toSnakeCase('Multi   Space'), 'multi_space');
     expect(toSnakeCase('Tab\tSeparated'), 'tab_separated');
+    // .NET / NSwag-style dotted schema keys must normalize the same way
+    // whitespace does — otherwise the dots survive into Dart type names.
+    expect(toSnakeCase('App.Features.Order'), 'app_features_order');
+    expect(
+      toSnakeCase('.App.Features.Marketplace.Order.Enums.OrderTimelineEvent'),
+      'app_features_marketplace_order_enums_order_timeline_event',
+    );
+    expect(toSnakeCase('Foo..Bar'), 'foo_bar');
   });
 
   test('camelFromSnake', () {


### PR DESCRIPTION
## Summary

- .NET / NSwag-style OpenAPI specs declare schemas under dotted namespace keys like `.App.Features.Marketplace.Order.Enums.Foo`. `toSnakeCase` currently passes `.` through verbatim, so the dotted name survives into the generated Dart type (`final .App.Features.…Foo foo;`), `dart format` rejects it, and the whole run aborts.
- Treat `.` like whitespace (collapse to single underscore) and strip a leading underscore introduced by a leading dot. `.App.Features.Foo` → `AppFeaturesFoo`.
- Surfaced by a real spec (watchcrunch) in `private_gen_tests` that couldn't generate at all before this fix.
- A future custom-generator hook to remap names (e.g. keep only the last segment) would give nicer output for deeply-namespaced specs, but out of scope for this PR — the minimal fix keeps names unique and valid with no new plumbing.

## Test plan

- [x] `dart test test/string_test.dart` — new `toSnakeCase` cases for dotted input pass
- [x] `dart test` — full suite (310 tests) passes
- [x] Regenerated `watchcrunch-api.json` into a clean Dart package (`dart analyze` → no issues)