### PR TITLE
fix: suppress comment_references in generated dartdoc

### DIFF
--- a/lib/src/render/file_renderer.dart
+++ b/lib/src/render/file_renderer.dart
@@ -113,6 +113,45 @@ void suppressLongLineLintInGeneratedFiles(Directory dir) {
   }
 }
 
+/// Block prepended to generated `.dart` files whose dartdoc contains
+/// `[…]` patterns that don't resolve (e.g. github's code-of-conduct
+/// description literally says "contacting the project team at
+/// [EMAIL]", and the MIT license template carries `[year] [fullname]`
+/// placeholders). Exposed for tests.
+@visibleForTesting
+const commentReferencesIgnoreBlock =
+    "// Spec descriptions copy prose verbatim into dartdoc, where `[x]`\n"
+    '// inside a sentence (placeholder text, ALL_CAPS tokens, license\n'
+    "// templates) is parsed as a symbol reference even when no such\n"
+    '// symbol exists. Suppress file-locally so the lint stays live\n'
+    '// elsewhere; spec authors do not always escape brackets.\n'
+    '// ignore_for_file: comment_references';
+
+/// Walks [dir] and prepends [commentReferencesIgnoreBlock] to any
+/// `.dart` file with a `///` line containing `[<token>]` that doesn't
+/// look like a `[Foo](link)` link reference. Sister to
+/// [suppressLongLineLintInGeneratedFiles] — same per-file pattern,
+/// different lint.
+@visibleForTesting
+void suppressCommentReferencesLintInGeneratedFiles(Directory dir) {
+  const marker = '// ignore_for_file: comment_references';
+  // `///` followed by anything, then a `[word]` bracketed token NOT
+  // followed by `(` (which would make it a `[Foo](url)` link). Matches
+  // both prose placeholders (`[EMAIL]`, `[year]`) and stray symbol
+  // references the spec author meant as plain text.
+  final docCommentBracketRe = RegExp(r'///.*\[[^\]\s]+\](?!\()');
+  final dartFiles = dir
+      .listSync(recursive: true)
+      .whereType<File>()
+      .where((f) => f.path.endsWith('.dart'));
+  for (final file in dartFiles) {
+    final content = file.readAsStringSync();
+    if (content.contains(marker)) continue;
+    if (!docCommentBracketRe.hasMatch(content)) continue;
+    file.writeAsStringSync('$commentReferencesIgnoreBlock\n$content');
+  }
+}
+
 @visibleForTesting
 String applyMandatoryReplacements(
   String template,
@@ -861,6 +900,7 @@ class FileRenderer {
     renderPublicApi(spec.apis, schemas);
     formatter.formatAndFix(pkgDir: fileWriter.outDir.path);
     suppressLongLineLintInGeneratedFiles(fileWriter.outDir);
+    suppressCommentReferencesLintInGeneratedFiles(fileWriter.outDir);
 
     final misspellings = spellChecker.collectMisspellings(fileWriter.outDir);
     renderCspellConfig(misspellings);

--- a/test/render/file_renderer_test.dart
+++ b/test/render/file_renderer_test.dart
@@ -2384,6 +2384,64 @@ void main() {
     });
   });
 
+  group('suppressCommentReferencesLintInGeneratedFiles', () {
+    Directory setUpDir(Map<String, String> files) {
+      final fs = MemoryFileSystem.test();
+      final dir = fs.directory('/out')..createSync(recursive: true);
+      for (final entry in files.entries) {
+        dir.childFile(entry.key)
+          ..parent.createSync(recursive: true)
+          ..writeAsStringSync(entry.value);
+      }
+      return dir;
+    }
+
+    test('leaves files without bracketed dartdoc references untouched', () {
+      const content = '/// A class with no bracket refs.\nclass Foo {}\n';
+      final dir = setUpDir({'lib/foo.dart': content});
+      suppressCommentReferencesLintInGeneratedFiles(dir);
+      expect(dir.childFile('lib/foo.dart').readAsStringSync(), content);
+    });
+
+    test('prepends directive when dartdoc has prose-style placeholder', () {
+      // Mirrors github's `code_of_conduct.dart` ("contacting the project
+      // team at [EMAIL]") and `license.dart` (`[year] [fullname]`).
+      const content =
+          '/// Reach out at [EMAIL] for support.\nclass CodeOfConduct {}\n';
+      final dir = setUpDir({'lib/code_of_conduct.dart': content});
+      suppressCommentReferencesLintInGeneratedFiles(dir);
+      expect(
+        dir.childFile('lib/code_of_conduct.dart').readAsStringSync(),
+        startsWith('$commentReferencesIgnoreBlock\n'),
+      );
+    });
+
+    test('skips legitimate `[Foo](url)` markdown links', () {
+      const content =
+          '/// See [the docs](https://example.com).\nclass Bar {}\n';
+      final dir = setUpDir({'lib/bar.dart': content});
+      suppressCommentReferencesLintInGeneratedFiles(dir);
+      expect(dir.childFile('lib/bar.dart').readAsStringSync(), content);
+    });
+
+    test('is idempotent — does not stack the directive', () {
+      const content =
+          '$commentReferencesIgnoreBlock\n/// Has [PLACEHOLDER] inside.\n'
+          'class Baz {}\n';
+      final dir = setUpDir({'lib/baz.dart': content});
+      suppressCommentReferencesLintInGeneratedFiles(dir);
+      final after = dir.childFile('lib/baz.dart').readAsStringSync();
+      expect(commentReferencesIgnoreBlock.allMatches(after).length, 1);
+    });
+
+    test('ignores non-dart files', () {
+      const content = '/// Has [EMAIL] in markdown';
+      final dir = setUpDir({'README.md': content});
+      suppressCommentReferencesLintInGeneratedFiles(dir);
+      expect(dir.childFile('README.md').readAsStringSync(), content);
+    });
+  });
+
   // While we still support logging, this should no longer happen since
   // we detect collisions and fix them during resolution.
   test('logNameCollisions', () {


### PR DESCRIPTION
## Summary

- Spec descriptions copy prose verbatim into dartdoc, where `[X]` in a sentence — placeholder text, ALL_CAPS tokens, license templates — gets parsed as a symbol reference. github's `code_of_conduct.dart` says "contacting the project team at [EMAIL]"; `license.dart` ships the MIT template's `[year] [fullname]` literally. Both trip `comment_references`.
- Add `suppressCommentReferencesLintInGeneratedFiles`, sister to the existing `suppressLongLineLintInGeneratedFiles`: scan each generated `.dart` file for `///` lines containing `[<token>]` *not* followed by `(` (legitimate `[Foo](url)` markdown links are left alone). On match, prepend `// ignore_for_file: comment_references` with a justifying comment block (so the directive itself satisfies `document_ignores`).
- Per the project's per-file-ignore preference (CLAUDE.md memory), this keeps the lint live for everyone else. Wired in alongside the long-line suppression after `formatAndFix`.

## Test plan

- [x] `dart test` — 322 pass; 5 new tests cover the prose-placeholder, plain markdown link, idempotency, non-`.dart` skipping, and untouched-file paths.
- [x] github regenerated → `comment_references` count: **2 → 0** (`code_of_conduct.dart` and `license.dart` both pick up the directive). The 4 residual lints are pre-existing `document_ignores` hits from the bool-newtype directive (#124) missing its own justifying comment — unrelated and fixed separately in #129.
- [x] petstore / spacetraders / watchcrunch regenerate clean (no spec descriptions trigger the regex).