### PR TITLE
fix: warn on unsupported Parameter/Header style/explode/allowReserved

### DIFF
--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -800,7 +800,6 @@ Schema _createCorrectSchemaSubtype(MapContext json) {
   }
 
   // Some of these probably apply to enum and array types.
-  _ignored<bool>(json, 'nullable');
   _ignored<bool>(json, 'readOnly');
   _ignored<bool>(json, 'writeOnly');
   _ignored<dynamic>(json, 'discriminator');

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -179,6 +179,69 @@ ParameterLocation _parseParameterLocation(MapContext context, String location) {
   }
 }
 
+/// Default `style` for a parameter at the given OpenAPI location.
+/// Per OpenAPI 3.x: query/cookie default to `form`, header/path to `simple`.
+String _defaultStyle(ParameterLocation location) {
+  switch (location) {
+    case ParameterLocation.query:
+    case ParameterLocation.cookie:
+      return 'form';
+    case ParameterLocation.header:
+    case ParameterLocation.path:
+      return 'simple';
+  }
+}
+
+/// Default `explode` for a parameter at the given OpenAPI location.
+/// True when the default style is `form`, false otherwise.
+bool _defaultExplode(ParameterLocation location) {
+  switch (location) {
+    case ParameterLocation.query:
+    case ParameterLocation.cookie:
+      return true;
+    case ParameterLocation.header:
+    case ParameterLocation.path:
+      return false;
+  }
+}
+
+/// Read `style`, `explode`, and `allowReserved` and warn if any non-default
+/// value is set. The generator only honors the default wire format today;
+/// non-default values would silently produce wrong output, so we surface
+/// them as `_warn` (visible without --verbose). Spec-explicit defaults are
+/// consumed quietly.
+void _warnUnsupportedSerialization(
+  MapContext json,
+  ParameterLocation location,
+) {
+  final style = _optional<String>(json, 'style');
+  final defaultStyle = _defaultStyle(location);
+  if (style != null && style != defaultStyle) {
+    _warn(
+      json,
+      'style="$style" is not honored on ${location.name} parameters; '
+      'generator emits the default ($defaultStyle) wire format',
+    );
+  }
+  final explode = _optional<bool>(json, 'explode');
+  final defaultExplode = _defaultExplode(location);
+  if (explode != null && explode != defaultExplode) {
+    _warn(
+      json,
+      'explode=$explode is not honored on ${location.name} parameters; '
+      'generator emits the default (explode=$defaultExplode) wire format',
+    );
+  }
+  final allowReserved = _optional<bool>(json, 'allowReserved') ?? false;
+  if (allowReserved) {
+    _warn(
+      json,
+      'allowReserved=true is not honored on ${location.name} parameters; '
+      'generator URL-encodes reserved characters',
+    );
+  }
+}
+
 /// Parse a parameter from a json object.
 Parameter parseParameter(MapContext json) {
   _refNotExpected(json);
@@ -201,9 +264,7 @@ Parameter parseParameter(MapContext json) {
   if (hasSchema && !hasContent) {
     // Schema fields.
     type = parseSchemaOrRef(schema);
-    _ignored<String>(json, 'style');
-    _ignored<bool>(json, 'explode');
-    _ignored<bool>(json, 'allowReserved');
+    _warnUnsupportedSerialization(json, inLocation);
     _ignored<dynamic>(json, 'example');
     _ignored<dynamic>(json, 'examples');
   } else if (!hasSchema && hasContent) {
@@ -248,9 +309,7 @@ Header parseHeader(MapContext json) {
   final description = _optional<String>(json, 'description');
   _ignored<bool>(json, 'deprecated');
   _ignored<bool>(json, 'allowEmptyValue');
-  _ignored<dynamic>(json, 'style');
-  _ignored<bool>(json, 'explode');
-  _ignored<bool>(json, 'allowReserved');
+  _warnUnsupportedSerialization(json, ParameterLocation.header);
   _ignored<dynamic>(json, 'example');
   _ignored<Map<String, dynamic>>(json, 'examples');
 

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -718,6 +718,133 @@ void main() {
       );
     });
 
+    group('parameter serialization', () {
+      Map<String, dynamic> specWithQueryParam(Map<String, dynamic> extra) {
+        return {
+          'openapi': '3.1.0',
+          'info': {'title': 'Space Traders API', 'version': '1.0.0'},
+          'servers': [
+            {'url': 'https://api.spacetraders.io/v2'},
+          ],
+          'paths': {
+            '/users': {
+              'get': {
+                'parameters': [
+                  {
+                    'name': 'foo',
+                    'in': 'query',
+                    'schema': {'type': 'string'},
+                    ...extra,
+                  },
+                ],
+                'responses': {
+                  '200': {'description': 'OK'},
+                },
+              },
+            },
+          },
+        };
+      }
+
+      Map<String, dynamic> specWithHeader(Map<String, dynamic> extra) {
+        return {
+          'openapi': '3.1.0',
+          'info': {'title': 'Space Traders API', 'version': '1.0.0'},
+          'servers': [
+            {'url': 'https://api.spacetraders.io/v2'},
+          ],
+          'paths': {
+            '/users': {
+              'get': {
+                'responses': {
+                  '200': {
+                    'description': 'OK',
+                    'headers': {
+                      'X-Foo': {
+                        'schema': {'type': 'string'},
+                        ...extra,
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        };
+      }
+
+      test('default style and explode on query are silent', () {
+        final logger = _MockLogger();
+        runWithLogger(
+          logger,
+          () => parseOpenApi(
+            specWithQueryParam({'style': 'form', 'explode': true}),
+          ),
+        );
+        verifyNever(() => logger.warn(any()));
+      });
+
+      test('non-default explode on query warns', () {
+        final logger = _MockLogger();
+        runWithLogger(
+          logger,
+          () => parseOpenApi(specWithQueryParam({'explode': false})),
+        );
+        verify(
+          () => logger.warn(
+            'explode=false is not honored on query parameters; '
+            'generator emits the default (explode=true) wire format '
+            'in #/paths/~1users/get/parameters/0',
+          ),
+        ).called(1);
+      });
+
+      test('non-default style on query warns', () {
+        final logger = _MockLogger();
+        runWithLogger(
+          logger,
+          () => parseOpenApi(specWithQueryParam({'style': 'spaceDelimited'})),
+        );
+        verify(
+          () => logger.warn(
+            'style="spaceDelimited" is not honored on query parameters; '
+            'generator emits the default (form) wire format '
+            'in #/paths/~1users/get/parameters/0',
+          ),
+        ).called(1);
+      });
+
+      test('non-default explode on header warns', () {
+        final logger = _MockLogger();
+        runWithLogger(
+          logger,
+          () => parseOpenApi(specWithHeader({'explode': true})),
+        );
+        verify(
+          () => logger.warn(
+            'explode=true is not honored on header parameters; '
+            'generator emits the default (explode=false) wire format '
+            'in #/paths/~1users/get/responses/200/headers/X-Foo',
+          ),
+        ).called(1);
+      });
+
+      test('allowReserved=true on query warns', () {
+        final logger = _MockLogger();
+        runWithLogger(
+          logger,
+          () => parseOpenApi(specWithQueryParam({'allowReserved': true})),
+        );
+        verify(
+          () => logger.warn(
+            'allowReserved=true is not honored on query parameters; '
+            'generator URL-encodes reserved characters '
+            'in #/paths/~1users/get/parameters/0',
+          ),
+        ).called(1);
+      });
+    });
+
     group('responses', () {
       test('wrong type for responses', () {
         final json = {


### PR DESCRIPTION
## Summary

- Promote non-default `style`, `explode`, and `allowReserved` on
  parameters and headers from silent `_ignored` (detail-only) to
  `_warn`. Spec-explicit defaults (e.g. `style: form` on a query
  parameter) are still consumed quietly.
- Drop the redundant `_ignored<bool>(json, 'nullable')` in the
  object-schema parser branch — `nullable` is consumed earlier and
  the trailing call only emitted a misleading detail log.

PR #134 implemented OpenAPI's *default* serialization for array
query/header parameters (form/explode=true for query, simple/explode=
false for headers). Prior to this PR, a spec that asked for a
non-default wire format (e.g. `style: spaceDelimited`, query
`explode: false`, `allowReserved: true`) would silently produce wrong
output. We are not implementing the non-default cases — just surfacing
them so users notice.

The github and spacetraders specs emit no new warnings (both stick to
defaults), so this is a no-op for current users.

## Test plan

- [x] `dart test` — full suite, 332 tests pass (5 new in
      `parser parameter serialization`).
- [x] `dart analyze lib` — no new issues.
- [x] `dart format .` — clean.
- [x] Generated github + spacetraders specs — no new warnings emitted.