### PR TITLE
feat: parse object schemas with required-only oneOf/anyOf as plain objects

### DIFF
--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -367,6 +367,9 @@ Schema? _handleCollectionTypes(
   required CommonProperties common,
 }) {
   if (json.containsKey('oneOf')) {
+    if (_isConstraintOnlyCollection(json, 'oneOf')) {
+      return null;
+    }
     final oneOf = json.childAsList('oneOf');
     final schemas = <SchemaRef>[];
     for (var i = 0; i < oneOf.length; i++) {
@@ -394,6 +397,9 @@ Schema? _handleCollectionTypes(
   }
 
   if (json.containsKey('anyOf')) {
+    if (_isConstraintOnlyCollection(json, 'anyOf')) {
+      return null;
+    }
     final anyOf = json.childAsList('anyOf');
     final schemas = <SchemaRef>[];
     for (var i = 0; i < anyOf.length; i++) {
@@ -404,6 +410,43 @@ Schema? _handleCollectionTypes(
     return SchemaAnyOf(common: common, schemas: schemas);
   }
   return null;
+}
+
+/// Returns true when [json] declares its own object shape (type:object
+/// + non-empty properties) AND every entry of the [collectionKey]
+/// (oneOf/anyOf) is a "required-only" constraint — a map containing
+/// nothing but a `required` list. Github uses this OpenAPI shape to
+/// say "exactly one of these properties must be present" (e.g.
+/// `pulls/request-reviewers` requires either `reviewers` or
+/// `team_reviewers`); the parent already names the properties, so the
+/// right Dart shape is a single object with all of them, and the
+/// oneOf is a runtime constraint we don't carry into the type system.
+///
+/// When this matches we return null from [_handleCollectionTypes] so
+/// the outer parse falls through to normal object parsing — the
+/// oneOf/anyOf becomes "ignored" (each variant's `required` already
+/// surfaces in the verbose log via `_warnUnused`).
+bool _isConstraintOnlyCollection(MapContext json, String collectionKey) {
+  // The parent must declare its own object shape — explicit
+  // `type: object` (or a list type containing `'object'`) and a
+  // non-empty `properties` map.
+  final type = json['type'];
+  final hasObjectType =
+      type == 'object' || (type is List && type.contains('object'));
+  if (!hasObjectType) return false;
+  final properties = json['properties'];
+  if (properties is! Map || properties.isEmpty) return false;
+  // Every variant must contain only `required` (and no other keys —
+  // no type, properties, oneOf, etc.). A variant that brings its own
+  // shape is a real polymorphic branch; only `required: [...]` is a
+  // constraint.
+  final list = json[collectionKey];
+  if (list is! List) return false;
+  for (final variant in list) {
+    if (variant is! Map) return false;
+    if (variant.length != 1 || !variant.containsKey('required')) return false;
+  }
+  return true;
 }
 
 SchemaRef? _handleAdditionalProperties(MapContext parent) {

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -378,6 +378,92 @@ void main() {
       expect(oneOf.discriminator, isNull);
     });
 
+    test('object with required-only oneOf constraint parses as object', () {
+      // Github's `pulls/request-reviewers` request body shape: a
+      // single object with two optional list properties, plus an
+      // anyOf saying "exactly one of `reviewers` or `team_reviewers`
+      // must be present". The constraint is a runtime-only thing
+      // (clients enforce it; servers should send valid responses) —
+      // the right Dart shape is the object, not a polymorphic wrapper.
+      final json = {
+        'type': 'object',
+        'properties': {
+          'reviewers': {
+            'type': 'array',
+            'items': {'type': 'string'},
+          },
+          'team_reviewers': {
+            'type': 'array',
+            'items': {'type': 'string'},
+          },
+        },
+        'anyOf': [
+          {
+            'required': ['reviewers'],
+          },
+          {
+            'required': ['team_reviewers'],
+          },
+        ],
+      };
+      final schema = parseTestSchema(json);
+      expect(schema, isA<SchemaObject>());
+      final obj = schema as SchemaObject;
+      expect(obj.properties.keys, ['reviewers', 'team_reviewers']);
+    });
+
+    test('oneOf with required-only constraint variants is also an object', () {
+      // Same shape as the anyOf case above, with `oneOf` instead of
+      // `anyOf` — the github `code-scanning/create-variant-analysis`
+      // request body. Either constraint kind drops out at parse time.
+      final json = {
+        'type': 'object',
+        'properties': {
+          'a': {'type': 'string'},
+          'b': {'type': 'string'},
+          'c': {'type': 'string'},
+        },
+        'required': ['a'],
+        'oneOf': [
+          {
+            'required': ['b'],
+          },
+          {
+            'required': ['c'],
+          },
+        ],
+      };
+      final schema = parseTestSchema(json);
+      expect(schema, isA<SchemaObject>());
+      final obj = schema as SchemaObject;
+      expect(obj.properties.keys, ['a', 'b', 'c']);
+      expect(obj.requiredProperties, ['a']);
+    });
+
+    test('oneOf with a real polymorphic variant stays a oneOf', () {
+      // A oneOf where any variant brings its own shape (here, a
+      // `type: string` variant) is a real polymorphic schema — the
+      // constraint-only short-circuit must not fire. The
+      // `required: [x]` sibling has no other keys and triggers
+      // `_warnUnused` during normal parse, which needs a logger
+      // scope.
+      final json = {
+        'type': 'object',
+        'properties': {
+          'x': {'type': 'string'},
+        },
+        'oneOf': [
+          {'type': 'string'},
+          {
+            'required': ['x'],
+          },
+        ],
+      };
+      final logger = _MockLogger();
+      final schema = runWithLogger(logger, () => parseTestSchema(json));
+      expect(schema, isA<SchemaOneOf>());
+    });
+
     test('components schemas as ref not supported', () {
       // Refs are generally fine.
       final json = {


### PR DESCRIPTION
## Summary

OpenAPI lets a single object schema use a sibling `oneOf`/`anyOf`
where every variant is just `{required: [...]}` — a runtime
constraint saying "exactly one of these properties must be present".
Parser-side, that arrived as a `SchemaOneOf`/`SchemaAnyOf` with empty
inline variants, the parent's `properties`/`required` got logged as
"Unused", and the renderer emitted an `UnimplementedError` stub for
the polymorphic shell.

Detect the pattern at parse time: when the schema declares its own
object shape (explicit `type: object`, non-empty `properties`) AND
every entry in the sibling `oneOf`/`anyOf` is exactly
`{required: [...]}` with no other keys, drop the constraint and
parse as a normal object. A variant that brings its own shape (its
own `type`, `properties`, etc.) keeps the schema polymorphic.

## Github regen impact

14 → 10 stubs:
- `pulls/request-reviewers` request body — `reviewers` xor
  `team_reviewers`.
- `repos/create-pages-site` request body — `source` xor
  `build_type`.
- `repos/update-information-about-pages-site` request body.
- `code-scanning/create-variant-analysis` request body —
  `repositories` xor `repository_lists` xor `repository_owners`.

The xor constraint becomes a runtime concern (callers enforce it).
The Dart shape is a single class with all properties optional —
which matches what users want for these request bodies anyway.

## Test plan

- [x] `dart test` — 380 tests pass; three new parser cases:
  - `object with required-only oneOf constraint parses as object`
    (anyOf shape).
  - `oneOf with required-only constraint variants is also an object`
    (oneOf shape, with parent-level required preserved).
  - `oneOf with a real polymorphic variant stays a oneOf` — pins
    that the short-circuit only fires for pure constraints.
- [x] github regen: `dart analyze` clean (`No issues found!`),
  `UnimplementedError` count 14 → 10.