### PR TITLE
feat: dispatch on HTTP status when operation has multiple successful responses

### DIFF
--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -582,14 +582,12 @@ class SpecResolver {
     // `Foo201`), and a range can't be enumerated. Range-mixed cases
     // fall through to the legacy oneOf path for now.
     if (successfulRange.isEmpty) {
-      final bodyByStatus = <int, RenderSchema?>{};
-      for (final response in explicit2xx) {
-        // RenderVoid means the response has no body — null in the map
-        // signals the wrapper for that status carries no value.
-        final body = toRenderSchema(response.content);
-        bodyByStatus[response.statusCode] = body is RenderVoid ? null : body;
-      }
-      return MultiStatusReturn(bodyByStatus: bodyByStatus);
+      return MultiStatusReturn(
+        responses: {
+          for (final response in explicit2xx)
+            response.statusCode: toRenderResponse(response),
+        },
+      );
     }
     return SingleSchemaReturn(
       RenderOneOf(
@@ -1181,21 +1179,29 @@ class Endpoint implements ToTemplateContext {
   /// snake name) that the legacy oneOf path used, so existing
   /// regenerated output only shows the dispatch change, not a rename.
   ///
-  /// Sorted-by-status iteration matters for output stability — the
-  /// underlying map is unordered.
+  /// Sorting on the status code guarantees `200` ahead of `204` in
+  /// the emitted switch regardless of spec ordering.
+  ///
+  /// Synthesized typeName can collide with a schema in the spec named
+  /// `<op>_response`. Not handled here — that's the job of a future
+  /// resolve-stage collision pass that accounts for generated names.
   _MultiStatusContext _buildMultiStatusContext(
     MultiStatusReturn multiStatus,
     SchemaRenderer context,
   ) {
     final typeName = camelFromSnake('${operation.snakeName}_response');
-    final sortedEntries = multiStatus.bodyByStatus.entries.toList()
+    final sortedEntries = multiStatus.responses.entries.toList()
       ..sort((a, b) => a.key.compareTo(b.key));
     final statuses = [
       for (final entry in sortedEntries)
         _StatusInfo(
           statusCode: entry.key,
           wrapperTypeName: '$typeName${entry.key}',
-          body: entry.value,
+          // RenderVoid means the response has no body — null in
+          // [_StatusInfo.body] signals the wrapper for that status
+          // carries no `value` field.
+          body: entry.value.content is RenderVoid ? null : entry.value.content,
+          contentType: entry.value.contentType,
         ),
     ];
     return _MultiStatusContext(
@@ -1231,24 +1237,22 @@ class Endpoint implements ToTemplateContext {
         multiStatusContext = null;
         returnType = schema.typeName;
         isVoidReturn = schema is RenderVoid;
-        // When the success response advertises a non-JSON content type
-        // (text/plain, text/html, application/octocat-stream, …) the
-        // wire body is NOT JSON. Skip `jsonDecode`: `package:http`'s
-        // `Response.body` is already a `String`, which matches the
-        // `type: string` schema such responses use in practice. github's
-        // `/zen`, `/octocat`, `/markdown`, `/markdown/raw` all live here.
-        final successContentType = operation.successContentType;
-        final isJsonResponse =
-            successContentType == null ||
-            successContentType == 'application/json';
-        responseFromJson = isJsonResponse
-            ? schema.fromJsonExpression(
-                'jsonDecode(response.body)',
+        // When the success response advertises a non-JSON content
+        // type, `_responseBodySource` returns the raw `response.body`
+        // string instead of the `jsonDecode(...)` expression — keeps
+        // github's `/zen`, `/octocat`, `/markdown`, `/markdown/raw`
+        // (text/plain) emitting clean Dart. The non-JSON path then
+        // falls back to the raw body without going through
+        // `fromJsonExpression`, since that expects JSON-shaped input.
+        final source = _responseBodySource(operation.successContentType);
+        responseFromJson = source == 'response.body'
+            ? source
+            : schema.fromJsonExpression(
+                source,
                 context,
                 jsonIsNullable: false,
                 dartIsNullable: false,
-              )
-            : 'response.body';
+              );
       case MultiStatusReturn():
         multiStatusContext = _buildMultiStatusContext(returnShape, context);
         returnType = multiStatusContext.typeName;
@@ -1538,12 +1542,13 @@ final class SingleSchemaReturn extends OperationReturn {
 /// right subclass.
 @immutable
 final class MultiStatusReturn extends OperationReturn {
-  const MultiStatusReturn({required this.bodyByStatus});
+  const MultiStatusReturn({required this.responses});
 
-  /// Status code → body schema. A `null` value means the response has
-  /// no body (e.g. `204 No Content`); the synthesized wrapper for that
-  /// status carries no `value` field.
-  final Map<int, RenderSchema?> bodyByStatus;
+  /// Status code → response. Carries content-type per status so each
+  /// switch arm can pick the right decode (`jsonDecode` vs raw
+  /// `response.body`); a `RenderVoid` content signals no body and
+  /// produces a value-less wrapper subclass.
+  final Map<int, RenderResponse> responses;
 }
 
 /// Sealed so the endpoint arg-builder can pattern-match exhaustively on
@@ -3956,23 +3961,37 @@ class RenderOneOf extends RenderNewType {
   }
 }
 
+/// Wire-source expression for decoding a response body. Returns
+/// `jsonDecode(response.body)` for JSON content (or unspecified —
+/// most specs imply JSON), and the raw `response.body` for everything
+/// else (`text/plain`, `text/html`, `application/octet-stream`, …).
+/// Used by both the single-schema return path and the per-arm
+/// decode in multi-status dispatch.
+String _responseBodySource(String? contentType) =>
+    contentType == null || contentType == 'application/json'
+    ? 'jsonDecode(response.body)'
+    : 'response.body';
+
 /// One status-code entry in a multi-status response: the status, the
-/// wrapper subclass name (`<Parent>200`), and the body schema (null
-/// for empty-body statuses like 204). Owns the per-status projection
-/// into the two template contexts it feeds — keeps the body / no-body
-/// branch in one place per output instead of fanning out across the
-/// caller's loop.
+/// wrapper subclass name (`<Parent>200`), the body schema (null for
+/// empty-body statuses like 204), and the wire content type (drives
+/// `jsonDecode` vs raw `response.body` per status). Owns the per-
+/// status projection into the two template contexts it feeds —
+/// keeps the body / no-body branch in one place per output instead
+/// of fanning out across the caller's loop.
 @immutable
 final class _StatusInfo {
   const _StatusInfo({
     required this.statusCode,
     required this.wrapperTypeName,
     required this.body,
+    required this.contentType,
   });
 
   final int statusCode;
   final String wrapperTypeName;
   final RenderSchema? body;
+  final String? contentType;
 
   /// Mustache context for the wrapper class definition emitted by the
   /// `_multi_status_response` partial.
@@ -4000,13 +4019,13 @@ final class _StatusInfo {
     if (body == null) {
       construction = 'const $wrapperTypeName()';
     } else {
-      final fromJson = body.fromJsonExpression(
-        'jsonDecode(response.body)',
+      final decoded = body.fromJsonExpression(
+        _responseBodySource(contentType),
         context,
         jsonIsNullable: false,
         dartIsNullable: false,
       );
-      construction = '$wrapperTypeName($fromJson)';
+      construction = '$wrapperTypeName($decoded)';
     }
     return {
       'statusCode': statusCode,

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -1190,9 +1190,9 @@ class Endpoint implements ToTemplateContext {
     final typeName = camelFromSnake('${operation.snakeName}_response');
     final sortedEntries = multiStatus.bodyByStatus.entries.toList()
       ..sort((a, b) => a.key.compareTo(b.key));
-    final arms = [
+    final statuses = [
       for (final entry in sortedEntries)
-        _StatusArmInfo(
+        _StatusInfo(
           statusCode: entry.key,
           wrapperTypeName: '$typeName${entry.key}',
           body: entry.value,
@@ -1200,8 +1200,8 @@ class Endpoint implements ToTemplateContext {
     ];
     return _MultiStatusContext(
       typeName: typeName,
-      wrapperClassDefs: arms.map((a) => a.wrapperClassDef()).toList(),
-      switchArms: arms.map((a) => a.switchArm(context)).toList(),
+      wrapperClassDefs: statuses.map((s) => s.wrapperClassDef()).toList(),
+      switchCases: statuses.map((s) => s.switchCase(context)).toList(),
     );
   }
 
@@ -1365,7 +1365,7 @@ class Endpoint implements ToTemplateContext {
           : {
               'typeName': multiStatusContext.typeName,
               'wrapperClassDefs': multiStatusContext.wrapperClassDefs,
-              'switchArms': multiStatusContext.switchArms,
+              'switchCases': multiStatusContext.switchCases,
             },
       'hasErrorType': hasErrorType,
       'errorType': errorType,
@@ -3956,15 +3956,15 @@ class RenderOneOf extends RenderNewType {
   }
 }
 
-/// One status-code arm of a multi-status response: the status, the
+/// One status-code entry in a multi-status response: the status, the
 /// wrapper subclass name (`<Parent>200`), and the body schema (null
-/// for empty-body statuses like 204). Owns the per-arm projection
+/// for empty-body statuses like 204). Owns the per-status projection
 /// into the two template contexts it feeds — keeps the body / no-body
 /// branch in one place per output instead of fanning out across the
 /// caller's loop.
 @immutable
-class _StatusArmInfo {
-  const _StatusArmInfo({
+final class _StatusInfo {
+  const _StatusInfo({
     required this.statusCode,
     required this.wrapperTypeName,
     required this.body,
@@ -3994,11 +3994,11 @@ class _StatusArmInfo {
 
   /// Mustache context for one `case` in the api method's
   /// `switch (response.statusCode)`.
-  Map<String, dynamic> switchArm(SchemaRenderer context) {
+  Map<String, dynamic> switchCase(SchemaRenderer context) {
     final body = this.body;
-    final String armConstruction;
+    final String construction;
     if (body == null) {
-      armConstruction = 'const $wrapperTypeName()';
+      construction = 'const $wrapperTypeName()';
     } else {
       final fromJson = body.fromJsonExpression(
         'jsonDecode(response.body)',
@@ -4006,22 +4006,22 @@ class _StatusArmInfo {
         jsonIsNullable: false,
         dartIsNullable: false,
       );
-      armConstruction = '$wrapperTypeName($fromJson)';
+      construction = '$wrapperTypeName($fromJson)';
     }
     return {
       'statusCode': statusCode,
-      'armConstruction': armConstruction,
+      'construction': construction,
     };
   }
 }
 
 /// Pre-built template context for a multi-status operation.
 @immutable
-class _MultiStatusContext {
+final class _MultiStatusContext {
   const _MultiStatusContext({
     required this.typeName,
     required this.wrapperClassDefs,
-    required this.switchArms,
+    required this.switchCases,
   });
 
   /// Synthesized sealed-class name (e.g. `ReposGetResponse`).
@@ -4035,8 +4035,8 @@ class _MultiStatusContext {
 
   /// One mustache context per `case` in the api method's
   /// `switch (response.statusCode)`. Carries `statusCode` and
-  /// `armConstruction` (the Dart expression that builds the wrapper).
-  final List<Map<String, dynamic>> switchArms;
+  /// `construction` (the Dart expression that builds the wrapper).
+  final List<Map<String, dynamic>> switchCases;
 }
 
 /// One arm of the required-field dispatch: a [RenderObject] variant

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -1188,8 +1188,8 @@ class Endpoint implements ToTemplateContext {
   /// Build the per-status sealed-class context for a multi-status
   /// operation. The synthesized class name follows the same
   /// `<snake>_response` convention (where `<snake>` is the operation's
-  /// snake name) that the legacy oneOf path used, so existing regen
-  /// diffs only show the dispatch change, not a rename.
+  /// snake name) that the legacy oneOf path used, so existing
+  /// regenerated output only shows the dispatch change, not a rename.
   ///
   /// Sorted-by-status iteration matters for output stability — the
   /// underlying map is unordered.

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -1188,46 +1188,20 @@ class Endpoint implements ToTemplateContext {
     SchemaRenderer context,
   ) {
     final typeName = camelFromSnake('${operation.snakeName}_response');
-    final entries = multiStatus.bodyByStatus.entries.toList()
+    final sortedEntries = multiStatus.bodyByStatus.entries.toList()
       ..sort((a, b) => a.key.compareTo(b.key));
-    final wrapperClassDefs = <Map<String, dynamic>>[];
-    final switchArms = <Map<String, dynamic>>[];
-    for (final entry in entries) {
-      final statusCode = entry.key;
-      final body = entry.value;
-      final wrapperTypeName = '$typeName$statusCode';
-      if (body == null) {
-        wrapperClassDefs.add({
-          'wrapperTypeName': wrapperTypeName,
-          'statusCode': statusCode,
-          'hasBody': false,
-        });
-        switchArms.add({
-          'statusCode': statusCode,
-          'armConstruction': 'const $wrapperTypeName()',
-        });
-      } else {
-        final fromJson = body.fromJsonExpression(
-          'jsonDecode(response.body)',
-          context,
-          jsonIsNullable: false,
-          dartIsNullable: false,
-        );
-        wrapperClassDefs.add({
-          'wrapperTypeName': wrapperTypeName,
-          'valueType': body.typeName,
-          'hasBody': true,
-        });
-        switchArms.add({
-          'statusCode': statusCode,
-          'armConstruction': '$wrapperTypeName($fromJson)',
-        });
-      }
-    }
+    final arms = [
+      for (final entry in sortedEntries)
+        _StatusArmInfo(
+          statusCode: entry.key,
+          wrapperTypeName: '$typeName${entry.key}',
+          body: entry.value,
+        ),
+    ];
     return _MultiStatusContext(
       typeName: typeName,
-      wrapperClassDefs: wrapperClassDefs,
-      switchArms: switchArms,
+      wrapperClassDefs: arms.map((a) => a.wrapperClassDef()).toList(),
+      switchArms: arms.map((a) => a.switchArm(context)).toList(),
     );
   }
 
@@ -3968,6 +3942,65 @@ class RenderOneOf extends RenderNewType {
     // don't compile. Restoring real coverage requires real
     // discriminator-aware subclass emission (#99).
     return null;
+  }
+}
+
+/// One status-code arm of a multi-status response: the status, the
+/// wrapper subclass name (`<Parent>200`), and the body schema (null
+/// for empty-body statuses like 204). Owns the per-arm projection
+/// into the two template contexts it feeds — keeps the body / no-body
+/// branch in one place per output instead of fanning out across the
+/// caller's loop.
+@immutable
+class _StatusArmInfo {
+  const _StatusArmInfo({
+    required this.statusCode,
+    required this.wrapperTypeName,
+    required this.body,
+  });
+
+  final int statusCode;
+  final String wrapperTypeName;
+  final RenderSchema? body;
+
+  /// Mustache context for the wrapper class definition emitted by the
+  /// `_multi_status_response` partial.
+  Map<String, dynamic> wrapperClassDef() {
+    final body = this.body;
+    if (body == null) {
+      return {
+        'wrapperTypeName': wrapperTypeName,
+        'statusCode': statusCode,
+        'hasBody': false,
+      };
+    }
+    return {
+      'wrapperTypeName': wrapperTypeName,
+      'valueType': body.typeName,
+      'hasBody': true,
+    };
+  }
+
+  /// Mustache context for one `case` in the api method's
+  /// `switch (response.statusCode)`.
+  Map<String, dynamic> switchArm(SchemaRenderer context) {
+    final body = this.body;
+    final String armConstruction;
+    if (body == null) {
+      armConstruction = 'const $wrapperTypeName()';
+    } else {
+      final fromJson = body.fromJsonExpression(
+        'jsonDecode(response.body)',
+        context,
+        jsonIsNullable: false,
+        dartIsNullable: false,
+      );
+      armConstruction = '$wrapperTypeName($fromJson)';
+    }
+    return {
+      'statusCode': statusCode,
+      'armConstruction': armConstruction,
+    };
   }
 }
 

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -539,39 +539,67 @@ class SpecResolver {
     }
   }
 
-  RenderSchema _determineReturnType(ResolvedOperation operation) {
+  ({RenderSchema returnType, MultiStatusReturn? multiStatus})
+  _determineReturnType(ResolvedOperation operation) {
+    RenderVoid voidReturn() => RenderVoid(
+      common: CommonProperties.empty(
+        snakeName: '${operation.snakeName}_response',
+        pointer: operation.pointer,
+      ),
+    );
+
     // Figure out how many different successful responses there are.
     // Successful = explicit 2xx codes plus the `2XX` range if declared.
+    final explicit2xx = operation.responses
+        .where((e) => e.statusCode >= 200 && e.statusCode < 300)
+        .toList();
+    final successfulRange = operation.rangeResponses
+        .where((e) => e.range == StatusCodeRange.success)
+        .toList();
     final successfulContent = [
-      ...operation.responses
-          .where((e) => e.statusCode >= 200 && e.statusCode < 300)
-          .map((e) => e.content),
-      ...operation.rangeResponses
-          .where((e) => e.range == StatusCodeRange.success)
-          .map((e) => e.content),
+      ...explicit2xx.map((e) => e.content),
+      ...successfulRange.map((e) => e.content),
     ];
     if (successfulContent.isEmpty) {
-      return RenderVoid(
-        common: CommonProperties.empty(
-          snakeName: '${operation.snakeName}_response',
-          pointer: operation.pointer,
-        ),
-      );
+      return (returnType: voidReturn(), multiStatus: null);
     }
     if (successfulContent.length == 1) {
-      return toRenderSchema(successfulContent.first);
+      return (
+        returnType: toRenderSchema(successfulContent.first),
+        multiStatus: null,
+      );
     }
     final renderSchemas = successfulContent.map(toRenderSchema).toList();
-    // We don't implement hashCode/equals but rather equalsIgnoringName
+    // We don't implement hashCode/equals but rather equalsIgnoringName.
     final distinctSchemas = <RenderSchema>{};
     for (final schema in renderSchemas) {
       if (!distinctSchemas.any((e) => e.equalsIgnoringName(schema))) {
         distinctSchemas.add(schema);
       }
     }
-    // If there are multiple and they are different, generate a OneOf type.
-    if (distinctSchemas.length > 1) {
-      return RenderOneOf(
+    if (distinctSchemas.length == 1) {
+      return (returnType: distinctSchemas.first, multiStatus: null);
+    }
+    // Multiple distinct success bodies. Status-code dispatch only kicks
+    // in when every response has an explicit status code (no `2XX`
+    // range): the wrapper subclasses are named per code (`Foo200`,
+    // `Foo201`), and a range can't be enumerated. Range-mixed cases
+    // fall through to the legacy oneOf path for now.
+    if (successfulRange.isEmpty) {
+      final bodyByStatus = <int, RenderSchema?>{};
+      for (final response in explicit2xx) {
+        // RenderVoid means the response has no body — null in the map
+        // signals the wrapper for that status carries no value.
+        final body = toRenderSchema(response.content);
+        bodyByStatus[response.statusCode] = body is RenderVoid ? null : body;
+      }
+      return (
+        returnType: voidReturn(),
+        multiStatus: MultiStatusReturn(bodyByStatus: bodyByStatus),
+      );
+    }
+    return (
+      returnType: RenderOneOf(
         // TODO(eseidel): Should this pass along description?
         common: CommonProperties.empty(
           snakeName: '${operation.snakeName}_response',
@@ -579,9 +607,9 @@ class SpecResolver {
         ),
         schemas: distinctSchemas.toList(),
         discriminator: null,
-      );
-    }
-    return distinctSchemas.first;
+      ),
+      multiStatus: null,
+    );
   }
 
   RenderRangeResponse toRenderRangeResponse(ResolvedRangeResponse response) {
@@ -594,7 +622,7 @@ class SpecResolver {
   }
 
   RenderOperation toRenderOperation(ResolvedOperation operation) {
-    final returnType = _determineReturnType(operation);
+    final returnInfo = _determineReturnType(operation);
     final resolvedDefault = operation.defaultResponse;
     final defaultResponse = resolvedDefault == null
         ? null
@@ -618,7 +646,8 @@ class SpecResolver {
           .toList(),
       defaultResponse: defaultResponse,
       requestBody: toRenderRequestBody(operation.requestBody),
-      returnType: returnType,
+      returnType: returnInfo.returnType,
+      multiStatus: returnInfo.multiStatus,
       securityRequirements: operation.securityRequirements,
     );
   }
@@ -1156,6 +1185,62 @@ class Endpoint implements ToTemplateContext {
     return '${indent}multipartFiles.add($constructor);';
   }
 
+  /// Build the per-status sealed-class context for a multi-status
+  /// operation. The synthesized class name follows the same
+  /// `<snake>_response` convention (where `<snake>` is the operation's
+  /// snake name) that the legacy oneOf path used, so existing regen
+  /// diffs only show the dispatch change, not a rename.
+  ///
+  /// Sorted-by-status iteration matters for output stability — the
+  /// underlying map is unordered.
+  _MultiStatusContext _buildMultiStatusContext(
+    MultiStatusReturn multiStatus,
+    SchemaRenderer context,
+  ) {
+    final typeName = camelFromSnake('${operation.snakeName}_response');
+    final entries = multiStatus.bodyByStatus.entries.toList()
+      ..sort((a, b) => a.key.compareTo(b.key));
+    final variants = <Map<String, dynamic>>[];
+    final arms = <Map<String, dynamic>>[];
+    for (final entry in entries) {
+      final statusCode = entry.key;
+      final body = entry.value;
+      final wrapperTypeName = '$typeName$statusCode';
+      if (body == null) {
+        variants.add({
+          'wrapperTypeName': wrapperTypeName,
+          'statusCode': statusCode,
+          'hasBody': false,
+        });
+        arms.add({
+          'statusCode': statusCode,
+          'armConstruction': 'const $wrapperTypeName()',
+        });
+      } else {
+        final fromJson = body.fromJsonExpression(
+          'jsonDecode(response.body)',
+          context,
+          jsonIsNullable: false,
+          dartIsNullable: false,
+        );
+        variants.add({
+          'wrapperTypeName': wrapperTypeName,
+          'valueType': body.typeName,
+          'hasBody': true,
+        });
+        arms.add({
+          'statusCode': statusCode,
+          'armConstruction': '$wrapperTypeName($fromJson)',
+        });
+      }
+    }
+    return _MultiStatusContext(
+      typeName: typeName,
+      variants: variants,
+      arms: arms,
+    );
+  }
+
   @override
   Map<String, dynamic> toTemplateContext(
     SchemaRenderer context, {
@@ -1165,9 +1250,23 @@ class Endpoint implements ToTemplateContext {
     // body if it exists.
     final dartParameters = <CanBeParameter>[...parameters, ?requestBody];
 
+    // Multi-status return: the operation has multiple successful
+    // responses with structurally-different bodies. Synthesize a sealed
+    // class named after the operation and emit per-status wrapper
+    // subclasses; the API method body switches on the response status
+    // code instead of decoding a single body type. The synthesized
+    // class lives inline at the top of the api file rather than as a
+    // schema-graph type, because the dispatch construct is operation-
+    // level (the key is the HTTP status, not anything in the JSON).
+    final multiStatus = operation.multiStatus;
+    final multiStatusContext = multiStatus == null
+        ? null
+        : _buildMultiStatusContext(multiStatus, context);
+
     final responseSchema = operation.returnType;
-    final returnType = responseSchema.typeName;
-    final isVoidReturn = responseSchema is RenderVoid;
+    final returnType = multiStatusContext?.typeName ?? responseSchema.typeName;
+    final isVoidReturn =
+        multiStatusContext == null && responseSchema is RenderVoid;
     // When the success response advertises a non-JSON content type
     // (text/plain, text/html, application/octocat-stream, …) the wire
     // body is NOT JSON. Skip `jsonDecode`: `package:http`'s
@@ -1177,14 +1276,16 @@ class Endpoint implements ToTemplateContext {
     final successContentType = operation.successContentType;
     final isJsonResponse =
         successContentType == null || successContentType == 'application/json';
-    final responseFromJson = isJsonResponse
-        ? responseSchema.fromJsonExpression(
-            'jsonDecode(response.body)',
-            context,
-            jsonIsNullable: false,
-            dartIsNullable: false,
-          )
-        : 'response.body';
+    final responseFromJson = multiStatusContext != null
+        ? null
+        : (isJsonResponse
+              ? responseSchema.fromJsonExpression(
+                  'jsonDecode(response.body)',
+                  context,
+                  jsonIsNullable: false,
+                  dartIsNullable: false,
+                )
+              : 'response.body');
 
     // Collect error-body schemas from `default:`, `4XX:`, and `5XX:` and
     // deduplicate by structural equality. When they all resolve to the same
@@ -1282,6 +1383,10 @@ class Endpoint implements ToTemplateContext {
       'returnType': returnType,
       'isVoidReturn': isVoidReturn,
       'responseFromJson': responseFromJson,
+      'hasMultiStatus': multiStatusContext != null,
+      'multiStatusTypeName': multiStatusContext?.typeName,
+      'multiStatusVariants': multiStatusContext?.variants,
+      'multiStatusArms': multiStatusContext?.arms,
       'hasErrorType': hasErrorType,
       'errorType': errorType,
       'errorFromJson': errorFromJson,
@@ -1339,6 +1444,7 @@ class RenderOperation {
     required this.rangeResponses,
     required this.defaultResponse,
     required this.returnType,
+    required this.multiStatus,
     required this.tags,
     required this.summary,
     required this.description,
@@ -1380,8 +1486,24 @@ class RenderOperation {
   /// 4xx/5xx status code also references it.
   final RenderDefaultResponse? defaultResponse;
 
-  /// The return type of the resolved operation.
+  /// The return type of the resolved operation. When [multiStatus] is
+  /// non-null, this is a placeholder ([RenderVoid]) — the real return
+  /// type is a sealed wrapper class synthesized at template-emit time
+  /// (see [Endpoint.toTemplateContext]). When [multiStatus] is null,
+  /// this is the single schema returned by every successful response.
   final RenderSchema returnType;
+
+  /// Per-status response bodies when the operation has multiple
+  /// successful responses with structurally-different body schemas
+  /// (e.g. github's `200` → user, `202` → accepted job). Null for the
+  /// single-response case where [returnType] alone suffices.
+  ///
+  /// Lives on the operation rather than in the schema graph because
+  /// status-code multiplexing is an operation-level construct: the
+  /// dispatch key is the HTTP status, not anything in the JSON body.
+  /// Conflating it with [RenderOneOf] (which dispatches on body shape)
+  /// is what produced the legacy `UnimplementedError` stub.
+  final MultiStatusReturn? multiStatus;
 
   /// Wire content type of the response that drove [returnType] — first
   /// matching 2xx, then `2XX` range. `null` when the operation has no
@@ -1412,6 +1534,22 @@ class RenderOperation {
 
   /// The security requirements of the resolved operation.
   final List<ResolvedSecurityRequirement> securityRequirements;
+}
+
+/// Multi-status response info for an operation whose successful responses
+/// resolve to structurally-different schemas per HTTP status. The Dart
+/// emit is a sealed parent (named after the operation, e.g.
+/// `ReposGetResponse`) plus one `final` subclass per status code; the
+/// API method body switches on `response.statusCode` to construct the
+/// right subclass.
+@immutable
+class MultiStatusReturn {
+  const MultiStatusReturn({required this.bodyByStatus});
+
+  /// Status code → body schema. A `null` value means the response has
+  /// no body (e.g. `204 No Content`); the synthesized wrapper for that
+  /// status carries no `value` field.
+  final Map<int, RenderSchema?> bodyByStatus;
 }
 
 /// Sealed so the endpoint arg-builder can pattern-match exhaustively on
@@ -3822,6 +3960,24 @@ class RenderOneOf extends RenderNewType {
     // discriminator-aware subclass emission (#99).
     return null;
   }
+}
+
+/// Pre-built template context for a multi-status operation: the
+/// synthesized sealed-class name, the wrapper subclass definitions
+/// (`variants`, consumed by the `_multi_status_response` partial), and
+/// the per-status switch arms (`arms`, consumed by `api.mustache` in
+/// the method body).
+@immutable
+class _MultiStatusContext {
+  const _MultiStatusContext({
+    required this.typeName,
+    required this.variants,
+    required this.arms,
+  });
+
+  final String typeName;
+  final List<Map<String, dynamic>> variants;
+  final List<Map<String, dynamic>> arms;
 }
 
 /// One arm of the required-field dispatch: a [RenderObject] variant

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -1352,10 +1352,21 @@ class Endpoint implements ToTemplateContext {
       'returnType': returnType,
       'isVoidReturn': isVoidReturn,
       'responseFromJson': responseFromJson,
-      'hasMultiStatus': multiStatusContext != null,
-      'multiStatusTypeName': multiStatusContext?.typeName,
-      'multiStatusWrapperClassDefs': multiStatusContext?.wrapperClassDefs,
-      'multiStatusSwitchArms': multiStatusContext?.switchArms,
+      // Mustache treats a non-empty map as a single-iteration section
+      // that pushes the map onto the context — so
+      // `{{#multiStatus}}...{{/multiStatus}}` doubles as both the
+      // presence check and the scope opener for `typeName`,
+      // `wrapperClassDefs`, `switchArms`. The `false` sentinel (rather
+      // than null) matters for the `{{^multiStatus}}` inverse: the
+      // mustache_template package errors on null in inverse sections
+      // but treats `false` correctly as "render the inverse."
+      'multiStatus': multiStatusContext == null
+          ? false
+          : {
+              'typeName': multiStatusContext.typeName,
+              'wrapperClassDefs': multiStatusContext.wrapperClassDefs,
+              'switchArms': multiStatusContext.switchArms,
+            },
       'hasErrorType': hasErrorType,
       'errorType': errorType,
       'errorFromJson': errorFromJson,

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -539,12 +539,13 @@ class SpecResolver {
     }
   }
 
-  ({RenderSchema returnType, MultiStatusReturn? multiStatus})
-  _determineReturnType(ResolvedOperation operation) {
-    RenderVoid voidReturn() => RenderVoid(
-      common: CommonProperties.empty(
-        snakeName: '${operation.snakeName}_response',
-        pointer: operation.pointer,
+  OperationReturn _determineReturnShape(ResolvedOperation operation) {
+    SingleSchemaReturn voidReturn() => SingleSchemaReturn(
+      RenderVoid(
+        common: CommonProperties.empty(
+          snakeName: '${operation.snakeName}_response',
+          pointer: operation.pointer,
+        ),
       ),
     );
 
@@ -561,13 +562,10 @@ class SpecResolver {
       ...successfulRange.map((e) => e.content),
     ];
     if (successfulContent.isEmpty) {
-      return (returnType: voidReturn(), multiStatus: null);
+      return voidReturn();
     }
     if (successfulContent.length == 1) {
-      return (
-        returnType: toRenderSchema(successfulContent.first),
-        multiStatus: null,
-      );
+      return SingleSchemaReturn(toRenderSchema(successfulContent.first));
     }
     final renderSchemas = successfulContent.map(toRenderSchema).toList();
     // We don't implement hashCode/equals but rather equalsIgnoringName.
@@ -578,7 +576,7 @@ class SpecResolver {
       }
     }
     if (distinctSchemas.length == 1) {
-      return (returnType: distinctSchemas.first, multiStatus: null);
+      return SingleSchemaReturn(distinctSchemas.first);
     }
     // Multiple distinct success bodies. Status-code dispatch only kicks
     // in when every response has an explicit status code (no `2XX`
@@ -593,13 +591,10 @@ class SpecResolver {
         final body = toRenderSchema(response.content);
         bodyByStatus[response.statusCode] = body is RenderVoid ? null : body;
       }
-      return (
-        returnType: voidReturn(),
-        multiStatus: MultiStatusReturn(bodyByStatus: bodyByStatus),
-      );
+      return MultiStatusReturn(bodyByStatus: bodyByStatus);
     }
-    return (
-      returnType: RenderOneOf(
+    return SingleSchemaReturn(
+      RenderOneOf(
         // TODO(eseidel): Should this pass along description?
         common: CommonProperties.empty(
           snakeName: '${operation.snakeName}_response',
@@ -608,7 +603,6 @@ class SpecResolver {
         schemas: distinctSchemas.toList(),
         discriminator: null,
       ),
-      multiStatus: null,
     );
   }
 
@@ -622,7 +616,6 @@ class SpecResolver {
   }
 
   RenderOperation toRenderOperation(ResolvedOperation operation) {
-    final returnInfo = _determineReturnType(operation);
     final resolvedDefault = operation.defaultResponse;
     final defaultResponse = resolvedDefault == null
         ? null
@@ -646,8 +639,7 @@ class SpecResolver {
           .toList(),
       defaultResponse: defaultResponse,
       requestBody: toRenderRequestBody(operation.requestBody),
-      returnType: returnInfo.returnType,
-      multiStatus: returnInfo.multiStatus,
+      returnShape: _determineReturnShape(operation),
       securityRequirements: operation.securityRequirements,
     );
   }
@@ -1200,19 +1192,19 @@ class Endpoint implements ToTemplateContext {
     final typeName = camelFromSnake('${operation.snakeName}_response');
     final entries = multiStatus.bodyByStatus.entries.toList()
       ..sort((a, b) => a.key.compareTo(b.key));
-    final variants = <Map<String, dynamic>>[];
-    final arms = <Map<String, dynamic>>[];
+    final wrapperClassDefs = <Map<String, dynamic>>[];
+    final switchArms = <Map<String, dynamic>>[];
     for (final entry in entries) {
       final statusCode = entry.key;
       final body = entry.value;
       final wrapperTypeName = '$typeName$statusCode';
       if (body == null) {
-        variants.add({
+        wrapperClassDefs.add({
           'wrapperTypeName': wrapperTypeName,
           'statusCode': statusCode,
           'hasBody': false,
         });
-        arms.add({
+        switchArms.add({
           'statusCode': statusCode,
           'armConstruction': 'const $wrapperTypeName()',
         });
@@ -1223,12 +1215,12 @@ class Endpoint implements ToTemplateContext {
           jsonIsNullable: false,
           dartIsNullable: false,
         );
-        variants.add({
+        wrapperClassDefs.add({
           'wrapperTypeName': wrapperTypeName,
           'valueType': body.typeName,
           'hasBody': true,
         });
-        arms.add({
+        switchArms.add({
           'statusCode': statusCode,
           'armConstruction': '$wrapperTypeName($fromJson)',
         });
@@ -1236,8 +1228,8 @@ class Endpoint implements ToTemplateContext {
     }
     return _MultiStatusContext(
       typeName: typeName,
-      variants: variants,
-      arms: arms,
+      wrapperClassDefs: wrapperClassDefs,
+      switchArms: switchArms,
     );
   }
 
@@ -1250,42 +1242,47 @@ class Endpoint implements ToTemplateContext {
     // body if it exists.
     final dartParameters = <CanBeParameter>[...parameters, ?requestBody];
 
-    // Multi-status return: the operation has multiple successful
-    // responses with structurally-different bodies. Synthesize a sealed
-    // class named after the operation and emit per-status wrapper
-    // subclasses; the API method body switches on the response status
-    // code instead of decoding a single body type. The synthesized
-    // class lives inline at the top of the api file rather than as a
-    // schema-graph type, because the dispatch construct is operation-
-    // level (the key is the HTTP status, not anything in the JSON).
-    final multiStatus = operation.multiStatus;
-    final multiStatusContext = multiStatus == null
-        ? null
-        : _buildMultiStatusContext(multiStatus, context);
-
-    final responseSchema = operation.returnType;
-    final returnType = multiStatusContext?.typeName ?? responseSchema.typeName;
-    final isVoidReturn =
-        multiStatusContext == null && responseSchema is RenderVoid;
-    // When the success response advertises a non-JSON content type
-    // (text/plain, text/html, application/octocat-stream, …) the wire
-    // body is NOT JSON. Skip `jsonDecode`: `package:http`'s
-    // `Response.body` is already a `String`, which matches the
-    // `type: string` schema such responses use in practice. github's
-    // `/zen`, `/octocat`, `/markdown`, `/markdown/raw` all live here.
-    final successContentType = operation.successContentType;
-    final isJsonResponse =
-        successContentType == null || successContentType == 'application/json';
-    final responseFromJson = multiStatusContext != null
-        ? null
-        : (isJsonResponse
-              ? responseSchema.fromJsonExpression(
-                  'jsonDecode(response.body)',
-                  context,
-                  jsonIsNullable: false,
-                  dartIsNullable: false,
-                )
-              : 'response.body');
+    // Pattern-match on the operation's return shape: single schema
+    // (the legacy / non-multi-status path) or multi-status (synthesize
+    // a sealed class inline in the api file and dispatch on
+    // `response.statusCode` in the method body). The sealed wrapper
+    // lives in the api file rather than the schema graph because
+    // status-code multiplexing is operation-level — the dispatch key
+    // is the HTTP status, not anything in the JSON body.
+    final returnShape = operation.returnShape;
+    final String returnType;
+    final bool isVoidReturn;
+    final String? responseFromJson;
+    final _MultiStatusContext? multiStatusContext;
+    switch (returnShape) {
+      case SingleSchemaReturn(:final schema):
+        multiStatusContext = null;
+        returnType = schema.typeName;
+        isVoidReturn = schema is RenderVoid;
+        // When the success response advertises a non-JSON content type
+        // (text/plain, text/html, application/octocat-stream, …) the
+        // wire body is NOT JSON. Skip `jsonDecode`: `package:http`'s
+        // `Response.body` is already a `String`, which matches the
+        // `type: string` schema such responses use in practice. github's
+        // `/zen`, `/octocat`, `/markdown`, `/markdown/raw` all live here.
+        final successContentType = operation.successContentType;
+        final isJsonResponse =
+            successContentType == null ||
+            successContentType == 'application/json';
+        responseFromJson = isJsonResponse
+            ? schema.fromJsonExpression(
+                'jsonDecode(response.body)',
+                context,
+                jsonIsNullable: false,
+                dartIsNullable: false,
+              )
+            : 'response.body';
+      case MultiStatusReturn():
+        multiStatusContext = _buildMultiStatusContext(returnShape, context);
+        returnType = multiStatusContext.typeName;
+        isVoidReturn = false;
+        responseFromJson = null;
+    }
 
     // Collect error-body schemas from `default:`, `4XX:`, and `5XX:` and
     // deduplicate by structural equality. When they all resolve to the same
@@ -1385,8 +1382,8 @@ class Endpoint implements ToTemplateContext {
       'responseFromJson': responseFromJson,
       'hasMultiStatus': multiStatusContext != null,
       'multiStatusTypeName': multiStatusContext?.typeName,
-      'multiStatusVariants': multiStatusContext?.variants,
-      'multiStatusArms': multiStatusContext?.arms,
+      'multiStatusWrapperClassDefs': multiStatusContext?.wrapperClassDefs,
+      'multiStatusSwitchArms': multiStatusContext?.switchArms,
       'hasErrorType': hasErrorType,
       'errorType': errorType,
       'errorFromJson': errorFromJson,
@@ -1443,8 +1440,7 @@ class RenderOperation {
     required this.responses,
     required this.rangeResponses,
     required this.defaultResponse,
-    required this.returnType,
-    required this.multiStatus,
+    required this.returnShape,
     required this.tags,
     required this.summary,
     required this.description,
@@ -1486,26 +1482,24 @@ class RenderOperation {
   /// 4xx/5xx status code also references it.
   final RenderDefaultResponse? defaultResponse;
 
-  /// The return type of the resolved operation. When [multiStatus] is
-  /// non-null, this is a placeholder ([RenderVoid]) — the real return
-  /// type is a sealed wrapper class synthesized at template-emit time
-  /// (see [Endpoint.toTemplateContext]). When [multiStatus] is null,
-  /// this is the single schema returned by every successful response.
-  final RenderSchema returnType;
-
-  /// Per-status response bodies when the operation has multiple
-  /// successful responses with structurally-different body schemas
-  /// (e.g. github's `200` → user, `202` → accepted job). Null for the
-  /// single-response case where [returnType] alone suffices.
+  /// What the operation's API method returns. Sealed so emit-time code
+  /// (template context, walker) pattern-matches on the case rather than
+  /// branching on a nullable. The two cases:
   ///
-  /// Lives on the operation rather than in the schema graph because
-  /// status-code multiplexing is an operation-level construct: the
-  /// dispatch key is the HTTP status, not anything in the JSON body.
-  /// Conflating it with [RenderOneOf] (which dispatches on body shape)
-  /// is what produced the legacy `UnimplementedError` stub.
-  final MultiStatusReturn? multiStatus;
+  /// - [SingleSchemaReturn]: one schema for every success path
+  ///   (no-content `RenderVoid`, a single 2xx, all-2xx-identical, or
+  ///   the legacy oneOf fallback for range-mixed cases). Today's
+  ///   default; matches the pre-multi-status world.
+  /// - [MultiStatusReturn]: structurally-different bodies per HTTP
+  ///   status (e.g. github's `200` → user, `202` → accepted job).
+  ///   Lives here rather than in the schema graph because status-code
+  ///   multiplexing is operation-level — the dispatch key is the HTTP
+  ///   status, not anything in the JSON body. Conflating it with
+  ///   [RenderOneOf] (which dispatches on body shape) is what
+  ///   produced the legacy `UnimplementedError` stub.
+  final OperationReturn returnShape;
 
-  /// Wire content type of the response that drove [returnType] — first
+  /// Wire content type of the response that drove [returnShape] — first
   /// matching 2xx, then `2XX` range. `null` when the operation has no
   /// successful response body. Used by the operation renderer to skip
   /// `jsonDecode` when the body isn't JSON.
@@ -1536,14 +1530,31 @@ class RenderOperation {
   final List<ResolvedSecurityRequirement> securityRequirements;
 }
 
-/// Multi-status response info for an operation whose successful responses
-/// resolve to structurally-different schemas per HTTP status. The Dart
-/// emit is a sealed parent (named after the operation, e.g.
+/// What an operation's API method returns at the Dart level. Sealed so
+/// the renderer pattern-matches exhaustively on the two emit shapes.
+sealed class OperationReturn {
+  const OperationReturn();
+}
+
+/// One schema covers every successful response path: a single 2xx,
+/// multiple 2xx with the same body, the no-content [RenderVoid] case,
+/// or the legacy `RenderOneOf` fallback for range-mixed responses.
+/// The API method's return type is `Future<schema.typeName>`.
+@immutable
+final class SingleSchemaReturn extends OperationReturn {
+  const SingleSchemaReturn(this.schema);
+
+  final RenderSchema schema;
+}
+
+/// Multi-status response: the operation has multiple successful
+/// responses with structurally-different body schemas. The Dart emit
+/// is a sealed parent (named after the operation, e.g.
 /// `ReposGetResponse`) plus one `final` subclass per status code; the
 /// API method body switches on `response.statusCode` to construct the
 /// right subclass.
 @immutable
-class MultiStatusReturn {
+final class MultiStatusReturn extends OperationReturn {
   const MultiStatusReturn({required this.bodyByStatus});
 
   /// Status code → body schema. A `null` value means the response has
@@ -3962,22 +3973,28 @@ class RenderOneOf extends RenderNewType {
   }
 }
 
-/// Pre-built template context for a multi-status operation: the
-/// synthesized sealed-class name, the wrapper subclass definitions
-/// (`variants`, consumed by the `_multi_status_response` partial), and
-/// the per-status switch arms (`arms`, consumed by `api.mustache` in
-/// the method body).
+/// Pre-built template context for a multi-status operation.
 @immutable
 class _MultiStatusContext {
   const _MultiStatusContext({
     required this.typeName,
-    required this.variants,
-    required this.arms,
+    required this.wrapperClassDefs,
+    required this.switchArms,
   });
 
+  /// Synthesized sealed-class name (e.g. `ReposGetResponse`).
   final String typeName;
-  final List<Map<String, dynamic>> variants;
-  final List<Map<String, dynamic>> arms;
+
+  /// One mustache context per wrapper subclass to emit, consumed by
+  /// the `_multi_status_response` partial. Carries `wrapperTypeName`,
+  /// `hasBody`, and either `valueType` (body present) or `statusCode`
+  /// (empty body, used for the identity-only `hashCode`).
+  final List<Map<String, dynamic>> wrapperClassDefs;
+
+  /// One mustache context per `case` in the api method's
+  /// `switch (response.statusCode)`. Carries `statusCode` and
+  /// `armConstruction` (the Dart expression that builds the wrapper).
+  final List<Map<String, dynamic>> switchArms;
 }
 
 /// One arm of the required-field dispatch: a [RenderObject] variant

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -540,15 +540,6 @@ class SpecResolver {
   }
 
   OperationReturn _determineReturnShape(ResolvedOperation operation) {
-    SingleSchemaReturn voidReturn() => SingleSchemaReturn(
-      RenderVoid(
-        common: CommonProperties.empty(
-          snakeName: '${operation.snakeName}_response',
-          pointer: operation.pointer,
-        ),
-      ),
-    );
-
     // Figure out how many different successful responses there are.
     // Successful = explicit 2xx codes plus the `2XX` range if declared.
     final explicit2xx = operation.responses
@@ -562,7 +553,14 @@ class SpecResolver {
       ...successfulRange.map((e) => e.content),
     ];
     if (successfulContent.isEmpty) {
-      return voidReturn();
+      return SingleSchemaReturn(
+        RenderVoid(
+          common: CommonProperties.empty(
+            snakeName: '${operation.snakeName}_response',
+            pointer: operation.pointer,
+          ),
+        ),
+      );
     }
     if (successfulContent.length == 1) {
       return SingleSchemaReturn(toRenderSchema(successfulContent.first));

--- a/lib/src/render/schema_renderer.dart
+++ b/lib/src/render/schema_renderer.dart
@@ -48,14 +48,23 @@ class SchemaUsage {
 /// Which imports a rendered api body needs beyond the schemas it
 /// references, plus which `model_helpers.dart` helpers the body calls.
 class ApiUsage {
-  const ApiUsage({this.modelHelpers = const {}});
+  const ApiUsage({
+    this.usesMetaAnnotations = false,
+    this.modelHelpers = const {},
+  });
 
   factory ApiUsage.fromBody(String body) => ApiUsage(
+    usesMetaAnnotations: body.contains('@immutable'),
     modelHelpers: {
       for (final h in ModelHelpers.all)
         if (body.contains(h)) h,
     },
   );
+
+  /// True when the body emits `@immutable` (multi-status response
+  /// wrappers do; the legacy single-return path does not). Drives the
+  /// `package:meta/meta.dart` import.
+  final bool usesMetaAnnotations;
 
   /// The set of `model_helpers.dart` identifiers referenced by the
   /// rendered body. A subset of [ModelHelpers.all].
@@ -64,6 +73,7 @@ class ApiUsage {
   bool get usesModelHelpers => modelHelpers.isNotEmpty;
 
   Iterable<Import> importsFor(String packageName) sync* {
+    if (usesMetaAnnotations) yield const Import('package:meta/meta.dart');
     if (usesModelHelpers) {
       yield Import('package:$packageName/model_helpers.dart');
     }

--- a/lib/src/render/tree_visitor.dart
+++ b/lib/src/render/tree_visitor.dart
@@ -93,7 +93,16 @@ class RenderTreeWalker {
     for (final parameter in operation.parameters) {
       walkParameter(parameter);
     }
-    walkSchema(operation.returnType);
+    // SingleSchemaReturn is a synthesized type (the legacy oneOf
+    // fallback or a real schema) that needs its imports collected.
+    // MultiStatusReturn's per-status bodies are already covered by the
+    // walkResponse loop above — they live on operation.responses.
+    switch (operation.returnShape) {
+      case SingleSchemaReturn(:final schema):
+        walkSchema(schema);
+      case MultiStatusReturn():
+        break;
+    }
   }
 
   void walkRequestBody(RenderRequestBody requestBody) {

--- a/lib/templates/_multi_status_response.mustache
+++ b/lib/templates/_multi_status_response.mustache
@@ -2,7 +2,7 @@ sealed class {{ multiStatusTypeName }} {
     const {{ multiStatusTypeName }}();
 }
 
-{{#multiStatusVariants}}
+{{#multiStatusWrapperClassDefs}}
 {{#hasBody}}
 @immutable
 final class {{ wrapperTypeName }} extends {{ multiStatusTypeName }} {
@@ -33,4 +33,4 @@ final class {{ wrapperTypeName }} extends {{ multiStatusTypeName }} {
 }
 {{/hasBody}}
 
-{{/multiStatusVariants}}
+{{/multiStatusWrapperClassDefs}}

--- a/lib/templates/_multi_status_response.mustache
+++ b/lib/templates/_multi_status_response.mustache
@@ -1,0 +1,36 @@
+sealed class {{ multiStatusTypeName }} {
+    const {{ multiStatusTypeName }}();
+}
+
+{{#multiStatusVariants}}
+{{#hasBody}}
+@immutable
+final class {{ wrapperTypeName }} extends {{ multiStatusTypeName }} {
+    const {{ wrapperTypeName }}(this.value);
+
+    final {{{ valueType }}} value;
+
+    @override
+    int get hashCode => value.hashCode;
+
+    @override
+    bool operator ==(Object other) {
+        if (identical(this, other)) return true;
+        return other is {{ wrapperTypeName }} && value == other.value;
+    }
+}
+{{/hasBody}}
+{{^hasBody}}
+@immutable
+final class {{ wrapperTypeName }} extends {{ multiStatusTypeName }} {
+    const {{ wrapperTypeName }}();
+
+    @override
+    int get hashCode => {{ statusCode }};
+
+    @override
+    bool operator ==(Object other) => other is {{ wrapperTypeName }};
+}
+{{/hasBody}}
+
+{{/multiStatusVariants}}

--- a/lib/templates/_multi_status_response.mustache
+++ b/lib/templates/_multi_status_response.mustache
@@ -1,11 +1,11 @@
-sealed class {{ multiStatusTypeName }} {
-    const {{ multiStatusTypeName }}();
+sealed class {{ typeName }} {
+    const {{ typeName }}();
 }
 
-{{#multiStatusWrapperClassDefs}}
+{{#wrapperClassDefs}}
 {{#hasBody}}
 @immutable
-final class {{ wrapperTypeName }} extends {{ multiStatusTypeName }} {
+final class {{ wrapperTypeName }} extends {{ typeName }} {
     const {{ wrapperTypeName }}(this.value);
 
     final {{{ valueType }}} value;
@@ -22,7 +22,7 @@ final class {{ wrapperTypeName }} extends {{ multiStatusTypeName }} {
 {{/hasBody}}
 {{^hasBody}}
 @immutable
-final class {{ wrapperTypeName }} extends {{ multiStatusTypeName }} {
+final class {{ wrapperTypeName }} extends {{ typeName }} {
     const {{ wrapperTypeName }}();
 
     @override
@@ -33,4 +33,4 @@ final class {{ wrapperTypeName }} extends {{ multiStatusTypeName }} {
 }
 {{/hasBody}}
 
-{{/multiStatusWrapperClassDefs}}
+{{/wrapperClassDefs}}

--- a/lib/templates/api.mustache
+++ b/lib/templates/api.mustache
@@ -37,9 +37,9 @@
 {{#hasMultiStatus}}
 
         return switch (response.statusCode) {
-{{#multiStatusArms}}
+{{#multiStatusSwitchArms}}
             {{ statusCode }} => {{{ armConstruction }}},
-{{/multiStatusArms}}
+{{/multiStatusSwitchArms}}
             _ => throw ApiException<Object?>.unhandled(response.statusCode),
         };
 {{/hasMultiStatus}}

--- a/lib/templates/api.mustache
+++ b/lib/templates/api.mustache
@@ -37,9 +37,9 @@
 {{#multiStatus}}
 
         return switch (response.statusCode) {
-{{#switchArms}}
-            {{ statusCode }} => {{{ armConstruction }}},
-{{/switchArms}}
+{{#switchCases}}
+            {{ statusCode }} => {{{ construction }}},
+{{/switchCases}}
             _ => throw ApiException<Object?>.unhandled(response.statusCode),
         };
 {{/multiStatus}}

--- a/lib/templates/api.mustache
+++ b/lib/templates/api.mustache
@@ -1,7 +1,7 @@
 {{#endpoints}}
-{{#hasMultiStatus}}
+{{#multiStatus}}
 {{> _multi_status_response}}
-{{/hasMultiStatus}}
+{{/multiStatus}}
 {{/endpoints}}
 {{{ api_doc_comment }}}class {{ className }} {
     {{ className }}(ApiClient? client) : client = client ?? ApiClient();
@@ -34,23 +34,23 @@
             {{/hasErrorType}}
         }
 {{^isVoidReturn}}
-{{#hasMultiStatus}}
+{{#multiStatus}}
 
         return switch (response.statusCode) {
-{{#multiStatusSwitchArms}}
+{{#switchArms}}
             {{ statusCode }} => {{{ armConstruction }}},
-{{/multiStatusSwitchArms}}
+{{/switchArms}}
             _ => throw ApiException<Object?>.unhandled(response.statusCode),
         };
-{{/hasMultiStatus}}
-{{^hasMultiStatus}}
+{{/multiStatus}}
+{{^multiStatus}}
 
         if (response.body.isNotEmpty) {
             return {{{ responseFromJson }}};
         }
 
         throw ApiException<Object?>.unhandled(response.statusCode);
-{{/hasMultiStatus}}
+{{/multiStatus}}
 {{/isVoidReturn}}
     }
     {{/endpoints}}

--- a/lib/templates/api.mustache
+++ b/lib/templates/api.mustache
@@ -1,3 +1,8 @@
+{{#endpoints}}
+{{#hasMultiStatus}}
+{{> _multi_status_response}}
+{{/hasMultiStatus}}
+{{/endpoints}}
 {{{ api_doc_comment }}}class {{ className }} {
     {{ className }}(ApiClient? client) : client = client ?? ApiClient();
 
@@ -29,12 +34,23 @@
             {{/hasErrorType}}
         }
 {{^isVoidReturn}}
+{{#hasMultiStatus}}
+
+        return switch (response.statusCode) {
+{{#multiStatusArms}}
+            {{ statusCode }} => {{{ armConstruction }}},
+{{/multiStatusArms}}
+            _ => throw ApiException<Object?>.unhandled(response.statusCode),
+        };
+{{/hasMultiStatus}}
+{{^hasMultiStatus}}
 
         if (response.body.isNotEmpty) {
             return {{{ responseFromJson }}};
         }
 
         throw ApiException<Object?>.unhandled(response.statusCode);
+{{/hasMultiStatus}}
 {{/isVoidReturn}}
     }
     {{/endpoints}}

--- a/test/render/file_renderer_test.dart
+++ b/test/render/file_renderer_test.dart
@@ -2634,11 +2634,13 @@ void main() {
               pointer: JsonPointer.parse('#/bar'),
               method: Method.get,
               tags: ['foo'],
-              returnType: RenderVoid(
-                common: CommonProperties.test(
-                  snakeName: 'bar',
-                  pointer: JsonPointer.parse('#/bar'),
-                  description: 'Bar description',
+              returnShape: SingleSchemaReturn(
+                RenderVoid(
+                  common: CommonProperties.test(
+                    snakeName: 'bar',
+                    pointer: JsonPointer.parse('#/bar'),
+                    description: 'Bar description',
+                  ),
                 ),
               ),
               summary: 'Bar',
@@ -2663,7 +2665,6 @@ void main() {
               responses: <RenderResponse>[],
               rangeResponses: <RenderRangeResponse>[],
               defaultResponse: null,
-              multiStatus: null,
               securityRequirements: <ResolvedSecurityRequirement>[],
             ),
             serverUrl: Uri.parse('https://api.spacetraders.io/v2'),

--- a/test/render/file_renderer_test.dart
+++ b/test/render/file_renderer_test.dart
@@ -1766,6 +1766,11 @@ void main() {
       },
     );
     test('multiple responses with different content', () async {
+      // Multi-status responses are operation-level, not schema-level —
+      // the sealed wrapper is emitted inline in the api file rather
+      // than carved into its own `users_response.dart`. See the
+      // matching render_operation_test.dart cases for the emitted
+      // dispatch shape.
       final spec = {
         'openapi': '3.1.0',
         'info': {'title': 'Space Traders API', 'version': '1.0.0'},
@@ -1801,11 +1806,14 @@ void main() {
       final out = fs.directory('spacetraders');
 
       await renderToDirectory(spec: spec, outDir: out);
-      expect(out.childFile('lib/api/default_api.dart'), exists);
-      expect(
-        out,
-        hasGeneratedSchemaFiles(['users_response.dart']),
-      );
+      final apiFile = out.childFile('lib/api/default_api.dart');
+      expect(apiFile, exists);
+      final apiContents = apiFile.readAsStringSync();
+      expect(apiContents, contains('sealed class UsersResponse {'));
+      expect(apiContents, contains('final class UsersResponse200'));
+      expect(apiContents, contains('final class UsersResponse201'));
+      expect(apiContents, contains('switch (response.statusCode)'));
+      expect(out.childFile('lib/models/users_response.dart'), isNot(exists));
     });
     test('empty object creates new file', () async {
       final spec = {
@@ -2655,6 +2663,7 @@ void main() {
               responses: <RenderResponse>[],
               rangeResponses: <RenderRangeResponse>[],
               defaultResponse: null,
+              multiStatus: null,
               securityRequirements: <ResolvedSecurityRequirement>[],
             ),
             serverUrl: Uri.parse('https://api.spacetraders.io/v2'),

--- a/test/render/render_operation_test.dart
+++ b/test/render/render_operation_test.dart
@@ -672,6 +672,47 @@ void main() {
       );
     });
 
+    test('mixed content types: each switch arm decodes per its own type', () {
+      // 200 returns text/plain (raw `response.body`), 201 returns
+      // JSON (`jsonDecode(response.body)`). Pre-fix, every arm would
+      // jsonDecode and crash at runtime on the text/plain status.
+      final json = {
+        'responses': {
+          '200': {
+            'description': 'OK',
+            'content': {
+              'text/plain': {
+                'schema': {'type': 'string'},
+              },
+            },
+          },
+          '201': {
+            'description': 'Created',
+            'content': {
+              'application/json': {
+                'schema': {'type': 'boolean'},
+              },
+            },
+          },
+        },
+      };
+      final result = renderTestOperation(
+        path: '/users',
+        operationJson: json,
+        serverUrl: Uri.parse('https://api.spacetraders.io/v2'),
+      );
+      expect(
+        result,
+        contains(
+          '        return switch (response.statusCode) {\n'
+          '            200 => UsersResponse200(response.body as String),\n'
+          '            201 => UsersResponse201(jsonDecode(response.body) as bool),\n'
+          '            _ => throw ApiException<Object?>.unhandled(response.statusCode),\n'
+          '        };\n',
+        ),
+      );
+    });
+
     test('2XX range mixed with explicit 2xx falls back to legacy oneOf', () {
       // Status-code dispatch only kicks in when every successful
       // response has an explicit code — `2XX` ranges can't be

--- a/test/render/render_operation_test.dart
+++ b/test/render/render_operation_test.dart
@@ -419,60 +419,100 @@ void main() {
       expect(result, isNot(contains('body:')));
     });
 
-    test('multiple successful responses with different content not supported', () {
-      final json = {
-        'responses': {
-          '200': {
-            'description': 'OK',
-            'content': {
-              'application/json': {
-                'schema': {'type': 'boolean'},
+    test(
+      'multiple successful responses with different content emit '
+      'status-code dispatch',
+      () {
+        final json = {
+          'responses': {
+            '200': {
+              'description': 'OK',
+              'content': {
+                'application/json': {
+                  'schema': {'type': 'boolean'},
+                },
+              },
+            },
+            '201': {
+              'description': 'Created',
+              'content': {
+                'application/json': {
+                  'schema': {'type': 'string'},
+                },
               },
             },
           },
-          '201': {
-            'description': 'Created',
-            'content': {
-              'application/json': {
-                'schema': {'type': 'string'},
-              },
-            },
-          },
-        },
-      };
-      final result = renderTestOperation(
-        path: '/users',
-        operationJson: json,
-        serverUrl: Uri.parse('https://api.spacetraders.io/v2'),
-      );
-      expect(
-        result,
-        '/// Test API\n'
-        'class DefaultApi {\n'
-        '    DefaultApi(ApiClient? client) : client = client ?? ApiClient();\n'
-        '\n'
-        '    final ApiClient client;\n'
-        '\n'
-        '    Future<UsersResponse> users(\n'
-        '    ) async {\n'
-        '        final response = await client.invokeApi(\n'
-        '            method: Method.post,\n'
-        "            path: '/users',\n"
-        '        );\n'
-        '\n'
-        '        if (response.statusCode >= HttpStatus.badRequest) {\n'
-        '            throw ApiException<Object?>(response.statusCode, response.body.toString());\n'
-        '        }\n'
-        '\n'
-        '        if (response.body.isNotEmpty) {\n'
-        '            return UsersResponse.fromJson(jsonDecode(response.body) as dynamic);\n'
-        '        }\n'
-        '\n'
-        '        throw ApiException<Object?>.unhandled(response.statusCode);\n'
-        '    }\n'
-        '}\n',
-      );
-    });
+        };
+        final result = renderTestOperation(
+          path: '/users',
+          operationJson: json,
+          serverUrl: Uri.parse('https://api.spacetraders.io/v2'),
+        );
+        expect(
+          result,
+          'sealed class UsersResponse {\n'
+          '    const UsersResponse();\n'
+          '}\n'
+          '\n'
+          '@immutable\n'
+          'final class UsersResponse200 extends UsersResponse {\n'
+          '    const UsersResponse200(this.value);\n'
+          '\n'
+          '    final bool value;\n'
+          '\n'
+          '    @override\n'
+          '    int get hashCode => value.hashCode;\n'
+          '\n'
+          '    @override\n'
+          '    bool operator ==(Object other) {\n'
+          '        if (identical(this, other)) return true;\n'
+          '        return other is UsersResponse200 && value == other.value;\n'
+          '    }\n'
+          '}\n'
+          '\n'
+          '@immutable\n'
+          'final class UsersResponse201 extends UsersResponse {\n'
+          '    const UsersResponse201(this.value);\n'
+          '\n'
+          '    final String value;\n'
+          '\n'
+          '    @override\n'
+          '    int get hashCode => value.hashCode;\n'
+          '\n'
+          '    @override\n'
+          '    bool operator ==(Object other) {\n'
+          '        if (identical(this, other)) return true;\n'
+          '        return other is UsersResponse201 && value == other.value;\n'
+          '    }\n'
+          '}\n'
+          '\n'
+          '/// Test API\n'
+          'class DefaultApi {\n'
+          '    DefaultApi(ApiClient? client) : client = client ?? ApiClient();\n'
+          '\n'
+          '    final ApiClient client;\n'
+          '\n'
+          '    Future<UsersResponse> users(\n'
+          '    ) async {\n'
+          '        final response = await client.invokeApi(\n'
+          '            method: Method.post,\n'
+          "            path: '/users',\n"
+          '        );\n'
+          '\n'
+          '        if (response.statusCode >= HttpStatus.badRequest) {\n'
+          '            throw ApiException<Object?>(response.statusCode, response.body.toString());\n'
+          '        }\n'
+          '\n'
+          '        return switch (response.statusCode) {\n'
+          '            200 => UsersResponse200(jsonDecode(response.body) as bool),\n'
+          '            201 => UsersResponse201(jsonDecode(response.body) as String),\n'
+          '            _ => throw ApiException<Object?>.unhandled(response.statusCode),\n'
+          '        };\n'
+          '    }\n'
+          '}\n',
+        );
+      },
+    );
 
     test('multiple successful responses with same content is supported', () {
       final json = {
@@ -529,7 +569,68 @@ void main() {
       );
     });
 
-    test('multiple successful responses with content ignores empty responses', () {
+    test(
+      'response with empty schema dispatches as a dynamic-valued arm',
+      () {
+        // The Space Traders `get-cooldown` 204 declares
+        // `content: application/json` with an empty (description-only)
+        // schema as a workaround for tooling that requires content. The
+        // schema parses as RenderUnknown, so the wrapper holds a
+        // `dynamic` value rather than collapsing to no-body. Specs that
+        // really mean "no body" should omit `content:` entirely (which
+        // resolves to RenderVoid → null arm — see the next test).
+        final json = {
+          'responses': {
+            '200': {
+              'description': 'OK',
+              'content': {
+                'application/json': {
+                  'schema': {'type': 'boolean'},
+                },
+              },
+            },
+            '204': {
+              'description': 'No content',
+              'content': {
+                'application/json': {
+                  'schema': {'description': 'No content'},
+                },
+              },
+            },
+          },
+        };
+        final result = renderTestOperation(
+          path: '/users',
+          operationJson: json,
+          serverUrl: Uri.parse('https://api.spacetraders.io/v2'),
+        );
+        expect(
+          result,
+          contains(
+            '        return switch (response.statusCode) {\n'
+            '            200 => UsersResponse200(jsonDecode(response.body) as bool),\n'
+            '            204 => UsersResponse204(jsonDecode(response.body)),\n'
+            '            _ => throw ApiException<Object?>.unhandled(response.statusCode),\n'
+            '        };\n',
+          ),
+        );
+        expect(
+          result,
+          contains(
+            '@immutable\n'
+            'final class UsersResponse204 extends UsersResponse {\n'
+            '    const UsersResponse204(this.value);\n'
+            '\n'
+            '    final dynamic value;\n',
+          ),
+        );
+      },
+    );
+
+    test('204 without content emits a no-value wrapper arm', () {
+      // The well-formed way to declare "no body": 204 carries only a
+      // description, no `content:`. Resolves to RenderVoid → null in
+      // bodyByStatus → empty wrapper subclass with no `value` field.
       final json = {
         'responses': {
           '200': {
@@ -540,13 +641,58 @@ void main() {
               },
             },
           },
-          '204': {
-            'description': 'No content',
+          '204': {'description': 'No content'},
+        },
+      };
+      final result = renderTestOperation(
+        path: '/users',
+        operationJson: json,
+        serverUrl: Uri.parse('https://api.spacetraders.io/v2'),
+      );
+      expect(
+        result,
+        contains(
+          '        return switch (response.statusCode) {\n'
+          '            200 => UsersResponse200(jsonDecode(response.body) as bool),\n'
+          '            204 => const UsersResponse204(),\n'
+          '            _ => throw ApiException<Object?>.unhandled(response.statusCode),\n'
+          '        };\n',
+        ),
+      );
+      expect(
+        result,
+        contains(
+          '@immutable\n'
+          'final class UsersResponse204 extends UsersResponse {\n'
+          '    const UsersResponse204();\n'
+          '\n'
+          '    @override\n'
+          '    int get hashCode => 204;\n',
+        ),
+      );
+    });
+
+    test('2XX range mixed with explicit 2xx falls back to legacy oneOf', () {
+      // Status-code dispatch only kicks in when every successful
+      // response has an explicit code — `2XX` ranges can't be
+      // enumerated, and the wrapper subclasses are named per code. This
+      // case keeps the legacy stub until either #144 covers ranges or
+      // the spec is rewritten to enumerate codes.
+      final json = {
+        'responses': {
+          '200': {
+            'description': 'OK',
             'content': {
               'application/json': {
-                // This doesn't error because schema is empty.
-                // This is a hack for Space Traders get-cooldown.
-                'schema': {'description': 'No content'},
+                'schema': {'type': 'boolean'},
+              },
+            },
+          },
+          '2XX': {
+            'description': 'Other success',
+            'content': {
+              'application/json': {
+                'schema': {'type': 'string'},
               },
             },
           },
@@ -557,33 +703,9 @@ void main() {
         operationJson: json,
         serverUrl: Uri.parse('https://api.spacetraders.io/v2'),
       );
-      expect(
-        result,
-        '/// Test API\n'
-        'class DefaultApi {\n'
-        '    DefaultApi(ApiClient? client) : client = client ?? ApiClient();\n'
-        '\n'
-        '    final ApiClient client;\n'
-        '\n'
-        '    Future<UsersResponse> users(\n'
-        '    ) async {\n'
-        '        final response = await client.invokeApi(\n'
-        '            method: Method.post,\n'
-        "            path: '/users',\n"
-        '        );\n'
-        '\n'
-        '        if (response.statusCode >= HttpStatus.badRequest) {\n'
-        '            throw ApiException<Object?>(response.statusCode, response.body.toString());\n'
-        '        }\n'
-        '\n'
-        '        if (response.body.isNotEmpty) {\n'
-        '            return UsersResponse.fromJson(jsonDecode(response.body) as dynamic);\n'
-        '        }\n'
-        '\n'
-        '        throw ApiException<Object?>.unhandled(response.statusCode);\n'
-        '    }\n'
-        '}\n',
-      );
+      expect(result, isNot(contains('switch (response.statusCode)')));
+      expect(result, isNot(contains('sealed class UsersResponse {')));
+      expect(result, contains('UsersResponse.fromJson'));
     });
 
     test('multiple responses with content ignores non-successful responses', () {


### PR DESCRIPTION
## Summary

Closes the gap on github's ~27 operations that declare multiple successful response codes with structurally-different bodies (e.g. `200: User, 202: AcceptedJob`; `201: Empty, 204: ø`). These previously coalesced into a discriminator-less `RenderOneOf` and emitted `UnimplementedError` — the body alone can't tell 200-with-Foo from 201-with-Bar.

The dispatch key here is **HTTP status, not body shape**. So this PR introduces an operation-level `MultiStatusReturn` (just `Map<int, RenderSchema?> bodyByStatus`) on `RenderOperation`. When set, the api template emits a sealed parent named after the operation plus one `final` wrapper subclass per status code, and the api method body switches on `response.statusCode`:

```dart
sealed class FooBarResponse {
  const FooBarResponse();
}

@immutable
final class FooBarResponse200 extends FooBarResponse {
  const FooBarResponse200(this.value);
  final Foo value;
}

@immutable
final class FooBarResponse204 extends FooBarResponse {
  const FooBarResponse204();
  // identity-only equality
}

Future<FooBarResponse> fooBar(...) async {
  ...
  return switch (response.statusCode) {
    200 => FooBarResponse200(Foo.fromJson(...)),
    204 => const FooBarResponse204(),
    _ => throw ApiException<Object?>.unhandled(response.statusCode),
  };
}
```

### Design notes

- **Lives on the operation, not in the schema graph.** Status-code multiplexing is an operation-level construct; conflating it with `RenderOneOf` (a schema-level keyword that dispatches on body shape) is what produced the broken stub. The synthesized sealed class is emitted inline at the top of the api file.
- **Empty-body 204s** (`204` with no `content:`) → value-less wrapper subclass (`const FooBarResponse204()`).
- **Empty-schema 204s** (`{description: 'No content'}`, the Space Traders workaround) → `dynamic`-valued wrapper. The spec author's intent isn't recoverable, so the wrapper is honest about what's on the wire.
- **`2XX` range mixed with explicit codes** falls back to the legacy oneOf path. Ranges can't be enumerated, and wrapper subclasses are named per code.

### Validation

- `dart analyze` clean on the github regen.
- 27 operations newly dispatch on status code (no UnimplementedError, no fake oneOf).
- Examples: `activity/mark-notifications-as-read` (202 + 205 empty), `actions/create-or-update-org-secret` (201 empty + 204 empty), `code-security/update-configuration` (200 + 204).

## Test plan
- [x] Existing render_operation tests updated for new dispatch shape (the two that asserted the broken stub).
- [x] New unit tests cover: explicit-codes status dispatch, empty-schema 204 wrapper, no-content 204 wrapper, range-mixed fallback.
- [x] file_renderer integration test updated: sealed class is now inline in api file, not a separate model file.
- [x] github regen analyzes clean.