### PR TITLE
feat: return raw response.body for non-JSON success responses

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -20,3 +20,4 @@ words:
   - uncompilable
   - endtemplate
   - codepush
+  - octocat

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -473,6 +473,7 @@ class SpecResolver {
       statusCode: response.statusCode,
       description: response.description,
       content: toRenderSchema(response.content),
+      contentType: response.contentType,
     );
   }
 
@@ -557,6 +558,7 @@ class SpecResolver {
       range: response.range,
       description: response.description,
       content: toRenderSchema(response.content),
+      contentType: response.contentType,
     );
   }
 
@@ -568,6 +570,7 @@ class SpecResolver {
         : RenderDefaultResponse(
             description: resolvedDefault.description,
             content: toRenderSchema(resolvedDefault.content),
+            contentType: resolvedDefault.contentType,
           );
     return RenderOperation(
       pointer: operation.pointer,
@@ -1094,12 +1097,23 @@ class Endpoint implements ToTemplateContext {
     final responseSchema = operation.returnType;
     final returnType = responseSchema.typeName;
     final isVoidReturn = responseSchema is RenderVoid;
-    final responseFromJson = responseSchema.fromJsonExpression(
-      'jsonDecode(response.body)',
-      context,
-      jsonIsNullable: false,
-      dartIsNullable: false,
-    );
+    // When the success response advertises a non-JSON content type
+    // (text/plain, text/html, application/octocat-stream, …) the wire
+    // body is NOT JSON. Skip `jsonDecode`: `package:http`'s
+    // `Response.body` is already a `String`, which matches the
+    // `type: string` schema such responses use in practice. github's
+    // `/zen`, `/octocat`, `/markdown`, `/markdown/raw` all live here.
+    final successContentType = operation.successContentType;
+    final isJsonResponse =
+        successContentType == null || successContentType == 'application/json';
+    final responseFromJson = isJsonResponse
+        ? responseSchema.fromJsonExpression(
+            'jsonDecode(response.body)',
+            context,
+            jsonIsNullable: false,
+            dartIsNullable: false,
+          )
+        : 'response.body';
 
     // Collect error-body schemas from `default:`, `4XX:`, and `5XX:` and
     // deduplicate by structural equality. When they all resolve to the same
@@ -1297,6 +1311,24 @@ class RenderOperation {
 
   /// The return type of the resolved operation.
   final RenderSchema returnType;
+
+  /// Wire content type of the response that drove [returnType] — first
+  /// matching 2xx, then `2XX` range. `null` when the operation has no
+  /// successful response body. Used by the operation renderer to skip
+  /// `jsonDecode` when the body isn't JSON.
+  String? get successContentType {
+    for (final r in responses) {
+      if (r.statusCode >= 200 && r.statusCode < 300) {
+        return r.contentType;
+      }
+    }
+    for (final r in rangeResponses) {
+      if (r.range == StatusCodeRange.success) {
+        return r.contentType;
+      }
+    }
+    return null;
+  }
 
   /// The tags of the resolved operation.
   final List<String> tags;
@@ -1612,6 +1644,7 @@ class RenderResponse {
     required this.statusCode,
     required this.description,
     required this.content,
+    required this.contentType,
   });
 
   /// The status code of the resolved response.
@@ -1621,8 +1654,11 @@ class RenderResponse {
   final String description;
 
   /// The resolved content of the resolved response.
-  /// We only support json, so we only need a single content.
   final RenderSchema content;
+
+  /// Wire content type of [content] (e.g. `application/json`,
+  /// `text/plain`). `null` when the response has no body.
+  final String? contentType;
 }
 
 /// A range (`NXX`) response on an operation. Shares the description +
@@ -1633,6 +1669,7 @@ class RenderRangeResponse {
     required this.range,
     required this.description,
     required this.content,
+    required this.contentType,
   });
 
   /// Which `NXX` range this response covers.
@@ -1642,8 +1679,10 @@ class RenderRangeResponse {
   final String description;
 
   /// The resolved content of the resolved range response.
-  /// We only support json, so we only need a single content.
   final RenderSchema content;
+
+  /// Wire content type of [content]; see [RenderResponse.contentType].
+  final String? contentType;
 }
 
 /// The `default:` (catch-all) response on an operation. Shares the
@@ -1653,14 +1692,17 @@ class RenderDefaultResponse {
   const RenderDefaultResponse({
     required this.description,
     required this.content,
+    required this.contentType,
   });
 
   /// The description of the resolved default response.
   final String description;
 
   /// The resolved content of the resolved default response.
-  /// We only support json, so we only need a single content.
   final RenderSchema content;
+
+  /// Wire content type of [content]; see [RenderResponse.contentType].
+  final String? contentType;
 }
 
 abstract class RenderSchema extends Equatable implements ToTemplateContext {

--- a/lib/src/resolver.dart
+++ b/lib/src/resolver.dart
@@ -567,7 +567,11 @@ List<ResolvedOperation> _resolveOperations(
   }).toList();
 }
 
-ResolvedSchema _resolveContent(Response response, ResolveContext context) {
+/// Resolved content + the wire content type the schema came from.
+/// `null` content type means "no body" (void).
+typedef _ResolvedContent = (ResolvedSchema schema, String? contentType);
+
+_ResolvedContent _resolveContent(Response response, ResolveContext context) {
   final content = response.content;
   final voidSchema = ResolvedVoid(
     // TODO(eseidel): Should this pass along description?
@@ -577,18 +581,22 @@ ResolvedSchema _resolveContent(Response response, ResolveContext context) {
     ),
   );
   if (content == null) {
-    return voidSchema;
+    return (voidSchema, null);
   }
   if (content.isEmpty) {
     _warn('Response has no content: $response', response.pointer);
-    return voidSchema;
+    return (voidSchema, null);
   }
-  final jsonSchema = content['application/json']?.schema;
-  if (jsonSchema != null) {
-    return resolveSchemaRef(jsonSchema, context);
+  final jsonContent = content['application/json'];
+  if (jsonContent != null) {
+    return (resolveSchemaRef(jsonContent.schema, context), 'application/json');
   }
-  _warn('Response has no application/json schema: $response', response.pointer);
-  return resolveSchemaRef(content.values.first.schema, context);
+  // No `application/json` declared. Fall back to the first content type
+  // and report it back so the renderer can decide whether the body needs
+  // jsonDecode (if it does turn out to be JSON-shaped) or pass-through
+  // (text/plain, text/html, application/octocat-stream, …).
+  final entry = content.entries.first;
+  return (resolveSchemaRef(entry.value.schema, context), entry.key);
 }
 
 List<ResolvedResponse> _resolveResponses(
@@ -597,14 +605,15 @@ List<ResolvedResponse> _resolveResponses(
 ) {
   return responses.responses.entries.map((entry) {
     final statusCode = entry.key;
-    return context.withResolved(
-      entry.value,
-      (response) => ResolvedResponse(
+    return context.withResolved(entry.value, (response) {
+      final (content, contentType) = _resolveContent(response, context);
+      return ResolvedResponse(
         statusCode: statusCode,
         description: response.description,
-        content: _resolveContent(response, context),
-      ),
-    );
+        content: content,
+        contentType: contentType,
+      );
+    });
   }).toList();
 }
 
@@ -614,14 +623,15 @@ List<ResolvedRangeResponse> _resolveRangeResponses(
 ) {
   return rangeResponses.entries.map((entry) {
     final range = entry.key;
-    return context.withResolved(
-      entry.value,
-      (response) => ResolvedRangeResponse(
+    return context.withResolved(entry.value, (response) {
+      final (content, contentType) = _resolveContent(response, context);
+      return ResolvedRangeResponse(
         range: range,
         description: response.description,
-        content: _resolveContent(response, context),
-      ),
-    );
+        content: content,
+        contentType: contentType,
+      );
+    });
   }).toList();
 }
 
@@ -630,13 +640,14 @@ ResolvedDefaultResponse? _resolveDefaultResponse(
   ResolveContext context,
 ) {
   if (ref == null) return null;
-  return context.withResolved(
-    ref,
-    (response) => ResolvedDefaultResponse(
+  return context.withResolved(ref, (response) {
+    final (content, contentType) = _resolveContent(response, context);
+    return ResolvedDefaultResponse(
       description: response.description,
-      content: _resolveContent(response, context),
-    ),
-  );
+      content: content,
+      contentType: contentType,
+    );
+  });
 }
 
 class RegistryBuilder extends Visitor {
@@ -985,6 +996,7 @@ class ResolvedResponse {
     required this.statusCode,
     required this.description,
     required this.content,
+    required this.contentType,
   });
 
   /// The status code of the resolved response.
@@ -994,8 +1006,11 @@ class ResolvedResponse {
   final String description;
 
   /// The resolved content of the resolved response.
-  /// We only support json, so we only need a single content.
   final ResolvedSchema content;
+
+  /// Wire content type of [content] (e.g. `application/json`,
+  /// `text/plain`). `null` when the response has no body.
+  final String? contentType;
 }
 
 /// A range (`NXX`) response on an operation. Shares the description +
@@ -1006,6 +1021,7 @@ class ResolvedRangeResponse {
     required this.range,
     required this.description,
     required this.content,
+    required this.contentType,
   });
 
   /// Which `NXX` range this response covers.
@@ -1015,8 +1031,10 @@ class ResolvedRangeResponse {
   final String description;
 
   /// The resolved content of the resolved range response.
-  /// We only support json, so we only need a single content.
   final ResolvedSchema content;
+
+  /// Wire content type of [content]; see [ResolvedResponse.contentType].
+  final String? contentType;
 }
 
 /// The `default:` (catch-all) response on an operation. Shares the
@@ -1026,14 +1044,17 @@ class ResolvedDefaultResponse {
   const ResolvedDefaultResponse({
     required this.description,
     required this.content,
+    required this.contentType,
   });
 
   /// The description of the resolved default response.
   final String description;
 
   /// The resolved content of the resolved default response.
-  /// We only support json, so we only need a single content.
   final ResolvedSchema content;
+
+  /// Wire content type of [content]; see [ResolvedResponse.contentType].
+  final String? contentType;
 }
 
 abstract class ResolvedSchema extends Equatable {

--- a/test/render/render_operation_test.dart
+++ b/test/render/render_operation_test.dart
@@ -289,6 +289,37 @@ void main() {
       );
     });
 
+    test('text/plain response body returns response.body without jsonDecode', () {
+      // Surfaced by github's `/zen` (and `/octocat`, `/markdown`,
+      // `/markdown/raw`): the spec declares non-JSON response content
+      // (`text/plain`, `text/html`, `application/octocat-stream`) with
+      // a `type: string` schema. `package:http`'s `Response.body` is
+      // already a `String`; wrapping it in `jsonDecode` would crash
+      // at runtime (`Mind your words …` isn't JSON).
+      final operation = {
+        'tags': ['meta'],
+        'summary': 'Get the zen',
+        'operationId': 'getZen',
+        'responses': {
+          '200': {
+            'description': 'Response',
+            'content': {
+              'text/plain': {
+                'schema': {'type': 'string'},
+              },
+            },
+          },
+        },
+      };
+      final result = renderTestOperation(
+        path: '/zen',
+        operationJson: operation,
+        serverUrl: Uri.parse('https://api.github.com'),
+      );
+      expect(result, contains('return response.body;'));
+      expect(result, isNot(contains('jsonDecode')));
+    });
+
     test('text/plain', () {
       final operation = {
         'tags': ['pet'],

--- a/test/render/render_operation_test.dart
+++ b/test/render/render_operation_test.dart
@@ -289,36 +289,39 @@ void main() {
       );
     });
 
-    test('text/plain response body returns response.body without jsonDecode', () {
-      // Surfaced by github's `/zen` (and `/octocat`, `/markdown`,
-      // `/markdown/raw`): the spec declares non-JSON response content
-      // (`text/plain`, `text/html`, `application/octocat-stream`) with
-      // a `type: string` schema. `package:http`'s `Response.body` is
-      // already a `String`; wrapping it in `jsonDecode` would crash
-      // at runtime (`Mind your words …` isn't JSON).
-      final operation = {
-        'tags': ['meta'],
-        'summary': 'Get the zen',
-        'operationId': 'getZen',
-        'responses': {
-          '200': {
-            'description': 'Response',
-            'content': {
-              'text/plain': {
-                'schema': {'type': 'string'},
+    test(
+      'text/plain response body returns response.body without jsonDecode',
+      () {
+        // Surfaced by github's `/zen` (and `/octocat`, `/markdown`,
+        // `/markdown/raw`): the spec declares non-JSON response content
+        // (`text/plain`, `text/html`, `application/octocat-stream`) with
+        // a `type: string` schema. `package:http`'s `Response.body` is
+        // already a `String`; wrapping it in `jsonDecode` would crash
+        // at runtime (`Mind your words …` isn't JSON).
+        final operation = {
+          'tags': ['meta'],
+          'summary': 'Get the zen',
+          'operationId': 'getZen',
+          'responses': {
+            '200': {
+              'description': 'Response',
+              'content': {
+                'text/plain': {
+                  'schema': {'type': 'string'},
+                },
               },
             },
           },
-        },
-      };
-      final result = renderTestOperation(
-        path: '/zen',
-        operationJson: operation,
-        serverUrl: Uri.parse('https://api.github.com'),
-      );
-      expect(result, contains('return response.body;'));
-      expect(result, isNot(contains('jsonDecode')));
-    });
+        };
+        final result = renderTestOperation(
+          path: '/zen',
+          operationJson: operation,
+          serverUrl: Uri.parse('https://api.github.com'),
+        );
+        expect(result, contains('return response.body;'));
+        expect(result, isNot(contains('jsonDecode')));
+      },
+    );
 
     test('text/plain', () {
       final operation = {


### PR DESCRIPTION
## Summary

- When a 2xx response declares only a non-JSON content type (`text/plain`, `text/html`, `application/octocat-stream`, …) the resolver picks that content type's schema (correct), but the renderer then wraps the body in `jsonDecode(response.body) as String` (incorrect — not JSON, crashes at runtime).
- Thread the chosen wire content type from the resolver through `ResolvedResponse` / `RenderResponse` (and their range / default siblings) into a new `RenderOperation.successContentType` accessor.
- When that's anything but `application/json`, the operation renderer emits `return response.body;` directly. `package:http`'s `Response.body` is already a `String`, which matches the `type: string` schema such responses use in practice.
- JSON responses still go through `responseSchema.fromJsonExpression('jsonDecode(...)')` as before. Drop the now-misleading `Response has no application/json schema` warning.

## Surfaced by

`gen_tests/api.github.com.json`. The four endpoints below previously generated runtime-broken `Future<String>` methods that called `jsonDecode` on plain text:

- `GET /zen` → `text/plain` (a random GitHub aphorism)
- `GET /octocat` → `application/octocat-stream` (ASCII art)
- `POST /markdown` → `text/html`
- `POST /markdown/raw` → `text/html`

After this PR they all compile and return the body as-is. Error / non-success bodies still go through `jsonDecode`; switching them is a separate change.

## Test plan

- [x] `dart test` — 317 pass (existing 316 + 1 new test that locks in `return response.body;` and the absence of `jsonDecode` for a text/plain success response).
- [x] Petstore / spacetraders / watchcrunch regenerate clean.
- [x] github regenerated; the four `Response has no application/json schema` warnings are gone, the four affected methods now emit `return response.body;`, lint count unchanged at 2 (residual `comment_references`).