### PR TITLE
fix: drop trailing '?' from URLs without query params

### DIFF
--- a/lib/templates/api_client.dart
+++ b/lib/templates/api_client.dart
@@ -74,6 +74,10 @@ class ApiClient {
       ...queryParameters,
     };
     auth.applyToParams(mergedParameters);
+    // `Uri.replace(queryParameters: {})` always appends a trailing `?`,
+    // so skip it when there's nothing to add — endpoints with no query
+    // params would otherwise ship URLs ending in `?` for no reason.
+    if (mergedParameters.isEmpty) return uri;
     return uri.replace(queryParameters: mergedParameters);
   }
 

--- a/test/templates/api_client_test.dart
+++ b/test/templates/api_client_test.dart
@@ -1,0 +1,42 @@
+import 'package:http/http.dart';
+import 'package:http/testing.dart';
+import 'package:space_gen/templates/api_client.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ApiClient._resolveUri', () {
+    test('omits trailing ? when there are no query params at all', () async {
+      // Regression for issue #136: `Uri.replace(queryParameters: {})` always
+      // appends `?`. Endpoints with no query params should ship clean URLs.
+      Uri? captured;
+      final client = ApiClient(
+        baseUri: Uri.parse('https://example.com'),
+        client: MockClient((req) async {
+          captured = req.url;
+          return Response('', 200);
+        }),
+      );
+      await client.invokeApi(method: Method.get, path: '/things');
+      expect(captured.toString(), 'https://example.com/things');
+    });
+
+    test('appends ? only when there are real params', () async {
+      Uri? captured;
+      final client = ApiClient(
+        baseUri: Uri.parse('https://example.com'),
+        client: MockClient((req) async {
+          captured = req.url;
+          return Response('', 200);
+        }),
+      );
+      await client.invokeApi(
+        method: Method.get,
+        path: '/things',
+        queryParameters: {
+          'foo': ['bar'],
+        },
+      );
+      expect(captured.toString(), 'https://example.com/things?foo=bar');
+    });
+  });
+}

--- a/test/templates/api_client_test.dart
+++ b/test/templates/api_client_test.dart
@@ -38,5 +38,56 @@ void main() {
       );
       expect(captured.toString(), 'https://example.com/things?foo=bar');
     });
+
+    test('multipart path also drops trailing ?', () async {
+      // `invokeApiMultipart` reuses `_resolveUri`, so the same shortcut
+      // has to apply to the upload path too.
+      Uri? captured;
+      final client = ApiClient(
+        baseUri: Uri.parse('https://example.com'),
+        client: MockClient((req) async {
+          captured = req.url;
+          return Response('', 200);
+        }),
+      );
+      await client.invokeApiMultipart(
+        method: Method.post,
+        path: '/upload',
+        fields: const {},
+        files: const [],
+      );
+      expect(captured.toString(), 'https://example.com/upload');
+    });
+
+    test(
+      'auth-injected query params still survive the empty-shortcut',
+      () async {
+        // ApiKeyAuth with sendIn: query adds to the merged map after the op
+        // contributes nothing. The shortcut must check the *merged* map, not
+        // just the caller's queryParameters, or we'd drop the api key.
+        Uri? captured;
+        final client = ApiClient(
+          baseUri: Uri.parse('https://example.com'),
+          readSecret: (name) => name == 'MyKey' ? 'secret-value' : null,
+          client: MockClient((req) async {
+            captured = req.url;
+            return Response('', 200);
+          }),
+        );
+        await client.invokeApi(
+          method: Method.get,
+          path: '/things',
+          authRequest: const ApiKeyAuth(
+            name: 'token',
+            sendIn: ApiKeyLocation.query,
+            secretName: 'MyKey',
+          ),
+        );
+        expect(
+          captured.toString(),
+          'https://example.com/things?token=secret-value',
+        );
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary

`Uri.replace(queryParameters: …)` always appends `?` whenever it's called, even when the merged map is empty. Operations with no query params and a baseUri that doesn't carry its own query were therefore shipping URLs ending in `?` for no reason. Skip `Uri.replace` when there's nothing to add.

Two new runtime tests under `test/templates/api_client_test.dart` (first tests in that location) exercise the public `ApiClient.invokeApi` via `package:http`'s `MockClient` and capture the outbound URL. Filed #139 along the way for a separate baseUri-with-query-string mishandling I tripped over while writing the tests — out of scope here.

Closes #136.

## Test plan

- [ ] `dart test` (329 tests including 2 new)
- [ ] `dart analyze` clean
- [ ] Generate any spec end-to-end and verify a URL with no query params no longer ends in `?`