### PR TITLE
feat: shape dispatch on RenderNumber (oneOf with `number` variant)

### DIFF
--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -2715,6 +2715,19 @@ class RenderNumber extends RenderNumeric<double> {
   String get typeName => createsNewType ? camelFromSnake(snakeName) : 'double';
 
   @override
+  String? get wrapperTag => createsNewType ? null : 'Num';
+
+  // Use `num` (matching jsonStorageType) rather than `double` so the
+  // shape test `case num v` accepts both JSON ints and doubles without
+  // a coercion step. A oneOf that mixes `integer` and `number` would
+  // be ambiguous (every int satisfies num too) — github has no such
+  // site, and `_canShapeDispatch` would still pass on key uniqueness;
+  // if one ever shows up, ordering int-before-num in the switch keeps
+  // the dispatch correct, but the spec is the real bug.
+  @override
+  String? get jsonShapeKey => createsNewType ? null : 'num';
+
+  @override
   String jsonStorageType({required bool isNullable}) =>
       isNullable ? 'num?' : 'num';
 
@@ -3750,6 +3763,7 @@ class RenderOneOf extends RenderNewType {
     // an inline pod.
     final podType = switch (variant) {
       RenderInteger() => 'int',
+      RenderNumber() => 'num',
       RenderString() => 'String',
       RenderPod(type: PodType.boolean) => 'bool',
       _ => null,

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -773,7 +773,10 @@ void main() {
       expect(result, isNot(contains('throw UnimplementedError')));
     });
 
-    test('oneOf with pods', () {
+    test('oneOf with [string, number] uses shape dispatch', () {
+      // RenderNumber's shape key is `num` (matching jsonStorageType),
+      // distinct from RenderString's `String`. Github's
+      // webhook-config-insecure-ssl is the canonical real-spec site.
       final schema = {
         'oneOf': [
           {'type': 'string'},
@@ -781,28 +784,12 @@ void main() {
         ],
       };
       final result = renderTestSchema(schema);
-      expect(
-        result,
-        'sealed class Test {\n'
-        '    static Test fromJson(dynamic jsonArg) {\n'
-        '        // Determine which schema to use based on the json.\n'
-        '        // TODO(eseidel): Implement this.\n'
-        "        throw UnimplementedError('Test.fromJson');\n"
-        '    }\n'
-        '\n'
-        '    /// Convenience to create a nullable type from a nullable json object.\n'
-        '    /// Useful when parsing optional fields.\n'
-        '    static Test? maybeFromJson(dynamic json) {\n'
-        '        if (json == null) {\n'
-        '            return null;\n'
-        '        }\n'
-        '        return Test.fromJson(json);\n'
-        '    }\n'
-        '\n'
-        '    /// Require all subclasses to implement toJson.\n'
-        '    dynamic toJson();\n'
-        '}\n',
-      );
+      expect(result, contains('String v => TestString(v)'));
+      expect(result, contains('num v => TestNum(v)'));
+      expect(result, contains('final class TestString extends Test'));
+      expect(result, contains('final class TestNum extends Test'));
+      expect(result, contains('final num value;'));
+      expect(result, isNot(contains('throw UnimplementedError')));
     });
 
     test('oneOf with objects', () {
@@ -1367,29 +1354,12 @@ void main() {
           ],
         };
         final result = renderTestSchema(schema);
-        // anyOf currently renders as a oneOf, which is wrong.
-        expect(
-          result,
-          'sealed class Test {\n'
-          '    static Test fromJson(dynamic jsonArg) {\n'
-          '        // Determine which schema to use based on the json.\n'
-          '        // TODO(eseidel): Implement this.\n'
-          "        throw UnimplementedError('Test.fromJson');\n"
-          '    }\n'
-          '\n'
-          '    /// Convenience to create a nullable type from a nullable json object.\n'
-          '    /// Useful when parsing optional fields.\n'
-          '    static Test? maybeFromJson(dynamic json) {\n'
-          '        if (json == null) {\n'
-          '            return null;\n'
-          '        }\n'
-          '        return Test.fromJson(json);\n'
-          '    }\n'
-          '\n'
-          '    /// Require all subclasses to implement toJson.\n'
-          '    dynamic toJson();\n'
-          '}\n',
-        );
+        // anyOf currently renders as a oneOf, which is wrong — but it
+        // is at least dispatched on shape now that RenderNumber has a
+        // shape key. The legacy stub here is gone.
+        expect(result, contains('String v => TestString(v)'));
+        expect(result, contains('num v => TestNum(v)'));
+        expect(result, isNot(contains('throw UnimplementedError')));
       });
 
       test('two object types', () {
@@ -2776,28 +2746,12 @@ void main() {
         final json = {
           'type': ['string', 'number'],
         };
-        expect(
-          renderTestSchema(json, asComponent: true),
-          'sealed class Test {\n'
-          '    static Test fromJson(dynamic jsonArg) {\n'
-          '        // Determine which schema to use based on the json.\n'
-          '        // TODO(eseidel): Implement this.\n'
-          "        throw UnimplementedError('Test.fromJson');\n"
-          '    }\n'
-          '\n'
-          '    /// Convenience to create a nullable type from a nullable json object.\n'
-          '    /// Useful when parsing optional fields.\n'
-          '    static Test? maybeFromJson(dynamic json) {\n'
-          '        if (json == null) {\n'
-          '            return null;\n'
-          '        }\n'
-          '        return Test.fromJson(json);\n'
-          '    }\n'
-          '\n'
-          '    /// Require all subclasses to implement toJson.\n'
-          '    dynamic toJson();\n'
-          '}\n',
-        );
+        // `type: [string, number]` resolves into a oneOf, which now
+        // shape-dispatches now that RenderNumber has a shape key.
+        final result = renderTestSchema(json, asComponent: true);
+        expect(result, contains('String v => TestString(v)'));
+        expect(result, contains('num v => TestNum(v)'));
+        expect(result, isNot(contains('throw UnimplementedError')));
       });
       test('string or number as property', () {
         final json = {

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -837,8 +837,8 @@ void main() {
     test('oneOf with [string, boolean] uses shape dispatch', () {
       // Pins the `RenderPod(type: PodType.boolean) => 'bool'` arm of
       // `_planVariant` — the only path that exercises it from a unit
-      // test. (Github's Metadata1 anyOf hits it end-to-end, but that
-      // is regen coverage, not test coverage.)
+      // test. (Github's Metadata1 anyOf hits it end-to-end via a full
+      // generator run, but that is not unit-test coverage.)
       final schema = {
         'oneOf': [
           {'type': 'string'},

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -834,6 +834,25 @@ void main() {
       expect(result, isNot(contains('throw UnimplementedError')));
     });
 
+    test('oneOf with [string, boolean] uses shape dispatch', () {
+      // Pins the `RenderPod(type: PodType.boolean) => 'bool'` arm of
+      // `_planVariant` — the only path that exercises it from a unit
+      // test. (Github's Metadata1 anyOf hits it end-to-end, but that
+      // is regen coverage, not test coverage.)
+      final schema = {
+        'oneOf': [
+          {'type': 'string'},
+          {'type': 'boolean'},
+        ],
+      };
+      final result = renderTestSchema(schema);
+      expect(result, contains('String v => TestString(v)'));
+      expect(result, contains('bool v => TestBool(v)'));
+      expect(result, contains('final bool value;'));
+      expect(result, contains('final class TestBool extends Test'));
+      expect(result, isNot(contains('throw UnimplementedError')));
+    });
+
     test('number newtype does not participate in shape dispatch', () {
       // A `number` schema with validations becomes a newtype (its own
       // class), and `wrapperTag` / `jsonShapeKey` deliberately gate on

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -784,12 +784,89 @@ void main() {
         ],
       };
       final result = renderTestSchema(schema);
+      expect(result, contains('factory Test.fromJson(dynamic json)'));
       expect(result, contains('String v => TestString(v)'));
       expect(result, contains('num v => TestNum(v)'));
       expect(result, contains('final class TestString extends Test'));
       expect(result, contains('final class TestNum extends Test'));
       expect(result, contains('final num value;'));
+      // Wrapper toJson returns the raw num — no `.toJson()` call,
+      // since num is already JSON-native.
+      expect(result, contains('dynamic toJson() => value;'));
+      expect(result, contains('@immutable'));
       expect(result, isNot(contains('throw UnimplementedError')));
+    });
+
+    test('oneOf with [number, object] uses shape dispatch (num vs Map)', () {
+      // Verifies RenderNumber's shape key composes with RenderObject's
+      // `Map<String, dynamic>` — distinct shapes, so dispatch works.
+      final schema = {
+        'oneOf': [
+          {'type': 'number'},
+          {
+            'type': 'object',
+            'properties': {
+              'foo': {'type': 'string'},
+            },
+          },
+        ],
+      };
+      final result = renderTestSchema(schema);
+      expect(result, contains('num v => TestNum(v)'));
+      expect(result, contains('Map<String, dynamic> v => TestTestOneOf1'));
+      expect(result, isNot(contains('throw UnimplementedError')));
+    });
+
+    test('oneOf with [number, array] uses shape dispatch (num vs List)', () {
+      // num and List<dynamic> are distinct runtime shapes.
+      final schema = {
+        'oneOf': [
+          {'type': 'number'},
+          {
+            'type': 'array',
+            'items': {'type': 'string'},
+          },
+        ],
+      };
+      final result = renderTestSchema(schema);
+      expect(result, contains('num v => TestNum(v)'));
+      expect(result, contains('List<dynamic> v => TestList'));
+      expect(result, isNot(contains('throw UnimplementedError')));
+    });
+
+    test('number newtype does not participate in shape dispatch', () {
+      // A `number` schema with validations becomes a newtype (its own
+      // class), and `wrapperTag` / `jsonShapeKey` deliberately gate on
+      // `!createsNewType`. So a oneOf whose variant is a *named* number
+      // newtype can't shape-dispatch — the wrapper would shadow the
+      // newtype's own class. This test pins that gate; without it, the
+      // newtype case would silently hit the inline-pod arm of
+      // `_planVariant` and emit a wrong dispatch.
+      final results = renderTestSchemas(
+        {
+          'Wrapper': {
+            'oneOf': [
+              {'type': 'string'},
+              {r'$ref': '#/components/schemas/Score'},
+            ],
+          },
+          'Score': {
+            'type': 'number',
+            'minimum': 0,
+            'maximum': 1,
+          },
+        },
+        specUrl: Uri.parse('file:///spec.yaml'),
+      );
+      final wrapper = results['Wrapper'];
+      expect(wrapper, isNotNull);
+      // Newtype-Number is not shape-dispatchable today (and the inline
+      // String variant alone isn't enough to dispatch a 2-variant
+      // oneOf), so this falls through to the legacy stub. The contract
+      // here is: whatever fallback fires, it must NOT emit a `num v =>`
+      // arm pointing at the newtype, since that would conflict with
+      // Score's own factory.
+      expect(wrapper, isNot(contains('num v => WrapperScore')));
     });
 
     test('oneOf with objects', () {

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -860,12 +860,12 @@ void main() {
       );
       final wrapper = results['Wrapper'];
       expect(wrapper, isNotNull);
-      // Newtype-Number is not shape-dispatchable today (and the inline
-      // String variant alone isn't enough to dispatch a 2-variant
-      // oneOf), so this falls through to the legacy stub. The contract
-      // here is: whatever fallback fires, it must NOT emit a `num v =>`
-      // arm pointing at the newtype, since that would conflict with
-      // Score's own factory.
+      // Newtype-Number cannot drive shape dispatch today (and the
+      // inline String variant alone isn't enough to dispatch a
+      // 2-variant oneOf), so this falls through to the legacy stub.
+      // The contract here is: whatever fallback fires, it must NOT
+      // emit a `num v =>` arm pointing at the newtype, since that
+      // would conflict with Score's own factory.
       expect(wrapper, isNot(contains('num v => WrapperScore')));
     });
 


### PR DESCRIPTION
## Summary

`RenderNumber` left `wrapperTag` and `jsonShapeKey` as null, so any
oneOf containing a `number` variant fell through to the legacy
`UnimplementedError` stub. Match `RenderInteger`'s pattern: emit
`Num` as the wrapper tag and `num` as the shape key (`case num v`
accepts both JSON ints and doubles without coercion).

Removes 2 stubs from the github regen:
- `webhook-config-insecure-ssl` (`oneOf: [string, number]`).
- `metadata` (renamed to `Metadata1` by the collision pass —
  `anyOf: [string, number, boolean]`, threaded through dependency
  manifests / snapshots).

## Test plan

- [x] `dart test` — 366 tests pass; existing `oneOf with pods`,
  `anyOf two pod types`, and `multiple types: string or number`
  cases (which previously asserted the stubbed-out behavior) updated
  to assert shape dispatch instead.
- [x] github regen: `dart analyze` clean (`No issues found!`),
  `UnimplementedError` count 28 → 26.

## Notes

Github has no oneOf that mixes `integer` and `number` variants; that
combination would be ambiguous (every JSON int satisfies both) and
the spec itself would be the bug. The existing `_canShapeDispatch`
distinct-key check still passes on `'int'` vs `'num'` as strings;
if such a oneOf ever shows up, dispatch order (int before num) keeps
it correct.