### PR TITLE
fix: camelCase non-enum identifiers even under openapi quirks

### DIFF
--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -21,8 +21,18 @@ Never _unimplemented(String message, JsonPointer pointer) {
   throw UnimplementedError('$message at $pointer');
 }
 
-/// Convert an enum value to a variable name.
-String variableSafeName(Quirks quirks, String jsonName) {
+/// Convert a spec-side identifier (enum value, property name, parameter
+/// name) into a legal Dart identifier. [preserveCase] preserves the
+/// input's original casing after sanitization — only enum values should
+/// set this (under the `screamingCapsEnums` quirk), so SCREAMING_CAPS
+/// enum constants survive. Everything else gets camelCased so
+/// snake_case spec-side names like `api_key` don't leak into generated
+/// parameter/property identifiers.
+String variableSafeName(
+  Quirks quirks,
+  String jsonName, {
+  bool preserveCase = false,
+}) {
   var escapedName = jsonName.replaceAll(' ', '_');
   escapedName = escapedName
       // These are kinda hacky for the GitHub spec which has +1 and -1 as names.
@@ -37,8 +47,7 @@ String variableSafeName(Quirks quirks, String jsonName) {
       // TODO(eseidel): Tweak this to make nicer names.
       .replaceAll(RegExp('[^a-zA-Z0-9_]'), '_');
 
-  // This should probably only apply to enums?
-  if (!quirks.screamingCapsEnums) {
+  if (!preserveCase) {
     // Dart style uses camelCase.
     escapedName = toLowerCamelCase(escapedName);
   }
@@ -3110,7 +3119,14 @@ class RenderEnum extends RenderNewType {
   static List<String> variableNamesFor(Quirks quirks, List<String> values) {
     final commonPrefix = sharedPrefixFromSnakeNames(values);
     String toShortVariableName(String value) {
-      var dartName = variableSafeName(quirks, value);
+      var dartName = variableSafeName(
+        quirks,
+        value,
+        // Enum values — and only enum values — honor the SCREAMING_CAPS
+        // preservation quirk. For every other identifier (parameters,
+        // properties) camelCase is the right Dart style.
+        preserveCase: quirks.screamingCapsEnums,
+      );
       // OpenAPI also removes shared prefixes from enum values.
       dartName = dartName.replaceAll(commonPrefix, '');
       // Avoid reserved words again in case removing the prefix caused

--- a/test/render/render_tree_test.dart
+++ b/test/render/render_tree_test.dart
@@ -81,6 +81,39 @@ void main() {
       expect(parameter.dartParameterName(quirks), 'aB');
     });
 
+    test('parameter names always camelCase under openapi quirks', () {
+      // `screamingCapsEnums: true` controls enum-value casing, not every
+      // identifier — petstore's `api_key` header parameter would otherwise
+      // survive into generated code as a snake_case Dart variable and trip
+      // `non_constant_identifier_names`.
+      const quirks = Quirks.openapi();
+      expect(quirks.screamingCapsEnums, isTrue);
+      const common = CommonProperties.test(
+        snakeName: 'api_key',
+        pointer: JsonPointer.empty(),
+      );
+      const parameter = RenderParameter(
+        description: null,
+        name: 'api_key',
+        type: RenderUnknown(common: common),
+        isRequired: false,
+        isDeprecated: false,
+        inLocation: ParameterLocation.header,
+      );
+      expect(parameter.dartParameterName(quirks), 'apiKey');
+    });
+
+    test('enum values preserve SCREAMING_CAPS under openapi quirks', () {
+      const quirks = Quirks.openapi();
+      expect(quirks.screamingCapsEnums, isTrue);
+      final names = RenderEnum.variableNamesFor(quirks, [
+        'AVAILABLE',
+        'PENDING',
+        'SOLD',
+      ]);
+      expect(names, ['AVAILABLE', 'PENDING', 'SOLD']);
+    });
+
     test('reserved-word parameter name is escaped in template context', () {
       // A spec with a parameter literally named `with` (or `try`/`case`/
       // ...) previously emitted `required String with` in the generated


### PR DESCRIPTION
## Summary

- `variableSafeName` gates its `toLowerCamelCase` step on `quirks.screamingCapsEnums`. The quirk's name is honest — it's meant to preserve SCREAMING_CAPS on enum values — but the gate has always applied to every other caller too (property names, parameter names), so snake_case spec-side identifiers like petstore's `api_key` header parameter survived into the generated Dart as snake_case variables, tripping `non_constant_identifier_names`.
- Split the concerns: `variableSafeName` grows a `preserveCase` flag that defaults to false (always camelCase). `RenderEnum.variableNamesFor` opts in to case preservation via `preserveCase: quirks.screamingCapsEnums`. Enum values keep their SCREAMING_CAPS behavior; parameters and properties now camelCase regardless of quirks.
- Surfaced by petstore from the sibling `gen_tests/` directory: `deletePet` now emits `String? apiKey` (was `String? api_key`) while the wire-level header key `'api_key'` stays snake_case.

## Test plan

- [x] `dart test` — 312 pass (existing 310 + 2 new regression tests: `parameter names always camelCase under openapi quirks`, `enum values preserve SCREAMING_CAPS under openapi quirks`).
- [x] petstore regenerates with **zero** analyzer issues (previously: `non_constant_identifier_names` on `api_key`).
- [x] spacetraders regenerates clean.
- [x] watchcrunch regenerates clean; its 822 generated round-trip tests still pass.