### PR TITLE
refactor: demote unknown-format warnings to detail logs

### DIFF
--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -495,7 +495,16 @@ TypeAndFormat parseTypeAndFormat(MapContext json) {
       if (ignored != null && ignored.contains(format)) {
         _ignored<String>(json, 'format');
       } else {
-        _warn(json, 'Unknown $type format: $format');
+        // Unknown format on a recognized base type — generated code
+        // falls back to the plain Dart type (`int`/`String`/...) which
+        // is correct for almost every real-world non-standard format
+        // (`timestamp`, `repo.nwo`, ...). Log as detail rather than
+        // warn: there's nothing the user can act on, and surfacing
+        // every spec-author idiosyncrasy at WARN level buries the
+        // diagnostics that actually matter.
+        logger.detail(
+          'Ignoring unknown $type format: $format in ${json.pointer}',
+        );
       }
     }
     return format;

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -39,7 +39,12 @@ void main() {
       // it falls through to SchemaString.
       expect(parse('string', format: 'time'), isNull);
       expect(parse('string', format: 'foo', expectLogs: true), isNull);
-      verify(() => logger.warn('Unknown string format: foo in #/')).called(1);
+      // Unknown formats are detail-logged (the generator falls back to
+      // the plain base type, which is correct for the vast majority of
+      // non-standard format names ship in real specs).
+      verify(
+        () => logger.detail('Ignoring unknown string format: foo in #/'),
+      ).called(1);
       expect(parse('number'), isNull);
       expect(parse('integer'), isNull);
       expect(parse('boolean'), PodType.boolean);


### PR DESCRIPTION
## Summary

Real specs ship plenty of non-standard `format:` strings that aren't in the OpenAPI registry but also aren't bugs:

- github's `x-rate-limit-reset` declares `format: timestamp`
- github's `head_repo` declares `format: repo.nwo`
- spacetraders' `ShipComponentQuality` declares `format: integer` on a `type: number`

The generator already falls back to the plain Dart base type — which is the right behavior — but the `[WARN]` label suggested the user could act on these and buried the warnings that actually matter (auth schemes, missing content types, etc.).

Switch to `logger.detail`. Verbose runs (`--verbose`) still surface the same diagnostic with full pointer/format/type context; default runs stay quiet. The known-but-explicitly-ignored `int32`/`int64`/`float`/`double` path was already detail-logged via `_ignored<String>(json, 'format')`, so this just brings unknown-but-fallback-correct formats into line with it.

## Test plan

- [x] `dart test` — 317 pass; the existing `parser parseTypeAndFormat single types` test now verifies `logger.detail(...)` instead of `logger.warn(...)` for the `format: foo` case.
- [x] github regenerated → 3 `[WARN]` lines gone (`timestamp`, `repo.nwo`, plus the non-JSON-response cohort already cleared by #127).
- [x] spacetraders regenerated → 1 `[WARN]` line gone.
- [x] petstore / watchcrunch unaffected (had no unknown formats).