### PR TITLE
refactor: lift dispatch picking into a `decideDispatch` phase on the resolved tree

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -10,20 +10,27 @@ current design questions — especially around external `$ref`s.
   specUrl
      │
      ▼
-┌─────────────┐   Map<Uri,Json>?  ┌──────────┐   OpenApi   ┌──────────┐   ResolvedSpec   ┌──────────┐   Dart files
-│  Load       │ ────────────────▶ │  Parse   │ ──────────▶ │  Resolve │ ───────────────▶ │  Render  │ ───────────▶
-│ (I/O)       │                   │  (pure)  │             │  (pure)  │                  │  (pure)  │
-└─────────────┘                   └──────────┘             └──────────┘                  └──────────┘
-     │                                                          │
-     │                                                          ▼
-     │                                                    ┌──────────┐
-     └───── reads cache (today: only the root) ──────────▶│ Registry │
-                                                          └──────────┘
+┌────────┐   ┌────────┐   ┌──────────┐   ┌──────────┐   ┌──────────┐   Dart files
+│ Load   │──▶│ Parse  │──▶│ Resolve  │──▶│ Dispatch │──▶│ Render   │──▶
+│ (I/O)  │   │ (pure) │   │ (pure)   │   │ (pure)   │   │ (pure)   │
+└────────┘   └────────┘   └──────────┘   └──────────┘   └──────────┘
+                              │                 ▲
+                              ▼                 │
+                          ┌──────────┐    sidecar lookup
+                          │ Registry │
+                          └──────────┘
 ```
 
 Only **Load** does I/O. Everything downstream is a pure function of its
 input — *in principle*. In practice, external `$ref` support has pushed
 a bit of I/O up into the phase orchestration (see "Open questions").
+
+The original three downstream phases (Parse / Resolve / Render) are
+gradually being split: dispatch decisions and (planned) name
+assignment are getting their own phases between Resolve and Render so
+they can be made *globally*, with the full set of named entities in
+view. The current state lives a single dispatch pass; the naming pass
+is on the way (see "Planned phases" below).
 
 ## Phase 1 — Load
 
@@ -81,26 +88,101 @@ keyed by absolute URI. Populated by `RegistryBuilder`
 `specUrl.resolveUri(ref.uri)` — i.e., the registry key is the absolute
 URI you get by resolving the ref against the root spec URL.
 
-## Phase 4 — Render
+## Phase 4 — Dispatch
+
+**Purpose:** decide how each polymorphic schema (`oneOf` / `anyOf`)
+will route its `fromJson` at runtime. Pure structural — operates on
+the resolved tree only, knows nothing about Dart names or per-variant
+Dart-string production.
+**Lives in:** `lib/src/dispatch.dart`.
+**Entry point:** `decideDispatch(ResolvedSchemaCollection)
+→ DispatchDecision`.
+
+**Output types:** sealed `DispatchDecision` family — `Discriminator
+Dispatch`, `ShapeDispatch`, `HybridDispatch`, `PredicateDispatch`,
+`NoDispatch`. Each carries the structural facts the renderer needs
+(predicate per arm, shape key per arm, declaration order, etc.) but
+references variants as `ResolvedSchema`s rather than by Dart name.
+
+**Why a separate phase:** the dispatch decision determines *which*
+wrapper subclasses get emitted for a given oneOf. A future global
+naming pass needs to know that wrapper set up front so it can hand
+each wrapper a name. Decision-making had to leave the renderer for
+that to be possible.
+
+**`Predicate` IR.** Each variant's "is this me?" test is a value:
+`KeyExists(prop)`, `ArrayElementHasKey(prop)`, `Always` (the
+unguarded fallback). Adding a new way to distinguish variants — e.g.
+peeking deeper than one level into JSON — is a new `Predicate`
+subtype, not a new dispatch mode.
+
+**Note:** dispatch is consumed only by `RenderOneOf`'s template-
+context production today. The renderer still owns Dart-string
+production (`wrapperTypeName`, per-variant `fromJson`/`toJson`
+expressions); it asks dispatch what the structural decision was and
+splices the strings around it.
+
+## Phase 5 — Render
 
 Renders split into two sub-phases:
 
-**4a. ResolvedSpec → RenderSpec.** `SpecResolver.toRenderSpec()` in
+**5a. ResolvedSpec → RenderSpec.** `SpecResolver.toRenderSpec()` in
 `lib/src/render/render_tree.dart`. `RenderSpec` is a rendering-friendly
 view: it adds computed fields (`endpoints`, `apis`, `tags`), groups
 operations by tag, computes import sets, etc. `ResolvedSpec` is
 semantic; `RenderSpec` is layout-aware.
 
-**4b. RenderSpec → Dart files.** `FileRenderer.render(RenderSpec)` in
+**5b. RenderSpec → Dart files.** `FileRenderer.render(RenderSpec)` in
 `lib/src/render/file_renderer.dart`. Walks the render tree, picks a
 file path for each schema (`modelPath`, `testPath`), runs Mustache
 templates from `lib/templates/`, and writes. `dart format` and `dart
 fix` run via an injected `runProcess`.
 
+**Linkage to dispatch.** `RenderOneOf` carries a back-reference to
+the source `ResolvedSchemaCollection` it was built from. When a
+oneOf renders, it calls `decideDispatch(source)` to retrieve the
+structural decision and then translates it into mustache context
+using its own render-side helpers (`wrapperTypeName`, `_planVariant`,
+etc.). The resolved → render variant mapping uses index parity:
+`source.schemas[i]` corresponds to the parallel `RenderOneOf.schemas[i]`.
+
+## Planned phases
+
+### Naming pass (between Dispatch and Render)
+
+Today, Dart class names are decided in three different layers — the
+parser synthesizes inline-schema names, the resolver resolves naming
+collisions with `_1` suffixes, and the renderer composes wrapper
+class names per oneOf. Each layer makes a local decision with only
+partial information, so we get artifacts like
+`ProjectsCreateCardRequestProjectsCreateCardRequestOneOf0` (parser
+named the variant by parent, renderer wrapped with parent again,
+neither knew the other did) and `RepositoryRulesetConditions1` (an
+inline schema collides with a top-level one, gets a numeric suffix).
+
+The plan: a `lib/src/naming.dart` pass that runs after Dispatch and
+before Render. It walks the resolved tree + dispatch decisions,
+enumerates every named entity (top-level schemas, inline schemas
+that produce types, wrapper subclasses, operation message types),
+and assigns each a Dart class name using a shortest-unique-with-
+fallback algorithm. Output is a sidecar `Map<NameId, String>` —
+not a mutated tree — keyed by JSON pointer for spec-rooted entities
+and by `(parentPointer, kind, index)` for synthesized ones.
+
+The renderer then *looks up* names instead of computing them. The
+collision-resolution code in the resolver and the `wrapperTypeName`
+/ `typeName` logic in `RenderOneOf` get gutted in favor of the
+single map.
+
+The resolver intentionally stays Dart-blind: it carries `snakeName`
+(a parser-level identifier) but no Dart class name. Naming sits
+between resolve and render so the resolver can be reused for any
+future non-Dart consumer.
+
 ## Top-level orchestration
 
 `loadAndRenderSpec(GeneratorConfig)` in `lib/src/render.dart` is the
-only entrypoint. It is a linear sequence of the four phases:
+only entrypoint. It is a linear sequence of the phases:
 
 ```dart
 final cache = Cache(fs);
@@ -108,8 +190,11 @@ final specJson = await cache.load(config.specUrl);         // Load
 final spec = parseOpenApi(specJson, baseUri: ...);         // Parse
 // ... build registry, resolve external refs ...
 final resolved = resolveSpec(spec, specUrl, refRegistry);  // Resolve
-final renderSpec = SpecResolver(quirks).toRenderSpec(...); // Render 4a
-fileRenderer.render(renderSpec);                           // Render 4b
+// Dispatch is currently called per-oneOf inside RenderOneOf.toTemplateContext
+// — it operates on the resolved source via the back-reference. A future
+// pre-pass will hoist these calls into the orchestrator.
+final renderSpec = SpecResolver(quirks).toRenderSpec(...); // Render 5a
+fileRenderer.render(renderSpec);                           // Render 5b
 ```
 
 The CLI (`bin/space_gen.dart`) just wires `argResults` to a

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -23,3 +23,4 @@ words:
   - octocat
   - regen
   - dispatchable
+  - unioned

--- a/lib/src/dispatch.dart
+++ b/lib/src/dispatch.dart
@@ -1,0 +1,521 @@
+/// Decides how a oneOf/anyOf renders its `fromJson` body. Operates on
+/// the resolved tree only — no Dart names, no template contexts. The
+/// renderer consumes a [DispatchDecision] alongside its own naming and
+/// per-variant Dart-string production to build the actual mustache
+/// context.
+///
+/// Splitting dispatch out of render is the precondition for a global
+/// naming pass: that pass needs to know every wrapper subclass that
+/// will be emitted (so it can hand each one a name), and the wrapper
+/// set is determined entirely by these decisions.
+library;
+
+import 'package:meta/meta.dart';
+import 'package:space_gen/src/resolver.dart';
+import 'package:space_gen/src/types.dart' show PodType;
+
+/// Boolean test that picks one variant of a oneOf at runtime. Each
+/// kind knows how to emit its own `if (...)` test as a single Dart
+/// expression rooted on a caller-provided variable name.
+sealed class Predicate {
+  const Predicate();
+
+  /// Dart boolean expression that's true iff [jsonVar] matches this
+  /// variant. [jsonVar] names the in-scope JSON value the test is
+  /// rooted on (typically `json` for the factory parameter, `v` for
+  /// a switch-pattern-bound or cast-to-List local).
+  String dartIfTest(String jsonVar);
+}
+
+/// `jsonVar.containsKey('propertyName')` — picks variants by the
+/// presence of a unique property (required or optional).
+@immutable
+class KeyExists extends Predicate {
+  const KeyExists(this.propertyName);
+
+  final String propertyName;
+
+  @override
+  String dartIfTest(String jsonVar) => "$jsonVar.containsKey('$propertyName')";
+}
+
+/// `(jsonVar.first as Map<String, dynamic>).containsKey('propertyName')`
+/// — peeks the first element of a List local for a unique property.
+/// Caller is responsible for binding `jsonVar` to a non-null `List`;
+/// the test short-circuits on `.isNotEmpty` so empty lists fall through
+/// to the next arm without throwing.
+@immutable
+class ArrayElementHasKey extends Predicate {
+  const ArrayElementHasKey(this.propertyName);
+
+  final String propertyName;
+
+  @override
+  String dartIfTest(String jsonVar) {
+    final cast = '($jsonVar.first as Map<String, dynamic>)';
+    return "$jsonVar.isNotEmpty && $cast.containsKey('$propertyName')";
+  }
+}
+
+/// Catch-all predicate — the dispatch's optional unguarded fallback.
+/// Never emits an `if` test; the template treats it as the
+/// unconditional `return Wrapper(...)` at the end of the chain.
+@immutable
+class Always extends Predicate {
+  const Always();
+
+  @override
+  String dartIfTest(String jsonVar) =>
+      throw StateError('Always has no if-test — emit it as the fallback.');
+}
+
+/// One arm of a [PredicateDispatch]: the variant and the predicate
+/// that picks it. [variant] is a [ResolvedSchema] reference rather
+/// than a Dart name — render does the name lookup.
+@immutable
+class PredicateArm {
+  const PredicateArm({required this.variant, required this.predicate});
+
+  final ResolvedSchema variant;
+  final Predicate predicate;
+
+  bool get isFallback => predicate is Always;
+}
+
+/// One arm of a shape-driven dispatch — the variant and its JSON
+/// runtime-type test (e.g. `String`, `List<dynamic>`,
+/// `Map<String, dynamic>`).
+@immutable
+class ShapeArm {
+  const ShapeArm({required this.variant, required this.shapeKey});
+
+  final ResolvedSchema variant;
+  final String shapeKey;
+}
+
+/// Distinguishes the two flavors of [PredicateDispatch] for the
+/// renderer — they share the if-chain shape but differ in factory
+/// parameter type, preamble (the cast-to-List local), throw message,
+/// and the wrapper-subclass `toJson()` return type.
+enum PredicateDispatchKind { requiredField, arrayElement }
+
+/// How a oneOf/anyOf's `fromJson` is structured. All variant
+/// references are [ResolvedSchema]s; render translates each into the
+/// concrete Dart wrapper-class name and per-variant conversion.
+sealed class DispatchDecision {
+  const DispatchDecision();
+}
+
+/// `switch (json[propertyName]) { 'value' => Wrapper(...), ... }` —
+/// either an explicit `discriminator` from the spec or an implicit
+/// one synthesized from variants whose required single-value enum
+/// property tags them uniquely.
+@immutable
+class DiscriminatorDispatch extends DispatchDecision {
+  const DiscriminatorDispatch({
+    required this.propertyName,
+    required this.mapping,
+    required this.variants,
+  });
+
+  /// JSON property to switch on.
+  final String propertyName;
+
+  /// Each entry is a `(value, variant)` pair. Order is the order
+  /// `mapping` keys appear; the renderer's `case` arms follow it.
+  final List<({String value, ResolvedSchema variant})> mapping;
+
+  /// All variants in declaration order (matches the spec's `oneOf`
+  /// ordering). Drives the order subclasses are declared.
+  final List<ResolvedSchema> variants;
+}
+
+/// `switch (json) { final T v => Wrapper(T-conversion), ... }` —
+/// every variant has a unique JSON shape (`String`, `int`, `List<…>`,
+/// `Map<String, dynamic>`, …) so the runtime type alone picks the
+/// arm.
+@immutable
+class ShapeDispatch extends DispatchDecision {
+  const ShapeDispatch({required this.arms});
+
+  /// One arm per variant, in declaration order.
+  final List<ShapeArm> arms;
+}
+
+/// Mixed-shape dispatch: some variants pick by JSON shape, the
+/// remaining (Map-shaped) collide and need a property-presence
+/// sub-dispatch in a single nested arm.
+@immutable
+class HybridDispatch extends DispatchDecision {
+  const HybridDispatch({
+    required this.shapeArms,
+    required this.mapArms,
+    required this.mapFallback,
+    required this.declarationOrder,
+  });
+
+  /// Non-Map variants — one per unique shape, dispatched by runtime
+  /// type pattern.
+  final List<ShapeArm> shapeArms;
+
+  /// Map-shaped variants — dispatched by `containsKey` on the
+  /// switch-bound `v` local. Each arm is a [PredicateArm] whose
+  /// predicate is [KeyExists] (or, for the implicit fallback,
+  /// [Always] — but the fallback is broken out separately as
+  /// [mapFallback]).
+  final List<PredicateArm> mapArms;
+
+  /// Optional unguarded fallback among the Map-shaped variants —
+  /// renders as `final Map<String, dynamic> v => Wrapper(…)` after
+  /// every checked Map arm. Null when no Map variant is fallback-
+  /// eligible (the sub-dispatch ends in a throw).
+  final ResolvedSchema? mapFallback;
+
+  /// All variants in spec declaration order, including both
+  /// shape arms and Map arms. Drives the order of subclass
+  /// declarations.
+  final List<ResolvedSchema> declarationOrder;
+}
+
+/// `if (predicate) return Wrapper(…)` chain followed by an optional
+/// unguarded fallback. Covers two flavors today:
+///
+/// - [PredicateDispatchKind.requiredField] — factory takes
+///   `Map<String, dynamic>` directly; predicates are [KeyExists] on
+///   the parameter; wrappers wrap the Map back as `value.toJson()`.
+/// - [PredicateDispatchKind.arrayElement] — factory takes `dynamic`,
+///   the renderer emits a `final v = json as List;` preamble, and
+///   predicates are [ArrayElementHasKey] on `v`.
+///
+/// Adding a future kind that fits the if-chain shape is a new
+/// [PredicateDispatchKind] value plus the predicate(s) it produces —
+/// no new [DispatchDecision] subclass.
+@immutable
+class PredicateDispatch extends DispatchDecision {
+  const PredicateDispatch({
+    required this.kind,
+    required this.arms,
+  });
+
+  final PredicateDispatchKind kind;
+
+  /// One arm per variant, in declaration order. At most one arm has
+  /// [Always] as its predicate (the unguarded fallback) — the
+  /// renderer emits it without an `if` guard at the end of the
+  /// chain.
+  final List<PredicateArm> arms;
+}
+
+/// No dispatch — render emits the legacy `UnimplementedError` stub.
+@immutable
+class NoDispatch extends DispatchDecision {
+  const NoDispatch();
+}
+
+/// Inspects a resolved oneOf/anyOf and decides how its `fromJson`
+/// will be structured. Pure structural — looks only at the resolved
+/// schemas' shapes (required/optional properties, items types,
+/// discriminator). Returns [NoDispatch] when no strategy fits.
+DispatchDecision decideDispatch(ResolvedSchemaCollection collection) {
+  final variants = collection.schemas;
+  return _pickDiscriminator(collection, variants) ??
+      _pickShape(variants) ??
+      _pickHybrid(variants) ??
+      _pickRequiredField(variants) ??
+      _pickArrayElement(variants) ??
+      const NoDispatch();
+}
+
+/// JSON runtime-type key for shape-driven dispatch. Returns null for
+/// schemas that have no fixed shape (open unions, refs whose target
+/// can't be classified, …) — those disqualify shape dispatch.
+///
+/// `createsNewType` schemas (named objects, enums, named newtypes)
+/// also return null here: they're fronted by a Dart class so the
+/// shape-dispatch arm would need to construct that class, which is
+/// what the wrapper-subclass machinery already does. Returning a
+/// shape key for them would let the picker route past their wrapper.
+String? _jsonShapeKey(ResolvedSchema schema) {
+  return switch (schema) {
+    ResolvedString() => schema.createsNewType ? null : 'String',
+    ResolvedInteger() => schema.createsNewType ? null : 'int',
+    ResolvedNumber() => schema.createsNewType ? null : 'num',
+    // Of the pod types only boolean has a JSON shape key today —
+    // DateTime / URI / email / etc. all serialize as strings, so they
+    // collide with bare strings on shape and need a different
+    // strategy. Boolean is `bool`-shaped and unambiguous.
+    ResolvedPod() =>
+      !schema.createsNewType && schema.type == PodType.boolean ? 'bool' : null,
+    ResolvedArray() => 'List<dynamic>',
+    ResolvedObject() => _mapShapeKey,
+    // allOf is rendered as a synthesized RenderObject (member-wise
+    // merge of properties + required), so for shape-dispatch purposes
+    // it's Map-shaped just like a plain object.
+    ResolvedAllOf() => _mapShapeKey,
+    ResolvedMap() => _mapShapeKey,
+    ResolvedEmptyObject() => _mapShapeKey,
+    // Enums always serialize as `String`; the wrapper class is the
+    // enum type itself. Shape-dispatchable as long as no sibling
+    // variant collides on the `String` key.
+    ResolvedEnum() => 'String',
+    // RecursiveRef points at a top-level (always object today). Treat
+    // as Map for shape collision purposes; render handles the actual
+    // construction via the target's name.
+    ResolvedRecursiveRef() => _mapShapeKey,
+    _ => null,
+  };
+}
+
+/// Required properties of an object-or-allOf variant. For
+/// [ResolvedObject] this is just `requiredProperties`; for
+/// [ResolvedAllOf] we walk the merged members and union the
+/// required-sets — matching the synthesized `RenderObject` that
+/// `toRenderSchema` will produce.
+Set<String> _flattenedRequiredProperties(ResolvedSchema schema) {
+  return switch (schema) {
+    ResolvedObject() => schema.requiredProperties.toSet(),
+    ResolvedAllOf() => {
+      for (final member in schema.schemas)
+        ..._flattenedRequiredProperties(member),
+    },
+    _ => const <String>{},
+  };
+}
+
+/// All properties of an object-or-allOf variant (key + ResolvedSchema
+/// value). [ResolvedAllOf] members are unioned; on key collision the
+/// last member wins, matching `toRenderSchema`'s `addAll` order.
+Map<String, ResolvedSchema> _flattenedProperties(ResolvedSchema schema) {
+  return switch (schema) {
+    ResolvedObject() => schema.properties,
+    ResolvedAllOf() => {
+      for (final member in schema.schemas) ..._flattenedProperties(member),
+    },
+    _ => const <String, ResolvedSchema>{},
+  };
+}
+
+bool _isObjectLike(ResolvedSchema schema) =>
+    schema is ResolvedObject ||
+    schema is ResolvedEmptyObject ||
+    schema is ResolvedAllOf;
+
+const String _mapShapeKey = 'Map<String, dynamic>';
+
+DiscriminatorDispatch? _pickDiscriminator(
+  ResolvedSchemaCollection collection,
+  List<ResolvedSchema> variants,
+) {
+  if (collection is! ResolvedOneOf) return null;
+  final disc = collection.discriminator ?? _implicitDiscriminator(variants);
+  if (disc == null) return null;
+  // Discriminator dispatch only works when every variant is
+  // object-shaped (i.e. has a `fromJson(Map<String, dynamic>)`).
+  // Includes allOf which renders as a synthesized object.
+  if (!variants.every(_isObjectLike)) return null;
+  final mapping = disc.mapping;
+  if (mapping == null) return null;
+  return DiscriminatorDispatch(
+    propertyName: disc.propertyName,
+    mapping: [
+      for (final entry in mapping.entries)
+        (value: entry.key, variant: entry.value),
+    ],
+    variants: variants,
+  );
+}
+
+/// Synthesized discriminator for object-only oneOfs whose variants
+/// each tag themselves with a single-value enum property — github's
+/// `repository-rule` shape. The spec doesn't declare a `discriminator`,
+/// but every variant has, e.g., `type: { enum: ['creation'] }` with
+/// that property required. The values are pairwise distinct, so the
+/// parent's `fromJson` can switch on `json[<that property>]`.
+///
+/// Variants may be [ResolvedObject] OR [ResolvedAllOf] — the latter
+/// flattens its members the same way `toRenderSchema` synthesizes a
+/// `RenderObject`, so a tag declared in one allOf member counts.
+ResolvedDiscriminator? _implicitDiscriminator(List<ResolvedSchema> variants) {
+  if (variants.isEmpty) return null;
+  if (!variants.every(_isObjectLike)) return null;
+  final flatRequired = variants.map(_flattenedRequiredProperties).toList();
+  final flatProps = variants.map(_flattenedProperties).toList();
+  final candidates = <(String, List<String>)>[];
+  for (final entry in flatProps.first.entries) {
+    final propName = entry.key;
+    if (!flatRequired.first.contains(propName)) continue;
+    final firstType = entry.value;
+    if (firstType is! ResolvedEnum || firstType.values.length != 1) continue;
+    final values = [firstType.values.first];
+    var allMatch = true;
+    for (var i = 1; i < variants.length; i++) {
+      if (!flatRequired[i].contains(propName)) {
+        allMatch = false;
+        break;
+      }
+      final otherType = flatProps[i][propName];
+      if (otherType is! ResolvedEnum || otherType.values.length != 1) {
+        allMatch = false;
+        break;
+      }
+      values.add(otherType.values.first);
+    }
+    if (allMatch) candidates.add((propName, values));
+  }
+  if (candidates.isEmpty) return null;
+  candidates.sort((a, b) => a.$1.compareTo(b.$1));
+  for (final (propName, values) in candidates) {
+    if (values.toSet().length != values.length) continue;
+    return ResolvedDiscriminator(
+      propertyName: propName,
+      mapping: {
+        for (var i = 0; i < variants.length; i++) values[i]: variants[i],
+      },
+    );
+  }
+  return null;
+}
+
+ShapeDispatch? _pickShape(List<ResolvedSchema> variants) {
+  final keys = <String>{};
+  final arms = <ShapeArm>[];
+  for (final v in variants) {
+    final k = _jsonShapeKey(v);
+    if (k == null) return null;
+    if (!keys.add(k)) return null;
+    arms.add(ShapeArm(variant: v, shapeKey: k));
+  }
+  return ShapeDispatch(arms: arms);
+}
+
+HybridDispatch? _pickHybrid(List<ResolvedSchema> variants) {
+  // Eligibility: every variant has a shape key, at least two
+  // collide on Map, and no other shape collides with itself.
+  final byShape = <String, List<ResolvedSchema>>{};
+  for (final v in variants) {
+    final k = _jsonShapeKey(v);
+    if (k == null) return null;
+    byShape.putIfAbsent(k, () => []).add(v);
+  }
+  final mapVariants = byShape[_mapShapeKey];
+  if (mapVariants == null || mapVariants.length < 2) return null;
+  if (byShape.length < 2) return null;
+  final shapeArms = <ShapeArm>[];
+  for (final entry in byShape.entries) {
+    if (entry.key == _mapShapeKey) continue;
+    if (entry.value.length > 1) return null;
+    shapeArms.add(ShapeArm(variant: entry.value.single, shapeKey: entry.key));
+  }
+  // Sub-dispatch the Map variants by required-field (loose mode —
+  // see [_requiredFieldArmsFor]).
+  final mapArms = _requiredFieldArmsFor(
+    mapVariants,
+    looseRequiredUniqueness: true,
+  );
+  if (mapArms == null) return null;
+  // Re-derive shape arms in spec declaration order so subclass
+  // declarations match the variant ordering.
+  final declarationOrder = variants;
+  final shapeArmsInOrder = <ShapeArm>[];
+  for (final v in declarationOrder) {
+    if (_jsonShapeKey(v) == _mapShapeKey) continue;
+    shapeArmsInOrder.add(shapeArms.firstWhere((a) => a.variant == v));
+  }
+  ResolvedSchema? mapFallback;
+  final checkedMapArms = <PredicateArm>[];
+  for (final arm in mapArms) {
+    if (arm.isFallback) {
+      mapFallback = arm.variant;
+    } else {
+      checkedMapArms.add(arm);
+    }
+  }
+  return HybridDispatch(
+    shapeArms: shapeArmsInOrder,
+    mapArms: checkedMapArms,
+    mapFallback: mapFallback,
+    declarationOrder: declarationOrder,
+  );
+}
+
+PredicateDispatch? _pickRequiredField(List<ResolvedSchema> variants) {
+  final arms = _requiredFieldArmsFor(variants);
+  if (arms == null) return null;
+  return PredicateDispatch(
+    kind: PredicateDispatchKind.requiredField,
+    arms: arms,
+  );
+}
+
+PredicateDispatch? _pickArrayElement(List<ResolvedSchema> variants) {
+  if (!variants.every((v) => v is ResolvedArray)) return null;
+  final arrays = variants.cast<ResolvedArray>();
+  final innerArms = _requiredFieldArmsFor(arrays.map((a) => a.items).toList());
+  if (innerArms == null) return null;
+  // Translate inner predicates (KeyExists on items' Map) to outer
+  // ones (ArrayElementHasKey on the cast list local).
+  final outerArms = <PredicateArm>[];
+  for (var i = 0; i < arrays.length; i++) {
+    final inner = innerArms[i].predicate;
+    final outer = switch (inner) {
+      KeyExists(:final propertyName) => ArrayElementHasKey(propertyName),
+      Always() => const Always(),
+      ArrayElementHasKey() => throw StateError(
+        'Unexpected nested array-element predicate from inner arms',
+      ),
+    };
+    outerArms.add(PredicateArm(variant: arrays[i], predicate: outer));
+  }
+  return PredicateDispatch(
+    kind: PredicateDispatchKind.arrayElement,
+    arms: outerArms,
+  );
+}
+
+/// Property-presence dispatch on object-shaped variants. Each variant
+/// is keyed off a property unique to it across the oneOf — required
+/// when possible, falling back to optional. A variant with no unique
+/// property at all becomes the fallback (at most one allowed).
+///
+/// [looseRequiredUniqueness] relaxes "required-unique" to "no sibling
+/// *requires* it" instead of "no sibling lists it as a property at
+/// all". Loose is needed by the hybrid path (whose Map sub-arms can
+/// have benign optional-overlap) but unsafe for the pure required-
+/// field path.
+List<PredicateArm>? _requiredFieldArmsFor(
+  List<ResolvedSchema> variants, {
+  bool looseRequiredUniqueness = false,
+}) {
+  if (!variants.every(_isObjectLike)) return null;
+  final allRequired = variants.map(_flattenedRequiredProperties).toList();
+  final allProps = variants
+      .map((s) => _flattenedProperties(s).keys.toSet())
+      .toList();
+  final arms = <PredicateArm>[];
+  var fallbackCount = 0;
+  for (var i = 0; i < variants.length; i++) {
+    final mineReq = allRequired[i];
+    final mineProps = allProps[i];
+    final othersReq = <String>{};
+    final othersProps = <String>{};
+    for (var j = 0; j < allRequired.length; j++) {
+      if (i == j) continue;
+      othersReq.addAll(allRequired[j]);
+      othersProps.addAll(allProps[j]);
+    }
+    final uniqueRequired = mineReq.difference(
+      looseRequiredUniqueness ? othersReq : othersProps,
+    );
+    final uniqueProps = mineProps.difference(othersProps);
+    final candidates = uniqueRequired.isNotEmpty ? uniqueRequired : uniqueProps;
+    if (candidates.isEmpty) {
+      fallbackCount++;
+      if (fallbackCount > 1) return null;
+      arms.add(PredicateArm(variant: variants[i], predicate: const Always()));
+      continue;
+    }
+    final tag = (candidates.toList()..sort()).first;
+    arms.add(PredicateArm(variant: variants[i], predicate: KeyExists(tag)));
+  }
+  return arms;
+}

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -1,6 +1,7 @@
 import 'package:collection/collection.dart';
 import 'package:equatable/equatable.dart';
 import 'package:meta/meta.dart';
+import 'package:space_gen/src/dispatch.dart';
 import 'package:space_gen/src/parse/spec.dart' show StatusCodeRange;
 import 'package:space_gen/src/quirks.dart';
 // Any code that depends on SchemaRenderer probably should be moved out
@@ -449,6 +450,7 @@ class SpecResolver {
           common: schema.common,
           schemas: renderSchemas,
           discriminator: renderDiscriminator,
+          source: schema,
         );
       case ResolvedAllOf():
         // Generate a synthetic object type for allOf. A property is
@@ -482,6 +484,7 @@ class SpecResolver {
           common: schema.common,
           schemas: schema.schemas.map(toRenderSchema).toList(),
           discriminator: null,
+          source: schema,
         );
       case ResolvedMap():
         final keyEnum = schema.keySchema;
@@ -610,6 +613,10 @@ class SpecResolver {
         ),
         schemas: distinctSchemas.toList(),
         discriminator: null,
+        // Synthesized — no resolved oneOf. Renders as the legacy
+        // `UnimplementedError` stub via the null-source `NoDispatch`
+        // path; closing this gap is a follow-up.
+        source: null,
       ),
     );
   }
@@ -3749,6 +3756,7 @@ class RenderOneOf extends RenderNewType {
     required super.common,
     required this.schemas,
     required this.discriminator,
+    required this.source,
   });
 
   /// The schemas of the resolved schema.
@@ -3760,6 +3768,20 @@ class RenderOneOf extends RenderNewType {
   /// right variant. When absent, today's renderer falls back to the
   /// UnimplementedError stub — a gap to close in a follow-up.
   final RenderDiscriminator? discriminator;
+
+  /// The source resolved oneOf/anyOf this RenderOneOf was built from,
+  /// when there is one. Carried so [toTemplateContext] can call
+  /// [decideDispatch] on the resolved tree (where dispatch belongs —
+  /// pure spec, no Dart names) and then translate the decision into
+  /// mustache context using render-side names + per-variant Dart
+  /// conversions. The variants of `source.schemas` and [schemas] are
+  /// parallel: index `i` is the resolved/render pair.
+  ///
+  /// Null for synthesized RenderOneOfs that don't correspond to a
+  /// resolved oneOf — e.g. the placeholder built for range-mixed
+  /// multi-status responses. These always render as [NoDispatch] /
+  /// the legacy `UnimplementedError` stub.
+  final ResolvedSchemaCollection? source;
 
   /// We could do something smarter here, to determine if the oneOf has a
   /// const constructor, but it's not worth the complexity for now.
@@ -3854,333 +3876,14 @@ class RenderOneOf extends RenderNewType {
     );
   }
 
-  /// The discriminator we'll dispatch on: the spec's explicit one when
-  /// present, otherwise an implicit one synthesized from variants that
-  /// each tag themselves with a single-value enum property (see
-  /// [_implicitDiscriminator]). Explicit always wins.
-  RenderDiscriminator? get _effectiveDiscriminator =>
-      discriminator ?? _implicitDiscriminator;
-
-  /// Discriminator-driven dispatch: every variant must be an object-
-  /// shaped newtype with a `fromJson` factory.
-  bool get _hasDiscriminatorDispatch =>
-      _effectiveDiscriminator != null &&
-      schemas.every((s) => s is RenderObject);
-
-  /// Synthesized discriminator for object-only oneOfs whose variants
-  /// each tag themselves with a single-value enum property — github's
-  /// `repository-rule` shape. The spec doesn't declare a
-  /// `discriminator`, but every variant has, e.g.,
-  /// `type: { enum: ['creation'] }` with that property required. The
-  /// values are pairwise distinct, so the parent's `fromJson` can
-  /// switch on `json[<that property>]` and pick a variant.
-  ///
-  /// Conservative on purpose: requires the tag property to be in
-  /// every variant's `requiredProperties` (an absent field would
-  /// crash dispatch) and that the single-enum values be unique
-  /// across variants (otherwise dispatch is ambiguous). Returns null
-  /// if no property qualifies; the caller falls through to shape /
-  /// required-field dispatch as usual.
-  RenderDiscriminator? get _implicitDiscriminator {
-    if (schemas.isEmpty) return null;
-    if (!schemas.every((s) => s is RenderObject)) return null;
-    final objects = schemas.cast<RenderObject>();
-    // A property qualifies as an implicit discriminator iff every
-    // variant has it as a required, single-value enum. Walk the first
-    // variant's properties to seed candidates; for each, gather the
-    // per-variant tag value while validating the others. Recording
-    // values here avoids a second lookup later.
-    final candidates = <(String, List<String>)>[];
-    for (final entry in objects.first.properties.entries) {
-      final propName = entry.key;
-      if (!objects.first.requiredProperties.contains(propName)) continue;
-      final firstType = entry.value;
-      if (firstType is! RenderEnum || firstType.values.length != 1) {
-        continue;
-      }
-      final values = [firstType.values.first];
-      var allMatch = true;
-      for (var i = 1; i < objects.length; i++) {
-        final other = objects[i];
-        if (!other.requiredProperties.contains(propName)) {
-          allMatch = false;
-          break;
-        }
-        final otherType = other.properties[propName];
-        if (otherType is! RenderEnum || otherType.values.length != 1) {
-          allMatch = false;
-          break;
-        }
-        values.add(otherType.values.first);
-      }
-      if (allMatch) candidates.add((propName, values));
-    }
-    if (candidates.isEmpty) return null;
-    // Stable pick: lexicographically-first candidate property whose
-    // values are unique. Sorting first means small spec edits don't
-    // shuffle the chosen discriminator.
-    candidates.sort((a, b) => a.$1.compareTo(b.$1));
-    for (final (propName, values) in candidates) {
-      if (values.toSet().length != values.length) continue;
-      return RenderDiscriminator(
-        propertyName: propName,
-        mapping: {
-          for (var i = 0; i < objects.length; i++) values[i]: objects[i],
-        },
-      );
-    }
-    return null;
+  /// Whether any dispatch strategy will fire — drives whether the
+  /// `@immutable` wrapper-class import is needed. Calls [decideDispatch]
+  /// on the resolved source; cheap and pure.
+  bool get _hasDispatch {
+    final src = source;
+    if (src == null) return false;
+    return decideDispatch(src) is! NoDispatch;
   }
-
-  /// True iff every variant has a known shape key AND all keys are
-  /// pairwise distinct. Context-free so [additionalImports] and
-  /// [_hasDispatch] can answer the can-we-dispatch question without a
-  /// [SchemaRenderer]; the context-taking [_shapeDispatchPlans] adds
-  /// the items' fromJson/toJson expressions when arrays are involved.
-  bool get _canShapeDispatch {
-    final keys = <String>{};
-    for (final v in schemas) {
-      final k = v.jsonShapeKey;
-      if (k == null) return false;
-      if (!keys.add(k)) return false;
-    }
-    return true;
-  }
-
-  /// Shape-driven dispatch (runtime-type switch). Falls through from
-  /// the discriminator path when the discriminator can't be honored
-  /// (e.g. non-object variants under a discriminator) — shape is a
-  /// strict fallback rather than a competitor.
-  List<_VariantPlan>? _shapeDispatchPlans(SchemaRenderer context) {
-    if (!_canShapeDispatch) return null;
-    final plans = <_VariantPlan>[];
-    for (final v in schemas) {
-      final plan = _planVariant(v, context);
-      if (plan == null) return null;
-      plans.add(plan);
-    }
-    return plans;
-  }
-
-  /// Property-presence dispatch on object-shaped variants: each
-  /// variant is keyed off the presence of a property unique to it
-  /// across the oneOf. "Unique" means *not present in any sibling's
-  /// property set* — required or optional. A required-unique tag is
-  /// always emitted in valid JSON for that variant (safe); an
-  /// optional-unique tag is best-effort but still works for typical
-  /// real-world responses where servers emit the distinguishing
-  /// optional (e.g. github's `validation-error` reliably emits
-  /// `errors`, `repository-rule-violation-error` reliably emits
-  /// `metadata`). A variant with no unique props at all is the
-  /// dispatch's fallback; at most one is allowed.
-  ///
-  /// Useful for (object, object) oneOfs without a discriminator —
-  /// github has ~9 such sites with disjoint required-sets (e.g.
-  /// `simple-user` requires `login`, `enterprise` requires `slug`),
-  /// a handful where one variant is empty (`commit.author` is
-  /// `[simple-user, empty-object]`, the `interactions` 200 responses
-  /// are `[interaction-limit-response, <empty>]`), plus
-  /// `environment.protection_rules.items` (three variants share
-  /// `[id, node_id, type]` as required and differ by unique
-  /// optionals) and `git/create-blob` 422
-  /// (`[validation-error, repository-rule-violation-error]`,
-  /// distinguished by `errors` vs `metadata`).
-  ///
-  /// Returns one [_RequiredFieldArm] per variant in [schemas] order,
-  /// or null if the dispatch can't be made unambiguous — in which
-  /// case dispatch falls through to the legacy stub.
-  List<_RequiredFieldArm>? get _requiredFieldDispatchArms =>
-      _requiredFieldArmsFor(schemas);
-
-  /// Same algorithm as [_requiredFieldDispatchArms] but operating on
-  /// an arbitrary subset of variants — used by the hybrid path below
-  /// to dispatch the Map-shaped variants when the shape arm sees a
-  /// `Map<String, dynamic>` collision.
-  ///
-  /// [looseRequiredUniqueness] relaxes the required-tag uniqueness
-  /// check to "no sibling *requires* it" instead of "no sibling
-  /// lists it as a property at all". The looser check lets the
-  /// hybrid path dispatch when a sibling spuriously lists the tag
-  /// as optional (github's `repos/get-content` shape — `content-file`
-  /// declares `target` and `submodule_git_url` optional even though
-  /// the server never emits them for files). It's NOT safe for the
-  /// pure required-field path: a real-world example is
-  /// `git/create-blob` 422, where every error variant emits
-  /// `documentation_url` even though only the validation error
-  /// requires it — loose would tag validation on `documentation_url`
-  /// and misclassify rule-violation responses. Strict is the default;
-  /// the hybrid caller opts in.
-  static List<_RequiredFieldArm>? _requiredFieldArmsFor(
-    List<RenderSchema> variants, {
-    bool looseRequiredUniqueness = false,
-  }) {
-    // Object-shaped variants only (RenderObject for normal objects,
-    // RenderEmptyObject for `{}`-shaped fallbacks).
-    if (!variants.every((s) => s is RenderObject || s is RenderEmptyObject)) {
-      return null;
-    }
-    final objects = variants.cast<RenderNewType>();
-    Set<String> requiredOf(RenderNewType o) =>
-        o is RenderObject ? o.requiredProperties.toSet() : const <String>{};
-    Set<String> propsOf(RenderNewType o) =>
-        o is RenderObject ? o.properties.keys.toSet() : const <String>{};
-    final allRequired = objects.map(requiredOf).toList();
-    final allProps = objects.map(propsOf).toList();
-    final arms = <_RequiredFieldArm>[];
-    var fallbackCount = 0;
-    for (var i = 0; i < objects.length; i++) {
-      final mineReq = allRequired[i];
-      final mineProps = allProps[i];
-      final othersReq = <String>{};
-      final othersProps = <String>{};
-      for (var j = 0; j < allRequired.length; j++) {
-        if (i == j) continue;
-        othersReq.addAll(allRequired[j]);
-        othersProps.addAll(allProps[j]);
-      }
-      // Required-unique: STRICT by default — fields no sibling
-      // lists at all (so no risk that a sibling's optional copy
-      // crosses with the tag). Hybrid callers flip to LOOSE
-      // (`mineReq - othersReq`) to accept benign optional-overlap
-      // cases like `repos/get-content` — see the doc on this
-      // function. Optional-unique always uses STRICT: an optional
-      // tag might or might not be emitted, so we want zero risk
-      // of cross-match.
-      final uniqueRequired = mineReq.difference(
-        looseRequiredUniqueness ? othersReq : othersProps,
-      );
-      final uniqueProps = mineProps.difference(othersProps);
-      final candidates = uniqueRequired.isNotEmpty
-          ? uniqueRequired
-          : uniqueProps;
-      if (candidates.isEmpty) {
-        // No unique anything — this variant is the fallback. At most
-        // one fallback per dispatch; with two the dispatch would be
-        // ambiguous.
-        fallbackCount++;
-        if (fallbackCount > 1) return null;
-        arms.add(
-          _RequiredFieldArm(variant: objects[i], predicate: const _Always()),
-        );
-        continue;
-      }
-      // Lex-first for stable output.
-      final tag = (candidates.toList()..sort()).first;
-      arms.add(
-        _RequiredFieldArm(variant: objects[i], predicate: _KeyExists(tag)),
-      );
-    }
-    return arms;
-  }
-
-  /// Hybrid dispatch when the variant set mixes shapes (e.g. an array
-  /// alongside several objects). Pure shape dispatch fails because the
-  /// objects collide on `Map<String, dynamic>`; pure required-field
-  /// fails because not every variant is an object. Hybrid: shape-arm
-  /// each non-Map variant, then required-field-dispatch the Map
-  /// variants in a single nested arm.
-  ///
-  /// Github's only current site is `repos/get-content` 200 — `[content-
-  /// directory (array), content-file, content-symlink, content-
-  /// submodule]` (3 objects with disjoint required properties).
-  ///
-  /// Returns null when any other dispatch (discriminator, pure shape,
-  /// pure required-field) already covers the case, when there are no
-  /// Map collisions to disambiguate, when a non-Map shape collides
-  /// (e.g. two arrays — the array sub-dispatch is a separate gap),
-  /// or when the Map variants themselves are not required-field
-  /// dispatchable.
-  _HybridDispatchPlan? _hybridDispatchPlan(SchemaRenderer context) {
-    final eligibility = _hybridEligibility();
-    if (eligibility == null) return null;
-    final mapArms = _requiredFieldArmsFor(
-      eligibility.mapVariants,
-      looseRequiredUniqueness: true,
-    );
-    if (mapArms == null) return null;
-
-    // Walk variants in [schemas] order — that's the order sealed
-    // subclasses get declared in the generated file. Each variant is
-    // either a Map arm (already keyed in [mapArms]) or a non-Map
-    // shape arm (we build the plan here). Building both arm lists
-    // and the parallel [variantContexts] in a single pass keeps the
-    // routing explicit; pulling them apart later would need lookup
-    // tables and bang-asserts.
-    final mapArmByVariant = {for (final a in mapArms) a.variant: a};
-    final shapeArms = <_VariantPlan>[];
-    final variantContexts = <Map<String, dynamic>>[];
-    for (final variant in schemas) {
-      final mapArm = mapArmByVariant[variant];
-      if (mapArm != null) {
-        variantContexts.add(objectWrapperContext(mapArm.variant));
-        continue;
-      }
-      final plan = _planVariant(variant, context);
-      if (plan == null) return null;
-      shapeArms.add(plan);
-      variantContexts.add(_shapeWrapperContext(plan));
-    }
-    return _HybridDispatchPlan(
-      shapeArms: shapeArms,
-      mapArms: mapArms,
-      variantContexts: variantContexts,
-    );
-  }
-
-  /// Shared eligibility gate for [_hybridDispatchPlan]: every
-  /// variant has a shape key, there's at least one Map variant
-  /// collision, at least one non-Map sibling, and no non-Map shape
-  /// collides with itself (e.g. two arrays — that's its own gap).
-  /// Returns the shape and Map partitions on success, null when the
-  /// hybrid path doesn't apply.
-  ///
-  /// [_hasDispatch] and [additionalImports] also use the eligibility
-  /// check directly — they need to know whether hybrid will fire but
-  /// run before a SchemaRenderer is available, so they can't invoke
-  /// [_planVariant] or the Map sub-dispatch. A false positive there
-  /// only adds a stray `package:meta/meta.dart` import that
-  /// `dart fix` strips.
-  _HybridEligibility? _hybridEligibility() {
-    final byShape = <String, List<RenderSchema>>{};
-    for (final v in schemas) {
-      final k = v.jsonShapeKey;
-      if (k == null) return null;
-      byShape.putIfAbsent(k, () => []).add(v);
-    }
-    final mapVariants = byShape[_mapShapeKey];
-    // Pure shape dispatch handles a no-Map-collision case; pure
-    // required-field handles an all-Map case.
-    if (mapVariants == null || mapVariants.length < 2) return null;
-    if (byShape.length < 2) return null;
-    final shapeVariants = <RenderSchema>[];
-    for (final entry in byShape.entries) {
-      if (entry.key == _mapShapeKey) continue;
-      // A non-Map shape collision (e.g. two arrays) is its own gap;
-      // bail rather than dispatching half the cases.
-      if (entry.value.length > 1) return null;
-      shapeVariants.add(entry.value.single);
-    }
-    return _HybridEligibility(
-      shapeVariants: shapeVariants,
-      mapVariants: mapVariants,
-    );
-  }
-
-  /// Context-free eligibility check for [_pickArrayElementMode] —
-  /// used by [_hasDispatch] (and through it, [additionalImports])
-  /// which run before a [SchemaRenderer] is available.
-  bool get _isArrayElementEligible {
-    if (!schemas.every((s) => s is RenderArray)) return false;
-    final arrays = schemas.cast<RenderArray>();
-    return _requiredFieldArmsFor(arrays.map((a) => a.items).toList()) != null;
-  }
-
-  bool get _hasDispatch =>
-      _hasDiscriminatorDispatch ||
-      _canShapeDispatch ||
-      _hybridEligibility() != null ||
-      _requiredFieldDispatchArms != null ||
-      _isArrayElementEligible;
 
   @override
   Iterable<Import> get additionalImports => [
@@ -4201,198 +3904,195 @@ class RenderOneOf extends RenderNewType {
     return ctx;
   }
 
-  /// Picks the dispatch mode for this oneOf in priority order:
-  /// discriminator → pure shape → hybrid → required-field →
-  /// array-element → none. Array-element is last among the typed
-  /// modes because it requires every variant to be `array<object>` —
-  /// strict enough that earlier modes have already claimed any
-  /// dispatch they can.
-  _DispatchMode _pickDispatchMode(SchemaRenderer context) =>
-      _pickDiscriminatorMode() ??
-      _pickShapeMode(context) ??
-      _pickHybridMode(context) ??
-      _pickRequiredFieldMode() ??
-      _pickArrayElementMode(context) ??
-      const _NoDispatchMode();
-
-  _DiscriminatorMode? _pickDiscriminatorMode() {
-    final disc = _effectiveDiscriminator;
-    if (disc == null || !_hasDiscriminatorDispatch) return null;
-    return _DiscriminatorMode(
-      discriminatorProperty: disc.propertyName,
-      dispatch: [
-        for (final entry in disc.mapping.entries)
-          {
-            'value': entry.key,
-            'wrapperTypeName': wrapperTypeName(entry.value),
-            'valueType': entry.value.typeName,
-          },
-      ],
-      variants: schemas.map(objectWrapperContext).toList(),
-    );
+  /// Picks the dispatch mode for this oneOf. Decision-making (the
+  /// structural "which strategy fits this oneOf") is delegated to
+  /// [decideDispatch], which operates on the resolved tree without
+  /// any Dart-name knowledge. This method is the render-side
+  /// translator: it converts the abstract [DispatchDecision] back
+  /// into the render-coupled [_DispatchMode] template-context bag,
+  /// using [wrapperTypeName] / [_planVariant] / [_VariantConversion]
+  /// to splice in Dart-name and per-variant conversion strings.
+  _DispatchMode _pickDispatchMode(SchemaRenderer context) {
+    final src = source;
+    if (src == null) return const _NoDispatchMode();
+    return _decisionToMode(decideDispatch(src), context);
   }
 
-  _ShapeMode? _pickShapeMode(SchemaRenderer context) {
-    final plans = _shapeDispatchPlans(context);
-    if (plans == null) return null;
-    return _ShapeMode(variants: plans.map(_shapeWrapperContext).toList());
+  /// Translates a structural [DispatchDecision] into a [_DispatchMode].
+  /// The resolved → render variant mapping uses index parity:
+  /// `source.schemas[i]` corresponds to [schemas]`[i]` (preserved by
+  /// [SpecResolver.toRenderSchema]).
+  _DispatchMode _decisionToMode(
+    DispatchDecision decision,
+    SchemaRenderer context,
+  ) {
+    // [_pickDispatchMode] short-circuits to NoDispatchMode when source
+    // is null, so any decision other than NoDispatch came from a real
+    // resolved oneOf — `source!` is sound here.
+    final src = source!;
+    RenderSchema renderOf(ResolvedSchema resolved) {
+      final i = src.schemas.indexWhere((s) => identical(s, resolved));
+      if (i == -1) {
+        throw StateError(
+          'Decision references variant not in source.schemas: $resolved',
+        );
+      }
+      return schemas[i];
+    }
+
+    return switch (decision) {
+      DiscriminatorDispatch(
+        :final propertyName,
+        :final mapping,
+        :final variants,
+      ) =>
+        _DiscriminatorMode(
+          discriminatorProperty: propertyName,
+          dispatch: [
+            for (final entry in mapping)
+              {
+                'value': entry.value,
+                'wrapperTypeName': wrapperTypeName(renderOf(entry.variant)),
+                'valueType': renderOf(entry.variant).typeName,
+              },
+          ],
+          variants: [
+            for (final v in variants) objectWrapperContext(renderOf(v)),
+          ],
+        ),
+      ShapeDispatch(:final arms) => _ShapeMode(
+        variants: [
+          for (final arm in arms)
+            _shapeWrapperContext(_planVariant(renderOf(arm.variant), context)!),
+        ],
+      ),
+      HybridDispatch(
+        :final shapeArms,
+        :final mapArms,
+        :final mapFallback,
+        :final declarationOrder,
+      ) =>
+        _HybridMode(
+          shapeArms: [
+            for (final arm in shapeArms)
+              _shapeWrapperContext(
+                _planVariant(renderOf(arm.variant), context)!,
+              ),
+          ],
+          mapArms: [
+            for (final arm in mapArms)
+              {
+                'predicateTest': arm.predicate.dartIfTest('v'),
+                'wrapperTypeName': wrapperTypeName(renderOf(arm.variant)),
+                'valueType': renderOf(arm.variant).typeName,
+              },
+          ],
+          mapFallback: mapFallback == null
+              ? null
+              : {
+                  'wrapperTypeName': wrapperTypeName(renderOf(mapFallback)),
+                  'valueType': renderOf(mapFallback).typeName,
+                },
+          variants: [
+            for (final v in declarationOrder)
+              if (mapArms.any((a) => identical(a.variant, v)) ||
+                  identical(v, mapFallback))
+                objectWrapperContext(renderOf(v))
+              else
+                _shapeWrapperContext(_planVariant(renderOf(v), context)!),
+          ],
+        ),
+      PredicateDispatch(:final kind, :final arms) => _buildPredicateMode(
+        kind,
+        arms,
+        renderOf,
+        context,
+      ),
+      NoDispatch() => const _NoDispatchMode(),
+    };
   }
 
-  _HybridMode? _pickHybridMode(SchemaRenderer context) {
-    final hybrid = _hybridDispatchPlan(context);
-    if (hybrid == null) return null;
-    // Map sub-dispatch arms split into checked (`when
-    // v.containsKey(tag)`) and the optional fallback (no `when`,
-    // catches everything else). The hybrid template's switch binds
-    // the matched JSON to `v`, so the predicate's if-test is rooted
-    // on `v` rather than `json`.
-    final checked = hybrid.mapArms.where((a) => !a.isFallback);
-    final fallback = hybrid.mapArms.where((a) => a.isFallback).firstOrNull;
-    return _HybridMode(
-      shapeArms: hybrid.shapeArms.map(_shapeWrapperContext).toList(),
-      mapArms: checked.map((a) => _taggedArmContext(a, jsonVar: 'v')).toList(),
-      mapFallback: fallback == null ? null : _fallbackArmContext(fallback),
-      variants: hybrid.variantContexts,
-    );
-  }
-
-  _PredicateDispatchMode? _pickRequiredFieldMode() {
-    final arms = _requiredFieldDispatchArms;
-    if (arms == null) return null;
-    // Pure required-field: factory takes the Map directly; predicates
-    // are rooted on `json`; wrappers wrap the Map back unchanged.
-    final checked = arms.where((a) => !a.isFallback);
-    final fallback = arms.where((a) => a.isFallback).firstOrNull;
-    String constructionFor(RenderNewType variant) =>
-        '${variant.typeName}.fromJson(json)';
-    return _PredicateDispatchMode(
-      dispatch: [
-        for (final arm in checked)
-          {
-            'predicateTest': arm.predicate.dartIfTest('json'),
-            'wrapperTypeName': wrapperTypeName(arm.variant),
-            'construction': constructionFor(arm.variant),
-          },
-      ],
-      fallback: fallback == null
-          ? null
-          : {
-              'wrapperTypeName': wrapperTypeName(fallback.variant),
-              'construction': constructionFor(fallback.variant),
-            },
-      variants: arms.map((a) => objectWrapperContext(a.variant)).toList(),
-      factoryParamType: 'Map<String, dynamic>',
-      preamble: false,
-      throwMessage:
-          'No variant of $typeName matched json keys: '
-          r'${json.keys.toList()}',
-      toJsonReturnType: 'Map<String, dynamic>',
-    );
-  }
-
-  /// Array-element dispatch fires when every variant is `array<object>`
-  /// and the *element* types have unique required-or-optional fields.
-  /// Same algorithm as required-field, but one level deeper through
-  /// [_requiredFieldArmsFor] applied to each array's `items`. Each
-  /// inner `_KeyExists(tag)` becomes an outer `_ArrayElementHasKey(tag)`
-  /// rooted on the cast list local (`v`).
-  _PredicateDispatchMode? _pickArrayElementMode(SchemaRenderer context) {
-    if (!schemas.every((s) => s is RenderArray)) return null;
-    final arrays = schemas.cast<RenderArray>();
-    final innerArms = _requiredFieldArmsFor(
-      arrays.map((a) => a.items).toList(),
-    );
-    if (innerArms == null) return null;
+  _PredicateDispatchMode _buildPredicateMode(
+    PredicateDispatchKind kind,
+    List<PredicateArm> arms,
+    RenderSchema Function(ResolvedSchema) renderOf,
+    SchemaRenderer context,
+  ) {
     final dispatch = <Map<String, dynamic>>[];
     Map<String, dynamic>? fallback;
     final variants = <Map<String, dynamic>>[];
-    for (var i = 0; i < arrays.length; i++) {
-      final plan = _planVariant(arrays[i], context);
-      // Every array variant has a known shape key (`List<dynamic>`)
-      // and a [_VariantConversion], so [_planVariant] never returns
-      // null here — but guarding keeps the picker honest if a future
-      // RenderSchema type weakens that guarantee.
-      if (plan == null) return null;
-      // [_planVariant] would name every array `<Parent>List` (the
-      // shared `wrapperTag = 'List'`), so the sibling array variants
-      // would collide. Splice in the items type to keep wrapper class
-      // names unique: `<Parent><ItemType>List`.
-      final wrapperName = '$typeName${arrays[i].items.typeName}List';
-      variants.add({
-        'wrapperTypeName': wrapperName,
-        'valueType': plan.valueType,
-        'jsonTestType': plan.jsonTestType,
-        'fromJson': plan.fromJson,
-        'toJsonBody': plan.toJson,
-        'toJsonReturnType': 'dynamic',
-        'positionalBoolIgnore': plan.positionalBoolIgnore,
-      });
-      final innerPredicate = innerArms[i].predicate;
-      // Translate the inner predicate (operating on the items'
-      // Map representation) to the outer one (operating on the
-      // List local, peeking [0]). _Always passes through unchanged —
-      // a fallback-eligible items schema produces a fallback-eligible
-      // array variant.
-      final outerPredicate = switch (innerPredicate) {
-        _KeyExists(:final propertyName) => _ArrayElementHasKey(propertyName),
-        _Always() => const _Always(),
-        // Composing _ArrayElementHasKey with itself would mean
-        // `array<array<object>>` element-of-element dispatch — a
-        // generalization we haven't needed.
-        _ArrayElementHasKey() => throw StateError(
-          'Unexpected nested array-element predicate from inner arms',
-        ),
-      };
-      final arm = <String, dynamic>{
-        'wrapperTypeName': wrapperName,
-        // Per-arm construction differs across siblings — each array
-        // wraps a `List<X>` of its own element type, so the conversion
-        // expression varies (`v.map<X>((e) => X.fromJson(e)).toList()`).
-        'construction': plan.fromJson,
-      };
-      if (outerPredicate is _Always) {
-        fallback = arm;
+    for (final arm in arms) {
+      final renderVariant = renderOf(arm.variant);
+      final Map<String, dynamic> armCtx;
+      switch (kind) {
+        case PredicateDispatchKind.requiredField:
+          // Wrappers wrap the Map back as `value.toJson()`; per-arm
+          // construction is `<typeName>.fromJson(json)`.
+          armCtx = {
+            'wrapperTypeName': wrapperTypeName(renderVariant),
+            'construction': '${renderVariant.typeName}.fromJson(json)',
+          };
+          variants.add(objectWrapperContext(renderVariant));
+        case PredicateDispatchKind.arrayElement:
+          // Each array variant wraps `List<X>` and serializes via
+          // the items' own conversion. Wrapper class name splices
+          // the items type so sibling array variants don't collide
+          // on the shared `wrapperTag = 'List'`. The items'
+          // RenderSchema is on the parallel render array (the
+          // resolved items aren't a direct member of source.schemas
+          // and so can't go through renderOf).
+          final renderArray = renderVariant as RenderArray;
+          final innerTypeName = renderArray.items.typeName;
+          final wrapperName = '$typeName${innerTypeName}List';
+          final plan = _planVariant(renderVariant, context)!;
+          armCtx = {
+            'wrapperTypeName': wrapperName,
+            'construction': plan.fromJson,
+          };
+          variants.add({
+            'wrapperTypeName': wrapperName,
+            'valueType': plan.valueType,
+            'jsonTestType': plan.jsonTestType,
+            'fromJson': plan.fromJson,
+            'toJsonBody': plan.toJson,
+            'toJsonReturnType': 'dynamic',
+            'positionalBoolIgnore': plan.positionalBoolIgnore,
+          });
+      }
+      if (arm.isFallback) {
+        fallback = armCtx;
       } else {
-        arm['predicateTest'] = outerPredicate.dartIfTest('v');
-        dispatch.add(arm);
+        armCtx['predicateTest'] = arm.predicate.dartIfTest(
+          kind == PredicateDispatchKind.arrayElement ? 'v' : 'json',
+        );
+        dispatch.add(armCtx);
       }
     }
+    final factoryParamType = kind == PredicateDispatchKind.arrayElement
+        ? 'dynamic'
+        : 'Map<String, dynamic>';
+    final preamble = kind == PredicateDispatchKind.arrayElement
+        ? const [
+            {'line': 'final v = json as List;'},
+          ]
+        : false;
+    final throwMessage = kind == PredicateDispatchKind.arrayElement
+        ? 'No variant of $typeName matched first array element'
+        : 'No variant of $typeName matched json keys: '
+              r'${json.keys.toList()}';
+    final toJsonReturnType = kind == PredicateDispatchKind.arrayElement
+        ? 'dynamic'
+        : 'Map<String, dynamic>';
     return _PredicateDispatchMode(
       dispatch: dispatch,
       fallback: fallback,
       variants: variants,
-      factoryParamType: 'dynamic',
-      preamble: const [
-        {'line': 'final v = json as List;'},
-      ],
-      throwMessage: 'No variant of $typeName matched first array element',
-      toJsonReturnType: 'dynamic',
+      factoryParamType: factoryParamType,
+      preamble: preamble,
+      throwMessage: throwMessage,
+      toJsonReturnType: toJsonReturnType,
     );
   }
-
-  /// Template-context shape for a checked required-field arm —
-  /// used by both the pure required-field path and the hybrid Map
-  /// sub-dispatch. The mustache template emits the `if (...)` guard
-  /// from the `predicateTest` field verbatim, so each predicate kind
-  /// owns its own test syntax (containsKey today; array-element peek
-  /// later). [jsonVar] names the in-scope JSON value the predicate
-  /// tests against — `json` for the pure required-field factory
-  /// parameter, `v` for the hybrid template's switch-bound variable.
-  Map<String, dynamic> _taggedArmContext(
-    _RequiredFieldArm arm, {
-    required String jsonVar,
-  }) => {
-    'predicateTest': arm.predicate.dartIfTest(jsonVar),
-    'wrapperTypeName': wrapperTypeName(arm.variant),
-    'valueType': arm.variant.typeName,
-  };
-
-  /// Template-context shape for the unguarded fallback arm of a
-  /// required-field or hybrid-Map dispatch.
-  Map<String, dynamic> _fallbackArmContext(_RequiredFieldArm arm) => {
-    'wrapperTypeName': wrapperTypeName(arm.variant),
-    'valueType': arm.variant.typeName,
-  };
 
   @override
   String fromJsonExpression(
@@ -4547,54 +4247,6 @@ Map<String, dynamic> _shapeWrapperContext(_VariantPlan p) => {
   'toJsonReturnType': 'dynamic',
   'positionalBoolIgnore': p.positionalBoolIgnore,
 };
-
-/// Eligibility result for [RenderOneOf._hybridEligibility]: which
-/// variants land in shape arms vs which collide on the Map shape and
-/// need a required-field sub-dispatch.
-@immutable
-class _HybridEligibility {
-  const _HybridEligibility({
-    required this.shapeVariants,
-    required this.mapVariants,
-  });
-
-  /// Variants whose shape key is unique within the oneOf — each
-  /// becomes a single shape arm in the dispatch.
-  final List<RenderSchema> shapeVariants;
-
-  /// Variants that share the `Map<String, dynamic>` shape — get
-  /// required-field-dispatched together inside the Map arm.
-  final List<RenderSchema> mapVariants;
-}
-
-/// Plan for a hybrid dispatch — non-Map variants land in shape arms,
-/// then the Map-shaped variants are sub-dispatched via required-field
-/// (so multiple objects can coexist alongside e.g. an array).
-@immutable
-class _HybridDispatchPlan {
-  const _HybridDispatchPlan({
-    required this.shapeArms,
-    required this.mapArms,
-    required this.variantContexts,
-  });
-
-  /// Per-shape arms for non-Map variants (e.g. array, string). Each
-  /// arm corresponds to exactly one variant. Order is the order
-  /// non-Map variants appear in [RenderOneOf.schemas].
-  final List<_VariantPlan> shapeArms;
-
-  /// Required-field arms for the Map-shaped variants — checked-then-
-  /// (optional)-fallback, same shape as a pure required-field
-  /// dispatch.
-  final List<_RequiredFieldArm> mapArms;
-
-  /// Wrapper-class template contexts in [RenderOneOf.schemas] order,
-  /// so the sealed subclass declarations match the spec's variant
-  /// order. Each context is either a [_shapeWrapperContext] (for
-  /// non-Map variants) or an `objectWrapperContext` (for Map
-  /// variants).
-  final List<Map<String, dynamic>> variantContexts;
-}
 
 /// Which dispatch mode a [RenderOneOf] picks for its `fromJson`
 /// body. Subtypes are mutually exclusive — exactly one is
@@ -4784,89 +4436,6 @@ void _applyDispatchMode(_DispatchMode mode, Map<String, dynamic> ctx) {
     case _NoDispatchMode():
       ctx['no_dispatch'] = true;
   }
-}
-
-/// Boolean test that picks one variant of a oneOf at runtime.
-///
-/// The dispatch picker collects one [_Predicate] per variant. Each
-/// kind knows how to emit its own Dart `if (...)` test, so adding a
-/// new way to distinguish variants (e.g. peeking at an array's first
-/// element) is a new subtype here rather than a new dispatch mode.
-///
-/// Today only the if-chain branches (pure required-field and the
-/// Map sub-dispatch of hybrid) consume predicates — the discriminator
-/// and shape branches stay specialized because their generated form
-/// (`switch` with literal/type patterns) is more idiomatic than an
-/// if-chain for those cases.
-sealed class _Predicate {
-  const _Predicate();
-
-  /// Dart boolean expression that's true iff [jsonVar] matches this
-  /// variant. [jsonVar] is the name of the in-scope JSON value
-  /// (typically `json`).
-  String dartIfTest(String jsonVar);
-}
-
-/// `jsonVar.containsKey('propertyName')` — picks variants by the
-/// presence of a unique property (required or optional).
-@immutable
-class _KeyExists extends _Predicate {
-  const _KeyExists(this.propertyName);
-
-  final String propertyName;
-
-  @override
-  String dartIfTest(String jsonVar) => "$jsonVar.containsKey('$propertyName')";
-}
-
-/// `(jsonVar.first as Map<String, dynamic>).containsKey('propertyName')` —
-/// peeks the first element of a List local for a unique property. Used
-/// by array-element dispatch to distinguish `array<object>` variants
-/// whose outer `List<dynamic>` shape collides but whose elements differ.
-/// Caller is responsible for binding `jsonVar` to a non-null `List`;
-/// the predicate short-circuits on `.isNotEmpty` so empty lists fall
-/// through to the next arm (or the unguarded fallback) without throwing.
-@immutable
-class _ArrayElementHasKey extends _Predicate {
-  const _ArrayElementHasKey(this.propertyName);
-
-  final String propertyName;
-
-  @override
-  String dartIfTest(String jsonVar) {
-    final cast = '($jsonVar.first as Map<String, dynamic>)';
-    return "$jsonVar.isNotEmpty && $cast.containsKey('$propertyName')";
-  }
-}
-
-/// Catch-all predicate — used by the dispatch's optional fallback
-/// variant. Never emits an `if` test; the template treats it as the
-/// unconditional `return Wrapper(...)` at the end of the chain.
-@immutable
-class _Always extends _Predicate {
-  const _Always();
-
-  @override
-  String dartIfTest(String jsonVar) =>
-      throw StateError('_Always has no if-test — emit it as the fallback.');
-}
-
-/// One arm of the required-field (a.k.a. property-presence) dispatch:
-/// an object-shaped variant (RenderObject or RenderEmptyObject) paired
-/// with the predicate that picks it. [predicate] is [_Always] for the
-/// fallback variant — at most one per dispatch — and [_KeyExists] for
-/// every checked arm. RenderEmptyObject is always a fallback since
-/// it requires nothing.
-@immutable
-class _RequiredFieldArm {
-  const _RequiredFieldArm({required this.variant, required this.predicate});
-
-  final RenderNewType variant;
-  final _Predicate predicate;
-
-  /// True when this arm is the unconditional fallback at the end of
-  /// the if-chain (no `if` guard emitted).
-  bool get isFallback => predicate is _Always;
 }
 
 /// The schema-specific bits of a shape-dispatch wrapper: how the

--- a/test/render/render_tree_test.dart
+++ b/test/render/render_tree_test.dart
@@ -622,6 +622,7 @@ void main() {
           ),
         ],
         discriminator: null,
+        source: null,
       );
       expect(a.equalsIgnoringName(a), isTrue);
 
@@ -643,6 +644,7 @@ void main() {
           ),
         ],
         discriminator: null,
+        source: null,
       );
       expect(a.equalsIgnoringName(b), isTrue);
 
@@ -673,6 +675,7 @@ void main() {
           ),
         ],
         discriminator: null,
+        source: null,
       );
       expect(a.equalsIgnoringName(c), isFalse);
     });
@@ -1019,6 +1022,7 @@ void main() {
           ),
         ],
         discriminator: null,
+        source: null,
       );
       expect(schema.exampleValue(context), isNull);
     });


### PR DESCRIPTION
## Summary

PR 1 of the architecture work to support a global naming pass.

The dispatch decision (which strategy: discriminator / shape / hybrid /
predicate / none) currently lives inside `RenderOneOf` and operates on
the render tree. To enable a future naming pass — which needs to know
every wrapper subclass that will be emitted up front — the decision has
to come *before* the renderer builds anything. This PR lifts dispatch
to its own pass that operates on the resolved tree only.

**`lib/src/dispatch.dart`** — new module. Public types:

- `DispatchDecision` sealed family: `DiscriminatorDispatch`, `ShapeDispatch`, `HybridDispatch`, `PredicateDispatch`, `NoDispatch`
- `Predicate` sealed family (lifted from `_Predicate`): `KeyExists`, `ArrayElementHasKey`, `Always`
- `decideDispatch(ResolvedSchemaCollection) → DispatchDecision`

The picker is pure structural — looks only at resolved schema shapes
(properties, required-sets, items types, discriminator), references
variants as `ResolvedSchema` rather than by Dart name. The resolver
stays Dart-blind; render owns Dart-string production
(`wrapperTypeName`, per-variant `fromJson`/`toJson`).

**`RenderOneOf`** gains a `source: ResolvedSchemaCollection?` back-
reference to its resolved origin. `_pickDispatchMode` becomes "call
`decideDispatch(source)`, translate the decision into the existing
`_DispatchMode` template-context shape using render-side helpers." The
resolved → render variant mapping uses index parity between
`source.schemas[i]` and the parallel `schemas[i]`.

`source` is null for synthesized RenderOneOfs (today only the range-mixed multi-status placeholder); those render as `NoDispatch` / the legacy `UnimplementedError` stub, same as before.

**`render_tree.dart` shrinks by ~650 lines** — the picker helpers and supporting types all delete. The new `dispatch.dart` is ~520 lines (heavily commented). Net algorithm is unchanged; it's just moved and operates on resolved instead of render, with three small flattening helpers (`_jsonShapeKey`, `_flattenedRequiredProperties`, `_flattenedProperties`) that mirror what the `RenderSchema` getters produced inline.

**`ARCHITECTURE.md`** — pipeline diagram updated; new "Phase 4 — Dispatch" section; "Planned phases / Naming pass" sketches the follow-up that motivated this lift.

## Test plan

- [x] 388 tests pass
- [x] `dart analyze` clean on lib/ and test/
- [x] github regen `dart analyze` clean (`No issues found!`)
- [x] github regen byte-identical to `origin/main` (verified via `diff -r` modulo package-name-length artifacts in the post-format `// ignore_for_file: lines_longer_than_80_chars` pass)
- [x] Stub count unchanged: 7

## Why a separate PR

This is the structural setup for the naming pass (the next PR). Doing them together would entangle "did the naming algorithm get the right answer" with "did the dispatch lift produce the same decisions" — two different bugs with the same diff signature. Byte-identical regen is a clean verification gate that dispatch alone moved correctly.