### PR TITLE
fix: suppress avoid_positional_boolean_parameters in bool newtypes

### DIFF
--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -2023,6 +2023,13 @@ class RenderPod extends RenderSchema {
       'jsonType': jsonStorageType(isNullable: false),
       'fromJsonBody': _jsonToValueBody('json'),
       'toJsonBody': _valueToJsonBody('value', nameIsNullable: false),
+      // Bool newtypes wrap a single positional `bool` in three places
+      // (the extension-type representation, `fromJson`, `maybeFromJson`)
+      // that all trip `avoid_positional_boolean_parameters`. The lint
+      // is right about user-facing APIs (`widget.setVisible(true)`) but
+      // wrong here — the type name *is* the disambiguation. Suppress
+      // file-locally so the lint stays live for everyone else.
+      'isBoolPod': type == PodType.boolean,
     };
   }
 

--- a/lib/templates/schema_pod_newtype.mustache
+++ b/lib/templates/schema_pod_newtype.mustache
@@ -1,4 +1,6 @@
-{{{ doc_comment }}}extension type const {{{ typeName }}}._({{{ dartType }}} value) {
+{{#isBoolPod}}// ignore_for_file: avoid_positional_boolean_parameters
+
+{{/isBoolPod}}{{{ doc_comment }}}extension type const {{{ typeName }}}._({{{ dartType }}} value) {
     const {{ typeName }}(this.value);
 
     factory {{ typeName }}.fromJson({{{ jsonType }}} json) => {{ typeName }}({{{ fromJsonBody }}});

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -1799,6 +1799,36 @@ void main() {
           '}\n',
         );
       });
+      test('bool newtype suppresses positional-bool lint', () {
+        // The generated extension-type, fromJson, and maybeFromJson all
+        // take a positional `bool`, which trips
+        // `avoid_positional_boolean_parameters`. The lint is correct
+        // for user-facing APIs but wrong for a newtype wrapper — the
+        // type name is the disambiguation. Suppress file-locally.
+        // See github's `prevent_self_review` in api.github.com.json.
+        final json = {'type': 'boolean'};
+        expect(
+          renderTestSchema(json, asComponent: true),
+          '// ignore_for_file: avoid_positional_boolean_parameters\n'
+          '\n'
+          'extension type const Test._(bool value) {\n'
+          '    const Test(this.value);\n'
+          '\n'
+          '    factory Test.fromJson(bool json) => Test(json);\n'
+          '\n'
+          '    /// Convenience to create a nullable type from a nullable json object.\n'
+          '    /// Useful when parsing optional fields.\n'
+          '    static Test? maybeFromJson(bool? json) {\n'
+          '        if (json == null) {\n'
+          '            return null;\n'
+          '        }\n'
+          '        return Test.fromJson(json);\n'
+          '    }\n'
+          '\n'
+          '    bool toJson() => value;\n'
+          '}\n',
+        );
+      });
       test('number newtype', () {
         final json = {
           'type': 'number',


### PR DESCRIPTION
## Summary

- A spec-side `type: boolean` schema with its own name renders as an extension type that wraps a single positional `bool` in three places (the representation, `fromJson`, `maybeFromJson`). Each one trips `avoid_positional_boolean_parameters`, leaving **12 lint hits across github's four bool newtypes alone** (plus more anywhere a real spec ships a named `boolean` schema).
- The lint is right about user-facing APIs (`widget.setVisible(true)`) where the call site loses meaning, but wrong for newtype wrappers — the type name *is* the disambiguation. `PreventSelfReview(true)` and `PreventSelfReview(value: true)` carry the same information.
- Add an `isBoolPod` flag to the pod-newtype template context (true only for `PodType.boolean`) and gate a per-file `// ignore_for_file: avoid_positional_boolean_parameters` directive on it. int / double / String / uuid / email / dateTime newtypes are unchanged — the directive only fires where the lint actually trips.
- Per project preference (CLAUDE.md memory note: per-file ignore over global `analysis_options.yaml`), this keeps the lint live for consumers not using our analyzer setup and still catches future template regressions.

## Test plan

- [x] `dart test` — 314 pass (existing 313 + 1 new regression test asserting the directive on a bool newtype).
- [x] Existing string / number / int newtype output tests still pass — directive is bool-only.
- [x] Regenerated `api.github.com.json` → `avoid_positional_boolean_parameters` count: **12 → 0**.
- [x] Petstore, spacetraders, watchcrunch unaffected (no bool newtypes in those specs); all still generate clean.