### PR TITLE
fix: merge required properties when synthesizing allOf RenderObject

### DIFF
--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -451,15 +451,27 @@ class SpecResolver {
           discriminator: renderDiscriminator,
         );
       case ResolvedAllOf():
-        // Generate a synthetic object type for allOf.
+        // Generate a synthetic object type for allOf. A property is
+        // required iff any member requires it (allOf semantics: all
+        // members must validate, so a member's required field is
+        // required overall). Dropping the union here would silently
+        // make required fields nullable in the generated constructor
+        // and also hide a required single-value-enum tag from oneOf
+        // dispatch detection (allOf-shaped variants).
         final properties = <String, RenderSchema>{};
+        final requiredProperties = <String>{};
         for (final schema in schema.schemas) {
           final renderSchema = toRenderSchema(schema);
           if (renderSchema is RenderObject) {
             properties.addAll(renderSchema.properties);
+            requiredProperties.addAll(renderSchema.requiredProperties);
           }
         }
-        return RenderObject(common: schema.common, properties: properties);
+        return RenderObject(
+          common: schema.common,
+          properties: properties,
+          requiredProperties: requiredProperties.toList(),
+        );
       case ResolvedAnyOf():
         // Resolver already makes anyOf with 1 schema to just be that schema.
         // For multiple schemas, we just generate a oneOf, which is wrong.

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -685,6 +685,94 @@ void main() {
       );
     });
 
+    test('allOf merges required across members', () {
+      // Both members require their own property; the synthesized
+      // RenderObject must mark both required, otherwise downstream
+      // generation drops the `required` modifier and silently makes
+      // them nullable.
+      final schema = {
+        'allOf': [
+          {
+            'type': 'object',
+            'required': ['foo'],
+            'properties': {
+              'foo': {'type': 'string'},
+            },
+          },
+          {
+            'type': 'object',
+            'required': ['bar'],
+            'properties': {
+              'bar': {'type': 'integer'},
+            },
+          },
+        ],
+      };
+      final result = renderTestSchema(schema);
+      expect(result, contains('required this.foo'));
+      expect(result, contains('required this.bar'));
+      expect(result, contains('final String foo;'));
+      expect(result, contains('final int bar;'));
+    });
+
+    test('oneOf of allOf variants tagged by single-value enum', () {
+      // Each variant is `allOf: [<rule>, <info>]` where the first
+      // member tags itself with a single-value enum on `type`. After
+      // the allOf merge propagates `requiredProperties`, the implicit
+      // discriminator detection should engage and produce a switch
+      // on `json['type']` instead of the legacy stub.
+      final schema = {
+        'oneOf': [
+          {
+            'allOf': [
+              {
+                'type': 'object',
+                'required': ['type'],
+                'properties': {
+                  'type': {
+                    'type': 'string',
+                    'enum': ['creation'],
+                  },
+                },
+              },
+              {
+                'type': 'object',
+                'properties': {
+                  'extra': {'type': 'string'},
+                },
+              },
+            ],
+          },
+          {
+            'allOf': [
+              {
+                'type': 'object',
+                'required': ['type'],
+                'properties': {
+                  'type': {
+                    'type': 'string',
+                    'enum': ['deletion'],
+                  },
+                },
+              },
+              {
+                'type': 'object',
+                'properties': {
+                  'extra': {'type': 'string'},
+                },
+              },
+            ],
+          },
+        ],
+      };
+      final result = renderTestSchema(schema);
+      expect(result, contains("final discriminator = json['type']"));
+      expect(result, contains('switch (discriminator)'));
+      expect(result, contains("'creation' =>"));
+      expect(result, contains("'deletion' =>"));
+      expect(result, isNot(contains('throw UnimplementedError')));
+    });
+
     test('oneOf with pods', () {
       final schema = {
         'oneOf': [


### PR DESCRIPTION
## Summary

The `ResolvedAllOf → RenderObject` synthesis at
`lib/src/render/render_tree.dart:453` merged each member's `properties` map
but dropped their `requiredProperties` lists. allOf semantics is "validates
against every member," so a property is required iff any member requires it
— but the union was being computed as the empty set.

This silently made required fields nullable in the generated constructor,
and (more visibly) hid required-property tags from the oneOf dispatch
detection — so allOf-shaped variants couldn't engage implicit-discriminator
dispatch (#149) or required-field dispatch (#146) even when the spec made
the dispatch obvious.

## Impact on the github regen

- **2 stub files eliminated** (30 → 28 `UnimplementedError`):
  - `RepositoryRuleDetailed`: 21 variants of
    `allOf: [<rule>, <ruleset-info>]` where each `<rule>` self-tags via
    a single-value `type` enum. Now dispatches via implicit-discriminator
    on `json['type']`.
  - `OrgRulesetConditions`: 3 variants of `allOf: [<base>, <target>]`
    with disjoint required-field sets. Now dispatches via required-field
    on `repository_name` / `repository_id` / `repository_property`.
- **25+ allOf-derived model files** now correctly mark required fields
  `required` (non-nullable). Examples: every
  `repository_rule_detailed_one_of_*.dart` (21 files) has
  `required this.type`; `apps_create_from_manifest201_response.dart`
  flips 15 properties from optional to required to match
  `integration` + the inline schema's required sets.

`dart analyze` clean on the regen.

## Test plan

- [x] `dart test` — 366 tests pass, including two new cases:
  - `allOf merges required across members` — verifies the union is
    propagated into the synthesized RenderObject.
  - `oneOf of allOf variants tagged by single-value enum` — verifies
    that the implicit-discriminator dispatch now fires through the
    allOf composition.
- [x] github regen: `dart analyze` reports `No issues found!`,
  `UnimplementedError` count drops 30 → 28.
- [x] Spot-checked the diff vs baseline: only the expected files
  change (the 2 dispatched parents, 24 allOf-derived variants gain
  `required` modifiers, and 1 long-line marker delta from the
  shorter local package name).