### PR TITLE
fix: enforce required-and-nullable keys via checkedKey helper

### DIFF
--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -279,6 +279,7 @@ abstract final class ModelHelpers {
   static const listHash = 'listHash';
   static const mapHash = 'mapHash';
   static const parseFromJson = 'parseFromJson';
+  static const checkedKey = 'checkedKey';
 
   static const List<String> all = [
     maybeParseDateTime,
@@ -290,6 +291,7 @@ abstract final class ModelHelpers {
     listHash,
     mapHash,
     parseFromJson,
+    checkedKey,
   ];
 }
 
@@ -2539,8 +2541,8 @@ class RenderObject extends RenderNewType {
   }) {
     final dartName = variableSafeName(context.quirks, jsonName);
     final hasDefaultValue = property.hasDefaultValue(context);
-    final jsonIsNullable =
-        !requiredProperties.contains(jsonName) || property.common.nullable;
+    final jsonKeyIsRequired = requiredProperties.contains(jsonName);
+    final jsonIsNullable = !jsonKeyIsRequired || property.common.nullable;
     final dartIsNullable =
         propertyDartIsNullable(
           jsonName: jsonName,
@@ -2548,6 +2550,15 @@ class RenderObject extends RenderNewType {
           propertyHasDefaultValue: hasDefaultValue,
         ) ||
         property.common.nullable;
+    // OpenAPI 3.1 lets a property be both `required` and accept `null`
+    // as its value (`type: [T, "null"]` + `required: [key]`). A plain
+    // `json[key] as T?` cast would then accept a missing key as a null
+    // value, silently violating `required`. Route the read through
+    // `checkedKey`, which throws `FormatException` when the key is
+    // absent — other combinations still read `json[key]` directly.
+    final jsonRead = jsonKeyIsRequired && property.common.nullable
+        ? "${ModelHelpers.checkedKey}(json, '$jsonName')"
+        : "json['$jsonName']";
 
     // Means that the constructor parameter is required which is only true if
     // both the json property is required and it does not have a default.
@@ -2586,7 +2597,7 @@ class RenderObject extends RenderNewType {
         dartIsNullable: dartIsNullable,
       ),
       'fromJson': property.fromJsonExpression(
-        "json['$jsonName']",
+        jsonRead,
         context,
         dartIsNullable: dartIsNullable,
         jsonIsNullable: jsonIsNullable,

--- a/lib/templates/model_helpers.mustache
+++ b/lib/templates/model_helpers.mustache
@@ -68,6 +68,20 @@ T parseFromJson<T>(
 }
 {{/parseFromJson}}
 
+{{#checkedKey}}
+/// Reads a key that is required to be present in [json] but whose value
+/// may legitimately be null (OpenAPI 3.1 `type: [T, "null"]` combined
+/// with `required`). A plain `json[key] as T?` cast would otherwise
+/// accept a missing key as a null value, silently violating `required`.
+/// Throws [FormatException] when the key is absent.
+dynamic checkedKey(Map<String, dynamic> json, String key) {
+  if (!json.containsKey(key)) {
+    throw FormatException("Missing required key '$key'", json);
+  }
+  return json[key];
+}
+{{/checkedKey}}
+
 {{#listsEqual}}
 /// Check if two nullable lists are deeply equal.
 bool listsEqual<T>(List<T>? a, List<T>? b) {

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -837,7 +837,7 @@ void main() {
           '    factory User.fromJson(Map<String, dynamic>\n'
           '        json) {\n'
           "        return parseFromJson('User', json, () => User(\n"
-          "            foo: Value.maybeFromJson(json['foo'] as Map<String, dynamic>?),\n"
+          "            foo: Value.maybeFromJson(checkedKey(json, 'foo') as Map<String, dynamic>?),\n"
           '        ));\n'
           '    }\n'
           '\n'
@@ -2000,7 +2000,7 @@ void main() {
           '    factory Test.fromJson(Map<String, dynamic>\n'
           '        json) {\n'
           "        return parseFromJson('Test', json, () => Test(\n"
-          "            reqNull: json['req_null'] as String?,\n"
+          "            reqNull: checkedKey(json, 'req_null') as String?,\n"
           "            optNull: json['opt_null'] as String?,\n"
           "            req: json['req'] as String,\n"
           "            opt: json['opt'] as String?,\n"


### PR DESCRIPTION
## Summary

- OpenAPI 3.1 lets a property be both `required` and accept `null` (`type: [T, "null"]` combined with the property being in the schema's `required` list). Today the generated `fromJson` reads such a property as `json[key] as T?`, which silently accepts a missing key as a null value — violating `required` and contradicting the generated round-trip test that asserts `fromJson({})` throws `FormatException`.
- Add a `checkedKey` helper in `model_helpers.dart` that verifies `containsKey` before returning the raw value; throws `FormatException` when the key is absent.
- Route the read through `checkedKey` at the emit site in `RenderObject.propertyTemplateContext` only when the property is both required *and* nullable. The three other combinations still read `json[key]` directly.
- Surfaced by `TagMiniDto` in `watchcrunch-api.json` (`private_gen_tests`, #120): after this PR the full generated test suite (822 tests) passes without touching any test template.

Closes #120.

## Test plan

- [x] `dart test` — all 310 unit tests pass; the existing `nullable > string` and `anyOf > two object types` tests (which assert the exact generated `fromJson` string) are updated to reflect the `checkedKey` wrapping on the required+nullable lines.
- [x] Regenerated `watchcrunch-api.json` → `dart analyze` clean, `dart test` → **822 / 822** pass (previously `TagMiniDto maybeFromJson throws FormatException on invalid input` failed).
- [x] Manual inspection of generated `tag_mini_dto.dart` confirms `checkedKey(json, 'title') as String?` replaces the old `json['title'] as String?`, and non-required / non-nullable sibling fields are unchanged.