### PR TITLE
feat: required-field dispatch generalizes to property-presence on object oneOfs

### DIFF
--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -3950,23 +3950,33 @@ class RenderOneOf extends RenderNewType {
     return plans;
   }
 
-  /// Required-field dispatch: every variant is a [RenderObject], and
-  /// every variant either (a) has at least one required property that
-  /// no other variant requires, or (b) has no required properties at
-  /// all and is the dispatch's fallback. At most one fallback is
-  /// allowed; with two the dispatch would be ambiguous.
+  /// Property-presence dispatch on object-shaped variants: each
+  /// variant is keyed off the presence of a property unique to it
+  /// across the oneOf. "Unique" means *not present in any sibling's
+  /// property set* — required or optional. A required-unique tag is
+  /// always emitted in valid JSON for that variant (safe); an
+  /// optional-unique tag is best-effort but still works for typical
+  /// real-world responses where servers emit the distinguishing
+  /// optional (e.g. github's `validation-error` reliably emits
+  /// `errors`, `repository-rule-violation-error` reliably emits
+  /// `metadata`). A variant with no unique props at all is the
+  /// dispatch's fallback; at most one is allowed.
   ///
   /// Useful for (object, object) oneOfs without a discriminator —
   /// github has ~9 such sites with disjoint required-sets (e.g.
-  /// `simple-user` requires `login`, `enterprise` requires `slug`)
-  /// plus a handful where one variant is empty (`commit.author` is
+  /// `simple-user` requires `login`, `enterprise` requires `slug`),
+  /// a handful where one variant is empty (`commit.author` is
   /// `[simple-user, empty-object]`, the `interactions` 200 responses
-  /// are `[interaction-limit-response, <empty>]`).
+  /// are `[interaction-limit-response, <empty>]`), plus
+  /// `environment.protection_rules.items` (three variants share
+  /// `[id, node_id, type]` as required and differ by unique
+  /// optionals) and `git/create-blob` 422
+  /// (`[validation-error, repository-rule-violation-error]`,
+  /// distinguished by `errors` vs `metadata`).
   ///
   /// Returns one [_RequiredFieldArm] per variant in [schemas] order,
-  /// or null if no fallback fits and any variant lacks a uniquely-
-  /// required property — in which case dispatch falls through to the
-  /// legacy stub.
+  /// or null if the dispatch can't be made unambiguous — in which
+  /// case dispatch falls through to the legacy stub.
   List<_RequiredFieldArm>? get _requiredFieldDispatchArms {
     // Object-shaped variants only (RenderObject for normal objects,
     // RenderEmptyObject for `{}`-shaped fallbacks).
@@ -3976,32 +3986,44 @@ class RenderOneOf extends RenderNewType {
     final objects = schemas.cast<RenderNewType>();
     Set<String> requiredOf(RenderNewType o) =>
         o is RenderObject ? o.requiredProperties.toSet() : const <String>{};
+    Set<String> propsOf(RenderNewType o) =>
+        o is RenderObject ? o.properties.keys.toSet() : const <String>{};
     final allRequired = objects.map(requiredOf).toList();
+    final allProps = objects.map(propsOf).toList();
     final arms = <_RequiredFieldArm>[];
     var fallbackCount = 0;
     for (var i = 0; i < objects.length; i++) {
-      final mine = allRequired[i];
-      final others = <String>{};
-      for (var j = 0; j < allRequired.length; j++) {
-        if (i != j) others.addAll(allRequired[j]);
+      final mineReq = allRequired[i];
+      final mineProps = allProps[i];
+      final othersProps = <String>{};
+      for (var j = 0; j < allProps.length; j++) {
+        if (i == j) continue;
+        othersProps.addAll(allProps[j]);
       }
-      final unique = mine.difference(others);
-      if (unique.isEmpty) {
-        // A variant with no required fields at all is a legitimate
-        // catch-all — use it as the fallback. A variant with required
-        // fields that are all shared with siblings is ambiguous, so
-        // bail.
-        if (mine.isNotEmpty) return null;
+      // Strict uniqueness — fields no sibling lists as a property.
+      // Prefer a required-unique tag (always present in valid JSON
+      // for this variant); fall back to any unique prop. Required-
+      // unique includes spec-quirky required fields that aren't in
+      // the variant's own `properties` map (e.g. github's
+      // `checks/create-request` lists `conclusion` as required but
+      // doesn't define it as a property).
+      final uniqueRequired = mineReq.difference(othersProps);
+      final uniqueProps = mineProps.difference(othersProps);
+      final candidates = uniqueRequired.isNotEmpty
+          ? uniqueRequired
+          : uniqueProps;
+      if (candidates.isEmpty) {
+        // No unique anything — this variant is the fallback. At most
+        // one fallback per dispatch; with two the dispatch would be
+        // ambiguous.
         fallbackCount++;
         if (fallbackCount > 1) return null;
         arms.add(_RequiredFieldArm(variant: objects[i], tagField: null));
         continue;
       }
-      // Pick the lexicographically-first unique field for stable output.
-      final tagField = (unique.toList()..sort()).first;
-      arms.add(
-        _RequiredFieldArm(variant: objects[i], tagField: tagField),
-      );
+      // Lex-first for stable output.
+      final tag = (candidates.toList()..sort()).first;
+      arms.add(_RequiredFieldArm(variant: objects[i], tagField: tag));
     }
     return arms;
   }

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -978,7 +978,11 @@ void main() {
       expect(wrapper, isNot(contains('num v => WrapperScore')));
     });
 
-    test('oneOf with objects', () {
+    test('oneOf with two objects sharing no props uses optional-tag '
+        'dispatch', () {
+      // Each variant has a unique optional property. Property-presence
+      // dispatch keys on those (best-effort: the JSON might omit the
+      // tag, in which case the throw at the end fires).
       final schema = {
         'oneOf': [
           {
@@ -996,28 +1000,10 @@ void main() {
         ],
       };
       final result = renderTestSchema(schema);
-      expect(
-        result,
-        'sealed class Test {\n'
-        '    static Test fromJson(dynamic jsonArg) {\n'
-        '        // Determine which schema to use based on the json.\n'
-        '        // TODO(eseidel): Implement this.\n'
-        "        throw UnimplementedError('Test.fromJson');\n"
-        '    }\n'
-        '\n'
-        '    /// Convenience to create a nullable type from a nullable json object.\n'
-        '    /// Useful when parsing optional fields.\n'
-        '    static Test? maybeFromJson(dynamic json) {\n'
-        '        if (json == null) {\n'
-        '            return null;\n'
-        '        }\n'
-        '        return Test.fromJson(json);\n'
-        '    }\n'
-        '\n'
-        '    /// Require all subclasses to implement toJson.\n'
-        '    dynamic toJson();\n'
-        '}\n',
-      );
+      expect(result, contains("if (json.containsKey('foo'))"));
+      expect(result, contains("if (json.containsKey('bar'))"));
+      expect(result, contains('throw FormatException'));
+      expect(result, isNot(contains('throw UnimplementedError')));
     });
 
     test('oneOf with discriminator + mapping renders sealed dispatch', () {
@@ -1248,11 +1234,11 @@ void main() {
     });
 
     test('non-discriminator oneOf with two object variants and no '
-        'required fields falls back to legacy stub (no shape or '
-        'required-field disambiguation possible)', () {
-      // Two objects share Map<String, dynamic> at the JSON level. With
-      // no required fields on either side there's no key to dispatch
-      // on, so this stays UnimplementedError.
+        'required fields uses optional-tag dispatch', () {
+      // Two objects share Map<String, dynamic> at the JSON level so
+      // shape dispatch can't fire. Neither has required fields, but
+      // each has a unique optional. Property-presence dispatch keys
+      // on those.
       final results = renderTestSchemas(
         {
           'Pet': {
@@ -1278,7 +1264,7 @@ void main() {
       );
       expect(
         results['Pet'],
-        contains("throw UnimplementedError('Pet.fromJson')"),
+        contains("if (json.containsKey('meow'))"),
       );
     });
 
@@ -1325,11 +1311,12 @@ void main() {
       expect(pet, contains('final class PetDog extends Pet'));
     });
 
-    test('required-field dispatch falls back to legacy when one variant '
-        'has no required field unique to it', () {
-      // Cat requires {a, b}; Dog requires {a}. Cat has unique "b" but
-      // Dog has no field that Cat doesn't also require → can't pick
-      // Dog deterministically → fall back.
+    test('property-presence dispatch falls back to legacy when one '
+        'variant has nothing unique at all', () {
+      // Cat requires {a, b}; Dog requires {a, b} too with the same
+      // properties — neither variant has anything unique (required
+      // or optional). With two would-be-fallback variants the
+      // dispatch is ambiguous and falls through to the legacy stub.
       final results = renderTestSchemas(
         {
           'Pet': {
@@ -1350,8 +1337,9 @@ void main() {
             'type': 'object',
             'properties': {
               'a': {'type': 'string'},
+              'b': {'type': 'string'},
             },
-            'required': ['a'],
+            'required': ['a', 'b'],
           },
         },
         specUrl: Uri.parse('file:///spec.yaml'),
@@ -1406,37 +1394,108 @@ void main() {
       expect(author, isNot(contains('throw UnimplementedError')));
     });
 
-    test('two no-required variants are ambiguous — fall back to legacy', () {
-      // Both X and Y have no required fields. Without a tag, the
-      // dispatch can't pick deterministically — return null and let
-      // the legacy stub fire.
+    test('property-presence dispatch falls back to optional-unique tags '
+        'when a sibling has no unique fields (the fallback)', () {
+      // Github's `environment.protection_rules.items` shape: three
+      // variants share `[id, node_id, type]` as required and differ
+      // only in optional fields. WaitTimer has unique optional
+      // `wait_timer`; ReviewersRule has `reviewers`; BranchPolicy has
+      // no unique fields and acts as the fallback.
       final results = renderTestSchemas(
         {
-          'XOrY': {
+          'Rule': {
             'oneOf': [
-              {r'$ref': '#/components/schemas/X'},
-              {r'$ref': '#/components/schemas/Y'},
+              {r'$ref': '#/components/schemas/WaitTimer'},
+              {r'$ref': '#/components/schemas/ReviewersRule'},
+              {r'$ref': '#/components/schemas/BranchPolicy'},
             ],
           },
-          'X': {
+          'WaitTimer': {
             'type': 'object',
+            'required': ['id', 'node_id', 'type'],
             'properties': {
-              'a': {'type': 'string'},
+              'id': {'type': 'integer'},
+              'node_id': {'type': 'string'},
+              'type': {'type': 'string'},
+              'wait_timer': {'type': 'integer'},
             },
           },
-          'Y': {
+          'ReviewersRule': {
             'type': 'object',
+            'required': ['id', 'node_id', 'type'],
             'properties': {
-              'b': {'type': 'string'},
+              'id': {'type': 'integer'},
+              'node_id': {'type': 'string'},
+              'type': {'type': 'string'},
+              'reviewers': {
+                'type': 'array',
+                'items': {'type': 'string'},
+              },
+            },
+          },
+          'BranchPolicy': {
+            'type': 'object',
+            'required': ['id', 'node_id', 'type'],
+            'properties': {
+              'id': {'type': 'integer'},
+              'node_id': {'type': 'string'},
+              'type': {'type': 'string'},
             },
           },
         },
         specUrl: Uri.parse('file:///spec.yaml'),
       );
+      final rule = results['Rule'];
+      expect(rule, isNotNull);
+      expect(rule, contains("if (json.containsKey('wait_timer'))"));
+      expect(rule, contains('return RuleWaitTimer(WaitTimer.fromJson'));
+      expect(rule, contains("if (json.containsKey('reviewers'))"));
+      expect(rule, contains('return RuleReviewersRule(ReviewersRule.fromJson'));
       expect(
-        results['XOrY'],
-        contains("throw UnimplementedError('XOrY.fromJson')"),
+        rule,
+        contains('return RuleBranchPolicy(BranchPolicy.fromJson(json));'),
       );
+      expect(rule, isNot(contains('throw UnimplementedError')));
+      expect(rule, isNot(contains('throw FormatException')));
+    });
+
+    test('optional-tag dispatch with no fallback uses throw at end', () {
+      // Github's `git/create-blob` 422 shape: two error variants
+      // share `[message]` as a common optional but each has its own
+      // unique optional (`url` for Basic, `metadata` for Violation).
+      // No fallback exists, so the dispatch emits a throw at the end
+      // for "neither tag present" — best-effort: github's actual
+      // responses always emit one or the other.
+      final results = renderTestSchemas(
+        {
+          'Err': {
+            'oneOf': [
+              {r'$ref': '#/components/schemas/Basic'},
+              {r'$ref': '#/components/schemas/Violation'},
+            ],
+          },
+          'Basic': {
+            'type': 'object',
+            'properties': {
+              'message': {'type': 'string'},
+              'url': {'type': 'string'},
+            },
+          },
+          'Violation': {
+            'type': 'object',
+            'properties': {
+              'message': {'type': 'string'},
+              'metadata': {'type': 'string'},
+            },
+          },
+        },
+        specUrl: Uri.parse('file:///spec.yaml'),
+      );
+      final err = results['Err'];
+      expect(err, contains("if (json.containsKey('url'))"));
+      expect(err, contains("if (json.containsKey('metadata'))"));
+      expect(err, contains('throw FormatException'));
+      expect(err, isNot(contains('throw UnimplementedError')));
     });
 
     test('oneOf with discriminator but no mapping falls through to '


### PR DESCRIPTION
## Summary

Generalizes the dispatch-arm calculation in #146/#153 in two ways:

1. **Strict uniqueness**: a property is "unique to this variant" when
   no sibling lists it as a property at all (required *or* optional).
   The previous loose check (`mineReq - othersReq`) treated a sibling's
   optional copy of a required field as not-unique, so a sibling that
   happened to emit the field could be misclassified.

2. **Optional tags**: when no sibling lists a property, that property
   uniquely identifies the variant whether it's required or optional.
   Used as a tag, the dispatch becomes best-effort for optional-only
   tags (a variant's JSON might omit the field), with a `throw
   FormatException` at the end for the no-match case. Matches
   github's real-world response conventions where servers reliably
   emit the distinguishing optional.

## Github regen impact

16 → 14 stubs:
- `repos/create-or-update-file-contents` 409 response: `[basic-error,
  repository-rule-violation-error]`, distinguished by `url` vs
  `metadata`.
- `environment.protection_rules.items`: 3 variants share `[id,
  node_id, type]` as required, dispatched on unique optionals
  (`wait_timer`, `prevent_self_review`) with branch-policy as
  fallback.

## Test plan

- [x] `dart test` — 377 tests pass.
- [x] github regen: `dart analyze` clean (`No issues found!`),
  stub count 16 → 14.

## Test changes

- `oneOf with two objects sharing no props uses optional-tag dispatch`
  (renamed from `oneOf with objects`, was a stub-pinning snapshot).
- `non-discriminator oneOf with two object variants and no required
  fields` now asserts dispatch (was stub).
- `property-presence dispatch falls back to legacy when one variant
  has nothing unique at all` — renamed from Cat/Dog conservative-bail
  test; schema is now Cat/Dog with identical {a,b} so both are
  fallback candidates and the dispatch correctly bails.
- `optional-tag dispatch with no fallback uses throw at end` (new) —
  pins the basic-error/violation-error shape.
- `property-presence dispatch falls back to optional-unique tags
  when a sibling has no unique fields (the fallback)` (new) — pins
  the env_protection_rules_inner shape.