### PR TITLE
feat: pass-through bearer auth for oauth2 / openIdConnect schemes

### DIFF
--- a/gen_tests/unsupported_auth.json
+++ b/gen_tests/unsupported_auth.json
@@ -3,7 +3,7 @@
     "info": {
         "title": "Unsupported Auth",
         "version": "1.0.0",
-        "description": "Exercises auth scheme handling beyond plain `http`. oauth2 and openIdConnect are pass-through bearer (renderer emits `HttpAuth(scheme: 'bearer', ...)`); mutualTLS is genuinely unsupported and walks the soft-fail branch that emits `NoAuth()`. Keep all three wired to operations so the codegen path is exercised end-to-end."
+        "description": "Exercises auth scheme handling beyond plain `http`. oauth2 and openIdConnect are pass-through bearer (renderer emits `HttpAuth(scheme: 'bearer', ...)`); mutualTLS is genuinely unsupported and walks the soft-fail branch that emits `NoAuth()`. Keep all three wired to operations so the generator path is exercised end-to-end."
     },
     "servers": [
         {

--- a/gen_tests/unsupported_auth.json
+++ b/gen_tests/unsupported_auth.json
@@ -3,7 +3,7 @@
     "info": {
         "title": "Unsupported Auth",
         "version": "1.0.0",
-        "description": "Exercises the soft-fail path for security schemes we don't implement (oauth2, openIdConnect, mutualTLS). All three are declared at the components level and wired to operations so that the renderer actually walks the UnsupportedSecurityScheme branch and emits NoAuth()."
+        "description": "Exercises auth scheme handling beyond plain `http`. oauth2 and openIdConnect are pass-through bearer (renderer emits `HttpAuth(scheme: 'bearer', ...)`); mutualTLS is genuinely unsupported and walks the soft-fail branch that emits `NoAuth()`. Keep all three wired to operations so the codegen path is exercised end-to-end."
     },
     "servers": [
         {
@@ -14,7 +14,7 @@
         "/oauth2-protected": {
             "get": {
                 "operationId": "oauth2Protected",
-                "summary": "Operation requires an oauth2 scheme we don't implement.",
+                "summary": "Requires an oauth2 scheme — pass-through bearer.",
                 "security": [
                     {
                         "oauth2Scheme": [
@@ -32,7 +32,7 @@
         "/oidc-protected": {
             "get": {
                 "operationId": "oidcProtected",
-                "summary": "Operation requires an openIdConnect scheme.",
+                "summary": "Requires an openIdConnect scheme — pass-through bearer.",
                 "security": [
                     {
                         "oidcScheme": []

--- a/gen_tests/unsupported_auth/lib/api/default_api.dart
+++ b/gen_tests/unsupported_auth/lib/api/default_api.dart
@@ -9,12 +9,12 @@ class DefaultApi {
 
   final ApiClient client;
 
-  /// Operation requires an oauth2 scheme we don't implement.
+  /// Requires an oauth2 scheme — pass-through bearer.
   Future<void> oauth2Protected() async {
     final response = await client.invokeApi(
       method: Method.get,
       path: '/oauth2-protected',
-      authRequest: const NoAuth(),
+      authRequest: const HttpAuth(scheme: 'bearer', secretName: 'oauth2Scheme'),
     );
 
     if (response.statusCode >= HttpStatus.badRequest) {
@@ -25,12 +25,12 @@ class DefaultApi {
     }
   }
 
-  /// Operation requires an openIdConnect scheme.
+  /// Requires an openIdConnect scheme — pass-through bearer.
   Future<void> oidcProtected() async {
     final response = await client.invokeApi(
       method: Method.get,
       path: '/oidc-protected',
-      authRequest: const NoAuth(),
+      authRequest: const HttpAuth(scheme: 'bearer', secretName: 'oidcScheme'),
     );
 
     if (response.statusCode >= HttpStatus.badRequest) {

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -1090,13 +1090,27 @@ SecurityScheme parseSecurityScheme(String name, MapContext json) {
         scheme: _required<String>(json, 'scheme'),
         bearerFormat: _optional<String>(json, 'bearerFormat'),
       );
-    case 'mutualTLS':
     case 'oauth2':
     case 'openIdConnect':
     // OpenAPI 3.0 uses `openIdConnect` in the schema text, but the
     // majority of real-world specs (and several 3.1 examples) use the
     // alternate-cased `openIDConnect`. Accept both.
     case 'openIDConnect':
+      // Pass-through: at the wire level both schemes deliver an opaque
+      // bearer token in the `Authorization` header. We don't generate
+      // any flow logic — token acquisition (OIDC discovery, the OAuth2
+      // grants, refresh) stays the caller's responsibility — but we DO
+      // generate the same `authRequest:` plumbing as `http` + `bearer`
+      // so the caller's existing secret resolver can supply the token.
+      // mutualTLS isn't bearer-shaped at all, so it stays unsupported.
+      return HttpSecurityScheme(
+        pointer: pointer,
+        name: name,
+        description: description,
+        scheme: 'bearer',
+        bearerFormat: null,
+      );
+    case 'mutualTLS':
       _warn(
         json,
         "Security scheme '$name' has type '$type', which isn't supported "

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -1575,12 +1575,11 @@ void main() {
           throwsA(isA<FormatException>()),
         );
       });
-      test('oauth2 declaration accepted as UnsupportedSecurityScheme', () {
-        // A spec that *declares* oauth2 (petstore, train-travel, and most
-        // nontrivial specs do) used to crash generation at parse time even
-        // if no operation actually required the scheme. Now it parses to a
-        // sentinel that renders as NoAuth(); consumers override
-        // ApiClient.resolveAuth or set defaultHeaders to inject real auth.
+      test('oauth2 parses as bearer pass-through', () {
+        // oauth2 schemes deliver an opaque bearer token at the wire
+        // level, so we generate the same `HttpAuth(scheme: 'bearer', …)`
+        // plumbing as a `http` + `bearer` scheme. Token acquisition (the
+        // OAuth2 grants, refresh) stays the caller's responsibility.
         final json = {
           'type': 'oauth2',
           'flows': {
@@ -1594,8 +1593,9 @@ void main() {
           Logger(),
           () => parseSecurityScheme('name', MapContext.initial(json)),
         );
-        expect(scheme, isA<UnsupportedSecurityScheme>());
-        expect((scheme as UnsupportedSecurityScheme).type, 'oauth2');
+        expect(scheme, isA<HttpSecurityScheme>());
+        expect((scheme as HttpSecurityScheme).scheme, 'bearer');
+        expect(scheme.bearerFormat, isNull);
       });
       test('mutualTLS declaration accepted as UnsupportedSecurityScheme', () {
         final json = {'type': 'mutualTLS'};
@@ -1606,10 +1606,11 @@ void main() {
         expect(scheme, isA<UnsupportedSecurityScheme>());
         expect((scheme as UnsupportedSecurityScheme).type, 'mutualTLS');
       });
-      test('openIdConnect declaration accepted (both spec spellings)', () {
+      test('openIdConnect parses as bearer pass-through', () {
         // OpenAPI 3.0 specs in the wild ship both 'openIdConnect' (as the
         // spec technically prescribes in some versions) and 'openIDConnect'
-        // (widely deployed). Accept both.
+        // (widely deployed). Accept both, treating each as bearer
+        // pass-through — at the wire level OIDC lands on a bearer token.
         for (final spelling in ['openIdConnect', 'openIDConnect']) {
           final json = {
             'type': spelling,
@@ -1621,10 +1622,10 @@ void main() {
           );
           expect(
             scheme,
-            isA<UnsupportedSecurityScheme>(),
+            isA<HttpSecurityScheme>(),
             reason: 'should accept type=$spelling',
           );
-          expect((scheme as UnsupportedSecurityScheme).type, spelling);
+          expect((scheme as HttpSecurityScheme).scheme, 'bearer');
         }
       });
       test('unknown type', () {

--- a/test/render/render_operation_test.dart
+++ b/test/render/render_operation_test.dart
@@ -1275,7 +1275,9 @@ void main() {
         'operationId': 'usersGet',
         'tags': ['users'],
         'security': [
-          {'oauth2': <String>['read']},
+          {
+            'oauth2': <String>['read'],
+          },
         ],
         'responses': {
           '200': {'description': 'OK'},

--- a/test/render/render_operation_test.dart
+++ b/test/render/render_operation_test.dart
@@ -1262,6 +1262,51 @@ void main() {
         '}\n',
       );
     });
+
+    test('oauth2 scheme emits bearer pass-through', () {
+      // oauth2 schemes deliver a bearer token at the wire level. We
+      // generate the same `HttpAuth(scheme: 'bearer', ...)` plumbing
+      // as `http` + `bearer` so callers can supply the token through
+      // the standard `readSecret` callback. Token acquisition (OAuth2
+      // grants, refresh) is the caller's problem — we don't generate
+      // any flow logic.
+      final json = {
+        'description': 'Get a user',
+        'operationId': 'usersGet',
+        'tags': ['users'],
+        'security': [
+          {'oauth2': <String>['read']},
+        ],
+        'responses': {
+          '200': {'description': 'OK'},
+        },
+      };
+      final componentsJson = {
+        'securitySchemes': {
+          'oauth2': {
+            'type': 'oauth2',
+            'flows': {
+              'implicit': {
+                'authorizationUrl': 'https://example.com/auth',
+                'scopes': {'read': 'Read access'},
+              },
+            },
+          },
+        },
+      };
+      final result = renderTestOperation(
+        path: '/users',
+        operationJson: json,
+        componentsJson: componentsJson,
+        serverUrl: Uri.parse('https://example.com'),
+      );
+      expect(
+        result,
+        contains(
+          "authRequest: HttpAuth(scheme: 'bearer', secretName: 'oauth2'),",
+        ),
+      );
+    });
   });
 
   group('range (NXX) responses', () {


### PR DESCRIPTION
## Summary

- Today the parser builds an `UnsupportedSecurityScheme` sentinel for `oauth2` / `openIdConnect` declarations and the renderer emits `NoAuth()` at every call site, with a warning telling the user to override `ApiClient.resolveAuth` or set `defaultHeaders` themselves.
- But oauth2 and OIDC both deliver an opaque bearer token at the wire level — at the moment of the HTTP request they're indistinguishable from a plain `http: { scheme: bearer }` declaration. Route them through `HttpSecurityScheme(scheme: 'bearer')` and reuse the existing bearer plumbing.
- Token acquisition (the OAuth2 grants, OIDC discovery, refresh) stays the caller's responsibility — no flow logic is generated. The caller supplies the token via the standard `ApiClient(readSecret: …)` callback and protected operations send `Authorization: bearer <token>`.
- `mutualTLS` stays on the unsupported branch (client certs, no token), and the `gen_tests/unsupported_auth` fixture keeps it as `NoAuth()` to exercise the soft-fail path.

## Surfaced by

`gen_tests/petstore.json` (`petstore_auth` is `type: oauth2`). Before this PR the warning fired and `addPet`/`updatePet`/`deletePet` all generated `authRequest: const NoAuth()`. After this PR the warning is gone and they generate `authRequest: const HttpAuth(scheme: 'bearer', secretName: 'petstore_auth')`.

The github spec we test against doesn't declare `security:` so it's not affected, but the same fix applies once a github spec with security declarations is exercised.

Closes #98 for oauth2 + openIdConnect; `mutualTLS` and cookie-`apiKey` remain unfixed.

## How callers use it

```dart
final api = PetApi(
  ApiClient(readSecret: (name) => name == 'petstore_auth' ? token : null),
);
await api.addPet(pet); // sends Authorization: bearer <token>
```

## Test plan

- [x] `dart test` — 316 pass (existing 314 + 2 new: `oauth2 parses as bearer pass-through` in `test/parser_test.dart` and `oauth2 scheme emits bearer pass-through` in `test/render/render_operation_test.dart`). Existing parser tests for `mutualTLS` (still UnsupportedSecurityScheme) and `openIdConnect` (now bearer pass-through) updated.
- [x] `gen_tests/unsupported_auth` regenerated: oauth2 / oidc operations now emit `HttpAuth(scheme: 'bearer', …)`; mtls operation still emits `NoAuth()`. Diff committed.
- [x] Petstore/spacetraders/watchcrunch/github regen — no analyzer regressions; petstore's oauth2 warning is gone.