### PR TITLE
fix: justify the bool-newtype ignore directive for document_ignores

### DIFF
--- a/lib/templates/schema_pod_newtype.mustache
+++ b/lib/templates/schema_pod_newtype.mustache
@@ -1,4 +1,7 @@
-{{#isBoolPod}}// ignore_for_file: avoid_positional_boolean_parameters
+{{#isBoolPod}}// `avoid_positional_boolean_parameters` is correct for user-facing
+// APIs but wrong for a newtype wrapper — the type name is the
+// disambiguation. Suppress file-locally.
+// ignore_for_file: avoid_positional_boolean_parameters
 
 {{/isBoolPod}}{{{ doc_comment }}}extension type const {{{ typeName }}}._({{{ dartType }}} value) {
     const {{ typeName }}(this.value);

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -1809,6 +1809,9 @@ void main() {
         final json = {'type': 'boolean'};
         expect(
           renderTestSchema(json, asComponent: true),
+          '// `avoid_positional_boolean_parameters` is correct for user-facing\n'
+          '// APIs but wrong for a newtype wrapper — the type name is the\n'
+          '// disambiguation. Suppress file-locally.\n'
           '// ignore_for_file: avoid_positional_boolean_parameters\n'
           '\n'
           'extension type const Test._(bool value) {\n'


### PR DESCRIPTION
## Summary

- The analyzer's `document_ignores` lint requires every `// ignore_for_file:` directive to be preceded by a `//` comment explaining why the diagnostic is suppressed.
- The bool-newtype template (#124) emits the directive without one, so every generated bool newtype reports a lint hit on line 1 of the file — 4 hits across github's `prevent_self_review`, `actions_enabled`, `actions_can_approve_pull_request_reviews`, `code_scanning_alert_create_request`.
- Add the same justification used in the `isBoolPod` doc comment and the existing unit test as a `//` block immediately above the directive.

Surfaced by `api.github.com` regen on current main. Petstore / spacetraders / watchcrunch unaffected (no bool newtypes).

## Test plan

- [x] `dart test` — 317 pass; the existing `bool newtype suppresses positional-bool lint` snapshot updated to include the 3-line justification block.
- [x] github regenerated → lint count: **6 → 2**. Specifically the 4 `document_ignores` are gone; the 2 residual `comment_references` are unrelated and stay open as a separate fix.