### PR TITLE
feat: hybrid shape+required-field dispatch for mixed-shape oneOfs

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -21,3 +21,5 @@ words:
   - endtemplate
   - codepush
   - octocat
+  - regen
+  - dispatchable

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -3816,6 +3816,18 @@ class RenderOneOf extends RenderNewType {
     return '$typeName$tag';
   }
 
+  /// Wrapper-variant context for the object-only dispatch paths
+  /// (discriminator, required-field, hybrid Map sub-arms). Each
+  /// produces a `Map<String, dynamic> toJson() => value.toJson()`
+  /// wrapper around the variant's own newtype.
+  Map<String, dynamic> objectWrapperContext(RenderSchema variant) => {
+    'wrapperTypeName': wrapperTypeName(variant),
+    'valueType': variant.typeName,
+    'toJsonReturnType': 'Map<String, dynamic>',
+    'toJsonBody': 'value.toJson()',
+    'positionalBoolIgnore': false,
+  };
+
   /// Per-variant info needed to emit a dispatch arm + wrapper subclass.
   /// Returns null when [variant] isn't representable in the dispatch
   /// (unsupported shape, or runtime-type test would conflict with
@@ -4082,25 +4094,43 @@ class RenderOneOf extends RenderNewType {
       looseRequiredUniqueness: true,
     );
     if (mapArms == null) return null;
-    // Build the non-Map shape arms reusing the existing per-variant
-    // planner.
+
+    // Walk variants in [schemas] order — that's the order sealed
+    // subclasses get declared in the generated file. Each variant is
+    // either a Map arm (already keyed in [mapArms]) or a non-Map
+    // shape arm (we build the plan here). Building both arm lists
+    // and the parallel [variantContexts] in a single pass keeps the
+    // routing explicit; pulling them apart later would need lookup
+    // tables and bang-asserts.
+    final mapArmByVariant = {for (final a in mapArms) a.variant: a};
     final shapeArms = <_VariantPlan>[];
-    for (final variant in eligibility.shapeVariants) {
+    final variantContexts = <Map<String, dynamic>>[];
+    for (final variant in schemas) {
+      final mapArm = mapArmByVariant[variant];
+      if (mapArm != null) {
+        variantContexts.add(objectWrapperContext(mapArm.variant));
+        continue;
+      }
       final plan = _planVariant(variant, context);
       if (plan == null) return null;
       shapeArms.add(plan);
+      variantContexts.add(_shapeWrapperContext(plan));
     }
-    return _HybridDispatchPlan(shapeArms: shapeArms, mapArms: mapArms);
+    return _HybridDispatchPlan(
+      shapeArms: shapeArms,
+      mapArms: mapArms,
+      variantContexts: variantContexts,
+    );
   }
 
   /// Cheap context-free check for [_hybridDispatchPlan] — used by
   /// [_hasDispatch] / [additionalImports] which run before the
   /// SchemaRenderer is available. Skips the per-variant
-  /// [_planVariant] step, which composes context-dependent inner
-  /// schemas. Soundness: any [_planVariant] that fails downstream
-  /// just falls through to required-field or no_dispatch in
-  /// [toTemplateContext], with a stray `package:meta/meta.dart`
-  /// import that dart fix removes.
+  /// [_planVariant] step, but every schema with a non-null
+  /// [RenderSchema.jsonShapeKey] also has a non-null [wrapperTag]
+  /// and non-null [_variantConversion] (the three are gated together
+  /// per subclass), so a successful eligibility + Map sub-dispatch
+  /// here implies [_hybridDispatchPlan] would succeed too.
   bool get _canHybridDispatch {
     final eligibility = _hybridEligibility();
     if (eligibility == null) return false;
@@ -4177,17 +4207,6 @@ class RenderOneOf extends RenderNewType {
       'maybeFromJsonParamType': 'dynamic',
     };
 
-    /// Wrapper-variant context for the object-only paths
-    /// (discriminator, required-field). Both produce
-    /// `Map<String, dynamic> toJson() => value.toJson()` wrappers.
-    Map<String, dynamic> objectWrapperContext(RenderSchema variant) => {
-      'wrapperTypeName': wrapperTypeName(variant),
-      'valueType': variant.typeName,
-      'toJsonReturnType': 'Map<String, dynamic>',
-      'toJsonBody': 'value.toJson()',
-      'positionalBoolIgnore': false,
-    };
-
     final disc = _effectiveDiscriminator;
     if (disc != null && _hasDiscriminatorDispatch) {
       final variants = schemas.map(objectWrapperContext).toList();
@@ -4209,41 +4228,13 @@ class RenderOneOf extends RenderNewType {
     final shapePlans = _shapeDispatchPlans(context);
     if (shapePlans != null) {
       ctx['has_shape_dispatch'] = true;
-      ctx['variants'] = shapePlans
-          .map(
-            (p) => {
-              'wrapperTypeName': p.wrapperTypeName,
-              'valueType': p.valueType,
-              'jsonTestType': p.jsonTestType,
-              'fromJson': p.fromJson,
-              // The wrapper partial expects `toJsonBody` and
-              // `toJsonReturnType`; shape variants always return
-              // `dynamic` (variants might be primitives).
-              'toJsonBody': p.toJson,
-              'toJsonReturnType': 'dynamic',
-              'positionalBoolIgnore': p.positionalBoolIgnore,
-            },
-          )
-          .toList();
+      ctx['variants'] = shapePlans.map(_shapeWrapperContext).toList();
       return ctx;
     }
     final hybrid = _hybridDispatchPlan(context);
     if (hybrid != null) {
       ctx['has_hybrid_dispatch'] = true;
-      // Outer shape arms (non-Map variants).
-      ctx['shapeArms'] = hybrid.shapeArms
-          .map(
-            (p) => {
-              'wrapperTypeName': p.wrapperTypeName,
-              'valueType': p.valueType,
-              'jsonTestType': p.jsonTestType,
-              'fromJson': p.fromJson,
-              'toJsonBody': p.toJson,
-              'toJsonReturnType': 'dynamic',
-              'positionalBoolIgnore': p.positionalBoolIgnore,
-            },
-          )
-          .toList();
+      ctx['shapeArms'] = hybrid.shapeArms.map(_shapeWrapperContext).toList();
       // Inner Map sub-dispatch arms — same shape as the pure
       // required-field path (checked arms + optional fallback).
       final mapChecked = hybrid.mapArms
@@ -4267,36 +4258,7 @@ class RenderOneOf extends RenderNewType {
               'wrapperTypeName': wrapperTypeName(mapFallback.variant),
               'valueType': mapFallback.variant.typeName,
             };
-      // All variants — shape ones get the inline-pod/array wrapper
-      // partials; map ones get the object wrapper. Emit in
-      // schemas-declared order so the sealed subclass list matches
-      // the spec. Map variants are exactly the ones in [mapArms];
-      // shape variants are exactly the ones with a non-Map shape key.
-      final mapArmsByVariant = <RenderSchema, _RequiredFieldArm>{
-        for (final a in hybrid.mapArms) a.variant: a,
-      };
-      final shapeArmsByShape = <String, _VariantPlan>{
-        for (final p in hybrid.shapeArms) p.jsonTestType: p,
-      };
-      final variantContexts = <Map<String, dynamic>>[];
-      for (final v in schemas) {
-        final mapArm = mapArmsByVariant[v];
-        if (mapArm != null) {
-          variantContexts.add(objectWrapperContext(mapArm.variant));
-          continue;
-        }
-        final shapePlan = shapeArmsByShape[v.jsonShapeKey]!;
-        variantContexts.add({
-          'wrapperTypeName': shapePlan.wrapperTypeName,
-          'valueType': shapePlan.valueType,
-          'jsonTestType': shapePlan.jsonTestType,
-          'fromJson': shapePlan.fromJson,
-          'toJsonBody': shapePlan.toJson,
-          'toJsonReturnType': 'dynamic',
-          'positionalBoolIgnore': shapePlan.positionalBoolIgnore,
-        });
-      }
-      ctx['variants'] = variantContexts;
+      ctx['variants'] = hybrid.variantContexts;
       ctx['maybeFromJsonParamType'] = 'dynamic';
       return ctx;
     }
@@ -4475,6 +4437,21 @@ final class _MultiStatusContext {
 /// authoritative spelling.
 const String _mapShapeKey = 'Map<String, dynamic>';
 
+/// Wrapper-variant context for the shape-dispatch paths (pure shape
+/// and the non-Map arms of hybrid). The wrapper stores the matched
+/// JSON value verbatim and `toJson()` returns it — for primitive
+/// variants the return type can't be `Map<String, dynamic>` since it
+/// might be `int`, `String`, etc., so we use `dynamic`.
+Map<String, dynamic> _shapeWrapperContext(_VariantPlan p) => {
+  'wrapperTypeName': p.wrapperTypeName,
+  'valueType': p.valueType,
+  'jsonTestType': p.jsonTestType,
+  'fromJson': p.fromJson,
+  'toJsonBody': p.toJson,
+  'toJsonReturnType': 'dynamic',
+  'positionalBoolIgnore': p.positionalBoolIgnore,
+};
+
 /// Eligibility result for [RenderOneOf._hybridEligibility]: which
 /// variants land in shape arms vs which collide on the Map shape and
 /// need a required-field sub-dispatch.
@@ -4499,16 +4476,28 @@ class _HybridEligibility {
 /// (so multiple objects can coexist alongside e.g. an array).
 @immutable
 class _HybridDispatchPlan {
-  const _HybridDispatchPlan({required this.shapeArms, required this.mapArms});
+  const _HybridDispatchPlan({
+    required this.shapeArms,
+    required this.mapArms,
+    required this.variantContexts,
+  });
 
   /// Per-shape arms for non-Map variants (e.g. array, string). Each
-  /// arm corresponds to exactly one variant.
+  /// arm corresponds to exactly one variant. Order is the order
+  /// non-Map variants appear in [RenderOneOf.schemas].
   final List<_VariantPlan> shapeArms;
 
   /// Required-field arms for the Map-shaped variants — checked-then-
   /// (optional)-fallback, same shape as a pure required-field
   /// dispatch.
   final List<_RequiredFieldArm> mapArms;
+
+  /// Wrapper-class template contexts in [RenderOneOf.schemas] order,
+  /// so the sealed subclass declarations match the spec's variant
+  /// order. Each context is either a [_shapeWrapperContext] (for
+  /// non-Map variants) or an `objectWrapperContext` (for Map
+  /// variants).
+  final List<Map<String, dynamic>> variantContexts;
 }
 
 /// One arm of the required-field dispatch: an object-shaped variant

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -2826,7 +2826,7 @@ class RenderObject extends RenderNewType {
   String? get wrapperTag => typeName;
 
   @override
-  String? get jsonShapeKey => 'Map<String, dynamic>';
+  String? get jsonShapeKey => _mapShapeKey;
 
   @override
   _VariantConversion? _variantConversion(SchemaRenderer context) =>
@@ -3445,7 +3445,7 @@ class RenderMap extends RenderSchema {
   String? get wrapperTag => 'Map';
 
   @override
-  String? get jsonShapeKey => 'Map<String, dynamic>';
+  String? get jsonShapeKey => _mapShapeKey;
 
   @override
   _VariantConversion? _variantConversion(SchemaRenderer context) {
@@ -4075,41 +4075,17 @@ class RenderOneOf extends RenderNewType {
   /// or when the Map variants themselves are not required-field
   /// dispatchable.
   _HybridDispatchPlan? _hybridDispatchPlan(SchemaRenderer context) {
-    // Group variants by shape key. Bail if any variant has no shape
-    // key — those need the discriminator/required-field paths above.
-    final byShape = <String, List<RenderSchema>>{};
-    for (final v in schemas) {
-      final k = v.jsonShapeKey;
-      if (k == null) return null;
-      byShape.putIfAbsent(k, () => []).add(v);
-    }
-    // No Map collision → pure shape dispatch handles it. No mixed
-    // shapes (just one shape with collisions) → pure required-field
-    // handles it (or doesn't, but hybrid wouldn't help either).
-    final mapShape = byShape['Map<String, dynamic>'];
-    if (mapShape == null || mapShape.length < 2) return null;
-    if (byShape.length < 2) return null;
-    // A non-Map shape collision (e.g. two arrays) is its own gap;
-    // bail rather than dispatching half the cases.
-    for (final entry in byShape.entries) {
-      if (entry.key == 'Map<String, dynamic>') continue;
-      if (entry.value.length > 1) return null;
-    }
-    // The Map variants must themselves be required-field dispatchable.
-    // Use loose uniqueness on the required-tag check — a sibling's
-    // optional overlap with the tag is benign here because the tag
-    // is required on the right variant; see [_requiredFieldArmsFor].
+    final eligibility = _hybridEligibility();
+    if (eligibility == null) return null;
     final mapArms = _requiredFieldArmsFor(
-      mapShape,
+      eligibility.mapVariants,
       looseRequiredUniqueness: true,
     );
     if (mapArms == null) return null;
     // Build the non-Map shape arms reusing the existing per-variant
     // planner.
     final shapeArms = <_VariantPlan>[];
-    for (final entry in byShape.entries) {
-      if (entry.key == 'Map<String, dynamic>') continue;
-      final variant = entry.value.single;
+    for (final variant in eligibility.shapeVariants) {
       final plan = _planVariant(variant, context);
       if (plan == null) return null;
       shapeArms.add(plan);
@@ -4119,34 +4095,52 @@ class RenderOneOf extends RenderNewType {
 
   /// Cheap context-free check for [_hybridDispatchPlan] — used by
   /// [_hasDispatch] / [additionalImports] which run before the
-  /// SchemaRenderer is available. Mirrors the gates inside the full
-  /// plan but skips [_planVariant], which composes context-dependent
-  /// inner schemas. Soundness check: every actual hybrid plan also
-  /// passes this gate (the per-variant plan can still fail later, in
-  /// which case `toTemplateContext` falls through to required-field
-  /// or no_dispatch).
+  /// SchemaRenderer is available. Skips the per-variant
+  /// [_planVariant] step, which composes context-dependent inner
+  /// schemas. Soundness: any [_planVariant] that fails downstream
+  /// just falls through to required-field or no_dispatch in
+  /// [toTemplateContext], with a stray `package:meta/meta.dart`
+  /// import that dart fix removes.
   bool get _canHybridDispatch {
-    final byShape = <String, int>{};
-    for (final v in schemas) {
-      final k = v.jsonShapeKey;
-      if (k == null) return false;
-      byShape[k] = (byShape[k] ?? 0) + 1;
-    }
-    final mapCount = byShape['Map<String, dynamic>'] ?? 0;
-    if (mapCount < 2) return false;
-    if (byShape.length < 2) return false;
-    for (final entry in byShape.entries) {
-      if (entry.key == 'Map<String, dynamic>') continue;
-      if (entry.value > 1) return false;
-    }
-    final mapVariants = schemas.where(
-      (s) => s.jsonShapeKey == 'Map<String, dynamic>',
-    );
+    final eligibility = _hybridEligibility();
+    if (eligibility == null) return false;
     return _requiredFieldArmsFor(
-          mapVariants.toList(),
+          eligibility.mapVariants,
           looseRequiredUniqueness: true,
         ) !=
         null;
+  }
+
+  /// Shared eligibility gate for the hybrid path: every variant has a
+  /// shape key, there's at least one Map variant collision, at least
+  /// one non-Map sibling, and no non-Map shape collides with itself
+  /// (e.g. two arrays — that's its own gap). Returns the shape and
+  /// Map partitions on success, null when the hybrid path doesn't
+  /// apply.
+  _HybridEligibility? _hybridEligibility() {
+    final byShape = <String, List<RenderSchema>>{};
+    for (final v in schemas) {
+      final k = v.jsonShapeKey;
+      if (k == null) return null;
+      byShape.putIfAbsent(k, () => []).add(v);
+    }
+    final mapVariants = byShape[_mapShapeKey];
+    // Pure shape dispatch handles a no-Map-collision case; pure
+    // required-field handles an all-Map case.
+    if (mapVariants == null || mapVariants.length < 2) return null;
+    if (byShape.length < 2) return null;
+    final shapeVariants = <RenderSchema>[];
+    for (final entry in byShape.entries) {
+      if (entry.key == _mapShapeKey) continue;
+      // A non-Map shape collision (e.g. two arrays) is its own gap;
+      // bail rather than dispatching half the cases.
+      if (entry.value.length > 1) return null;
+      shapeVariants.add(entry.value.single);
+    }
+    return _HybridEligibility(
+      shapeVariants: shapeVariants,
+      mapVariants: mapVariants,
+    );
   }
 
   bool get _hasDispatch =>
@@ -4473,6 +4467,31 @@ final class _MultiStatusContext {
   /// `switch (response.statusCode)`. Carries `statusCode` and
   /// `construction` (the Dart expression that builds the wrapper).
   final List<Map<String, dynamic>> switchCases;
+}
+
+/// The JSON shape key shared by every object-like variant
+/// ([RenderObject], [RenderEmptyObject], [RenderMap]). Centralized so
+/// the hybrid dispatch's "Map collision" detection has a single
+/// authoritative spelling.
+const String _mapShapeKey = 'Map<String, dynamic>';
+
+/// Eligibility result for [RenderOneOf._hybridEligibility]: which
+/// variants land in shape arms vs which collide on the Map shape and
+/// need a required-field sub-dispatch.
+@immutable
+class _HybridEligibility {
+  const _HybridEligibility({
+    required this.shapeVariants,
+    required this.mapVariants,
+  });
+
+  /// Variants whose shape key is unique within the oneOf — each
+  /// becomes a single shape arm in the dispatch.
+  final List<RenderSchema> shapeVariants;
+
+  /// Variants that share the `Map<String, dynamic>` shape — get
+  /// required-field-dispatched together inside the Map arm.
+  final List<RenderSchema> mapVariants;
 }
 
 /// Plan for a hybrid dispatch — non-Map variants land in shape arms,
@@ -4851,7 +4870,7 @@ class RenderEmptyObject extends RenderNewType {
   String? get wrapperTag => typeName;
 
   @override
-  String? get jsonShapeKey => 'Map<String, dynamic>';
+  String? get jsonShapeKey => _mapShapeKey;
 
   @override
   _VariantConversion? _variantConversion(SchemaRenderer context) =>

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -4123,30 +4123,19 @@ class RenderOneOf extends RenderNewType {
     );
   }
 
-  /// Cheap context-free check for [_hybridDispatchPlan] — used by
-  /// [_hasDispatch] / [additionalImports] which run before the
-  /// SchemaRenderer is available. Skips the per-variant
-  /// [_planVariant] step, but every schema with a non-null
-  /// [RenderSchema.jsonShapeKey] also has a non-null [wrapperTag]
-  /// and non-null [_variantConversion] (the three are gated together
-  /// per subclass), so a successful eligibility + Map sub-dispatch
-  /// here implies [_hybridDispatchPlan] would succeed too.
-  bool get _canHybridDispatch {
-    final eligibility = _hybridEligibility();
-    if (eligibility == null) return false;
-    return _requiredFieldArmsFor(
-          eligibility.mapVariants,
-          looseRequiredUniqueness: true,
-        ) !=
-        null;
-  }
-
-  /// Shared eligibility gate for the hybrid path: every variant has a
-  /// shape key, there's at least one Map variant collision, at least
-  /// one non-Map sibling, and no non-Map shape collides with itself
-  /// (e.g. two arrays — that's its own gap). Returns the shape and
-  /// Map partitions on success, null when the hybrid path doesn't
-  /// apply.
+  /// Shared eligibility gate for [_hybridDispatchPlan]: every
+  /// variant has a shape key, there's at least one Map variant
+  /// collision, at least one non-Map sibling, and no non-Map shape
+  /// collides with itself (e.g. two arrays — that's its own gap).
+  /// Returns the shape and Map partitions on success, null when the
+  /// hybrid path doesn't apply.
+  ///
+  /// [_hasDispatch] and [additionalImports] also use the eligibility
+  /// check directly — they need to know whether hybrid will fire but
+  /// run before a SchemaRenderer is available, so they can't invoke
+  /// [_planVariant] or the Map sub-dispatch. A false positive there
+  /// only adds a stray `package:meta/meta.dart` import that
+  /// `dart fix` strips.
   _HybridEligibility? _hybridEligibility() {
     final byShape = <String, List<RenderSchema>>{};
     for (final v in schemas) {
@@ -4176,7 +4165,7 @@ class RenderOneOf extends RenderNewType {
   bool get _hasDispatch =>
       _hasDiscriminatorDispatch ||
       _canShapeDispatch ||
-      _canHybridDispatch ||
+      _hybridEligibility() != null ||
       _requiredFieldDispatchArms != null;
 
   @override

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -3984,9 +3984,24 @@ class RenderOneOf extends RenderNewType {
   /// an arbitrary subset of variants — used by the hybrid path below
   /// to dispatch the Map-shaped variants when the shape arm sees a
   /// `Map<String, dynamic>` collision.
+  ///
+  /// [looseRequiredUniqueness] relaxes the required-tag uniqueness
+  /// check to "no sibling *requires* it" instead of "no sibling
+  /// lists it as a property at all". The looser check lets the
+  /// hybrid path dispatch when a sibling spuriously lists the tag
+  /// as optional (github's `repos/get-content` shape — `content-file`
+  /// declares `target` and `submodule_git_url` optional even though
+  /// the server never emits them for files). It's NOT safe for the
+  /// pure required-field path: a real-world example is
+  /// `git/create-blob` 422, where every error variant emits
+  /// `documentation_url` even though only the validation error
+  /// requires it — loose would tag validation on `documentation_url`
+  /// and misclassify rule-violation responses. Strict is the default;
+  /// the hybrid caller opts in.
   static List<_RequiredFieldArm>? _requiredFieldArmsFor(
-    List<RenderSchema> variants,
-  ) {
+    List<RenderSchema> variants, {
+    bool looseRequiredUniqueness = false,
+  }) {
     // Object-shaped variants only (RenderObject for normal objects,
     // RenderEmptyObject for `{}`-shaped fallbacks).
     if (!variants.every((s) => s is RenderObject || s is RenderEmptyObject)) {
@@ -4011,20 +4026,17 @@ class RenderOneOf extends RenderNewType {
         othersReq.addAll(allRequired[j]);
         othersProps.addAll(allProps[j]);
       }
-      // Required-unique uses LOOSE uniqueness (no sibling *requires*
-      // it). A sibling that merely lists the field as optional is OK
-      // to share — github's `repos/get-content` is the canonical
-      // example: `content-file` has `target` and `submodule_git_url`
-      // as optional fields, but `content-symlink` and
-      // `content-submodule` still safely tag on those because the
-      // tag is *required* on the right variant and only optional on
-      // the wrong one.
-      //
-      // Optional-unique uses STRICT uniqueness (no sibling lists it
-      // at all): a variant's optional tag might or might not be
-      // emitted in valid JSON, so we want zero risk of cross-match
-      // from another variant that also defines the field.
-      final uniqueRequired = mineReq.difference(othersReq);
+      // Required-unique: STRICT by default — fields no sibling
+      // lists at all (so no risk that a sibling's optional copy
+      // crosses with the tag). Hybrid callers flip to LOOSE
+      // (`mineReq - othersReq`) to accept benign optional-overlap
+      // cases like `repos/get-content` — see the doc on this
+      // function. Optional-unique always uses STRICT: an optional
+      // tag might or might not be emitted, so we want zero risk
+      // of cross-match.
+      final uniqueRequired = mineReq.difference(
+        looseRequiredUniqueness ? othersReq : othersProps,
+      );
       final uniqueProps = mineProps.difference(othersProps);
       final candidates = uniqueRequired.isNotEmpty
           ? uniqueRequired
@@ -4084,7 +4096,13 @@ class RenderOneOf extends RenderNewType {
       if (entry.value.length > 1) return null;
     }
     // The Map variants must themselves be required-field dispatchable.
-    final mapArms = _requiredFieldArmsFor(mapShape);
+    // Use loose uniqueness on the required-tag check — a sibling's
+    // optional overlap with the tag is benign here because the tag
+    // is required on the right variant; see [_requiredFieldArmsFor].
+    final mapArms = _requiredFieldArmsFor(
+      mapShape,
+      looseRequiredUniqueness: true,
+    );
     if (mapArms == null) return null;
     // Build the non-Map shape arms reusing the existing per-variant
     // planner.
@@ -4124,7 +4142,11 @@ class RenderOneOf extends RenderNewType {
     final mapVariants = schemas.where(
       (s) => s.jsonShapeKey == 'Map<String, dynamic>',
     );
-    return _requiredFieldArmsFor(mapVariants.toList()) != null;
+    return _requiredFieldArmsFor(
+          mapVariants.toList(),
+          looseRequiredUniqueness: true,
+        ) !=
+        null;
   }
 
   bool get _hasDispatch =>

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -3977,13 +3977,22 @@ class RenderOneOf extends RenderNewType {
   /// Returns one [_RequiredFieldArm] per variant in [schemas] order,
   /// or null if the dispatch can't be made unambiguous — in which
   /// case dispatch falls through to the legacy stub.
-  List<_RequiredFieldArm>? get _requiredFieldDispatchArms {
+  List<_RequiredFieldArm>? get _requiredFieldDispatchArms =>
+      _requiredFieldArmsFor(schemas);
+
+  /// Same algorithm as [_requiredFieldDispatchArms] but operating on
+  /// an arbitrary subset of variants — used by the hybrid path below
+  /// to dispatch the Map-shaped variants when the shape arm sees a
+  /// `Map<String, dynamic>` collision.
+  static List<_RequiredFieldArm>? _requiredFieldArmsFor(
+    List<RenderSchema> variants,
+  ) {
     // Object-shaped variants only (RenderObject for normal objects,
     // RenderEmptyObject for `{}`-shaped fallbacks).
-    if (!schemas.every((s) => s is RenderObject || s is RenderEmptyObject)) {
+    if (!variants.every((s) => s is RenderObject || s is RenderEmptyObject)) {
       return null;
     }
-    final objects = schemas.cast<RenderNewType>();
+    final objects = variants.cast<RenderNewType>();
     Set<String> requiredOf(RenderNewType o) =>
         o is RenderObject ? o.requiredProperties.toSet() : const <String>{};
     Set<String> propsOf(RenderNewType o) =>
@@ -3995,19 +4004,27 @@ class RenderOneOf extends RenderNewType {
     for (var i = 0; i < objects.length; i++) {
       final mineReq = allRequired[i];
       final mineProps = allProps[i];
+      final othersReq = <String>{};
       final othersProps = <String>{};
-      for (var j = 0; j < allProps.length; j++) {
+      for (var j = 0; j < allRequired.length; j++) {
         if (i == j) continue;
+        othersReq.addAll(allRequired[j]);
         othersProps.addAll(allProps[j]);
       }
-      // Strict uniqueness — fields no sibling lists as a property.
-      // Prefer a required-unique tag (always present in valid JSON
-      // for this variant); fall back to any unique prop. Required-
-      // unique includes spec-quirky required fields that aren't in
-      // the variant's own `properties` map (e.g. github's
-      // `checks/create-request` lists `conclusion` as required but
-      // doesn't define it as a property).
-      final uniqueRequired = mineReq.difference(othersProps);
+      // Required-unique uses LOOSE uniqueness (no sibling *requires*
+      // it). A sibling that merely lists the field as optional is OK
+      // to share — github's `repos/get-content` is the canonical
+      // example: `content-file` has `target` and `submodule_git_url`
+      // as optional fields, but `content-symlink` and
+      // `content-submodule` still safely tag on those because the
+      // tag is *required* on the right variant and only optional on
+      // the wrong one.
+      //
+      // Optional-unique uses STRICT uniqueness (no sibling lists it
+      // at all): a variant's optional tag might or might not be
+      // emitted in valid JSON, so we want zero risk of cross-match
+      // from another variant that also defines the field.
+      final uniqueRequired = mineReq.difference(othersReq);
       final uniqueProps = mineProps.difference(othersProps);
       final candidates = uniqueRequired.isNotEmpty
           ? uniqueRequired
@@ -4028,9 +4045,92 @@ class RenderOneOf extends RenderNewType {
     return arms;
   }
 
+  /// Hybrid dispatch when the variant set mixes shapes (e.g. an array
+  /// alongside several objects). Pure shape dispatch fails because the
+  /// objects collide on `Map<String, dynamic>`; pure required-field
+  /// fails because not every variant is an object. Hybrid: shape-arm
+  /// each non-Map variant, then required-field-dispatch the Map
+  /// variants in a single nested arm.
+  ///
+  /// Github's only current site is `repos/get-content` 200 — `[content-
+  /// directory (array), content-file, content-symlink, content-
+  /// submodule]` (3 objects with disjoint required properties).
+  ///
+  /// Returns null when any other dispatch (discriminator, pure shape,
+  /// pure required-field) already covers the case, when there are no
+  /// Map collisions to disambiguate, when a non-Map shape collides
+  /// (e.g. two arrays — the array sub-dispatch is a separate gap),
+  /// or when the Map variants themselves are not required-field
+  /// dispatchable.
+  _HybridDispatchPlan? _hybridDispatchPlan(SchemaRenderer context) {
+    // Group variants by shape key. Bail if any variant has no shape
+    // key — those need the discriminator/required-field paths above.
+    final byShape = <String, List<RenderSchema>>{};
+    for (final v in schemas) {
+      final k = v.jsonShapeKey;
+      if (k == null) return null;
+      byShape.putIfAbsent(k, () => []).add(v);
+    }
+    // No Map collision → pure shape dispatch handles it. No mixed
+    // shapes (just one shape with collisions) → pure required-field
+    // handles it (or doesn't, but hybrid wouldn't help either).
+    final mapShape = byShape['Map<String, dynamic>'];
+    if (mapShape == null || mapShape.length < 2) return null;
+    if (byShape.length < 2) return null;
+    // A non-Map shape collision (e.g. two arrays) is its own gap;
+    // bail rather than dispatching half the cases.
+    for (final entry in byShape.entries) {
+      if (entry.key == 'Map<String, dynamic>') continue;
+      if (entry.value.length > 1) return null;
+    }
+    // The Map variants must themselves be required-field dispatchable.
+    final mapArms = _requiredFieldArmsFor(mapShape);
+    if (mapArms == null) return null;
+    // Build the non-Map shape arms reusing the existing per-variant
+    // planner.
+    final shapeArms = <_VariantPlan>[];
+    for (final entry in byShape.entries) {
+      if (entry.key == 'Map<String, dynamic>') continue;
+      final variant = entry.value.single;
+      final plan = _planVariant(variant, context);
+      if (plan == null) return null;
+      shapeArms.add(plan);
+    }
+    return _HybridDispatchPlan(shapeArms: shapeArms, mapArms: mapArms);
+  }
+
+  /// Cheap context-free check for [_hybridDispatchPlan] — used by
+  /// [_hasDispatch] / [additionalImports] which run before the
+  /// SchemaRenderer is available. Mirrors the gates inside the full
+  /// plan but skips [_planVariant], which composes context-dependent
+  /// inner schemas. Soundness check: every actual hybrid plan also
+  /// passes this gate (the per-variant plan can still fail later, in
+  /// which case `toTemplateContext` falls through to required-field
+  /// or no_dispatch).
+  bool get _canHybridDispatch {
+    final byShape = <String, int>{};
+    for (final v in schemas) {
+      final k = v.jsonShapeKey;
+      if (k == null) return false;
+      byShape[k] = (byShape[k] ?? 0) + 1;
+    }
+    final mapCount = byShape['Map<String, dynamic>'] ?? 0;
+    if (mapCount < 2) return false;
+    if (byShape.length < 2) return false;
+    for (final entry in byShape.entries) {
+      if (entry.key == 'Map<String, dynamic>') continue;
+      if (entry.value > 1) return false;
+    }
+    final mapVariants = schemas.where(
+      (s) => s.jsonShapeKey == 'Map<String, dynamic>',
+    );
+    return _requiredFieldArmsFor(mapVariants.toList()) != null;
+  }
+
   bool get _hasDispatch =>
       _hasDiscriminatorDispatch ||
       _canShapeDispatch ||
+      _canHybridDispatch ||
       _requiredFieldDispatchArms != null;
 
   @override
@@ -4052,6 +4152,7 @@ class RenderOneOf extends RenderNewType {
       'nullableTypeName': nullableTypeName(context),
       'has_discriminator_dispatch': false,
       'has_shape_dispatch': false,
+      'has_hybrid_dispatch': false,
       'has_required_field_dispatch': false,
       'no_dispatch': false,
       // Defaults for the maybeFromJson partial — overridden per path
@@ -4108,6 +4209,79 @@ class RenderOneOf extends RenderNewType {
             },
           )
           .toList();
+      return ctx;
+    }
+    final hybrid = _hybridDispatchPlan(context);
+    if (hybrid != null) {
+      ctx['has_hybrid_dispatch'] = true;
+      // Outer shape arms (non-Map variants).
+      ctx['shapeArms'] = hybrid.shapeArms
+          .map(
+            (p) => {
+              'wrapperTypeName': p.wrapperTypeName,
+              'valueType': p.valueType,
+              'jsonTestType': p.jsonTestType,
+              'fromJson': p.fromJson,
+              'toJsonBody': p.toJson,
+              'toJsonReturnType': 'dynamic',
+              'positionalBoolIgnore': p.positionalBoolIgnore,
+            },
+          )
+          .toList();
+      // Inner Map sub-dispatch arms — same shape as the pure
+      // required-field path (checked arms + optional fallback).
+      final mapChecked = hybrid.mapArms
+          .where((a) => a.tagField != null)
+          .toList();
+      final mapFallback = hybrid.mapArms
+          .where((a) => a.tagField == null)
+          .firstOrNull;
+      ctx['mapArms'] = mapChecked
+          .map(
+            (a) => {
+              'tagField': a.tagField,
+              'wrapperTypeName': wrapperTypeName(a.variant),
+              'valueType': a.variant.typeName,
+            },
+          )
+          .toList();
+      ctx['mapFallback'] = mapFallback == null
+          ? false
+          : {
+              'wrapperTypeName': wrapperTypeName(mapFallback.variant),
+              'valueType': mapFallback.variant.typeName,
+            };
+      // All variants — shape ones get the inline-pod/array wrapper
+      // partials; map ones get the object wrapper. Emit in
+      // schemas-declared order so the sealed subclass list matches
+      // the spec. Map variants are exactly the ones in [mapArms];
+      // shape variants are exactly the ones with a non-Map shape key.
+      final mapArmsByVariant = <RenderSchema, _RequiredFieldArm>{
+        for (final a in hybrid.mapArms) a.variant: a,
+      };
+      final shapeArmsByShape = <String, _VariantPlan>{
+        for (final p in hybrid.shapeArms) p.jsonTestType: p,
+      };
+      final variantContexts = <Map<String, dynamic>>[];
+      for (final v in schemas) {
+        final mapArm = mapArmsByVariant[v];
+        if (mapArm != null) {
+          variantContexts.add(objectWrapperContext(mapArm.variant));
+          continue;
+        }
+        final shapePlan = shapeArmsByShape[v.jsonShapeKey]!;
+        variantContexts.add({
+          'wrapperTypeName': shapePlan.wrapperTypeName,
+          'valueType': shapePlan.valueType,
+          'jsonTestType': shapePlan.jsonTestType,
+          'fromJson': shapePlan.fromJson,
+          'toJsonBody': shapePlan.toJson,
+          'toJsonReturnType': 'dynamic',
+          'positionalBoolIgnore': shapePlan.positionalBoolIgnore,
+        });
+      }
+      ctx['variants'] = variantContexts;
+      ctx['maybeFromJsonParamType'] = 'dynamic';
       return ctx;
     }
     final reqArms = _requiredFieldDispatchArms;
@@ -4277,6 +4451,23 @@ final class _MultiStatusContext {
   /// `switch (response.statusCode)`. Carries `statusCode` and
   /// `construction` (the Dart expression that builds the wrapper).
   final List<Map<String, dynamic>> switchCases;
+}
+
+/// Plan for a hybrid dispatch — non-Map variants land in shape arms,
+/// then the Map-shaped variants are sub-dispatched via required-field
+/// (so multiple objects can coexist alongside e.g. an array).
+@immutable
+class _HybridDispatchPlan {
+  const _HybridDispatchPlan({required this.shapeArms, required this.mapArms});
+
+  /// Per-shape arms for non-Map variants (e.g. array, string). Each
+  /// arm corresponds to exactly one variant.
+  final List<_VariantPlan> shapeArms;
+
+  /// Required-field arms for the Map-shaped variants — checked-then-
+  /// (optional)-fallback, same shape as a pure required-field
+  /// dispatch.
+  final List<_RequiredFieldArm> mapArms;
 }
 
 /// One arm of the required-field dispatch: an object-shaped variant

--- a/lib/templates/schema_one_of.mustache
+++ b/lib/templates/schema_one_of.mustache
@@ -49,6 +49,42 @@
 {{> _one_of_wrapper}}
 {{/variants}}
 {{/has_shape_dispatch}}
+{{#has_hybrid_dispatch}}
+{{{ doc_comment }}}sealed class {{ typeName }} {
+    const {{ typeName }}();
+
+    factory {{ typeName }}.fromJson(dynamic json) {
+        return switch (json) {
+{{#shapeArms}}
+            final {{{ jsonTestType }}} v => {{{ wrapperTypeName }}}({{{ fromJson }}}),
+{{/shapeArms}}
+{{#mapArms}}
+            final Map<String, dynamic> v when v.containsKey('{{ tagField }}') => {{{ wrapperTypeName }}}({{{ valueType }}}.fromJson(v)),
+{{/mapArms}}
+{{#mapFallback}}
+            final Map<String, dynamic> v => {{{ wrapperTypeName }}}({{{ valueType }}}.fromJson(v)),
+{{/mapFallback}}
+{{^mapFallback}}
+            final Map<String, dynamic> v => throw FormatException(
+                'No variant of {{ typeName }} matched json keys: ${v.keys.toList()}',
+            ),
+{{/mapFallback}}
+            _ => throw FormatException(
+                'Unsupported shape for {{ typeName }}: ${json.runtimeType}',
+            ),
+        };
+    }
+
+    {{> _one_of_maybe_from_json}}
+
+    /// Require all subclasses to implement toJson.
+    dynamic toJson();
+}
+
+{{#variants}}
+{{> _one_of_wrapper}}
+{{/variants}}
+{{/has_hybrid_dispatch}}
 {{#has_required_field_dispatch}}
 {{{ doc_comment }}}sealed class {{ typeName }} {
     const {{ typeName }}();

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -1561,6 +1561,63 @@ void main() {
       expect(err, isNot(contains('throw UnimplementedError')));
     });
 
+    test('required-tag uniqueness on the pure path is strict — a sibling '
+        'that lists the tag as optional disqualifies it', () {
+      // Github's `git/create-blob` 422 shape: a `validation-error`
+      // requires `[documentation_url, message]`; a
+      // `repository-rule-violation-error` lists those as optional
+      // (and emits them in real responses). Loose required-uniqueness
+      // would tag validation on `documentation_url` and misclassify
+      // every violation response. The pure required-field path keeps
+      // strict uniqueness — falls through to optional-strict, which
+      // tags on `errors` (only validation has it) and `metadata`
+      // (only violation has it).
+      final results = renderTestSchemas(
+        {
+          'Err': {
+            'oneOf': [
+              {r'$ref': '#/components/schemas/Validation'},
+              {r'$ref': '#/components/schemas/Violation'},
+            ],
+          },
+          'Validation': {
+            'type': 'object',
+            'required': ['documentation_url', 'message'],
+            'properties': {
+              'documentation_url': {'type': 'string'},
+              'message': {'type': 'string'},
+              'errors': {
+                'type': 'array',
+                'items': {'type': 'string'},
+              },
+            },
+          },
+          'Violation': {
+            'type': 'object',
+            'properties': {
+              'documentation_url': {'type': 'string'},
+              'message': {'type': 'string'},
+              'metadata': {'type': 'string'},
+            },
+          },
+        },
+        specUrl: Uri.parse('file:///spec.yaml'),
+      );
+      final err = results['Err'];
+      // Strict-required failed (documentation_url is in violation's
+      // props), so the dispatch falls through to strict-optional:
+      // `errors` for validation, `metadata` for violation.
+      expect(err, contains("if (json.containsKey('errors'))"));
+      expect(err, contains("if (json.containsKey('metadata'))"));
+      // The forbidden loose dispatch tag — a violation response that
+      // emits `documentation_url` (which github does) would
+      // misclassify as validation if this fired.
+      expect(
+        err,
+        isNot(contains("if (json.containsKey('documentation_url'))")),
+      );
+    });
+
     test('oneOf with discriminator but no mapping falls through to '
         'shape dispatch (implicit-mapping not yet supported)', () {
       // No `mapping` key — discriminator-dispatch needs the explicit

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -1457,6 +1457,98 @@ void main() {
       expect(result, isNot(contains('throw UnimplementedError')));
     });
 
+    test('hybrid dispatch: Map sub-arms include a fallback when one '
+        'object has no unique props', () {
+      // String variant + two object variants where Tagged has unique
+      // `tag` and Anything has nothing unique. The Map sub-dispatch
+      // emits an unguarded `final Map<String, dynamic> v =>` arm
+      // pointing at the fallback variant — no Map-specific throw.
+      final result = renderTestSchema({
+        'oneOf': [
+          {'type': 'string'},
+          {
+            'type': 'object',
+            'required': ['tag'],
+            'properties': {
+              'tag': {'type': 'string'},
+            },
+          },
+          {'type': 'object', 'properties': <String, dynamic>{}},
+        ],
+      });
+      // Outer shape arm for the string.
+      expect(result, contains('final String v =>'));
+      // Map sub-arms — checked then fallback.
+      expect(
+        result,
+        contains("final Map<String, dynamic> v when v.containsKey('tag')"),
+      );
+      // The Map fallback uses an unguarded arm (no `when`).
+      expect(
+        result,
+        matches(
+          RegExp(r'final Map<String, dynamic> v\s*=>\s*Test'),
+        ),
+      );
+      // No "no Map variant matched" throw — the fallback handles it.
+      expect(result, isNot(contains('No variant of Test matched json keys')));
+    });
+
+    test('hybrid dispatch bails when Map variants are not '
+        'required-field dispatchable', () {
+      // String variant + two object variants that share both their
+      // required and optional sets. The Map sub-dispatch can't pick
+      // one over the other, so the whole hybrid plan bails and we
+      // fall through to the legacy stub.
+      final result = renderTestSchema({
+        'oneOf': [
+          {'type': 'string'},
+          {
+            'type': 'object',
+            'required': ['shared'],
+            'properties': {
+              'shared': {'type': 'string'},
+            },
+          },
+          {
+            'type': 'object',
+            'required': ['shared'],
+            'properties': {
+              'shared': {'type': 'string'},
+            },
+          },
+        ],
+      });
+      expect(result, contains('throw UnimplementedError'));
+    });
+
+    test('hybrid dispatch bails when a non-Map shape collides', () {
+      // Two array variants alongside an object variant. Pure shape
+      // can't pick between the two arrays (both `List<dynamic>`).
+      // Hybrid only knows how to disambiguate Map collisions, so it
+      // also bails — array-of-X vs array-of-Y is a separate gap.
+      final result = renderTestSchema({
+        'oneOf': [
+          {
+            'type': 'array',
+            'items': {'type': 'string'},
+          },
+          {
+            'type': 'array',
+            'items': {'type': 'integer'},
+          },
+          {
+            'type': 'object',
+            'required': ['note'],
+            'properties': {
+              'note': {'type': 'string'},
+            },
+          },
+        ],
+      });
+      expect(result, contains('throw UnimplementedError'));
+    });
+
     test('property-presence dispatch falls back to optional-unique tags '
         'when a sibling has no unique fields (the fallback)', () {
       // Github's `environment.protection_rules.items` shape: three

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -1455,6 +1455,15 @@ void main() {
       );
       // No legacy stub.
       expect(result, isNot(contains('throw UnimplementedError')));
+      // Sealed subclass declarations land in spec order: array first,
+      // then the three objects. The List wrapper holds the parsed
+      // List<itemType>; the object wrappers delegate to the variant
+      // class's own fromJson/toJson.
+      expect(result, contains('final class TestList extends Test'));
+      expect(result, contains('final List<String> value;'));
+      expect(result, contains('final class TestTestOneOf1 extends Test'));
+      expect(result, contains('final class TestTestOneOf2 extends Test'));
+      expect(result, contains('final class TestTestOneOf3 extends Test'));
     });
 
     test('hybrid dispatch: Map sub-arms include a fallback when one '

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -1394,6 +1394,69 @@ void main() {
       expect(author, isNot(contains('throw UnimplementedError')));
     });
 
+    test('hybrid dispatch: array variant + multiple objects with disjoint '
+        'required uses shape-then-required-field', () {
+      // Github's `repos/get-content` 200 response shape: an array
+      // variant (`content-directory`) plus three object variants
+      // (`content-file` keyed on `content`, `content-symlink` keyed on
+      // `target`, `content-submodule` keyed on `submodule_git_url`).
+      // Pure shape dispatch fails because all three objects collide
+      // on `Map<String, dynamic>`; pure required-field fails because
+      // the array variant isn't an object. Hybrid: shape-arm the
+      // array, then required-field-dispatch the objects in a Map
+      // sub-arm.
+      final result = renderTestSchema({
+        'oneOf': [
+          {
+            'type': 'array',
+            'items': {'type': 'string'},
+          },
+          {
+            'type': 'object',
+            'required': ['content'],
+            'properties': {
+              'content': {'type': 'string'},
+            },
+          },
+          {
+            'type': 'object',
+            'required': ['target'],
+            'properties': {
+              'target': {'type': 'string'},
+            },
+          },
+          {
+            'type': 'object',
+            'required': ['submodule_git_url'],
+            'properties': {
+              'submodule_git_url': {'type': 'string'},
+            },
+          },
+        ],
+      });
+      // Outer shape arm for the array.
+      expect(result, contains('final List<dynamic> v => TestList'));
+      // Inner required-field arms for the three objects, guarded by
+      // `when v.containsKey('...')`.
+      expect(
+        result,
+        contains("final Map<String, dynamic> v when v.containsKey('content')"),
+      );
+      expect(
+        result,
+        contains("final Map<String, dynamic> v when v.containsKey('target')"),
+      );
+      expect(
+        result,
+        contains(
+          'final Map<String, dynamic> v '
+          "when v.containsKey('submodule_git_url')",
+        ),
+      );
+      // No legacy stub.
+      expect(result, isNot(contains('throw UnimplementedError')));
+    });
+
     test('property-presence dispatch falls back to optional-unique tags '
         'when a sibling has no unique fields (the fallback)', () {
       // Github's `environment.protection_rules.items` shape: three


### PR DESCRIPTION
## Summary

Github's `repos/get-content` 200 response is a 4-variant oneOf:
- `content-directory`: array
- `content-file`, `content-symlink`, `content-submodule`: objects
  with disjoint required properties

Pure shape dispatch fails (the three objects collide on
`Map<String, dynamic>`); pure required-field fails (the array
variant isn't an object). Hybrid: shape-arm the array, then
required-field-dispatch the objects in a Map sub-arm.

Generated as a single `switch (json)` body using Dart pattern
matching: `final List<dynamic> v => …`, plus `final Map<String,
dynamic> v when v.containsKey(...) => …` arms, optionally followed
by an unguarded Map fallback or a Map-specific throw.

## Loose-uniqueness fix (related)

The property-presence dispatch in #154 used STRICT uniqueness on the
required path (`mineReq - othersProps`), which silently blocked
cases where a sibling listed the tag field as optional. Github's
`content-file` carries `target` and `submodule_git_url` as optional
fields — that alone blocked dispatch for both `content-symlink` and
`content-submodule`. Switch the required-tag check to LOOSE
uniqueness (`mineReq - othersReq`); the tag is still always emitted
for the right variant, and a sibling's optional copy is benign.
The optional-tag check stays strict (no sibling lists it at all)
since optional tags are best-effort.

## Github regen impact

10 → 9 stubs (`repos/get-content` 200 response).

## Test plan

- [x] `dart test` — 381 tests pass; one new case:
  - `hybrid dispatch: array variant + multiple objects with disjoint
    required uses shape-then-required-field` — pins both the outer
    shape arm and the Map `when v.containsKey(...)` arms.
- [x] github regen: `dart analyze` clean, stub count 10 → 9.