### PR TITLE
feat: implicit-discriminator dispatch on single-value enum tag properties

### DIFF
--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -3753,10 +3753,83 @@ class RenderOneOf extends RenderNewType {
     );
   }
 
+  /// The discriminator we'll dispatch on: the spec's explicit one when
+  /// present, otherwise an implicit one synthesized from variants that
+  /// each tag themselves with a single-value enum property (see
+  /// [_implicitDiscriminator]). Explicit always wins.
+  RenderDiscriminator? get _effectiveDiscriminator =>
+      discriminator ?? _implicitDiscriminator;
+
   /// Discriminator-driven dispatch: every variant must be an object-
   /// shaped newtype with a `fromJson` factory.
   bool get _hasDiscriminatorDispatch =>
-      discriminator != null && schemas.every((s) => s is RenderObject);
+      _effectiveDiscriminator != null &&
+      schemas.every((s) => s is RenderObject);
+
+  /// Synthesized discriminator for object-only oneOfs whose variants
+  /// each tag themselves with a single-value enum property — github's
+  /// `repository-rule` shape. The spec doesn't declare a
+  /// `discriminator`, but every variant has, e.g.,
+  /// `type: { enum: ['creation'] }` with that property required. The
+  /// values are pairwise distinct, so the parent's `fromJson` can
+  /// switch on `json[<that property>]` and pick a variant.
+  ///
+  /// Conservative on purpose: requires the tag property to be in
+  /// every variant's `requiredProperties` (an absent field would
+  /// crash dispatch) and that the single-enum values be unique
+  /// across variants (otherwise dispatch is ambiguous). Returns null
+  /// if no property qualifies; the caller falls through to shape /
+  /// required-field dispatch as usual.
+  RenderDiscriminator? get _implicitDiscriminator {
+    if (schemas.isEmpty) return null;
+    if (!schemas.every((s) => s is RenderObject)) return null;
+    final objects = schemas.cast<RenderObject>();
+    // A property qualifies as an implicit discriminator iff every
+    // variant has it as a required, single-value enum. Walk the first
+    // variant's properties to seed candidates; for each, gather the
+    // per-variant tag value while validating the others. Recording
+    // values here avoids a second lookup later.
+    final candidates = <(String, List<String>)>[];
+    for (final entry in objects.first.properties.entries) {
+      final propName = entry.key;
+      if (!objects.first.requiredProperties.contains(propName)) continue;
+      final firstType = entry.value;
+      if (firstType is! RenderEnum || firstType.values.length != 1) {
+        continue;
+      }
+      final values = [firstType.values.first];
+      var allMatch = true;
+      for (var i = 1; i < objects.length; i++) {
+        final other = objects[i];
+        if (!other.requiredProperties.contains(propName)) {
+          allMatch = false;
+          break;
+        }
+        final otherType = other.properties[propName];
+        if (otherType is! RenderEnum || otherType.values.length != 1) {
+          allMatch = false;
+          break;
+        }
+        values.add(otherType.values.first);
+      }
+      if (allMatch) candidates.add((propName, values));
+    }
+    if (candidates.isEmpty) return null;
+    // Stable pick: lexicographically-first candidate property whose
+    // values are unique. Sorting first means small spec edits don't
+    // shuffle the chosen discriminator.
+    candidates.sort((a, b) => a.$1.compareTo(b.$1));
+    for (final (propName, values) in candidates) {
+      if (values.toSet().length != values.length) continue;
+      return RenderDiscriminator(
+        propertyName: propName,
+        mapping: {
+          for (var i = 0; i < objects.length; i++) values[i]: objects[i],
+        },
+      );
+    }
+    return null;
+  }
 
   /// True iff every variant has a known shape key AND all keys are
   /// pairwise distinct. Context-free so [additionalImports] and
@@ -3864,7 +3937,7 @@ class RenderOneOf extends RenderNewType {
       'positionalBoolIgnore': false,
     };
 
-    final disc = discriminator;
+    final disc = _effectiveDiscriminator;
     if (disc != null && _hasDiscriminatorDispatch) {
       final variants = schemas.map(objectWrapperContext).toList();
       final dispatch = <Map<String, dynamic>>[];

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -1130,6 +1130,146 @@ void main() {
       expect(pet, isNot(contains('UnimplementedError')));
     });
 
+    test('non-discriminator oneOf whose object variants each tag '
+        'themselves with a single-value enum property uses '
+        'implicit-discriminator dispatch', () {
+      // github's `repository-rule` shape: no explicit discriminator,
+      // but every variant has a required `type` property whose enum
+      // has a single, variant-unique value. Treat that as an implicit
+      // discriminator so we generate real dispatch instead of a stub.
+      final results = renderTestSchemas(
+        {
+          'Rule': {
+            'oneOf': [
+              {r'$ref': '#/components/schemas/Creation'},
+              {r'$ref': '#/components/schemas/Deletion'},
+            ],
+          },
+          'Creation': {
+            'type': 'object',
+            'properties': {
+              'type': {
+                'type': 'string',
+                'enum': ['creation'],
+              },
+            },
+            'required': ['type'],
+          },
+          'Deletion': {
+            'type': 'object',
+            'properties': {
+              'type': {
+                'type': 'string',
+                'enum': ['deletion'],
+              },
+            },
+            'required': ['type'],
+          },
+        },
+        specUrl: Uri.parse('file:///spec.yaml'),
+      );
+      final rule = results['Rule'];
+      expect(rule, isNotNull);
+      expect(rule, contains('sealed class Rule'));
+      expect(
+        rule,
+        contains('factory Rule.fromJson(Map<String, dynamic> json)'),
+      );
+      expect(rule, contains("final discriminator = json['type']"));
+      expect(
+        rule,
+        contains("'creation' => RuleCreation(Creation.fromJson(json))"),
+      );
+      expect(
+        rule,
+        contains("'deletion' => RuleDeletion(Deletion.fromJson(json))"),
+      );
+      expect(rule, contains('final class RuleCreation extends Rule'));
+      expect(rule, contains('final class RuleDeletion extends Rule'));
+      expect(rule, isNot(contains('UnimplementedError')));
+    });
+
+    test('implicit-discriminator dispatch falls back when the single-enum '
+        'values collide across variants', () {
+      // Both variants tag themselves `type: 'creation'` — no unique
+      // dispatch value, so we can't pick a variant from the JSON.
+      final results = renderTestSchemas(
+        {
+          'Rule': {
+            'oneOf': [
+              {r'$ref': '#/components/schemas/A'},
+              {r'$ref': '#/components/schemas/B'},
+            ],
+          },
+          'A': {
+            'type': 'object',
+            'properties': {
+              'type': {
+                'type': 'string',
+                'enum': ['creation'],
+              },
+            },
+            'required': ['type'],
+          },
+          'B': {
+            'type': 'object',
+            'properties': {
+              'type': {
+                'type': 'string',
+                'enum': ['creation'],
+              },
+            },
+            'required': ['type'],
+          },
+        },
+        specUrl: Uri.parse('file:///spec.yaml'),
+      );
+      expect(
+        results['Rule'],
+        contains("throw UnimplementedError('Rule.fromJson')"),
+      );
+    });
+
+    test('implicit-discriminator dispatch ignores a tag property that is '
+        'not required by every variant', () {
+      // `type` is single-enum on both, but optional on B. An absent
+      // discriminator field would crash dispatch, so don't bite.
+      final results = renderTestSchemas(
+        {
+          'Rule': {
+            'oneOf': [
+              {r'$ref': '#/components/schemas/A'},
+              {r'$ref': '#/components/schemas/B'},
+            ],
+          },
+          'A': {
+            'type': 'object',
+            'properties': {
+              'type': {
+                'type': 'string',
+                'enum': ['a'],
+              },
+            },
+            'required': ['type'],
+          },
+          'B': {
+            'type': 'object',
+            'properties': {
+              'type': {
+                'type': 'string',
+                'enum': ['b'],
+              },
+            },
+          },
+        },
+        specUrl: Uri.parse('file:///spec.yaml'),
+      );
+      expect(
+        results['Rule'],
+        contains("throw UnimplementedError('Rule.fromJson')"),
+      );
+    });
+
     group('anyOf', () {
       test('two pod types', () {
         final schema = {


### PR DESCRIPTION
## Summary

Detect oneOfs whose object variants each tag themselves with a required
single-value enum property and dispatch on it as if the spec had
declared an explicit `discriminator`.

github's `repository-rule` is the canonical case — 21 variants, no
declared discriminator, but each has a required `type` like
`enum: ['creation']` / `['update']` / `['deletion']`. The values are
unique across variants, so the parent's `fromJson` can switch on
`json['type']` and pick a variant. Today that schema emits
`throw UnimplementedError`; after this PR it emits real sealed
dispatch.

The detection is conservative: every variant must be a `RenderObject`,
the tag property must be in every variant's `requiredProperties`
(an absent field would crash dispatch), and the per-variant tag values
must be pairwise distinct (otherwise dispatch is ambiguous). Falls
through to shape / required-field / no-dispatch otherwise — explicit
discriminators still take precedence.

On the github regen, `repository_rule.dart` flips from a stub to typed
sealed dispatch with 21 wrapper subclasses; `dart analyze` stays clean.
The matching `repository-rule-detailed` shape doesn't yet flip — its
variants are `allOf`-merged synthetic objects and the render-tree's
`ResolvedAllOf` → `RenderObject` lowering drops `requiredProperties`,
so the dispatch detection rejects them. Separate fix.

## Test plan
- [x] `dart test test/render/render_schema_test.dart -N implicit-discriminator` covers the positive case plus two fall-back guards (colliding tag values; tag property not required by every variant).
- [x] Full `dart test` suite passes.
- [x] `dart analyze` clean.
- [x] github regen: `dart analyze` reports `No issues found!`; `UnimplementedError` stub count 31 → 30 (the one drop is `repository_rule.dart` flipping to dispatch).