### PR TITLE
feat: required-field dispatch for object-variant oneOfs

### DIFF
--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -3569,8 +3569,43 @@ class RenderOneOf extends RenderNewType {
     return plans;
   }
 
+  /// Required-field dispatch: every variant is a [RenderObject] and
+  /// each has at least one required property that no other variant
+  /// requires. We dispatch by checking for that property's presence
+  /// in the JSON. Useful for (object, object) oneOfs without a
+  /// discriminator — github has ~9 such sites, e.g. `simple-user`
+  /// (requires `login`) vs `enterprise` (requires `slug`).
+  ///
+  /// Returns one [_RequiredFieldArm] per variant in [schemas] order,
+  /// or null if any variant lacks a uniquely-required property.
+  List<_RequiredFieldArm>? get _requiredFieldDispatchArms {
+    if (!schemas.every((s) => s is RenderObject)) return null;
+    final objects = schemas.cast<RenderObject>();
+    final allRequired = objects
+        .map((o) => o.requiredProperties.toSet())
+        .toList();
+    final arms = <_RequiredFieldArm>[];
+    for (var i = 0; i < objects.length; i++) {
+      final mine = allRequired[i];
+      final others = <String>{};
+      for (var j = 0; j < allRequired.length; j++) {
+        if (i != j) others.addAll(allRequired[j]);
+      }
+      final unique = mine.difference(others);
+      if (unique.isEmpty) return null;
+      // Pick the lexicographically-first unique field for stable output.
+      final tagField = (unique.toList()..sort()).first;
+      arms.add(
+        _RequiredFieldArm(variant: objects[i], tagField: tagField),
+      );
+    }
+    return arms;
+  }
+
   bool get _hasDispatch =>
-      _hasDiscriminatorDispatch || _shapeDispatchPlans != null;
+      _hasDiscriminatorDispatch ||
+      _shapeDispatchPlans != null ||
+      _requiredFieldDispatchArms != null;
 
   @override
   Iterable<Import> get additionalImports => [
@@ -3591,6 +3626,7 @@ class RenderOneOf extends RenderNewType {
       'nullableTypeName': nullableTypeName(context),
       'has_discriminator_dispatch': false,
       'has_shape_dispatch': false,
+      'has_required_field_dispatch': false,
       'no_dispatch': false,
     };
     final disc = discriminator;
@@ -3628,6 +3664,30 @@ class RenderOneOf extends RenderNewType {
               'fromJson': p.fromJson,
               'toJson': p.toJson,
               'positionalBoolIgnore': p.positionalBoolIgnore,
+            },
+          )
+          .toList();
+      return ctx;
+    }
+    final reqArms = _requiredFieldDispatchArms;
+    if (reqArms != null) {
+      ctx['has_required_field_dispatch'] = true;
+      ctx['dispatch'] = reqArms
+          .map(
+            (a) => {
+              'tagField': a.tagField,
+              'wrapperTypeName': wrapperTypeName(a.variant),
+              'valueType': a.variant.typeName,
+            },
+          )
+          .toList();
+      // Same wrapper-block shape as the discriminator path (object-only,
+      // delegates fromJson/toJson to the variant class).
+      ctx['variants'] = reqArms
+          .map(
+            (a) => {
+              'wrapperTypeName': wrapperTypeName(a.variant),
+              'valueType': a.variant.typeName,
             },
           )
           .toList();
@@ -3671,6 +3731,19 @@ class RenderOneOf extends RenderNewType {
     // discriminator-aware subclass emission (#99).
     return null;
   }
+}
+
+/// One arm of the required-field dispatch: a [RenderObject] variant
+/// keyed off the presence of a property unique to its required-set.
+@immutable
+class _RequiredFieldArm {
+  const _RequiredFieldArm({required this.variant, required this.tagField});
+
+  final RenderObject variant;
+
+  /// JSON property name whose presence picks this variant. Required
+  /// only by [variant]; absent from every sibling's required-set.
+  final String tagField;
 }
 
 /// One arm of the shape-based dispatch: how a single variant in a

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -3628,16 +3628,26 @@ class RenderOneOf extends RenderNewType {
       'has_shape_dispatch': false,
       'has_required_field_dispatch': false,
       'no_dispatch': false,
+      // Defaults for the maybeFromJson partial — overridden per path
+      // below. Dispatch paths that take a Map override; shape and the
+      // legacy stub keep this dynamic default.
+      'maybeFromJsonParamType': 'dynamic',
     };
+
+    /// Wrapper-variant context for the object-only paths
+    /// (discriminator, required-field). Both produce
+    /// `Map<String, dynamic> toJson() => value.toJson()` wrappers.
+    Map<String, dynamic> objectWrapperContext(RenderSchema variant) => {
+      'wrapperTypeName': wrapperTypeName(variant),
+      'valueType': variant.typeName,
+      'toJsonReturnType': 'Map<String, dynamic>',
+      'toJsonBody': 'value.toJson()',
+      'positionalBoolIgnore': false,
+    };
+
     final disc = discriminator;
     if (disc != null && _hasDiscriminatorDispatch) {
-      final variants = <Map<String, dynamic>>[];
-      for (final schema in schemas) {
-        variants.add({
-          'wrapperTypeName': wrapperTypeName(schema),
-          'valueType': schema.typeName,
-        });
-      }
+      final variants = schemas.map(objectWrapperContext).toList();
       final dispatch = <Map<String, dynamic>>[];
       for (final entry in disc.mapping.entries) {
         dispatch.add({
@@ -3650,6 +3660,7 @@ class RenderOneOf extends RenderNewType {
       ctx['discriminatorProperty'] = disc.propertyName;
       ctx['variants'] = variants;
       ctx['dispatch'] = dispatch;
+      ctx['maybeFromJsonParamType'] = 'Map<String, dynamic>?';
       return ctx;
     }
     final shapePlans = _shapeDispatchPlans;
@@ -3662,7 +3673,11 @@ class RenderOneOf extends RenderNewType {
               'valueType': p.valueType,
               'jsonTestType': p.jsonTestType,
               'fromJson': p.fromJson,
-              'toJson': p.toJson,
+              // The wrapper partial expects `toJsonBody` and
+              // `toJsonReturnType`; shape variants always return
+              // `dynamic` (variants might be primitives).
+              'toJsonBody': p.toJson,
+              'toJsonReturnType': 'dynamic',
               'positionalBoolIgnore': p.positionalBoolIgnore,
             },
           )
@@ -3681,16 +3696,10 @@ class RenderOneOf extends RenderNewType {
             },
           )
           .toList();
-      // Same wrapper-block shape as the discriminator path (object-only,
-      // delegates fromJson/toJson to the variant class).
       ctx['variants'] = reqArms
-          .map(
-            (a) => {
-              'wrapperTypeName': wrapperTypeName(a.variant),
-              'valueType': a.variant.typeName,
-            },
-          )
+          .map((a) => objectWrapperContext(a.variant))
           .toList();
+      ctx['maybeFromJsonParamType'] = 'Map<String, dynamic>?';
       return ctx;
     }
     ctx['no_dispatch'] = true;

--- a/lib/templates/_one_of_maybe_from_json.mustache
+++ b/lib/templates/_one_of_maybe_from_json.mustache
@@ -1,0 +1,8 @@
+/// Convenience to create a nullable type from a nullable json object.
+/// Useful when parsing optional fields.
+static {{ nullableTypeName }} maybeFromJson({{{ maybeFromJsonParamType }}} json) {
+    if (json == null) {
+        return null;
+    }
+    return {{ typeName }}.fromJson(json);
+}

--- a/lib/templates/_one_of_wrapper.mustache
+++ b/lib/templates/_one_of_wrapper.mustache
@@ -1,0 +1,24 @@
+@immutable
+final class {{{ wrapperTypeName }}} extends {{ typeName }} {
+{{#positionalBoolIgnore}}
+    // The wrapper has a single positional arg by design — naming it
+    // would force `Wrapper(value: x)` at every call site, which buys
+    // nothing for a one-field shim.
+    // ignore: avoid_positional_boolean_parameters
+{{/positionalBoolIgnore}}
+    const {{{ wrapperTypeName }}}(this.value);
+
+    final {{{ valueType }}} value;
+
+    @override
+    {{{ toJsonReturnType }}} toJson() => {{{ toJsonBody }}};
+
+    @override
+    int get hashCode => value.hashCode;
+
+    @override
+    bool operator ==(Object other) {
+        if (identical(this, other)) return true;
+        return other is {{{ wrapperTypeName }}} && value == other.value;
+    }
+}

--- a/lib/templates/schema_one_of.mustache
+++ b/lib/templates/schema_one_of.mustache
@@ -105,6 +105,56 @@ final class {{{ wrapperTypeName }}} extends {{ typeName }} {
 
 {{/variants}}
 {{/has_shape_dispatch}}
+{{#has_required_field_dispatch}}
+{{{ doc_comment }}}sealed class {{ typeName }} {
+    const {{ typeName }}();
+
+    factory {{ typeName }}.fromJson(Map<String, dynamic> json) {
+{{#dispatch}}
+        if (json.containsKey('{{ tagField }}')) {
+            return {{{ wrapperTypeName }}}({{{ valueType }}}.fromJson(json));
+        }
+{{/dispatch}}
+        throw FormatException(
+            'No variant of {{ typeName }} matched json keys: ${json.keys.toList()}',
+        );
+    }
+
+    /// Convenience to create a nullable type from a nullable json object.
+    /// Useful when parsing optional fields.
+    static {{ nullableTypeName }} maybeFromJson(Map<String, dynamic>? json) {
+        if (json == null) {
+            return null;
+        }
+        return {{ typeName }}.fromJson(json);
+    }
+
+    /// Require all subclasses to implement toJson.
+    Map<String, dynamic> toJson();
+}
+
+{{#variants}}
+@immutable
+final class {{{ wrapperTypeName }}} extends {{ typeName }} {
+    const {{{ wrapperTypeName }}}(this.value);
+
+    final {{{ valueType }}} value;
+
+    @override
+    Map<String, dynamic> toJson() => value.toJson();
+
+    @override
+    int get hashCode => value.hashCode;
+
+    @override
+    bool operator ==(Object other) {
+        if (identical(this, other)) return true;
+        return other is {{{ wrapperTypeName }}} && value == other.value;
+    }
+}
+
+{{/variants}}
+{{/has_required_field_dispatch}}
 {{#no_dispatch}}
 {{{ doc_comment }}}sealed class {{ typeName }} {
     static {{ typeName }} fromJson(dynamic jsonArg) {

--- a/lib/templates/schema_one_of.mustache
+++ b/lib/templates/schema_one_of.mustache
@@ -14,39 +14,14 @@
         };
     }
 
-    /// Convenience to create a nullable type from a nullable json object.
-    /// Useful when parsing optional fields.
-    static {{ nullableTypeName }} maybeFromJson(Map<String, dynamic>? json) {
-        if (json == null) {
-            return null;
-        }
-        return {{ typeName }}.fromJson(json);
-    }
+    {{> _one_of_maybe_from_json}}
 
     /// Require all subclasses to implement toJson.
     Map<String, dynamic> toJson();
 }
 
 {{#variants}}
-@immutable
-final class {{{ wrapperTypeName }}} extends {{ typeName }} {
-    const {{{ wrapperTypeName }}}(this.value);
-
-    final {{{ valueType }}} value;
-
-    @override
-    Map<String, dynamic> toJson() => value.toJson();
-
-    @override
-    int get hashCode => value.hashCode;
-
-    @override
-    bool operator ==(Object other) {
-        if (identical(this, other)) return true;
-        return other is {{{ wrapperTypeName }}} && value == other.value;
-    }
-}
-
+{{> _one_of_wrapper}}
 {{/variants}}
 {{/has_discriminator_dispatch}}
 {{#has_shape_dispatch}}
@@ -64,45 +39,14 @@ final class {{{ wrapperTypeName }}} extends {{ typeName }} {
         };
     }
 
-    /// Convenience to create a nullable type from a nullable json object.
-    /// Useful when parsing optional fields.
-    static {{ nullableTypeName }} maybeFromJson(dynamic json) {
-        if (json == null) {
-            return null;
-        }
-        return {{ typeName }}.fromJson(json);
-    }
+    {{> _one_of_maybe_from_json}}
 
     /// Require all subclasses to implement toJson.
     dynamic toJson();
 }
 
 {{#variants}}
-@immutable
-final class {{{ wrapperTypeName }}} extends {{ typeName }} {
-{{#positionalBoolIgnore}}
-    // The wrapper has a single positional arg by design — naming it
-    // would force `Wrapper(value: x)` at every call site, which buys
-    // nothing for a one-field shim.
-    // ignore: avoid_positional_boolean_parameters
-{{/positionalBoolIgnore}}
-    const {{{ wrapperTypeName }}}(this.value);
-
-    final {{{ valueType }}} value;
-
-    @override
-    dynamic toJson() => {{{ toJson }}};
-
-    @override
-    int get hashCode => value.hashCode;
-
-    @override
-    bool operator ==(Object other) {
-        if (identical(this, other)) return true;
-        return other is {{{ wrapperTypeName }}} && value == other.value;
-    }
-}
-
+{{> _one_of_wrapper}}
 {{/variants}}
 {{/has_shape_dispatch}}
 {{#has_required_field_dispatch}}
@@ -120,39 +64,14 @@ final class {{{ wrapperTypeName }}} extends {{ typeName }} {
         );
     }
 
-    /// Convenience to create a nullable type from a nullable json object.
-    /// Useful when parsing optional fields.
-    static {{ nullableTypeName }} maybeFromJson(Map<String, dynamic>? json) {
-        if (json == null) {
-            return null;
-        }
-        return {{ typeName }}.fromJson(json);
-    }
+    {{> _one_of_maybe_from_json}}
 
     /// Require all subclasses to implement toJson.
     Map<String, dynamic> toJson();
 }
 
 {{#variants}}
-@immutable
-final class {{{ wrapperTypeName }}} extends {{ typeName }} {
-    const {{{ wrapperTypeName }}}(this.value);
-
-    final {{{ valueType }}} value;
-
-    @override
-    Map<String, dynamic> toJson() => value.toJson();
-
-    @override
-    int get hashCode => value.hashCode;
-
-    @override
-    bool operator ==(Object other) {
-        if (identical(this, other)) return true;
-        return other is {{{ wrapperTypeName }}} && value == other.value;
-    }
-}
-
+{{> _one_of_wrapper}}
 {{/variants}}
 {{/has_required_field_dispatch}}
 {{#no_dispatch}}
@@ -163,14 +82,7 @@ final class {{{ wrapperTypeName }}} extends {{ typeName }} {
         throw UnimplementedError('{{ typeName }}.fromJson');
     }
 
-    /// Convenience to create a nullable type from a nullable json object.
-    /// Useful when parsing optional fields.
-    static {{ nullableTypeName }} maybeFromJson(dynamic json) {
-        if (json == null) {
-            return null;
-        }
-        return {{ typeName }}.fromJson(json);
-    }
+    {{> _one_of_maybe_from_json}}
 
     /// Require all subclasses to implement toJson.
     dynamic toJson();

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -910,12 +910,12 @@ void main() {
       expect(result, contains('value.toJson()'));
     });
 
-    test('non-discriminator oneOf with two object variants falls back '
-        'to legacy stub (no shape disambiguation possible)', () {
-      // Two objects share Map<String, dynamic> at the JSON level — no
-      // way to pick by runtime type. Without a discriminator + without
-      // structural-required-field disambiguation (follow-up), this
-      // stays UnimplementedError.
+    test('non-discriminator oneOf with two object variants and no '
+        'required fields falls back to legacy stub (no shape or '
+        'required-field disambiguation possible)', () {
+      // Two objects share Map<String, dynamic> at the JSON level. With
+      // no required fields on either side there's no key to dispatch
+      // on, so this stays UnimplementedError.
       final results = renderTestSchemas(
         {
           'Pet': {
@@ -935,6 +935,86 @@ void main() {
             'properties': {
               'bark': {'type': 'boolean'},
             },
+          },
+        },
+        specUrl: Uri.parse('file:///spec.yaml'),
+      );
+      expect(
+        results['Pet'],
+        contains("throw UnimplementedError('Pet.fromJson')"),
+      );
+    });
+
+    test('non-discriminator oneOf with two object variants and disjoint '
+        'required fields uses required-field dispatch', () {
+      // Each variant has a property uniquely required by it — pick the
+      // variant by checking which key is present.
+      final results = renderTestSchemas(
+        {
+          'Pet': {
+            'oneOf': [
+              {r'$ref': '#/components/schemas/Cat'},
+              {r'$ref': '#/components/schemas/Dog'},
+            ],
+          },
+          'Cat': {
+            'type': 'object',
+            'properties': {
+              'meow': {'type': 'boolean'},
+              'shared': {'type': 'string'},
+            },
+            'required': ['meow', 'shared'],
+          },
+          'Dog': {
+            'type': 'object',
+            'properties': {
+              'bark': {'type': 'boolean'},
+              'shared': {'type': 'string'},
+            },
+            'required': ['bark', 'shared'],
+          },
+        },
+        specUrl: Uri.parse('file:///spec.yaml'),
+      );
+      final pet = results['Pet'];
+      expect(pet, isNotNull);
+      expect(pet, contains('factory Pet.fromJson(Map<String, dynamic> json)'));
+      expect(pet, contains("if (json.containsKey('meow'))"));
+      expect(pet, contains('return PetCat(Cat.fromJson(json))'));
+      expect(pet, contains("if (json.containsKey('bark'))"));
+      expect(pet, contains('return PetDog(Dog.fromJson(json))'));
+      expect(pet, contains('No variant of Pet matched json keys'));
+      expect(pet, contains('final class PetCat extends Pet'));
+      expect(pet, contains('final class PetDog extends Pet'));
+    });
+
+    test('required-field dispatch falls back to legacy when one variant '
+        'has no required field unique to it', () {
+      // Cat requires {a, b}; Dog requires {a}. Cat has unique "b" but
+      // Dog has no field that Cat doesn't also require → can't pick
+      // Dog deterministically → fall back.
+      final results = renderTestSchemas(
+        {
+          'Pet': {
+            'oneOf': [
+              {r'$ref': '#/components/schemas/Cat'},
+              {r'$ref': '#/components/schemas/Dog'},
+            ],
+          },
+          'Cat': {
+            'type': 'object',
+            'properties': {
+              'a': {'type': 'string'},
+              'b': {'type': 'string'},
+            },
+            'required': ['a', 'b'],
+          },
+          'Dog': {
+            'type': 'object',
+            'properties': {
+              'a': {'type': 'string'},
+            },
+            'required': ['a'],
           },
         },
         specUrl: Uri.parse('file:///spec.yaml'),


### PR DESCRIPTION
## Summary

Builds on #143 (discriminator dispatch) and #145 (shape dispatch). Adds a third dispatch strategy for `(object, object)` oneOfs without a discriminator, by checking for a uniquely-required JSON property.

```dart
// Before: UnimplementedError.
// After:
factory ProjectsCreateCardRequest.fromJson(Map<String, dynamic> json) {
  if (json.containsKey('note')) {
    return ProjectsCreateCardRequestProjectsCreateCardRequestOneOf0(
      ProjectsCreateCardRequestOneOf0.fromJson(json),
    );
  }
  if (json.containsKey('content_id')) {
    return ProjectsCreateCardRequestProjectsCreateCardRequestOneOf1(
      ProjectsCreateCardRequestOneOf1.fromJson(json),
    );
  }
  throw FormatException(
    'No variant of ProjectsCreateCardRequest matched json keys: ${json.keys.toList()}',
  );
}
```

### Gating

For each object variant V in the oneOf, find a property required by V but absent from every other variant's required-set. If every variant has at least one such field, dispatch by checking presence of (deterministically) the lexicographically-first one. Otherwise fall back to the legacy stub.

### Github regen

| State | Count | Source |
|---|---|---|
| Discriminator dispatch | 3 | #143 |
| Shape dispatch | 14 | #145 |
| **Required-field dispatch** | **12** | **this PR** |
| Legacy UnimplementedError stub | ~73 | follow-ups |

The remaining ~73 legacy sites split roughly:
- 8 (object, object) variants where required-sets are identical (e.g. `validation-error` vs `validation-error-simple` — they only differ in optional fields). Need a smarter check than required-property names.
- ~12 sites with array variants — needs `(string, array)` / `(object, array)` shape support.
- Status-code-multiplexed unions (different mechanism altogether).

All tracked in #144.

### Notes

- Same wrapper-subclass shape as #143's discriminator path (object-only, delegates fromJson/toJson). The dispatch arm is the only thing that differs.
- Order of dispatch in `toTemplateContext`: discriminator → shape → required-field → legacy. Strict fallthrough — never two paths active at once.
- Picks the lexicographically-first unique field for stable, deterministic output.
- Wrapper names still double-prefix on inline variants (`ProjectsCreateCardRequestProjectsCreateCardRequestOneOf0`) — co-locating inline variants into the parent file is a separate follow-up.

## Test plan

- [x] Render-layer unit tests: required-field dispatch with disjoint required-sets, fallback when a variant has no unique-required field, fallback when all variants have empty required-sets
- [x] Github regen: 12 new dispatch sites, `dart analyze` clean
- [x] Existing discriminator and shape paths unaffected (all 353 prior tests pass; 2 new = 355 total)