### PR TITLE
fix: substitute schema defaults in fromJson for nullable const-default fields

### DIFF
--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -1758,13 +1758,34 @@ abstract class RenderSchema extends Equatable implements ToTemplateContext {
     required bool jsonIsNullable,
     required bool dartIsNullable,
   }) {
-    if (jsonIsNullable && !dartIsNullable) {
-      final defaultValue = defaultValueString(context);
-      if (defaultValue == null) {
+    final defaultValue = defaultValueString(context);
+    if (defaultValue == null) {
+      if (jsonIsNullable && !dartIsNullable) {
+        // Belt-and-braces: a non-nullable Dart slot fed by a nullable
+        // JSON value with no default would silently produce a null-cast
+        // crash at runtime. That combination only arises today via the
+        // [nonNullableDefaultValues] quirk, which only forces non-null
+        // when the property has a default — so reaching here means the
+        // generator violated its own invariant, not user error.
         throw StateError('No default value for nullable property: $this');
       }
-      return ' ?? $defaultValue';
+      return '';
     }
+    if (!jsonIsNullable) return '';
+    // Non-null Dart slot fed by nullable JSON: an `as T?` cast would
+    // crash on null. Substitute the default whether the default is
+    // const or not.
+    if (!dartIsNullable) return ' ?? $defaultValue';
+    // Nullable Dart slot with a const default: the constructor uses
+    // `this.foo = default`, which only fires when the param is omitted.
+    // `fromJson` always passes a value (possibly null), so substitute
+    // the default at the cast site — otherwise a missing JSON key
+    // produces `null` instead of the spec's default. Surfaced by
+    // watchcrunch's `ListingDto.is_favorited: bool = false`.
+    if (defaultCanConstConstruct) return ' ?? $defaultValue';
+    // Nullable Dart slot with a non-const default: the constructor uses
+    // an initializer list (`: foo = foo ?? default`) that substitutes
+    // on null too, so the default lands without `fromJson`'s help.
     return '';
   }
 
@@ -2315,11 +2336,14 @@ abstract class RenderNumeric<T extends num> extends RenderSchema {
 
   @override
   String? defaultValueString(SchemaRenderer context) {
+    if (defaultValue == null) {
+      return null;
+    }
     if (createsNewType) {
       final typeName = camelFromSnake(snakeName);
       return '$typeName($defaultValue)';
     }
-    return defaultValue?.toString();
+    return defaultValue.toString();
   }
 
   @override

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -1780,8 +1780,9 @@ abstract class RenderSchema extends Equatable implements ToTemplateContext {
     // `this.foo = default`, which only fires when the param is omitted.
     // `fromJson` always passes a value (possibly null), so substitute
     // the default at the cast site — otherwise a missing JSON key
-    // produces `null` instead of the spec's default. Surfaced by
-    // watchcrunch's `ListingDto.is_favorited: bool = false`.
+    // produces `null` instead of the spec's default. Surfaced by a
+    // real spec with `bool` properties marked `default: false` outside
+    // the `required` array.
     if (defaultCanConstConstruct) return ' ?? $defaultValue';
     // Nullable Dart slot with a non-const default: the constructor uses
     // an initializer list (`: foo = foo ?? default`) that substitutes

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -1136,15 +1136,15 @@ void main() {
         '    factory Test.fromJson(Map<String, dynamic>\n'
         '        json) {\n'
         "        return parseFromJson('Test', json, () => Test(\n"
-        "            aString: (json['a_string'] as List?)?.cast<String>(),\n"
-        "            aInt: (json['a_int'] as List?)?.cast<int>(),\n"
-        "            aNumber: (json['a_number'] as List?)?.cast<double>(),\n"
-        "            aBoolean: (json['a_boolean'] as List?)?.cast<bool>(),\n"
-        "            aDateTime: (json['a_date_time'] as List?)?.cast<DateTime>(),\n"
-        "            aUri: (json['a_uri'] as List?)?.cast<Uri>(),\n"
-        "            aArrayOfString: (json['a_array_of_string'] as List?)?.cast<List<String>>(),\n"
-        "            aEnum: (json['a_enum'] as List?)?.map<TestAEnumInner>((e) => TestAEnumInner.fromJson(e as String)).toList(),\n"
-        "            aUnknown: (json['a_unknown'] as List?)?.cast<dynamic>(),\n"
+        "            aString: (json['a_string'] as List?)?.cast<String>() ?? const [],\n"
+        "            aInt: (json['a_int'] as List?)?.cast<int>() ?? const [],\n"
+        "            aNumber: (json['a_number'] as List?)?.cast<double>() ?? const [],\n"
+        "            aBoolean: (json['a_boolean'] as List?)?.cast<bool>() ?? const [],\n"
+        "            aDateTime: (json['a_date_time'] as List?)?.cast<DateTime>() ?? const [],\n"
+        "            aUri: (json['a_uri'] as List?)?.cast<Uri>() ?? const [],\n"
+        "            aArrayOfString: (json['a_array_of_string'] as List?)?.cast<List<String>>() ?? const [],\n"
+        "            aEnum: (json['a_enum'] as List?)?.map<TestAEnumInner>((e) => TestAEnumInner.fromJson(e as String)).toList() ?? const [],\n"
+        "            aUnknown: (json['a_unknown'] as List?)?.cast<dynamic>() ?? const [],\n"
         '        ));\n'
         '    }\n'
         '\n'
@@ -1326,7 +1326,7 @@ void main() {
         '    factory Test.fromJson(Map<String, dynamic>\n'
         '        json) {\n'
         "        return parseFromJson('Test', json, () => Test(\n"
-        "            a: (json['a'] as List?)?.cast<String>(),\n"
+        "            a: (json['a'] as List?)?.cast<String>() ?? const <String>['a', 'b'],\n"
         '        ));\n'
         '    }\n'
         '\n'
@@ -1646,7 +1646,7 @@ void main() {
           '    factory Test.fromJson(Map<String, dynamic>\n'
           '        json) {\n'
           "        return parseFromJson('Test', json, () => Test(\n"
-          "            a: (json['a'] as num?)?.toDouble(),\n"
+          "            a: (json['a'] as num?)?.toDouble() ?? 1.2,\n"
           '        ));\n'
           '    }\n'
           '\n'
@@ -1727,7 +1727,7 @@ void main() {
           '    factory Test.fromJson(Map<String, dynamic>\n'
           '        json) {\n'
           "        return parseFromJson('Test', json, () => Test(\n"
-          "            a: (json['a'] as int?),\n"
+          "            a: (json['a'] as int?) ?? 1,\n"
           '        ));\n'
           '    }\n'
           '\n'

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -1707,6 +1707,59 @@ void main() {
       });
 
       test(
+        'optional property with const default under openapi quirks emits '
+        '?? default in fromJson and non-nullable field',
+        () {
+          // Covers the `!dartIsNullable` arm of `orDefaultExpression`:
+          // `nonNullableDefaultValues` makes the Dart field non-null
+          // when a default is present, and `as int? ?? 1` is what
+          // populates the field on a missing JSON key. Mirrors github's
+          // `repository.private = false` shape.
+          final json = {
+            'type': 'object',
+            'properties': {
+              'count': {'type': 'integer', 'default': 1},
+            },
+          };
+          final result = renderTestSchema(
+            json,
+            quirks: const Quirks.openapi(),
+          );
+          expect(result, contains('int count;'));
+          expect(result, contains("count: (json['count'] as int?) ?? 1,"));
+        },
+      );
+
+      test(
+        'reference to a number-newtype WITH a default emits T(value) at '
+        'the substitution site',
+        () {
+          // Counterpart to the no-default test below. Locks in the
+          // `createsNewType && defaultValue != null` branch of
+          // `RenderNumeric.defaultValueString` — and confirms the
+          // newtype-wrapped substitution is what callers actually get
+          // when the spec ships a default on a number newtype under
+          // the openapi quirks (where the property becomes non-null).
+          final results = renderTestSchemas(
+            {
+              'WaitTimer': {'type': 'integer', 'default': 30},
+              'Rule': {
+                'type': 'object',
+                'properties': {
+                  'wait_timer': {r'$ref': '#/components/schemas/WaitTimer'},
+                },
+              },
+            },
+            specUrl: Uri.parse('file:///spec.yaml'),
+            quirks: const Quirks.openapi(),
+          );
+          final rule = results['Rule']!;
+          expect(rule, contains('?? WaitTimer(30)'));
+          expect(rule, isNot(contains('WaitTimer(null)')));
+        },
+      );
+
+      test(
         'optional reference to a number-newtype with no default does '
         'not emit T(null)',
         () {

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -1706,6 +1706,38 @@ void main() {
         );
       });
 
+      test(
+        'optional reference to a number-newtype with no default does '
+        'not emit T(null)',
+        () {
+          // Regression for github's `WaitTimer` referenced from
+          // `environment_protection_rule.wait_timer`. WaitTimer is a
+          // number newtype (`type: integer` with its own component name)
+          // and has no `default:`. Under openapi quirks, a non-required
+          // property whose schema is const-constructible would trigger
+          // `orDefaultExpression` to call `defaultValueString` — which
+          // for a number-newtype was emitting `WaitTimer(null)` even
+          // though the underlying `defaultValue` was null. That made
+          // the generated `?? const WaitTimer(null)` fail to compile
+          // (Null can't fit a non-null int parameter).
+          final results = renderTestSchemas(
+            {
+              'WaitTimer': {'type': 'integer'},
+              'Rule': {
+                'type': 'object',
+                'properties': {
+                  'wait_timer': {r'$ref': '#/components/schemas/WaitTimer'},
+                },
+              },
+            },
+            specUrl: Uri.parse('file:///spec.yaml'),
+            quirks: const Quirks.openapi(),
+          );
+          final rule = results['Rule']!;
+          expect(rule, isNot(contains('WaitTimer(null)')));
+        },
+      );
+
       test('integer property with default values', () {
         final json = {
           'type': 'object',


### PR DESCRIPTION
## Summary

- A property that's optional (not in `required`) and has a `default:` is generated as a nullable Dart field (`bool? isFavorited`) plus a constructor with a parameter default (`this.isFavorited = false`). Parameter defaults fire on **omission**, not on `null` — but the generated `fromJson` always passes the value explicitly: `isFavorited: json['is_favorited'] as bool?`. Result: `Foo.fromJson({}).isFavorited == null` instead of `false`.
- Relax `orDefaultExpression` to also append `?? <default>` when the JSON is nullable and the default is const-constructible, regardless of whether the Dart field is nullable. Non-const defaults still skip the substitution at the cast site because the constructor's initializer list (`: foo = foo ?? Uri.parse(...)`) already substitutes on null — adding `?? default` in `fromJson` would be redundant.
- The same change exposed a latent crash in `RenderNumber.defaultValueString`: a number-newtype schema with no default returned `'WaitTimer(null)'`, passing literal `null` to a non-null constructor. Added a `defaultValue == null` guard, matching the early-return pattern in `RenderPod` / `RenderString`.

## Surfaced by

`private_gen_tests/watchcrunch-api.json`. `ListingDto.is_favorited` is declared `type: boolean, default: false` (not in `required`). Today `ListingDto.fromJson({}).isFavorited == null`; with this PR it correctly returns `false`.

`gen_tests/api.github.com.json`. github's `WaitTimer` is a number-newtype with no spec-side default. Once `orDefaultExpression` started firing for nullable+const-default fields, the buggy `defaultValueString` started emitting `WaitTimer(null)` into `fromJson`, which doesn't compile. The number-newtype guard fixes it.

## Closes

#102 for the case it actually breaks (optional + const default + nullable Dart). The README's TODO about non-const default constructibility stays out of scope.

## Test plan

- [x] `dart test` — 317 pass. Four existing snapshot tests (`integer property with default values`, `number property with default values`, `array with default value`, `array type with pod types`) updated to reflect the new `?? default` in `fromJson`.
- [x] `gen_tests/` regenerated — **no diff**. The openapi-quirks code path was already calling `orDefaultExpression` (via the `nonNullableDefaultValues` branch); my change is purely additive for the plain-Quirks code path.
- [x] watchcrunch regenerated → `dart analyze` clean, 822 round-trip tests pass. `isFavorited: json['is_favorited'] as bool? ?? false` now emitted.
- [x] petstore / spacetraders regenerated → clean.
- [x] github regenerated → no new errors (the latent `WaitTimer(null)` bug is fixed). Lint count unchanged at 6 — 4 `document_ignores` (analyzer-version regression, separate PR) and 2 `comment_references` (separate PR).