### PR TITLE
feat: required-field dispatch picks up an object-shaped fallback variant

### DIFF
--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -3950,22 +3950,35 @@ class RenderOneOf extends RenderNewType {
     return plans;
   }
 
-  /// Required-field dispatch: every variant is a [RenderObject] and
-  /// each has at least one required property that no other variant
-  /// requires. We dispatch by checking for that property's presence
-  /// in the JSON. Useful for (object, object) oneOfs without a
-  /// discriminator — github has ~9 such sites, e.g. `simple-user`
-  /// (requires `login`) vs `enterprise` (requires `slug`).
+  /// Required-field dispatch: every variant is a [RenderObject], and
+  /// every variant either (a) has at least one required property that
+  /// no other variant requires, or (b) has no required properties at
+  /// all and is the dispatch's fallback. At most one fallback is
+  /// allowed; with two the dispatch would be ambiguous.
+  ///
+  /// Useful for (object, object) oneOfs without a discriminator —
+  /// github has ~9 such sites with disjoint required-sets (e.g.
+  /// `simple-user` requires `login`, `enterprise` requires `slug`)
+  /// plus a handful where one variant is empty (`commit.author` is
+  /// `[simple-user, empty-object]`, the `interactions` 200 responses
+  /// are `[interaction-limit-response, <empty>]`).
   ///
   /// Returns one [_RequiredFieldArm] per variant in [schemas] order,
-  /// or null if any variant lacks a uniquely-required property.
+  /// or null if no fallback fits and any variant lacks a uniquely-
+  /// required property — in which case dispatch falls through to the
+  /// legacy stub.
   List<_RequiredFieldArm>? get _requiredFieldDispatchArms {
-    if (!schemas.every((s) => s is RenderObject)) return null;
-    final objects = schemas.cast<RenderObject>();
-    final allRequired = objects
-        .map((o) => o.requiredProperties.toSet())
-        .toList();
+    // Object-shaped variants only (RenderObject for normal objects,
+    // RenderEmptyObject for `{}`-shaped fallbacks).
+    if (!schemas.every((s) => s is RenderObject || s is RenderEmptyObject)) {
+      return null;
+    }
+    final objects = schemas.cast<RenderNewType>();
+    Set<String> requiredOf(RenderNewType o) =>
+        o is RenderObject ? o.requiredProperties.toSet() : const <String>{};
+    final allRequired = objects.map(requiredOf).toList();
     final arms = <_RequiredFieldArm>[];
+    var fallbackCount = 0;
     for (var i = 0; i < objects.length; i++) {
       final mine = allRequired[i];
       final others = <String>{};
@@ -3973,7 +3986,17 @@ class RenderOneOf extends RenderNewType {
         if (i != j) others.addAll(allRequired[j]);
       }
       final unique = mine.difference(others);
-      if (unique.isEmpty) return null;
+      if (unique.isEmpty) {
+        // A variant with no required fields at all is a legitimate
+        // catch-all — use it as the fallback. A variant with required
+        // fields that are all shared with siblings is ambiguous, so
+        // bail.
+        if (mine.isNotEmpty) return null;
+        fallbackCount++;
+        if (fallbackCount > 1) return null;
+        arms.add(_RequiredFieldArm(variant: objects[i], tagField: null));
+        continue;
+      }
       // Pick the lexicographically-first unique field for stable output.
       final tagField = (unique.toList()..sort()).first;
       arms.add(
@@ -4068,7 +4091,15 @@ class RenderOneOf extends RenderNewType {
     final reqArms = _requiredFieldDispatchArms;
     if (reqArms != null) {
       ctx['has_required_field_dispatch'] = true;
-      ctx['dispatch'] = reqArms
+      // Checked arms (have a uniquely-required tagField) get their
+      // own `if (json.containsKey(...))` guard. The fallback arm (at
+      // most one, no required fields) emits without a guard at the
+      // bottom and replaces the throw — so the template needs the
+      // two groups separately. Subclasses still emit in the schemas-
+      // declared order via `variants`.
+      final checked = reqArms.where((a) => a.tagField != null).toList();
+      final fallback = reqArms.where((a) => a.tagField == null).firstOrNull;
+      ctx['dispatch'] = checked
           .map(
             (a) => {
               'tagField': a.tagField,
@@ -4077,6 +4108,12 @@ class RenderOneOf extends RenderNewType {
             },
           )
           .toList();
+      ctx['fallback'] = fallback == null
+          ? false
+          : {
+              'wrapperTypeName': wrapperTypeName(fallback.variant),
+              'valueType': fallback.variant.typeName,
+            };
       ctx['variants'] = reqArms
           .map((a) => objectWrapperContext(a.variant))
           .toList();
@@ -4220,17 +4257,22 @@ final class _MultiStatusContext {
   final List<Map<String, dynamic>> switchCases;
 }
 
-/// One arm of the required-field dispatch: a [RenderObject] variant
-/// keyed off the presence of a property unique to its required-set.
+/// One arm of the required-field dispatch: an object-shaped variant
+/// (RenderObject or RenderEmptyObject) keyed off the presence of a
+/// property unique to its required-set. [tagField] is null for the
+/// fallback variant (one variant per oneOf is allowed to have no
+/// required fields and act as the catch-all). RenderEmptyObject is
+/// always a fallback since it requires nothing.
 @immutable
 class _RequiredFieldArm {
   const _RequiredFieldArm({required this.variant, required this.tagField});
 
-  final RenderObject variant;
+  final RenderNewType variant;
 
   /// JSON property name whose presence picks this variant. Required
   /// only by [variant]; absent from every sibling's required-set.
-  final String tagField;
+  /// Null when this is the fallback (no-required) variant.
+  final String? tagField;
 }
 
 /// The schema-specific bits of a shape-dispatch wrapper: how the
@@ -4562,6 +4604,23 @@ class RenderEmptyObject extends RenderNewType {
 
   @override
   bool get defaultCanConstConstruct => true;
+
+  // EmptyObject is always a newtype with a Map<String, dynamic> wire
+  // shape. Participates in shape dispatch (when the only Map-shaped
+  // variant in a oneOf) and in required-field dispatch as the
+  // fallback variant (since it requires no fields). A second Map-
+  // shaped sibling collides on shape key; `_canShapeDispatch` rejects
+  // that path and required-field dispatch's no-fallback gate would
+  // also bail.
+  @override
+  String? get wrapperTag => typeName;
+
+  @override
+  String? get jsonShapeKey => 'Map<String, dynamic>';
+
+  @override
+  _VariantConversion? _variantConversion(SchemaRenderer context) =>
+      _newtypeConversion(typeName);
 
   @override
   String jsonStorageType({required bool isNullable}) => 'Map<String, dynamic>';

--- a/lib/templates/schema_one_of.mustache
+++ b/lib/templates/schema_one_of.mustache
@@ -59,9 +59,14 @@
             return {{{ wrapperTypeName }}}({{{ valueType }}}.fromJson(json));
         }
 {{/dispatch}}
+{{#fallback}}
+        return {{{ wrapperTypeName }}}({{{ valueType }}}.fromJson(json));
+{{/fallback}}
+{{^fallback}}
         throw FormatException(
             'No variant of {{ typeName }} matched json keys: ${json.keys.toList()}',
         );
+{{/fallback}}
     }
 
     {{> _one_of_maybe_from_json}}

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -1340,6 +1340,83 @@ void main() {
       );
     });
 
+    test('required-field dispatch with one no-required variant uses it as '
+        'the fallback', () {
+      // SimpleUser-like A requires {login, id}; B has no required at
+      // all. Required-field dispatch picks A on `id` (or `login`),
+      // and falls through to B as the catch-all. No throw.
+      final results = renderTestSchemas(
+        {
+          'Author': {
+            'oneOf': [
+              {r'$ref': '#/components/schemas/SimpleUser'},
+              {r'$ref': '#/components/schemas/EmptyAuthor'},
+            ],
+          },
+          'SimpleUser': {
+            'type': 'object',
+            'properties': {
+              'login': {'type': 'string'},
+              'id': {'type': 'integer'},
+            },
+            'required': ['login', 'id'],
+          },
+          'EmptyAuthor': {
+            'type': 'object',
+            'properties': <String, dynamic>{},
+          },
+        },
+        specUrl: Uri.parse('file:///spec.yaml'),
+      );
+      final author = results['Author'];
+      expect(author, isNotNull);
+      // Checked arm fires when the unique required field is present.
+      expect(author, contains("if (json.containsKey('id'))"));
+      expect(author, contains('return AuthorSimpleUser(SimpleUser.fromJson'));
+      // Fallback arm has no `containsKey` guard — emitted as a
+      // bare `return …`.
+      expect(
+        author,
+        contains('return AuthorEmptyAuthor(EmptyAuthor.fromJson(json));'),
+      );
+      // No throw — the fallback always matches.
+      expect(author, isNot(contains('throw FormatException')));
+      expect(author, isNot(contains('throw UnimplementedError')));
+    });
+
+    test('two no-required variants are ambiguous — fall back to legacy', () {
+      // Both X and Y have no required fields. Without a tag, the
+      // dispatch can't pick deterministically — return null and let
+      // the legacy stub fire.
+      final results = renderTestSchemas(
+        {
+          'XOrY': {
+            'oneOf': [
+              {r'$ref': '#/components/schemas/X'},
+              {r'$ref': '#/components/schemas/Y'},
+            ],
+          },
+          'X': {
+            'type': 'object',
+            'properties': {
+              'a': {'type': 'string'},
+            },
+          },
+          'Y': {
+            'type': 'object',
+            'properties': {
+              'b': {'type': 'string'},
+            },
+          },
+        },
+        specUrl: Uri.parse('file:///spec.yaml'),
+      );
+      expect(
+        results['XOrY'],
+        contains("throw UnimplementedError('XOrY.fromJson')"),
+      );
+    });
+
     test('oneOf with discriminator but no mapping falls through to '
         'shape dispatch (implicit-mapping not yet supported)', () {
       // No `mapping` key — discriminator-dispatch needs the explicit
@@ -1503,10 +1580,14 @@ void main() {
         },
         specUrl: Uri.parse('file:///spec.yaml'),
       );
-      expect(
-        results['Rule'],
-        contains("throw UnimplementedError('Rule.fromJson')"),
-      );
+      // The implicit-discriminator gate on `type` is the contract
+      // here — we must NOT switch on `json['type']` over 'a' / 'b',
+      // because B doesn't require `type`. Required-field-with-fallback
+      // dispatch happens to pick this up legitimately (A is keyed on
+      // `type`, B is the fallback), which is fine; just verify the
+      // implicit-discriminator path didn't engage.
+      expect(results['Rule'], isNot(contains("'a' =>")));
+      expect(results['Rule'], isNot(contains('switch (discriminator)')));
     });
 
     group('anyOf', () {

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -921,6 +921,28 @@ void main() {
       expect(result, contains('throw UnimplementedError'));
     });
 
+    test('oneOf with [empty-object, string] uses shape dispatch', () {
+      // RenderEmptyObject (an inline `type: object` with no
+      // properties, or a `$ref` to one) needs `wrapperTag` and
+      // `jsonShapeKey` to participate in shape dispatch. Pinning that
+      // here covers the per-schema overrides plus the
+      // `_variantConversion` arm that delegates to the EmptyObject
+      // newtype's own `fromJson`/`toJson`.
+      final schema = {
+        'oneOf': [
+          {'type': 'object', 'properties': <String, dynamic>{}},
+          {'type': 'string'},
+        ],
+      };
+      final result = renderTestSchema(schema);
+      // Empty-object wrapper delegates to the named class.
+      expect(result, contains('Map<String, dynamic> v =>'));
+      expect(result, contains('.fromJson(v)'));
+      expect(result, contains('value.toJson()'));
+      expect(result, contains('String v => TestString(v)'));
+      expect(result, isNot(contains('throw UnimplementedError')));
+    });
+
     test('number newtype does not participate in shape dispatch', () {
       // A `number` schema with validations becomes a newtype (its own
       // class), and `wrapperTag` / `jsonShapeKey` deliberately gate on


### PR DESCRIPTION
## Summary

Generalizes the required-field dispatch (#146) so that one variant is
allowed to have no required fields at all and act as the catch-all
when none of the keyed arms fire. Previously such a oneOf fell through
to the legacy `UnimplementedError` stub even though the intent was
unambiguous.

The fallback variant can be a plain `RenderObject` with empty
required (e.g. an inline `type: object`) or a `RenderEmptyObject` (the
named `empty-object` schema). Two no-required variants are still
ambiguous and bail. `RenderEmptyObject` also gains its `wrapperTag` /
`jsonShapeKey` / `_variantConversion` overrides so the fallback
wrapper subclass can be named and built consistently with
`RenderObject`.

The template emits the keyed arms first (each guarded by
`if (json.containsKey(...))`), then a bare `return Fallback(...)` in
place of the throw.

Removes 8 stubs from the github regen (24 → 16):
- `commit.author`, `commit.committer`: `[simple-user, empty-object]`
- 3x `interactions_get_restrictions_for_*`:
  `[interaction-limit-response, <empty-inline>]`
- `checks/create-request`, `checks/update-request`: inline
  `[<has required>, <empty>]` request bodies
- `git/create-blob` 422 response: `[validation-error,
  repository-rule-violation-error]` (latter has no required → fallback)

## Test plan

- [x] `dart test` — 375 tests pass.
  - Two new cases: fallback fires when one variant has no required;
    two no-required variants are ambiguous and fall through.
  - One existing test updated: the implicit-discriminator gate test
    used a schema that now correctly engages required-field-with-
    fallback dispatch; the assertion now pins the actual contract
    (no `switch (discriminator)`, no `'a' =>` arm).
- [x] github regen: `dart analyze` clean (`No issues found!`),
  `UnimplementedError` count 24 → 16.