### PR TITLE
feat: dispatch oneOf via discriminator + emit sealed wrapper subclasses

### DIFF
--- a/lib/src/parse/spec.dart
+++ b/lib/src/parse/spec.dart
@@ -341,7 +341,43 @@ class SchemaAllOf extends SchemaCombiner {
 }
 
 class SchemaOneOf extends SchemaCombiner {
-  const SchemaOneOf({required super.common, required super.schemas});
+  const SchemaOneOf({
+    required super.common,
+    required super.schemas,
+    required this.discriminator,
+  });
+
+  /// The OpenAPI discriminator object, if any.
+  final SchemaDiscriminator? discriminator;
+
+  @override
+  List<Object?> get props => [super.props, discriminator];
+}
+
+/// An OpenAPI discriminator object.
+/// https://spec.openapis.org/oas/v3.0.0#discriminator-object
+///
+/// `propertyName` names the JSON property whose value selects which
+/// variant of the oneOf is in use. `mapping` optionally maps property
+/// values to specific variants; without it, the variant is selected
+/// implicitly by schema name (we don't yet support the implicit form).
+@immutable
+class SchemaDiscriminator extends Equatable {
+  const SchemaDiscriminator({
+    required this.propertyName,
+    required this.mapping,
+  });
+
+  final String propertyName;
+
+  /// Map of discriminator property values to references to one of the
+  /// oneOf variants. Stored as raw [SchemaRef]s (already normalized to
+  /// `#/components/schemas/<name>` form when the spec used a short name);
+  /// the resolver matches them up to entries in the oneOf.
+  final Map<String, SchemaRef>? mapping;
+
+  @override
+  List<Object?> get props => [propertyName, mapping];
 }
 
 /// A schema is a json object that describes the shape of a json object.

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -330,6 +330,38 @@ RefOr<Header> parseHeaderOrRef(MapContext json) {
   return RefOr<Header>.object(parseHeader(json), json.pointer);
 }
 
+/// Parse the optional `discriminator` keyword that appears alongside
+/// oneOf/anyOf/allOf. Mapping values may be either a JSON Pointer
+/// (`#/components/schemas/Foo`) or a bare schema name (`Foo`); the
+/// latter is normalized here to the canonical pointer form. The
+/// resolver later matches each mapping value to one of the variants.
+SchemaDiscriminator? _parseDiscriminator(MapContext json) {
+  final discriminatorJson = _optionalMap(json, 'discriminator');
+  if (discriminatorJson == null) {
+    return null;
+  }
+  final propertyName = _required<String>(discriminatorJson, 'propertyName');
+  final mappingJson = _optionalMap(discriminatorJson, 'mapping');
+  Map<String, SchemaRef>? mapping;
+  if (mappingJson != null) {
+    mapping = <String, SchemaRef>{};
+    for (final key in mappingJson.json.keys) {
+      final raw = mappingJson[key];
+      if (raw is! String) {
+        _error(
+          mappingJson,
+          'discriminator.mapping[$key] must be a string',
+        );
+      }
+      final refString = raw.startsWith('#/') || raw.startsWith('/')
+          ? raw
+          : '#/components/schemas/$raw';
+      mapping[key] = SchemaRef.ref(refString, mappingJson.pointer.add(key));
+    }
+  }
+  return SchemaDiscriminator(propertyName: propertyName, mapping: mapping);
+}
+
 Schema? _handleCollectionTypes(
   MapContext json, {
   required CommonProperties common,
@@ -342,7 +374,12 @@ Schema? _handleCollectionTypes(
         parseSchemaOrRef(oneOf.indexAsMap(i).addSnakeName('one_of_$i')),
       );
     }
-    return SchemaOneOf(common: common, schemas: schemas);
+    final discriminator = _parseDiscriminator(json);
+    return SchemaOneOf(
+      common: common,
+      schemas: schemas,
+      discriminator: discriminator,
+    );
   }
 
   if (json.containsKey('allOf')) {
@@ -694,7 +731,11 @@ Schema _createCorrectSchemaSubtype(MapContext json) {
       final schema = _createCorrectSchemaSubtype(fakeJson);
       schemas.add(SchemaRef.object(schema, json.pointer));
     }
-    return SchemaOneOf(common: common, schemas: schemas);
+    return SchemaOneOf(
+      common: common,
+      schemas: schemas,
+      discriminator: null,
+    );
   }
 
   final collectionType = _handleCollectionTypes(json, common: common);

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -3438,10 +3438,7 @@ class RenderOneOf extends RenderNewType {
         return false;
       }
     }
-    if ((discriminator == null) != (other.discriminator == null)) {
-      return false;
-    }
-    if (discriminator != null && discriminator != other.discriminator) {
+    if (discriminator != other.discriminator) {
       return false;
     }
     return super.equalsIgnoringName(other);
@@ -3463,32 +3460,27 @@ class RenderOneOf extends RenderNewType {
   String wrapperTypeName(RenderSchema variant) =>
       '$typeName${variant.typeName}';
 
-  /// The discriminator iff dispatch can be generated. Dispatch reads a
+  /// True when the dispatch path can be emitted. Dispatch reads a
   /// discriminator property out of a `Map<String, dynamic>` and calls
   /// `<Variant>.fromJson(json)` on the chosen variant — both require
   /// every variant to be an object-shaped newtype with a fromJson
   /// factory. Array/map/pod variants (e.g. github's `content-directory`,
   /// which is `type: array`) fall through to the legacy stub.
-  RenderDiscriminator? get _dispatchableDiscriminator {
-    final disc = discriminator;
-    if (disc == null) return null;
-    if (!schemas.every((s) => s is RenderObject)) return null;
-    return disc;
-  }
+  bool get _hasDispatch =>
+      discriminator != null && schemas.every((s) => s is RenderObject);
 
   @override
   Iterable<Import> get additionalImports => [
     ...super.additionalImports,
     // The dispatch path emits @immutable wrappers that override == /
     // hashCode; the legacy UnimplementedError stub doesn't need it.
-    if (_dispatchableDiscriminator != null)
-      const Import('package:meta/meta.dart'),
+    if (_hasDispatch) const Import('package:meta/meta.dart'),
   ];
 
   @override
   Map<String, dynamic> toTemplateContext(SchemaRenderer context) {
-    final disc = _dispatchableDiscriminator;
-    if (disc == null) {
+    final disc = discriminator;
+    if (disc == null || !_hasDispatch) {
       return {
         'doc_comment': createDocComment(common: common),
         'typeName': typeName,

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -417,9 +417,38 @@ class SpecResolver {
       case ResolvedBinary():
         return RenderBinary(common: schema.common);
       case ResolvedOneOf():
+        final renderSchemas = schema.schemas.map(toRenderSchema).toList();
+        final disc = schema.discriminator;
+        RenderDiscriminator? renderDiscriminator;
+        if (disc != null) {
+          final rawMapping = disc.mapping;
+          if (rawMapping != null) {
+            // For each ResolvedSchema in the resolver-side mapping, find
+            // its index in schema.schemas (identity match, established by
+            // the resolver) and use the corresponding rendered variant.
+            final renderMapping = <String, RenderSchema>{};
+            for (final entry in rawMapping.entries) {
+              final i = schema.schemas.indexWhere(
+                (s) => identical(s, entry.value),
+              );
+              if (i == -1) {
+                // Resolver invariant violation — should never happen.
+                throw StateError(
+                  'discriminator mapping target not in oneOf.schemas',
+                );
+              }
+              renderMapping[entry.key] = renderSchemas[i];
+            }
+            renderDiscriminator = RenderDiscriminator(
+              propertyName: disc.propertyName,
+              mapping: renderMapping,
+            );
+          }
+        }
         return RenderOneOf(
           common: schema.common,
-          schemas: schema.schemas.map(toRenderSchema).toList(),
+          schemas: renderSchemas,
+          discriminator: renderDiscriminator,
         );
       case ResolvedAllOf():
         // Generate a synthetic object type for allOf.
@@ -440,6 +469,7 @@ class SpecResolver {
         return RenderOneOf(
           common: schema.common,
           schemas: schema.schemas.map(toRenderSchema).toList(),
+          discriminator: null,
         );
       case ResolvedMap():
         final keyEnum = schema.keySchema;
@@ -548,6 +578,7 @@ class SpecResolver {
           pointer: operation.pointer,
         ),
         schemas: distinctSchemas.toList(),
+        discriminator: null,
       );
     }
     return distinctSchemas.first;
@@ -3370,10 +3401,21 @@ class RenderEnum extends RenderNewType {
 }
 
 class RenderOneOf extends RenderNewType {
-  const RenderOneOf({required super.common, required this.schemas});
+  const RenderOneOf({
+    required super.common,
+    required this.schemas,
+    required this.discriminator,
+  });
 
   /// The schemas of the resolved schema.
   final List<RenderSchema> schemas;
+
+  /// Optional discriminator dispatch table. When present, [schemas] are
+  /// rendered as final wrapper subclasses of the sealed parent and the
+  /// generated `fromJson` reads the discriminator property to pick the
+  /// right variant. When absent, today's renderer falls back to the
+  /// UnimplementedError stub — a gap to close in a follow-up.
+  final RenderDiscriminator? discriminator;
 
   /// We could do something smarter here, to determine if the oneOf has a
   /// const constructor, but it's not worth the complexity for now.
@@ -3381,7 +3423,7 @@ class RenderOneOf extends RenderNewType {
   bool get defaultCanConstConstruct => false;
 
   @override
-  List<Object?> get props => [super.props, schemas];
+  List<Object?> get props => [super.props, schemas, discriminator];
 
   @override
   bool equalsIgnoringName(RenderSchema other) {
@@ -3396,6 +3438,12 @@ class RenderOneOf extends RenderNewType {
         return false;
       }
     }
+    if ((discriminator == null) != (other.discriminator == null)) {
+      return false;
+    }
+    if (discriminator != null && discriminator != other.discriminator) {
+      return false;
+    }
     return super.equalsIgnoringName(other);
   }
 
@@ -3407,12 +3455,70 @@ class RenderOneOf extends RenderNewType {
     return 'Map<String, dynamic>';
   }
 
+  /// Wrapper subclass name for [variant], shaped
+  /// `<ParentTypeName><VariantTypeName>`. We don't shorten using the
+  /// discriminator value (e.g. "private") because the variant's own
+  /// typeName is already a unique, valid Dart identifier while
+  /// discriminator strings are arbitrary.
+  String wrapperTypeName(RenderSchema variant) =>
+      '$typeName${variant.typeName}';
+
+  /// The discriminator iff dispatch can be generated. Dispatch reads a
+  /// discriminator property out of a `Map<String, dynamic>` and calls
+  /// `<Variant>.fromJson(json)` on the chosen variant — both require
+  /// every variant to be an object-shaped newtype with a fromJson
+  /// factory. Array/map/pod variants (e.g. github's `content-directory`,
+  /// which is `type: array`) fall through to the legacy stub.
+  RenderDiscriminator? get _dispatchableDiscriminator {
+    final disc = discriminator;
+    if (disc == null) return null;
+    if (!schemas.every((s) => s is RenderObject)) return null;
+    return disc;
+  }
+
+  @override
+  Iterable<Import> get additionalImports => [
+    ...super.additionalImports,
+    // The dispatch path emits @immutable wrappers that override == /
+    // hashCode; the legacy UnimplementedError stub doesn't need it.
+    if (_dispatchableDiscriminator != null)
+      const Import('package:meta/meta.dart'),
+  ];
+
   @override
   Map<String, dynamic> toTemplateContext(SchemaRenderer context) {
+    final disc = _dispatchableDiscriminator;
+    if (disc == null) {
+      return {
+        'doc_comment': createDocComment(common: common),
+        'typeName': typeName,
+        'nullableTypeName': nullableTypeName(context),
+        'has_dispatch': false,
+      };
+    }
+    final variants = <Map<String, dynamic>>[];
+    for (final schema in schemas) {
+      variants.add({
+        'wrapperTypeName': wrapperTypeName(schema),
+        'innerTypeName': schema.typeName,
+      });
+    }
+    final dispatch = <Map<String, dynamic>>[];
+    for (final entry in disc.mapping.entries) {
+      dispatch.add({
+        'value': entry.key,
+        'wrapperTypeName': wrapperTypeName(entry.value),
+        'innerTypeName': entry.value.typeName,
+      });
+    }
     return {
       'doc_comment': createDocComment(common: common),
       'typeName': typeName,
       'nullableTypeName': nullableTypeName(context),
+      'has_dispatch': true,
+      'discriminatorProperty': disc.propertyName,
+      'variants': variants,
+      'dispatch': dispatch,
     };
   }
 
@@ -3450,6 +3556,24 @@ class RenderOneOf extends RenderNewType {
     // discriminator-aware subclass emission (#99).
     return null;
   }
+}
+
+/// Render-side discriminator dispatch table for a [RenderOneOf].
+/// Each [mapping] value is one of the entries in
+/// [RenderOneOf.schemas] (same instance), so the renderer can look up
+/// wrapper names by variant.
+@immutable
+class RenderDiscriminator extends Equatable {
+  const RenderDiscriminator({
+    required this.propertyName,
+    required this.mapping,
+  });
+
+  final String propertyName;
+  final Map<String, RenderSchema> mapping;
+
+  @override
+  List<Object?> get props => [propertyName, mapping];
 }
 
 class RenderParameter implements CanBeParameter {

--- a/lib/src/resolver.dart
+++ b/lib/src/resolver.dart
@@ -5,6 +5,7 @@
 
 import 'package:collection/collection.dart';
 import 'package:equatable/equatable.dart';
+import 'package:meta/meta.dart';
 import 'package:space_gen/src/logger.dart';
 import 'package:space_gen/src/parse/spec.dart';
 import 'package:space_gen/src/parse/visitor.dart';
@@ -162,6 +163,54 @@ ResolvedSchema resolveSchemaRef(SchemaRef ref, ResolveContext context) {
   });
 }
 
+/// Resolve a [SchemaDiscriminator]: turn each mapping ref into a pointer
+/// match against [resolvedVariants], so the result shares identity with
+/// the corresponding ResolvedOneOf.schemas entry.
+ResolvedDiscriminator? _resolveDiscriminator(
+  SchemaDiscriminator? discriminator,
+  List<ResolvedSchema> resolvedVariants,
+  JsonPointer oneOfPointer,
+) {
+  if (discriminator == null) {
+    return null;
+  }
+  final rawMapping = discriminator.mapping;
+  if (rawMapping == null) {
+    return ResolvedDiscriminator(
+      propertyName: discriminator.propertyName,
+      mapping: null,
+    );
+  }
+  final byPointer = <JsonPointer, ResolvedSchema>{
+    for (final v in resolvedVariants) v.common.pointer: v,
+  };
+  final mapping = <String, ResolvedSchema>{};
+  for (final entry in rawMapping.entries) {
+    final ref = entry.value.ref;
+    if (ref == null) {
+      // Parser invariant: mapping values are built via SchemaRef.ref.
+      _error(
+        'discriminator.mapping[${entry.key}] must be a \$ref',
+        oneOfPointer,
+      );
+    }
+    final targetPointer = JsonPointer.parse(ref.uri.toString());
+    final variant = byPointer[targetPointer];
+    if (variant == null) {
+      _error(
+        'discriminator.mapping[${entry.key}] = $targetPointer does not '
+        'point at any of the oneOf variants',
+        oneOfPointer,
+      );
+    }
+    mapping[entry.key] = variant;
+  }
+  return ResolvedDiscriminator(
+    propertyName: discriminator.propertyName,
+    mapping: mapping,
+  );
+}
+
 ResolvedSchema _resolveSchemaFully(
   Schema schema,
   CommonProperties resolvedCommon,
@@ -257,9 +306,18 @@ ResolvedSchema _resolveSchemaFully(
   if (schema is SchemaOneOf) {
     assert(createsNewType, 'SchemaOneOf should create a new type');
     final oneOf = schema;
+    final resolvedSchemas = oneOf.schemas
+        .map((e) => resolveSchemaRef(e, context))
+        .toList();
+    final discriminator = _resolveDiscriminator(
+      oneOf.discriminator,
+      resolvedSchemas,
+      oneOf.pointer,
+    );
     return ResolvedOneOf(
       common: resolvedCommon,
-      schemas: oneOf.schemas.map((e) => resolveSchemaRef(e, context)).toList(),
+      schemas: resolvedSchemas,
+      discriminator: discriminator,
     );
   }
   if (schema is SchemaAllOf) {
@@ -1394,13 +1452,44 @@ abstract class ResolvedSchemaCollection extends ResolvedSchema {
 }
 
 class ResolvedOneOf extends ResolvedSchemaCollection {
-  const ResolvedOneOf({required super.schemas, required super.common})
-    : super(createsNewType: true);
+  const ResolvedOneOf({
+    required super.schemas,
+    required super.common,
+    required this.discriminator,
+  }) : super(createsNewType: true);
+
+  /// The resolved discriminator, if any. Each [ResolvedDiscriminator.mapping]
+  /// value points at one of the [schemas] entries (same instance), so
+  /// callers can do identity lookups.
+  final ResolvedDiscriminator? discriminator;
+
+  @override
+  List<Object?> get props => [super.props, discriminator];
 
   @override
   ResolvedOneOf copyWith({CommonProperties? common}) {
-    return ResolvedOneOf(common: common ?? this.common, schemas: schemas);
+    return ResolvedOneOf(
+      common: common ?? this.common,
+      schemas: schemas,
+      discriminator: discriminator,
+    );
   }
+}
+
+/// Resolved form of [SchemaDiscriminator]. Each [mapping] value is one
+/// of the [ResolvedOneOf.schemas] entries, identified by pointer match.
+@immutable
+class ResolvedDiscriminator extends Equatable {
+  const ResolvedDiscriminator({
+    required this.propertyName,
+    required this.mapping,
+  });
+
+  final String propertyName;
+  final Map<String, ResolvedSchema>? mapping;
+
+  @override
+  List<Object?> get props => [propertyName, mapping];
 }
 
 class ResolvedAnyOf extends ResolvedSchemaCollection {

--- a/lib/templates/schema_one_of.mustache
+++ b/lib/templates/schema_one_of.mustache
@@ -1,3 +1,55 @@
+{{#has_dispatch}}
+{{{ doc_comment }}}sealed class {{ typeName }} {
+    const {{ typeName }}();
+
+    factory {{ typeName }}.fromJson(Map<String, dynamic> json) {
+        final discriminator = json['{{ discriminatorProperty }}'];
+        return switch (discriminator) {
+{{#dispatch}}
+            '{{ value }}' => {{{ wrapperTypeName }}}({{{ innerTypeName }}}.fromJson(json)),
+{{/dispatch}}
+            _ => throw FormatException(
+                "Unknown {{ discriminatorProperty }} '$discriminator' for {{ typeName }}",
+            ),
+        };
+    }
+
+    /// Convenience to create a nullable type from a nullable json object.
+    /// Useful when parsing optional fields.
+    static {{ nullableTypeName }} maybeFromJson(Map<String, dynamic>? json) {
+        if (json == null) {
+            return null;
+        }
+        return {{ typeName }}.fromJson(json);
+    }
+
+    /// Require all subclasses to implement toJson.
+    Map<String, dynamic> toJson();
+}
+
+{{#variants}}
+@immutable
+final class {{{ wrapperTypeName }}} extends {{ typeName }} {
+    const {{{ wrapperTypeName }}}(this.value);
+
+    final {{{ innerTypeName }}} value;
+
+    @override
+    Map<String, dynamic> toJson() => value.toJson();
+
+    @override
+    int get hashCode => value.hashCode;
+
+    @override
+    bool operator ==(Object other) {
+        if (identical(this, other)) return true;
+        return other is {{{ wrapperTypeName }}} && value == other.value;
+    }
+}
+
+{{/variants}}
+{{/has_dispatch}}
+{{^has_dispatch}}
 {{{ doc_comment }}}sealed class {{ typeName }} {
     static {{ typeName }} fromJson(dynamic jsonArg) {
         // Determine which schema to use based on the json.
@@ -17,3 +69,4 @@
     /// Require all subclasses to implement toJson.
     dynamic toJson();
 }
+{{/has_dispatch}}

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -328,6 +328,56 @@ void main() {
       expect(schema, isA<SchemaOneOf>());
     });
 
+    test('oneOf with discriminator + mapping', () {
+      final json = {
+        'oneOf': [
+          {r'$ref': '#/components/schemas/Cat'},
+          {r'$ref': '#/components/schemas/Dog'},
+        ],
+        'discriminator': {
+          'propertyName': 'pet_type',
+          'mapping': {
+            'cat': '#/components/schemas/Cat',
+            // Bare-name form is normalized to a full ref.
+            'dog': 'Dog',
+          },
+        },
+      };
+      final schemas = parseTestSchemas({
+        'Test': json,
+        'Cat': {'type': 'object'},
+        'Dog': {'type': 'object'},
+      });
+      final object = schemas['Test']?.object;
+      if (object is! SchemaOneOf) {
+        fail('Expected SchemaOneOf, got ${object.runtimeType}');
+      }
+      final discriminator = object.discriminator;
+      if (discriminator == null) fail('discriminator unexpectedly null');
+      expect(discriminator.propertyName, 'pet_type');
+      final mapping = discriminator.mapping;
+      if (mapping == null) fail('mapping unexpectedly null');
+      expect(
+        mapping['cat']?.ref?.uri,
+        Uri.parse('#/components/schemas/Cat'),
+      );
+      expect(
+        mapping['dog']?.ref?.uri,
+        Uri.parse('#/components/schemas/Dog'),
+      );
+    });
+
+    test('oneOf without discriminator', () {
+      final json = {
+        'oneOf': [
+          {'type': 'string'},
+          {'type': 'integer'},
+        ],
+      };
+      final oneOf = parseTestSchema(json) as SchemaOneOf;
+      expect(oneOf.discriminator, isNull);
+    });
+
     test('components schemas as ref not supported', () {
       // Refs are generally fine.
       final json = {

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -759,6 +759,123 @@ void main() {
       );
     });
 
+    test('oneOf with discriminator + mapping renders sealed dispatch', () {
+      final results = renderTestSchemas(
+        {
+          'Pet': {
+            'oneOf': [
+              {r'$ref': '#/components/schemas/Cat'},
+              {r'$ref': '#/components/schemas/Dog'},
+            ],
+            'discriminator': {
+              'propertyName': 'pet_type',
+              'mapping': {
+                'cat': '#/components/schemas/Cat',
+                'dog': '#/components/schemas/Dog',
+              },
+            },
+          },
+          'Cat': {
+            'type': 'object',
+            'properties': {
+              'pet_type': {'type': 'string'},
+            },
+            'required': ['pet_type'],
+          },
+          'Dog': {
+            'type': 'object',
+            'properties': {
+              'pet_type': {'type': 'string'},
+            },
+            'required': ['pet_type'],
+          },
+        },
+        specUrl: Uri.parse('file:///spec.yaml'),
+      );
+      final pet = results['Pet'];
+      expect(pet, isNotNull);
+      // Spot-check the dispatch shape rather than snapshot-matching the
+      // full template — keeps the test resilient to whitespace tweaks.
+      expect(pet, contains('sealed class Pet'));
+      expect(pet, contains('factory Pet.fromJson(Map<String, dynamic> json)'));
+      expect(pet, contains("final discriminator = json['pet_type']"));
+      expect(pet, contains("'cat' => PetCat(Cat.fromJson(json))"));
+      expect(pet, contains("'dog' => PetDog(Dog.fromJson(json))"));
+      expect(pet, contains("Unknown pet_type '\$discriminator' for Pet"));
+      // Wrapper subclasses with @immutable + structural equality.
+      expect(pet, contains('@immutable'));
+      expect(pet, contains('final class PetCat extends Pet'));
+      expect(pet, contains('final Cat value;'));
+      expect(pet, contains('final class PetDog extends Pet'));
+      expect(pet, contains('final Dog value;'));
+      expect(pet, contains('Map<String, dynamic> toJson() => value.toJson()'));
+    });
+
+    test(
+      'oneOf with discriminator but a non-object variant falls back to '
+      'the legacy stub',
+      () {
+        // Mixed-shape oneOf: dispatch needs `<Variant>.fromJson(Map)` on
+        // every variant, which doesn't exist for the inline pod.
+        final results = renderTestSchemas(
+          {
+            'Mixed': {
+              'oneOf': [
+                {r'$ref': '#/components/schemas/Cat'},
+                {'type': 'string'},
+              ],
+              'discriminator': {
+                'propertyName': 'pet_type',
+                'mapping': {
+                  'cat': '#/components/schemas/Cat',
+                },
+              },
+            },
+            'Cat': {
+              'type': 'object',
+              'properties': {
+                'pet_type': {'type': 'string'},
+              },
+              'required': ['pet_type'],
+            },
+          },
+          specUrl: Uri.parse('file:///spec.yaml'),
+        );
+        final mixed = results['Mixed'];
+        expect(mixed, isNotNull);
+        expect(mixed, contains("throw UnimplementedError('Mixed.fromJson')"));
+        expect(mixed, isNot(contains('factory Mixed.fromJson')));
+        expect(mixed, isNot(contains('final class MixedCat')));
+      },
+    );
+
+    test('oneOf with discriminator but no mapping falls back to legacy '
+        'stub (implicit mapping not yet supported)', () {
+      // No `mapping` key — discriminator is parsed but we don't yet
+      // emit dispatch without an explicit table.
+      final results = renderTestSchemas(
+        {
+          'Pet': {
+            'oneOf': [
+              {r'$ref': '#/components/schemas/Cat'},
+            ],
+            'discriminator': {'propertyName': 'pet_type'},
+          },
+          'Cat': {
+            'type': 'object',
+            'properties': {
+              'pet_type': {'type': 'string'},
+            },
+            'required': ['pet_type'],
+          },
+        },
+        specUrl: Uri.parse('file:///spec.yaml'),
+      );
+      final pet = results['Pet'];
+      expect(pet, contains("throw UnimplementedError('Pet.fromJson')"));
+      expect(pet, isNot(contains('factory Pet.fromJson')));
+    });
+
     group('anyOf', () {
       test('two pod types', () {
         final schema = {

--- a/test/render/render_tree_test.dart
+++ b/test/render/render_tree_test.dart
@@ -621,6 +621,7 @@ void main() {
             createsNewType: false,
           ),
         ],
+        discriminator: null,
       );
       expect(a.equalsIgnoringName(a), isTrue);
 
@@ -641,6 +642,7 @@ void main() {
             createsNewType: false,
           ),
         ],
+        discriminator: null,
       );
       expect(a.equalsIgnoringName(b), isTrue);
 
@@ -670,6 +672,7 @@ void main() {
             createsNewType: false,
           ),
         ],
+        discriminator: null,
       );
       expect(a.equalsIgnoringName(c), isFalse);
     });
@@ -1015,6 +1018,7 @@ void main() {
             createsNewType: false,
           ),
         ],
+        discriminator: null,
       );
       expect(schema.exampleValue(context), isNull);
     });

--- a/test/resolver_test.dart
+++ b/test/resolver_test.dart
@@ -587,11 +587,14 @@ void main() {
         'discriminator': {'propertyName': 'kind'},
       };
       final logger = _MockLogger();
-      final schema = runWithLogger(
+      final resolved = runWithLogger(
         logger,
         () => parseAndResolveTestSchema(json),
-      ) as ResolvedOneOf;
-      final discriminator = schema.discriminator;
+      );
+      if (resolved is! ResolvedOneOf) {
+        fail('Expected ResolvedOneOf, got ${resolved.runtimeType}');
+      }
+      final discriminator = resolved.discriminator;
       expect(discriminator, isNotNull);
       expect(discriminator?.propertyName, 'kind');
       expect(discriminator?.mapping, isNull);

--- a/test/resolver_test.dart
+++ b/test/resolver_test.dart
@@ -507,6 +507,151 @@ void main() {
       );
     });
 
+    test('oneOf with discriminator + mapping resolves variants by '
+        'identity', () {
+      final json = {
+        'openapi': '3.1.0',
+        'info': {'title': 'Pets', 'version': '1.0.0'},
+        'servers': [
+          {'url': 'https://api.example.com'},
+        ],
+        'paths': {
+          '/pet': {
+            'get': {
+              'responses': {
+                '200': {
+                  'description': 'OK',
+                  'content': {
+                    'application/json': {
+                      'schema': {
+                        'oneOf': [
+                          {r'$ref': '#/components/schemas/Cat'},
+                          {r'$ref': '#/components/schemas/Dog'},
+                        ],
+                        'discriminator': {
+                          'propertyName': 'pet_type',
+                          'mapping': {
+                            'cat': '#/components/schemas/Cat',
+                            'dog': 'Dog',
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        'components': {
+          'schemas': {
+            'Cat': {
+              'type': 'object',
+              'properties': {
+                'pet_type': {'type': 'string'},
+              },
+              'required': ['pet_type'],
+            },
+            'Dog': {
+              'type': 'object',
+              'properties': {
+                'pet_type': {'type': 'string'},
+              },
+              'required': ['pet_type'],
+            },
+          },
+        },
+      };
+      final logger = _MockLogger();
+      final spec = runWithLogger(logger, () => parseAndResolveTestSpec(json));
+      final response =
+          spec.paths.first.operations.first.responses.first.content
+              as ResolvedOneOf;
+      final discriminator = response.discriminator;
+      expect(discriminator, isNotNull);
+      expect(discriminator?.propertyName, 'pet_type');
+      // Mapping values must be identical (same instance) to one of the
+      // oneOf variant entries — that's the contract the renderer relies on.
+      final mapping = discriminator?.mapping;
+      expect(mapping, isNotNull);
+      expect(identical(mapping?['cat'], response.schemas[0]), isTrue);
+      expect(identical(mapping?['dog'], response.schemas[1]), isTrue);
+    });
+
+    test('oneOf with discriminator but no mapping', () {
+      final json = {
+        'oneOf': [
+          {'type': 'string'},
+          {'type': 'integer'},
+        ],
+        'discriminator': {'propertyName': 'kind'},
+      };
+      final logger = _MockLogger();
+      final schema = runWithLogger(
+        logger,
+        () => parseAndResolveTestSchema(json),
+      ) as ResolvedOneOf;
+      final discriminator = schema.discriminator;
+      expect(discriminator, isNotNull);
+      expect(discriminator?.propertyName, 'kind');
+      expect(discriminator?.mapping, isNull);
+    });
+
+    test('discriminator mapping that does not reference a oneOf variant '
+        'errors', () {
+      final json = {
+        'openapi': '3.1.0',
+        'info': {'title': 'Pets', 'version': '1.0.0'},
+        'servers': [
+          {'url': 'https://api.example.com'},
+        ],
+        'paths': {
+          '/pet': {
+            'get': {
+              'responses': {
+                '200': {
+                  'description': 'OK',
+                  'content': {
+                    'application/json': {
+                      'schema': {
+                        'oneOf': [
+                          {r'$ref': '#/components/schemas/Cat'},
+                        ],
+                        'discriminator': {
+                          'propertyName': 'pet_type',
+                          'mapping': {
+                            // Points at a schema that's not in the oneOf list.
+                            'dog': '#/components/schemas/Dog',
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        'components': {
+          'schemas': {
+            'Cat': {'type': 'object'},
+            'Dog': {'type': 'object'},
+          },
+        },
+      };
+      final logger = _MockLogger();
+      expect(
+        () => runWithLogger(logger, () => parseAndResolveTestSpec(json)),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            contains('does not point at any of the oneOf variants'),
+          ),
+        ),
+      );
+    });
+
     test('allOf with one item', () {
       final json = {
         'allOf': [
@@ -1445,6 +1590,7 @@ void main() {
               type: PodType.boolean,
             ),
           ],
+          discriminator: null,
         );
         testCopyWith(schema, (schema, copy) {
           expect(copy.schemas, equals(schema.schemas));


### PR DESCRIPTION
## Summary

- Wires up OpenAPI's `discriminator` end-to-end so a `oneOf` with a `propertyName` + `mapping` emits a real sealed-class dispatch instead of throwing `UnimplementedError` at runtime. Today every oneOf is dead at runtime (≈375 sites in github's spec).
- Variants stay where they live. Each oneOf gets its own `@immutable final class` wrapper subclasses that hold the inner value — callers get exhaustive `switch` on the sealed parent, and `toJson`/`==`/`hashCode` delegate to the wrapped value. PrivateUser/PublicUser are shared across github's three `/user` endpoints so they can't extend any single sealed class — wrappers are the universal mechanism.
- Dispatch is gated on every variant being a `RenderObject` (object-shaped newtype with a fromJson factory). Non-object variants like github's `content-directory` (`type: array`) keep the existing UnimplementedError stub for now.

Verified on `api.github.com.json`: the three discriminator sites at `/user`, `/user/{id}`, `/users/{username}` now generate working dispatch with `dart analyze` clean.

### Layered changes

- **Parser** (`lib/src/parse/spec.dart`, `lib/src/parser.dart`): `SchemaDiscriminator { propertyName, mapping }` threaded onto `SchemaOneOf`. Bare-name mapping values are normalized to `#/components/schemas/<name>`.
- **Resolver** (`lib/src/resolver.dart`): `ResolvedDiscriminator`. Mapping values are matched by pointer back to the same `ResolvedSchema` instances already in `oneOf.schemas` so the renderer can do identity lookups. Errors clearly when mapping points outside the oneOf.
- **Renderer** (`lib/src/render/render_tree.dart`, `lib/templates/schema_one_of.mustache`): `RenderDiscriminator` + the new dispatch path in the mustache template.

### Follow-ups (out of scope here)

- Smoosh-when-exclusive: when a variant is used in only one oneOf, co-locate it in the parent file as a direct subclass instead of a wrapper, for handwritten-quality output.
- Structural dedup: github's three `/user` endpoints all share the same `[private-user, public-user]` union — a dedup pass would fold them into a single `User` sealed type.
- Non-discriminator oneOf and non-object variants are still the legacy UnimplementedError stub.

## Test plan

- [x] Parser unit tests: discriminator + mapping (with bare-name normalization), no-discriminator
- [x] Resolver unit tests: identity match against oneOf variants, no-mapping variant, mapping-outside-oneOf errors
- [x] End-to-end smoke test on a minimal repro spec covering dispatch, exhaustive switch, FormatException for unknown values, toJson round-trip
- [x] Regenerated against `~/Documents/GitHub/personal/gen_tests/api.github.com.json`; the three /user dispatch sites are `dart analyze` clean
- [x] Full test suite: 347 tests pass, no new analyzer issues vs. baseline