### PR TITLE
feat: shape-based dispatch for non-discriminator oneOf

### DIFF
--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -3461,11 +3461,13 @@ class RenderOneOf extends RenderNewType {
     if (variant is RenderObject || variant is RenderEnum) {
       return variant.typeName;
     }
-    if (variant is RenderInteger && !variant.createsNewType) return 'Int';
-    if (variant is RenderString && !variant.createsNewType) return 'String';
-    if (variant is RenderPod &&
-        !variant.createsNewType &&
-        variant.type == PodType.boolean) {
+    // Anything beyond here is only handled in its inline form (the
+    // newtype variants generate their own classes and would also fit
+    // RenderObject/RenderEnum-style wrapping, but we don't bother yet).
+    if (variant.createsNewType) return null;
+    if (variant is RenderInteger) return 'Int';
+    if (variant is RenderString) return 'String';
+    if (variant is RenderPod && variant.type == PodType.boolean) {
       return 'Bool';
     }
     return null;
@@ -3496,55 +3498,45 @@ class RenderOneOf extends RenderNewType {
   _VariantPlan? _planVariant(RenderSchema variant) {
     final tag = _wrapperTagFor(variant);
     if (tag == null) return null;
-    if (variant is RenderObject) {
+    final wrapperTypeName = '$typeName$tag';
+
+    // Newtype variants (objects, enums): the wrapper holds the parsed
+    // value and forwards fromJson/toJson to the variant's own class.
+    // Only the JSON shape distinguishes them.
+    if (variant is RenderObject || variant is RenderEnum) {
       return _VariantPlan(
-        wrapperTypeName: '$typeName$tag',
+        wrapperTypeName: wrapperTypeName,
         valueType: variant.typeName,
-        jsonTestType: 'Map<String, dynamic>',
+        jsonTestType: variant is RenderObject
+            ? 'Map<String, dynamic>'
+            : 'String',
         fromJson: '${variant.typeName}.fromJson(v)',
         toJson: 'value.toJson()',
       );
     }
-    if (variant is RenderEnum) {
-      return _VariantPlan(
-        wrapperTypeName: '$typeName$tag',
-        valueType: variant.typeName,
-        jsonTestType: 'String',
-        fromJson: '${variant.typeName}.fromJson(v)',
-        toJson: 'value.toJson()',
-      );
+
+    // Inline pod variants: the wrapper just stores the raw JSON value
+    // (int / String / bool) — no parsing on either side. _wrapperTagFor
+    // has already filtered out the createsNewType case.
+    final String? podType;
+    if (variant is RenderInteger) {
+      podType = 'int';
+    } else if (variant is RenderString) {
+      podType = 'String';
+    } else if (variant is RenderPod && variant.type == PodType.boolean) {
+      podType = 'bool';
+    } else {
+      podType = null;
     }
-    if (variant is RenderInteger && !variant.createsNewType) {
-      return _VariantPlan(
-        wrapperTypeName: '$typeName$tag',
-        valueType: 'int',
-        jsonTestType: 'int',
-        fromJson: 'v',
-        toJson: 'value',
-      );
-    }
-    if (variant is RenderString && !variant.createsNewType) {
-      return _VariantPlan(
-        wrapperTypeName: '$typeName$tag',
-        valueType: 'String',
-        jsonTestType: 'String',
-        fromJson: 'v',
-        toJson: 'value',
-      );
-    }
-    if (variant is RenderPod &&
-        !variant.createsNewType &&
-        variant.type == PodType.boolean) {
-      return _VariantPlan(
-        wrapperTypeName: '$typeName$tag',
-        valueType: 'bool',
-        jsonTestType: 'bool',
-        fromJson: 'v',
-        toJson: 'value',
-        positionalBoolIgnore: true,
-      );
-    }
-    return null;
+    if (podType == null) return null;
+    return _VariantPlan(
+      wrapperTypeName: wrapperTypeName,
+      valueType: podType,
+      jsonTestType: podType,
+      fromJson: 'v',
+      toJson: 'value',
+      positionalBoolIgnore: podType == 'bool',
+    );
   }
 
   /// Discriminator-driven dispatch: every variant must be an object-

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -1821,6 +1821,13 @@ abstract class RenderSchema extends Equatable implements ToTemplateContext {
   /// toJson to convert to json.
   bool get shouldCallToJson => createsNewType;
 
+  /// Suffix used to name a [RenderOneOf] wrapper subclass for this
+  /// schema in shape dispatch (`<ParentTypeName><wrapperTag>`).
+  /// Returns null when this schema can't appear as a shape-dispatch
+  /// variant (the runtime-type test wouldn't pin it down, or we
+  /// haven't taught the dispatch to handle it yet).
+  String? get wrapperTag => null;
+
   @override
   List<Object?> get props => [snakeName, pointer];
 
@@ -2025,6 +2032,15 @@ class RenderPod extends RenderSchema {
 
   @override
   String get typeName => createsNewType ? camelFromSnake(snakeName) : dartType;
+
+  // Boolean is the only PodType with a `is bool` test that's distinct
+  // from the other JSON storage types (the date/uri/uuid/etc. all
+  // parse from String, which would conflict with RenderString in a
+  // oneOf — we'd need to inspect the format at runtime, which we
+  // don't).
+  @override
+  String? get wrapperTag =>
+      !createsNewType && type == PodType.boolean ? 'Bool' : null;
 
   @override
   String jsonStorageType({required bool isNullable}) {
@@ -2288,6 +2304,9 @@ class RenderString extends RenderSchema {
     'typeName': typeName,
     'nullableTypeName': nullableTypeName(context),
   };
+
+  @override
+  String? get wrapperTag => createsNewType ? null : 'String';
 
   @override
   String jsonStorageType({required bool isNullable}) =>
@@ -2561,6 +2580,9 @@ class RenderInteger extends RenderNumeric<int> {
   String get typeName => createsNewType ? camelFromSnake(snakeName) : 'int';
 
   @override
+  String? get wrapperTag => createsNewType ? null : 'Int';
+
+  @override
   String jsonStorageType({required bool isNullable}) =>
       isNullable ? 'int?' : 'int';
 
@@ -2589,6 +2611,9 @@ class RenderObject extends RenderNewType {
 
   /// The required properties of the resolved schema.
   final List<String> requiredProperties;
+
+  @override
+  String? get wrapperTag => typeName;
 
   @override
   List<Object?> get props => [
@@ -3309,6 +3334,9 @@ class RenderEnum extends RenderNewType {
   final List<String>? descriptions;
 
   @override
+  String? get wrapperTag => typeName;
+
+  @override
   List<Object?> get props => [
     super.props,
     values,
@@ -3452,38 +3480,20 @@ class RenderOneOf extends RenderNewType {
     return 'Map<String, dynamic>';
   }
 
-  /// Wrapper subclass name for [variant], shaped `<ParentTypeName><Tag>`.
-  /// For named variants (objects/enums with their own typeName) the tag
-  /// is the variant's typeName. For inline primitive variants there is
-  /// no useful name, so we tag by the Dart storage type — `Int`,
-  /// `String`, `Bool`. Returns null if we can't form a stable tag.
-  String? _wrapperTagFor(RenderSchema variant) {
-    if (variant is RenderObject || variant is RenderEnum) {
-      return variant.typeName;
-    }
-    // Anything beyond here is only handled in its inline form (the
-    // newtype variants generate their own classes and would also fit
-    // RenderObject/RenderEnum-style wrapping, but we don't bother yet).
-    if (variant.createsNewType) return null;
-    if (variant is RenderInteger) return 'Int';
-    if (variant is RenderString) return 'String';
-    if (variant is RenderPod && variant.type == PodType.boolean) {
-      return 'Bool';
-    }
-    return null;
-  }
-
-  /// Build the wrapper class name as `<ParentTypeName><Tag>`. We
-  /// always prepend even when the tag already starts with the parent's
-  /// typeName — stripping the duplicate would collide with the
-  /// variant's own standalone class (the parser names inline variants
-  /// `<parent_snake>_one_of_<i>`, so the variant typeName equals the
-  /// would-be deduped wrapper name). The double-prefix is ugly but
-  /// unambiguous; co-locating the inline variant into the parent's
-  /// file is a follow-up that fixes both the ugliness and the
-  /// duplicate emission.
+  /// Build the wrapper class name as `<ParentTypeName><wrapperTag>`.
+  /// We always prepend — even when the variant's tag already starts
+  /// with the parent's typeName — because stripping the duplicate
+  /// would collide with the variant's own standalone class (the
+  /// parser names inline variants `<parent_snake>_one_of_<i>`, so the
+  /// variant typeName equals the would-be deduped wrapper name). The
+  /// double-prefix is ugly but unambiguous; co-locating the inline
+  /// variant into the parent's file is a follow-up that fixes both
+  /// the ugliness and the duplicate emission.
+  ///
+  /// Caller must have established that [variant] has a non-null
+  /// [RenderSchema.wrapperTag] (e.g. via the dispatch gates).
   String wrapperTypeName(RenderSchema variant) {
-    final tag = _wrapperTagFor(variant);
+    final tag = variant.wrapperTag;
     if (tag == null) {
       throw StateError('No wrapper tag available for $variant');
     }
@@ -3492,11 +3502,11 @@ class RenderOneOf extends RenderNewType {
 
   /// Per-variant info needed to emit a dispatch arm + wrapper subclass.
   /// Returns null when [variant] isn't representable in the dispatch
-  /// (unsupported shape, or runtime-type test would conflict with another
-  /// variant). The caller checks for null + checks for distinct test
-  /// types before committing to the dispatch path.
+  /// (unsupported shape, or runtime-type test would conflict with
+  /// another variant). The caller checks for null and checks for
+  /// distinct test types before committing to the dispatch path.
   _VariantPlan? _planVariant(RenderSchema variant) {
-    final tag = _wrapperTagFor(variant);
+    final tag = variant.wrapperTag;
     if (tag == null) return null;
     final wrapperTypeName = '$typeName$tag';
 
@@ -3516,18 +3526,15 @@ class RenderOneOf extends RenderNewType {
     }
 
     // Inline pod variants: the wrapper just stores the raw JSON value
-    // (int / String / bool) — no parsing on either side. _wrapperTagFor
-    // has already filtered out the createsNewType case.
-    final String? podType;
-    if (variant is RenderInteger) {
-      podType = 'int';
-    } else if (variant is RenderString) {
-      podType = 'String';
-    } else if (variant is RenderPod && variant.type == PodType.boolean) {
-      podType = 'bool';
-    } else {
-      podType = null;
-    }
+    // (int / String / bool) — no parsing on either side. wrapperTag is
+    // null on the createsNewType branch, so by here we're guaranteed
+    // an inline pod.
+    final podType = switch (variant) {
+      RenderInteger() => 'int',
+      RenderString() => 'String',
+      RenderPod(type: PodType.boolean) => 'bool',
+      _ => null,
+    };
     if (podType == null) return null;
     return _VariantPlan(
       wrapperTypeName: wrapperTypeName,
@@ -3592,7 +3599,7 @@ class RenderOneOf extends RenderNewType {
       for (final schema in schemas) {
         variants.add({
           'wrapperTypeName': wrapperTypeName(schema),
-          'innerTypeName': schema.typeName,
+          'valueType': schema.typeName,
         });
       }
       final dispatch = <Map<String, dynamic>>[];
@@ -3600,7 +3607,7 @@ class RenderOneOf extends RenderNewType {
         dispatch.add({
           'value': entry.key,
           'wrapperTypeName': wrapperTypeName(entry.value),
-          'innerTypeName': entry.value.typeName,
+          'valueType': entry.value.typeName,
         });
       }
       ctx['has_discriminator_dispatch'] = true;

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -3477,9 +3477,9 @@ class RenderOneOf extends RenderNewType {
   /// variant's own standalone class (the parser names inline variants
   /// `<parent_snake>_one_of_<i>`, so the variant typeName equals the
   /// would-be deduped wrapper name). The double-prefix is ugly but
-  /// unambiguous; smooshing the inline variant into the parent's file
-  /// is a follow-up that fixes both the ugliness and the duplicate
-  /// emission.
+  /// unambiguous; co-locating the inline variant into the parent's
+  /// file is a follow-up that fixes both the ugliness and the
+  /// duplicate emission.
   String wrapperTypeName(RenderSchema variant) {
     final tag = _wrapperTagFor(variant);
     if (tag == null) {
@@ -3552,12 +3552,12 @@ class RenderOneOf extends RenderNewType {
   bool get _hasDiscriminatorDispatch =>
       discriminator != null && schemas.every((s) => s is RenderObject);
 
-  /// Shape-driven dispatch (runtime-type switch). Every variant must be
-  /// plannable AND every plan's [_VariantPlan.jsonTestType] must be
-  /// unique so a `case T v =>` arm is unambiguous. Falls through from
-  /// the discriminator path when the discriminator can't be honored
-  /// (e.g. non-object variants under a discriminator) — shape is a
-  /// strict fallback rather than a competitor.
+  /// Shape-driven dispatch (runtime-type switch). Every variant must
+  /// have a known plan AND every plan's [_VariantPlan.jsonTestType]
+  /// must be unique so a `case T v =>` arm is unambiguous. Falls
+  /// through from the discriminator path when the discriminator can't
+  /// be honored (e.g. non-object variants under a discriminator) —
+  /// shape is a strict fallback rather than a competitor.
   List<_VariantPlan>? get _shapeDispatchPlans {
     final plans = <_VariantPlan>[];
     for (final v in schemas) {

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -3452,22 +3452,126 @@ class RenderOneOf extends RenderNewType {
     return 'Map<String, dynamic>';
   }
 
-  /// Wrapper subclass name for [variant], shaped
-  /// `<ParentTypeName><VariantTypeName>`. We don't shorten using the
-  /// discriminator value (e.g. "private") because the variant's own
-  /// typeName is already a unique, valid Dart identifier while
-  /// discriminator strings are arbitrary.
-  String wrapperTypeName(RenderSchema variant) =>
-      '$typeName${variant.typeName}';
+  /// Wrapper subclass name for [variant], shaped `<ParentTypeName><Tag>`.
+  /// For named variants (objects/enums with their own typeName) the tag
+  /// is the variant's typeName. For inline primitive variants there is
+  /// no useful name, so we tag by the Dart storage type — `Int`,
+  /// `String`, `Bool`. Returns null if we can't form a stable tag.
+  String? _wrapperTagFor(RenderSchema variant) {
+    if (variant is RenderObject || variant is RenderEnum) {
+      return variant.typeName;
+    }
+    if (variant is RenderInteger && !variant.createsNewType) return 'Int';
+    if (variant is RenderString && !variant.createsNewType) return 'String';
+    if (variant is RenderPod &&
+        !variant.createsNewType &&
+        variant.type == PodType.boolean) {
+      return 'Bool';
+    }
+    return null;
+  }
 
-  /// True when the dispatch path can be emitted. Dispatch reads a
-  /// discriminator property out of a `Map<String, dynamic>` and calls
-  /// `<Variant>.fromJson(json)` on the chosen variant — both require
-  /// every variant to be an object-shaped newtype with a fromJson
-  /// factory. Array/map/pod variants (e.g. github's `content-directory`,
-  /// which is `type: array`) fall through to the legacy stub.
-  bool get _hasDispatch =>
+  /// Build the wrapper class name as `<ParentTypeName><Tag>`. We
+  /// always prepend even when the tag already starts with the parent's
+  /// typeName — stripping the duplicate would collide with the
+  /// variant's own standalone class (the parser names inline variants
+  /// `<parent_snake>_one_of_<i>`, so the variant typeName equals the
+  /// would-be deduped wrapper name). The double-prefix is ugly but
+  /// unambiguous; smooshing the inline variant into the parent's file
+  /// is a follow-up that fixes both the ugliness and the duplicate
+  /// emission.
+  String wrapperTypeName(RenderSchema variant) {
+    final tag = _wrapperTagFor(variant);
+    if (tag == null) {
+      throw StateError('No wrapper tag available for $variant');
+    }
+    return '$typeName$tag';
+  }
+
+  /// Per-variant info needed to emit a dispatch arm + wrapper subclass.
+  /// Returns null when [variant] isn't representable in the dispatch
+  /// (unsupported shape, or runtime-type test would conflict with another
+  /// variant). The caller checks for null + checks for distinct test
+  /// types before committing to the dispatch path.
+  _VariantPlan? _planVariant(RenderSchema variant) {
+    final tag = _wrapperTagFor(variant);
+    if (tag == null) return null;
+    if (variant is RenderObject) {
+      return _VariantPlan(
+        wrapperTypeName: '$typeName$tag',
+        valueType: variant.typeName,
+        jsonTestType: 'Map<String, dynamic>',
+        fromJson: '${variant.typeName}.fromJson(v)',
+        toJson: 'value.toJson()',
+      );
+    }
+    if (variant is RenderEnum) {
+      return _VariantPlan(
+        wrapperTypeName: '$typeName$tag',
+        valueType: variant.typeName,
+        jsonTestType: 'String',
+        fromJson: '${variant.typeName}.fromJson(v)',
+        toJson: 'value.toJson()',
+      );
+    }
+    if (variant is RenderInteger && !variant.createsNewType) {
+      return _VariantPlan(
+        wrapperTypeName: '$typeName$tag',
+        valueType: 'int',
+        jsonTestType: 'int',
+        fromJson: 'v',
+        toJson: 'value',
+      );
+    }
+    if (variant is RenderString && !variant.createsNewType) {
+      return _VariantPlan(
+        wrapperTypeName: '$typeName$tag',
+        valueType: 'String',
+        jsonTestType: 'String',
+        fromJson: 'v',
+        toJson: 'value',
+      );
+    }
+    if (variant is RenderPod &&
+        !variant.createsNewType &&
+        variant.type == PodType.boolean) {
+      return _VariantPlan(
+        wrapperTypeName: '$typeName$tag',
+        valueType: 'bool',
+        jsonTestType: 'bool',
+        fromJson: 'v',
+        toJson: 'value',
+        positionalBoolIgnore: true,
+      );
+    }
+    return null;
+  }
+
+  /// Discriminator-driven dispatch: every variant must be an object-
+  /// shaped newtype with a `fromJson` factory.
+  bool get _hasDiscriminatorDispatch =>
       discriminator != null && schemas.every((s) => s is RenderObject);
+
+  /// Shape-driven dispatch (runtime-type switch). Every variant must be
+  /// plannable AND every plan's [_VariantPlan.jsonTestType] must be
+  /// unique so a `case T v =>` arm is unambiguous. Falls through from
+  /// the discriminator path when the discriminator can't be honored
+  /// (e.g. non-object variants under a discriminator) — shape is a
+  /// strict fallback rather than a competitor.
+  List<_VariantPlan>? get _shapeDispatchPlans {
+    final plans = <_VariantPlan>[];
+    for (final v in schemas) {
+      final plan = _planVariant(v);
+      if (plan == null) return null;
+      plans.add(plan);
+    }
+    final testTypes = plans.map((p) => p.jsonTestType).toSet();
+    if (testTypes.length != plans.length) return null;
+    return plans;
+  }
+
+  bool get _hasDispatch =>
+      _hasDiscriminatorDispatch || _shapeDispatchPlans != null;
 
   @override
   Iterable<Import> get additionalImports => [
@@ -3479,39 +3583,59 @@ class RenderOneOf extends RenderNewType {
 
   @override
   Map<String, dynamic> toTemplateContext(SchemaRenderer context) {
-    final disc = discriminator;
-    if (disc == null || !_hasDispatch) {
-      return {
-        'doc_comment': createDocComment(common: common),
-        'typeName': typeName,
-        'nullableTypeName': nullableTypeName(context),
-        'has_dispatch': false,
-      };
-    }
-    final variants = <Map<String, dynamic>>[];
-    for (final schema in schemas) {
-      variants.add({
-        'wrapperTypeName': wrapperTypeName(schema),
-        'innerTypeName': schema.typeName,
-      });
-    }
-    final dispatch = <Map<String, dynamic>>[];
-    for (final entry in disc.mapping.entries) {
-      dispatch.add({
-        'value': entry.key,
-        'wrapperTypeName': wrapperTypeName(entry.value),
-        'innerTypeName': entry.value.typeName,
-      });
-    }
-    return {
+    // Mustache section tags must all be present in the context map (with
+    // a falsy value to skip). Default all three modes off, then enable
+    // exactly one below.
+    final ctx = <String, dynamic>{
       'doc_comment': createDocComment(common: common),
       'typeName': typeName,
       'nullableTypeName': nullableTypeName(context),
-      'has_dispatch': true,
-      'discriminatorProperty': disc.propertyName,
-      'variants': variants,
-      'dispatch': dispatch,
+      'has_discriminator_dispatch': false,
+      'has_shape_dispatch': false,
+      'no_dispatch': false,
     };
+    final disc = discriminator;
+    if (disc != null && _hasDiscriminatorDispatch) {
+      final variants = <Map<String, dynamic>>[];
+      for (final schema in schemas) {
+        variants.add({
+          'wrapperTypeName': wrapperTypeName(schema),
+          'innerTypeName': schema.typeName,
+        });
+      }
+      final dispatch = <Map<String, dynamic>>[];
+      for (final entry in disc.mapping.entries) {
+        dispatch.add({
+          'value': entry.key,
+          'wrapperTypeName': wrapperTypeName(entry.value),
+          'innerTypeName': entry.value.typeName,
+        });
+      }
+      ctx['has_discriminator_dispatch'] = true;
+      ctx['discriminatorProperty'] = disc.propertyName;
+      ctx['variants'] = variants;
+      ctx['dispatch'] = dispatch;
+      return ctx;
+    }
+    final shapePlans = _shapeDispatchPlans;
+    if (shapePlans != null) {
+      ctx['has_shape_dispatch'] = true;
+      ctx['variants'] = shapePlans
+          .map(
+            (p) => {
+              'wrapperTypeName': p.wrapperTypeName,
+              'valueType': p.valueType,
+              'jsonTestType': p.jsonTestType,
+              'fromJson': p.fromJson,
+              'toJson': p.toJson,
+              'positionalBoolIgnore': p.positionalBoolIgnore,
+            },
+          )
+          .toList();
+      return ctx;
+    }
+    ctx['no_dispatch'] = true;
+    return ctx;
   }
 
   @override
@@ -3548,6 +3672,46 @@ class RenderOneOf extends RenderNewType {
     // discriminator-aware subclass emission (#99).
     return null;
   }
+}
+
+/// One arm of the shape-based dispatch: how a single variant in a
+/// non-discriminator [RenderOneOf] turns into a wrapper subclass and a
+/// `case T v =>` arm in the parent's `fromJson`.
+@immutable
+class _VariantPlan {
+  const _VariantPlan({
+    required this.wrapperTypeName,
+    required this.valueType,
+    required this.jsonTestType,
+    required this.fromJson,
+    required this.toJson,
+    this.positionalBoolIgnore = false,
+  });
+
+  /// The wrapper subclass name (e.g. `FooInt`, `FooBar`).
+  final String wrapperTypeName;
+
+  /// The wrapper's `value` field type (e.g. `int`, `Bar`).
+  final String valueType;
+
+  /// The Dart type used in the `case` pattern (e.g. `int`,
+  /// `Map<String, dynamic>`). All test types in a single dispatch must
+  /// be pairwise distinct so the dispatch is unambiguous.
+  final String jsonTestType;
+
+  /// Expression that constructs the wrapper's `value` from the matched
+  /// variable `v` (the JSON, already promoted to [jsonTestType]).
+  final String fromJson;
+
+  /// Expression that the wrapper's `toJson()` returns. References
+  /// `value` (the wrapper field).
+  final String toJson;
+
+  /// True for `bool`-valued wrappers; the template emits an
+  /// `// ignore: avoid_positional_boolean_parameters` above the
+  /// constructor since the wrapper has exactly one positional arg by
+  /// design.
+  final bool positionalBoolIgnore;
 }
 
 /// Render-side discriminator dispatch table for a [RenderOneOf].

--- a/lib/templates/schema_one_of.mustache
+++ b/lib/templates/schema_one_of.mustache
@@ -6,7 +6,7 @@
         final discriminator = json['{{ discriminatorProperty }}'];
         return switch (discriminator) {
 {{#dispatch}}
-            '{{ value }}' => {{{ wrapperTypeName }}}({{{ innerTypeName }}}.fromJson(json)),
+            '{{ value }}' => {{{ wrapperTypeName }}}({{{ valueType }}}.fromJson(json)),
 {{/dispatch}}
             _ => throw FormatException(
                 "Unknown {{ discriminatorProperty }} '$discriminator' for {{ typeName }}",
@@ -32,7 +32,7 @@
 final class {{{ wrapperTypeName }}} extends {{ typeName }} {
     const {{{ wrapperTypeName }}}(this.value);
 
-    final {{{ innerTypeName }}} value;
+    final {{{ valueType }}} value;
 
     @override
     Map<String, dynamic> toJson() => value.toJson();

--- a/lib/templates/schema_one_of.mustache
+++ b/lib/templates/schema_one_of.mustache
@@ -1,4 +1,4 @@
-{{#has_dispatch}}
+{{#has_discriminator_dispatch}}
 {{{ doc_comment }}}sealed class {{ typeName }} {
     const {{ typeName }}();
 
@@ -48,8 +48,64 @@ final class {{{ wrapperTypeName }}} extends {{ typeName }} {
 }
 
 {{/variants}}
-{{/has_dispatch}}
-{{^has_dispatch}}
+{{/has_discriminator_dispatch}}
+{{#has_shape_dispatch}}
+{{{ doc_comment }}}sealed class {{ typeName }} {
+    const {{ typeName }}();
+
+    factory {{ typeName }}.fromJson(dynamic json) {
+        return switch (json) {
+{{#variants}}
+            {{{ jsonTestType }}} v => {{{ wrapperTypeName }}}({{{ fromJson }}}),
+{{/variants}}
+            _ => throw FormatException(
+                'Unsupported shape for {{ typeName }}: ${json.runtimeType}',
+            ),
+        };
+    }
+
+    /// Convenience to create a nullable type from a nullable json object.
+    /// Useful when parsing optional fields.
+    static {{ nullableTypeName }} maybeFromJson(dynamic json) {
+        if (json == null) {
+            return null;
+        }
+        return {{ typeName }}.fromJson(json);
+    }
+
+    /// Require all subclasses to implement toJson.
+    dynamic toJson();
+}
+
+{{#variants}}
+@immutable
+final class {{{ wrapperTypeName }}} extends {{ typeName }} {
+{{#positionalBoolIgnore}}
+    // The wrapper has a single positional arg by design — naming it
+    // would force `Wrapper(value: x)` at every call site, which buys
+    // nothing for a one-field shim.
+    // ignore: avoid_positional_boolean_parameters
+{{/positionalBoolIgnore}}
+    const {{{ wrapperTypeName }}}(this.value);
+
+    final {{{ valueType }}} value;
+
+    @override
+    dynamic toJson() => {{{ toJson }}};
+
+    @override
+    int get hashCode => value.hashCode;
+
+    @override
+    bool operator ==(Object other) {
+        if (identical(this, other)) return true;
+        return other is {{{ wrapperTypeName }}} && value == other.value;
+    }
+}
+
+{{/variants}}
+{{/has_shape_dispatch}}
+{{#no_dispatch}}
 {{{ doc_comment }}}sealed class {{ typeName }} {
     static {{ typeName }} fromJson(dynamic jsonArg) {
         // Determine which schema to use based on the json.
@@ -69,4 +125,4 @@ final class {{{ wrapperTypeName }}} extends {{ typeName }} {
     /// Require all subclasses to implement toJson.
     dynamic toJson();
 }
-{{/has_dispatch}}
+{{/no_dispatch}}

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -801,7 +801,7 @@ void main() {
       expect(pet, contains("final discriminator = json['pet_type']"));
       expect(pet, contains("'cat' => PetCat(Cat.fromJson(json))"));
       expect(pet, contains("'dog' => PetDog(Dog.fromJson(json))"));
-      expect(pet, contains("Unknown pet_type '\$discriminator' for Pet"));
+      expect(pet, contains(r"Unknown pet_type '$discriminator' for Pet"));
       // Wrapper subclasses with @immutable + structural equality.
       expect(pet, contains('@immutable'));
       expect(pet, contains('final class PetCat extends Pet'));
@@ -812,11 +812,10 @@ void main() {
     });
 
     test(
-      'oneOf with discriminator but a non-object variant falls back to '
-      'the legacy stub',
+      'oneOf with discriminator but a non-object variant falls through '
+      'to shape dispatch (discriminator is ignored — un-honorable on '
+      'the non-object branch)',
       () {
-        // Mixed-shape oneOf: dispatch needs `<Variant>.fromJson(Map)` on
-        // every variant, which doesn't exist for the inline pod.
         final results = renderTestSchemas(
           {
             'Mixed': {
@@ -843,16 +842,75 @@ void main() {
         );
         final mixed = results['Mixed'];
         expect(mixed, isNotNull);
-        expect(mixed, contains("throw UnimplementedError('Mixed.fromJson')"));
-        expect(mixed, isNot(contains('factory Mixed.fromJson')));
-        expect(mixed, isNot(contains('final class MixedCat')));
+        // Distinct shapes (Map vs String) → shape dispatch.
+        expect(mixed, contains('factory Mixed.fromJson(dynamic json)'));
+        expect(mixed, contains('Map<String, dynamic> v => MixedCat'));
+        expect(mixed, contains('String v => MixedString'));
+        expect(mixed, isNot(contains('UnimplementedError')));
       },
     );
 
-    test('oneOf with discriminator but no mapping falls back to legacy '
-        'stub (implicit mapping not yet supported)', () {
-      // No `mapping` key — discriminator is parsed but we don't yet
-      // emit dispatch without an explicit table.
+    test('non-discriminator oneOf with distinct shapes uses shape '
+        'dispatch', () {
+      final result = renderTestSchema({
+        'oneOf': [
+          {'type': 'integer'},
+          {'type': 'string'},
+        ],
+      });
+      // Pattern-matched switch on the runtime json type.
+      expect(result, contains('factory Test.fromJson(dynamic json)'));
+      expect(result, contains('int v => TestInt(v)'));
+      expect(result, contains('String v => TestString(v)'));
+      // Wrappers store the primitive value directly, toJson is just the
+      // value.
+      expect(result, contains('final int value;'));
+      expect(result, contains('dynamic toJson() => value;'));
+      expect(result, contains('final class TestInt extends Test'));
+      expect(result, contains('final class TestString extends Test'));
+      expect(result, contains('@immutable'));
+    });
+
+    test('non-discriminator oneOf with two object variants falls back '
+        'to legacy stub (no shape disambiguation possible)', () {
+      // Two objects share Map<String, dynamic> at the JSON level — no
+      // way to pick by runtime type. Without a discriminator + without
+      // structural-required-field disambiguation (follow-up), this
+      // stays UnimplementedError.
+      final results = renderTestSchemas(
+        {
+          'Pet': {
+            'oneOf': [
+              {r'$ref': '#/components/schemas/Cat'},
+              {r'$ref': '#/components/schemas/Dog'},
+            ],
+          },
+          'Cat': {
+            'type': 'object',
+            'properties': {
+              'meow': {'type': 'boolean'},
+            },
+          },
+          'Dog': {
+            'type': 'object',
+            'properties': {
+              'bark': {'type': 'boolean'},
+            },
+          },
+        },
+        specUrl: Uri.parse('file:///spec.yaml'),
+      );
+      expect(
+        results['Pet'],
+        contains("throw UnimplementedError('Pet.fromJson')"),
+      );
+    });
+
+    test('oneOf with discriminator but no mapping falls through to '
+        'shape dispatch (implicit-mapping not yet supported)', () {
+      // No `mapping` key — discriminator-dispatch needs the explicit
+      // table, so we drop into the shape-dispatch path. With a single
+      // object variant, shape dispatch trivially picks it.
       final results = renderTestSchemas(
         {
           'Pet': {
@@ -872,8 +930,9 @@ void main() {
         specUrl: Uri.parse('file:///spec.yaml'),
       );
       final pet = results['Pet'];
-      expect(pet, contains("throw UnimplementedError('Pet.fromJson')"));
-      expect(pet, isNot(contains('factory Pet.fromJson')));
+      expect(pet, contains('factory Pet.fromJson(dynamic json)'));
+      expect(pet, contains('Map<String, dynamic> v => PetCat'));
+      expect(pet, isNot(contains('UnimplementedError')));
     });
 
     group('anyOf', () {

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -871,6 +871,45 @@ void main() {
       expect(result, contains('@immutable'));
     });
 
+    test('non-discriminator oneOf shape-dispatch with an enum variant '
+        '(distinct from a Map<String, dynamic> object variant)', () {
+      // The enum's JSON storage type is `String` — same as RenderString,
+      // so it would conflict with a String variant; but here it's
+      // paired with an object, which uses Map<String, dynamic>. The
+      // dispatch picks the enum on String inputs.
+      final results = renderTestSchemas(
+        {
+          'Result': {
+            'oneOf': [
+              {r'$ref': '#/components/schemas/Status'},
+              {r'$ref': '#/components/schemas/Detail'},
+            ],
+          },
+          'Status': {
+            'type': 'string',
+            'enum': ['ok', 'error'],
+          },
+          'Detail': {
+            'type': 'object',
+            'properties': {
+              'message': {'type': 'string'},
+            },
+          },
+        },
+        specUrl: Uri.parse('file:///spec.yaml'),
+      );
+      final result = results['Result'];
+      expect(result, isNotNull);
+      expect(result, contains('factory Result.fromJson(dynamic json)'));
+      expect(result, contains('String v => ResultStatus(Status.fromJson(v))'));
+      expect(
+        result,
+        contains('Map<String, dynamic> v => ResultDetail(Detail.fromJson(v))'),
+      );
+      expect(result, contains('final Status value;'));
+      expect(result, contains('value.toJson()'));
+    });
+
     test('non-discriminator oneOf with two object variants falls back '
         'to legacy stub (no shape disambiguation possible)', () {
       // Two objects share Map<String, dynamic> at the JSON level — no


### PR DESCRIPTION
## Summary

Builds on #143. Adds a runtime-shape switch for oneOfs without a discriminator, using each variant's JSON storage type (`int`, `String`, `Map<String, dynamic>`, `bool`) as the dispatch key. When every variant has a distinct shape, emit a sealed parent + per-variant wrapper subclasses (modeled on the discriminator path) with a Dart 3 pattern-matched switch in `fromJson`. Falls back to the legacy `UnimplementedError` stub when two variants share a JSON shape.

```dart
factory GetThing200Response.fromJson(dynamic json) {
  return switch (json) {
    final int v => GetThing200ResponseInt(v),
    final String v => GetThing200ResponseString(v),
    final Map<String, dynamic> v => GetThing200ResponseThing(Thing.fromJson(v)),
    _ => throw FormatException(
      'Unsupported shape for GetThing200Response: ${json.runtimeType}',
    ),
  };
}
```

### Github regen impact

Out of github's 103 oneOf sites that emit a sealed-class file:

| State | Count | Source |
|---|---|---|
| Discriminator dispatch | 3 | #143 |
| **Shape dispatch** | **14** | **this PR** |
| Legacy UnimplementedError stub | 85 | follow-ups |

The 85 still-legacy sites are mostly object-vs-object pairs (need structural required-field disambiguation) and status-code-multiplexed unions (need a different mechanism altogether). Both tracked in #144.

### Coverage

The dominant shape in github's non-discriminator 2-variant oneOfs:

| Shape | Count | Handled? |
|---|---|---|
| `(integer, string)` | 118 | ✅ |
| `(string, object)` | 11 | ✅ |
| `(object, array)` | 6 | ❌ (no array support yet) |
| `(string, array)` | 6 | ❌ |
| `(object, object)` | 5 | ❌ (needs required-field disambiguation) |
| `(string, integer)` | 4 | ✅ |
| `(boolean, string)` | 1 | ✅ |
| ... | | |

Most of the 118 dominant `(integer, string)` cases are inline-anonymous (parameter or property), so they don't surface as distinct sealed-class files — they get reused at the use site. Hence the smaller "14 sites" count vs the 118 spec hits.

### Notes

- Wrapper class names always prepend the parent's typeName, even when the variant typeName already starts with it (parser-generated `<parent>_one_of_<i>`). Stripping the duplicate would collide with the variant's own standalone class. The double-prefix is ugly but unambiguous; smooshing inline variants into the parent's file (#144) is the right long-term fix.
- A `// ignore: avoid_positional_boolean_parameters` is emitted (with a justifying comment) above wrapper constructors that take a single bool — wrappers are intentionally one-positional-arg shims.

## Test plan

- [x] Render-layer unit tests: shape dispatch with primitives + objects, shape disambiguation gate (two-objects-no-discriminator falls back), discriminator-with-non-object-variant falls through to shape, discriminator-without-mapping falls through to shape (1-variant case)
- [x] End-to-end smoke test on a synthetic spec: int/string/object dispatch, FormatException with runtimeType, exhaustive switch
- [x] Discriminator path from #143 still works (regenerated + ran existing dispatch_smoke_test.dart)
- [x] Github regen: 14 new shape-dispatch sites, `dart analyze` clean, no regressions
- [x] Full test suite: 352 tests pass (5 new), no new analyzer issues vs. baseline