### PR TITLE
feat: auto-sanitize invalid Dart package names in CLI

### DIFF
--- a/lib/src/cli.dart
+++ b/lib/src/cli.dart
@@ -61,7 +61,14 @@ Future<int> _runCli(
 
   final specUrl = Uri.parse(results['in'] as String);
   final outDir = fs.directory(results['out'] as String);
-  final packageName = p.basename(outDir.path);
+  final rawPackageName = p.basename(outDir.path);
+  final packageName = sanitizePackageName(rawPackageName);
+  if (packageName != rawPackageName) {
+    logger.info(
+      "Using '$packageName' as the package name "
+      "since '$rawPackageName' is not a valid Dart package name.",
+    );
+  }
   final quirks = results['openapi'] as bool
       ? const Quirks.openapi()
       : const Quirks();

--- a/lib/src/render.dart
+++ b/lib/src/render.dart
@@ -117,11 +117,11 @@ void validatePackageName(String packageName) {
 }
 
 /// Coerce an arbitrary string into something that passes
-/// [validatePackageName]: `.` `-` and any other non-alnum characters
-/// collapse to `_`, casing is lowered, leading underscores and digits
-/// are prefixed with `p`, and the result is clamped to 64 chars.
-/// Used by the CLI so `--out api.github.com` works without the user
-/// having to pre-sanitize the directory name for pub.
+/// [validatePackageName]: `.`, `-`, and any other non-alphanumeric
+/// character collapse to `_`, casing is lowered, leading underscores
+/// and digits are prefixed with `p`, and the result is clamped to 64
+/// chars. Used by the CLI so `--out api.github.com` works without the
+/// user having to pre-sanitize the directory name for pub.
 String sanitizePackageName(String raw) {
   var s = raw.toLowerCase().replaceAll(RegExp(r'[^a-z0-9_]'), '_');
   s = s.replaceAll(RegExp('_+'), '_').replaceAll(RegExp(r'^_+|_+$'), '');

--- a/lib/src/render.dart
+++ b/lib/src/render.dart
@@ -116,6 +116,23 @@ void validatePackageName(String packageName) {
   }
 }
 
+/// Coerce an arbitrary string into something that passes
+/// [validatePackageName]: `.` `-` and any other non-alnum characters
+/// collapse to `_`, casing is lowered, leading underscores and digits
+/// are prefixed with `p`, and the result is clamped to 64 chars.
+/// Used by the CLI so `--out api.github.com` works without the user
+/// having to pre-sanitize the directory name for pub.
+String sanitizePackageName(String raw) {
+  var s = raw.toLowerCase().replaceAll(RegExp(r'[^a-z0-9_]'), '_');
+  s = s.replaceAll(RegExp('_+'), '_').replaceAll(RegExp(r'^_+|_+$'), '');
+  if (s.isEmpty || RegExp('^[0-9]').hasMatch(s)) {
+    s = 'p_$s';
+    s = s.replaceAll(RegExp(r'_+$'), '');
+  }
+  if (s.length > 64) s = s.substring(0, 64);
+  return s;
+}
+
 /// Format [url] for log output: `file:` URLs are shown as paths
 /// relative to the cwd (readable), everything else prints as-is.
 @visibleForTesting

--- a/test/render_test.dart
+++ b/test/render_test.dart
@@ -25,16 +25,22 @@ void main() {
     expect(sanitizePackageName('api.github.com'), 'api_github_com');
     expect(sanitizePackageName('my-package'), 'my_package');
     // Uppercase gets lowered.
-    expect(sanitizePackageName('MyApi'), 'myapi');
+    expect(sanitizePackageName('Package'), 'package');
     // Leading digits get a `p_` prefix.
-    expect(sanitizePackageName('123api'), 'p_123api');
+    expect(sanitizePackageName('123_client'), 'p_123_client');
     // Leading underscores strip, not prefix.
-    expect(sanitizePackageName('_api'), 'api');
+    expect(sanitizePackageName('_client'), 'client');
     // Empty-after-sanitize falls back to a non-empty valid name.
     expect(sanitizePackageName('.'), 'p');
     expect(sanitizePackageName(''), 'p');
     // Result always passes validatePackageName.
-    for (final raw in ['api.github.com', '123api', '.', '_api', 'MyApi']) {
+    for (final raw in [
+      'api.github.com',
+      '123_client',
+      '.',
+      '_client',
+      'Package',
+    ]) {
       expect(
         () => validatePackageName(sanitizePackageName(raw)),
         returnsNormally,

--- a/test/render_test.dart
+++ b/test/render_test.dart
@@ -17,6 +17,31 @@ void main() {
     );
   });
 
+  test('sanitizePackageName coerces to a valid Dart package name', () {
+    // Already valid — no change.
+    expect(sanitizePackageName('petstore'), 'petstore');
+    expect(sanitizePackageName('a_123'), 'a_123');
+    // Dots and dashes (common in spec filenames / output dirs).
+    expect(sanitizePackageName('api.github.com'), 'api_github_com');
+    expect(sanitizePackageName('my-package'), 'my_package');
+    // Uppercase gets lowered.
+    expect(sanitizePackageName('MyApi'), 'myapi');
+    // Leading digits get a `p_` prefix.
+    expect(sanitizePackageName('123api'), 'p_123api');
+    // Leading underscores strip, not prefix.
+    expect(sanitizePackageName('_api'), 'api');
+    // Empty-after-sanitize falls back to a non-empty valid name.
+    expect(sanitizePackageName('.'), 'p');
+    expect(sanitizePackageName(''), 'p');
+    // Result always passes validatePackageName.
+    for (final raw in ['api.github.com', '123api', '.', '_api', 'MyApi']) {
+      expect(
+        () => validatePackageName(sanitizePackageName(raw)),
+        returnsNormally,
+      );
+    }
+  });
+
   group('describeSpecUrl', () {
     test('file: URL becomes a path relative to the cwd', () {
       // Absolute path under cwd → empty relative path wouldn't be


### PR DESCRIPTION
## Summary

- The CLI derives the package name from `--out`'s basename and hands it straight to `validatePackageName`, which throws `FormatException` for anything that isn't lowercase snake_case. Trying to generate `api.github.com` that way fails out before a single file is written — even though the fix is mechanical.
- Add `sanitizePackageName`: lowercase the input, collapse any non-alnum to `_`, strip leading/trailing underscores, prepend `p_` on leading-digit / empty results, clamp to 64 chars. Call it from the CLI before the name reaches `GeneratorConfig`; log a one-liner when the name changed so the user can see what landed in `pubspec.yaml`.
- `validatePackageName` still throws — it's the safety net for programmatic callers that build `GeneratorConfig` directly. The CLI just makes sure it never trips.
- Surfaced by the GitHub spec (`gen_tests/api.github.com.json`), which had no workaround short of passing a pre-sanitized `-o` path.

## Test plan

- [x] `dart test test/render_test.dart` — new `sanitizePackageName` cases pass, and every sanitized output still passes `validatePackageName`.
- [x] `dart test` — full suite (313) passes.
- [x] `space_gen -i api.github.com.json -o /tmp/api.github.com` now succeeds; log line: `Using 'api_github_com' as the package name since 'api.github.com' is not a valid Dart package name.`. `dart analyze` on the output no longer blocks at the CLI layer (18 pre-existing content lints remain — separate bugs).