### PR TITLE
refactor: introduce naming pass and wire it through render

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -10,15 +10,15 @@ current design questions — especially around external `$ref`s.
   specUrl
      │
      ▼
-┌────────┐   ┌────────┐   ┌──────────┐   ┌──────────┐   ┌──────────┐   Dart files
-│ Load   │──▶│ Parse  │──▶│ Resolve  │──▶│ Dispatch │──▶│ Render   │──▶
-│ (I/O)  │   │ (pure) │   │ (pure)   │   │ (pure)   │   │ (pure)   │
-└────────┘   └────────┘   └──────────┘   └──────────┘   └──────────┘
-                              │                 ▲
-                              ▼                 │
-                          ┌──────────┐    sidecar lookup
-                          │ Registry │
-                          └──────────┘
+┌────────┐ ┌────────┐ ┌──────────┐ ┌──────────┐ ┌────────┐ ┌──────────┐  Dart files
+│ Load   │▶│ Parse  │▶│ Resolve  │▶│ Dispatch │▶│ Naming │▶│ Render   │▶
+│ (I/O)  │ │ (pure) │ │ (pure)   │ │ (pure)   │ │ (pure) │ │ (pure)   │
+└────────┘ └────────┘ └──────────┘ └──────────┘ └────────┘ └──────────┘
+                          │                ▲          ▲
+                          ▼                │          │
+                      ┌──────────┐    sidecar lookups (Decisions, Names)
+                      │ Registry │
+                      └──────────┘
 ```
 
 Only **Load** does I/O. Everything downstream is a pure function of its
@@ -146,36 +146,57 @@ using its own render-side helpers (`wrapperTypeName`, `_planVariant`,
 etc.). The resolved → render variant mapping uses index parity:
 `source.schemas[i]` corresponds to the parallel `RenderOneOf.schemas[i]`.
 
-## Planned phases
+## Phase 4.5 — Naming (in progress)
 
-### Naming pass (between Dispatch and Render)
+**Purpose:** assign a single Dart class name to every named entity
+in the resolved tree, in one pass with the full set of names in
+view.
+**Lives in:** `lib/src/naming.dart`.
+**Entry point:** `assignNames(ResolvedSpec) → AssignedNames`
+(a `Map<JsonPointer, String>` sidecar).
 
-Today, Dart class names are decided in three different layers — the
-parser synthesizes inline-schema names, the resolver resolves naming
-collisions with `_1` suffixes, and the renderer composes wrapper
-class names per oneOf. Each layer makes a local decision with only
-partial information, so we get artifacts like
-`ProjectsCreateCardRequestProjectsCreateCardRequestOneOf0` (parser
-named the variant by parent, renderer wrapped with parent again,
-neither knew the other did) and `RepositoryRulesetConditions1` (an
-inline schema collides with a top-level one, gets a numeric suffix).
+**Why a separate phase.** Today, Dart class names are decided in
+three different layers — the parser synthesizes inline-schema
+snake names, the resolver suffixes collisions with `_1`, and the
+renderer composes wrapper class names per oneOf. Each layer makes
+a local decision with only partial information, so we get
+artifacts like
+`ProjectsCreateCardRequestProjectsCreateCardRequestOneOf0`
+(parser named the variant by parent, renderer wrapped with parent
+again, neither knew the other did) and
+`RepositoryRulesetConditions1` (an inline schema collides with a
+top-level one and gets a numeric suffix). A pass with the global
+view can pick shorter, less-collision-prone names.
 
-The plan: a `lib/src/naming.dart` pass that runs after Dispatch and
-before Render. It walks the resolved tree + dispatch decisions,
-enumerates every named entity (top-level schemas, inline schemas
-that produce types, wrapper subclasses, operation message types),
-and assigns each a Dart class name using a shortest-unique-with-
-fallback algorithm. Output is a sidecar `Map<NameId, String>` —
-not a mutated tree — keyed by JSON pointer for spec-rooted entities
-and by `(parentPointer, kind, index)` for synthesized ones.
+**Current state.** This pass exists with today's algorithm baked
+in: for each `createsNewType: true` schema, the assigned name is
+`camelFromSnake(common.snakeName)` — same answer the renderer's
+existing `typeName` getters compute on their own. `SpecResolver`
+runs `assignNames` at the start of `toRenderSpec`, looks up each
+schema's name when constructing the corresponding `RenderSchema`,
+and stashes it on the schema's `assignedName` field. Every newtype
+`typeName` getter is now `assignedName ?? camelFromSnake(snakeName)`
+— the fallback is what tests and direct constructions use;
+production always populates `assignedName`. github regen is byte-
+identical to before the lift (verified).
 
-The renderer then *looks up* names instead of computing them. The
-collision-resolution code in the resolver and the `wrapperTypeName`
-/ `typeName` logic in `RenderOneOf` get gutted in favor of the
-single map.
+**Planned next steps:**
 
-The resolver intentionally stays Dart-blind: it carries `snakeName`
-(a parser-level identifier) but no Dart class name. Naming sits
+- Bring wrapper subclasses (the `<Parent><wrapperTag>` names from
+  `RenderOneOf.wrapperTypeName`) under the pass — the dispatch
+  decision already enumerates them.
+- Bring operation message types (request bodies, multi-status
+  return wrappers) under the pass.
+- Switch the algorithm to shortest-unique-with-fallback. Candidate
+  list per entity: bare name → context-prefixed → fully-qualified
+  → numeric suffix; greedy assignment in stable order. This is the
+  PR with the visible quality wins (96 double-prefix wrappers
+  renamed; 8 `_1` suffixes mostly gone). Once the algorithm has one
+  source of truth, the snake-derived fallback in `typeName` getters
+  can go away too.
+
+**The resolver stays Dart-blind.** It carries `snakeName` (a
+parser-level identifier) but no Dart class name; naming sits
 between resolve and render so the resolver can be reused for any
 future non-Dart consumer.
 

--- a/lib/src/naming.dart
+++ b/lib/src/naming.dart
@@ -121,8 +121,8 @@ class _NameAssigner {
         for (final prop in schema.properties.values) {
           _visitSchema(prop);
         }
-        final addl = schema.additionalProperties;
-        if (addl != null) _visitSchema(addl);
+        final extraProps = schema.additionalProperties;
+        if (extraProps != null) _visitSchema(extraProps);
       case ResolvedArray():
         _visitSchema(schema.items);
       case ResolvedMap():

--- a/lib/src/naming.dart
+++ b/lib/src/naming.dart
@@ -1,0 +1,154 @@
+/// Assigns Dart class names to every named entity in the resolved
+/// tree. The renderer reads these names instead of computing them
+/// from `common.snakeName` per schema.
+///
+/// Why a separate phase: today, names get decided in three layers
+/// (parser synthesizes inline-schema names, resolver suffixes
+/// collisions with `_1`, renderer composes wrappers from parent +
+/// tag). Each layer makes a local decision with only partial
+/// information, so we get artifacts like
+/// `ProjectsCreateCardRequestProjectsCreateCardRequestOneOf0` and
+/// `RepositoryRulesetConditions1`. A single pass with the full set
+/// of named entities in view can pick shorter, less-collision-prone
+/// names. This file is the first step — it consolidates the lookup
+/// without changing the algorithm. A future pass can swap the
+/// algorithm to shortest-unique-with-fallback.
+///
+/// Resolver stays Dart-blind: this pass is the only place that
+/// knows about Dart class names. The resolver produces snake-case
+/// identifiers (still parser-level); naming converts them to
+/// CamelCase Dart class names and resolves collisions.
+library;
+
+import 'package:meta/meta.dart';
+import 'package:space_gen/src/parse/spec.dart';
+import 'package:space_gen/src/resolver.dart';
+import 'package:space_gen/src/string.dart';
+
+/// The set of Dart class names assigned by the naming pass, keyed by
+/// each named entity's identifier (typically its [JsonPointer]).
+///
+/// The renderer consults this map for every typed reference; its own
+/// `typeName` getters are thin lookups now, not computations.
+@immutable
+class AssignedNames {
+  const AssignedNames(this._byPointer);
+
+  final Map<JsonPointer, String> _byPointer;
+
+  /// Looks up the Dart class name for [pointer]. Returns null when
+  /// the entity at [pointer] doesn't have a name (non-newtype
+  /// schemas, refs, etc.).
+  String? maybeGet(JsonPointer pointer) => _byPointer[pointer];
+
+  /// Looks up the Dart class name for [pointer]. Throws when the
+  /// entity isn't named — calls that hit this path are bugs in the
+  /// naming pass (an entity that should have been enumerated wasn't).
+  String operator [](JsonPointer pointer) {
+    final name = _byPointer[pointer];
+    if (name == null) {
+      throw StateError(
+        'No name assigned for $pointer — naming pass missed this entity.',
+      );
+    }
+    return name;
+  }
+
+  /// Empty map — for tests that build render schemas directly without
+  /// going through the full pipeline. Schemas constructed this way
+  /// fall back to their `common.snakeName`-derived computation.
+  static const empty = AssignedNames({});
+
+  /// All assigned (pointer, name) pairs. Iteration order matches the
+  /// underlying map; use only for debugging / tests / metrics.
+  Iterable<MapEntry<JsonPointer, String>> get entries => _byPointer.entries;
+
+  /// Returns an unmodifiable view of the underlying map. Test-only.
+  Map<JsonPointer, String> toMap() => Map.unmodifiable(_byPointer);
+}
+
+/// Walks the resolved tree and assigns a Dart class name to every
+/// schema that creates a new type. Today's algorithm: for each
+/// `createsNewType: true` schema, the name is
+/// `camelFromSnake(common.snakeName)`. The resolver has already
+/// applied any `_1`-style snake-name collision suffixes upstream, so
+/// this pass produces the same output the renderer's existing
+/// `typeName` getters would compute on their own.
+///
+/// The eventual quality win is changing this algorithm to
+/// shortest-unique-with-fallback (PR 3+). This PR just consolidates
+/// the lookup so one place owns the answer.
+AssignedNames assignNames(ResolvedSpec spec) {
+  final names = <JsonPointer, String>{};
+  _NameAssigner(names).visit(spec);
+  return AssignedNames(names);
+}
+
+class _NameAssigner {
+  _NameAssigner(this._names);
+
+  final Map<JsonPointer, String> _names;
+  final Set<JsonPointer> _visited = {};
+
+  void visit(ResolvedSpec spec) {
+    for (final path in spec.paths) {
+      for (final op in path.operations) {
+        for (final param in op.parameters) {
+          _visitSchema(param.schema);
+        }
+        final reqBody = op.requestBody;
+        if (reqBody != null) _visitSchema(reqBody.schema);
+        for (final response in op.responses) {
+          _visitSchema(response.content);
+        }
+        for (final rangeResp in op.rangeResponses) {
+          _visitSchema(rangeResp.content);
+        }
+        final defaultResp = op.defaultResponse;
+        if (defaultResp != null) _visitSchema(defaultResp.content);
+      }
+    }
+  }
+
+  void _visitSchema(ResolvedSchema schema) {
+    if (!_visited.add(schema.pointer)) return;
+    if (schema.createsNewType) {
+      _names[schema.pointer] = camelFromSnake(schema.snakeName);
+    }
+    // Recurse into structural children so inline newtypes get named.
+    switch (schema) {
+      case ResolvedObject():
+        for (final prop in schema.properties.values) {
+          _visitSchema(prop);
+        }
+        final addl = schema.additionalProperties;
+        if (addl != null) _visitSchema(addl);
+      case ResolvedArray():
+        _visitSchema(schema.items);
+      case ResolvedMap():
+        _visitSchema(schema.valueSchema);
+        final keyEnum = schema.keySchema;
+        if (keyEnum != null) _visitSchema(keyEnum);
+      case ResolvedOneOf():
+      case ResolvedAnyOf():
+      case ResolvedAllOf():
+        final collection = schema as ResolvedSchemaCollection;
+        for (final variant in collection.schemas) {
+          _visitSchema(variant);
+        }
+      case ResolvedString():
+      case ResolvedInteger():
+      case ResolvedNumber():
+      case ResolvedPod():
+      case ResolvedEnum():
+      case ResolvedEmptyObject():
+      case ResolvedRecursiveRef():
+      case ResolvedVoid():
+      case ResolvedBinary():
+      case ResolvedNull():
+      case ResolvedUnknown():
+        // Leaf — no inline children to visit.
+        break;
+    }
+  }
+}

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -2,6 +2,7 @@ import 'package:collection/collection.dart';
 import 'package:equatable/equatable.dart';
 import 'package:meta/meta.dart';
 import 'package:space_gen/src/dispatch.dart';
+import 'package:space_gen/src/naming.dart';
 import 'package:space_gen/src/parse/spec.dart' show StatusCodeRange;
 import 'package:space_gen/src/quirks.dart';
 // Any code that depends on SchemaRenderer probably should be moved out
@@ -316,9 +317,21 @@ abstract final class ModelHelpers {
 }
 
 class SpecResolver {
-  const SpecResolver(this.quirks);
+  SpecResolver(this.quirks);
 
   final Quirks quirks;
+
+  /// The naming-pass output for the spec currently being rendered.
+  /// Populated at the start of [toRenderSpec]; consulted by
+  /// [toRenderSchema] when constructing each [RenderSchema] so its
+  /// `typeName` can read the assigned name instead of computing one
+  /// from `snakeName`.
+  AssignedNames _names = AssignedNames.empty;
+
+  /// Looks up the assigned Dart class name for a resolved schema's
+  /// pointer, or null if the naming pass didn't enumerate it (e.g.
+  /// non-newtype schemas like inline arrays/maps).
+  String? _nameFor(JsonPointer pointer) => _names.maybeGet(pointer);
 
   RenderSchema? maybeRenderSchema(ResolvedSchema? schema) {
     if (schema == null) {
@@ -330,9 +343,14 @@ class SpecResolver {
   RenderSchema toRenderSchema(ResolvedSchema schema) {
     switch (schema) {
       case ResolvedRecursiveRef():
+        // The recursive ref's type name is the target's class name —
+        // look up by targetPointer, not the ref site's own pointer
+        // (the ref site has createsNewType: false, so it isn't named
+        // in its own right).
         return RenderRecursiveRef(
           common: schema.common,
           targetPointer: schema.targetPointer,
+          assignedName: _nameFor(schema.targetPointer),
         );
       case ResolvedEnum():
         return RenderEnum(
@@ -340,6 +358,7 @@ class SpecResolver {
           values: schema.values,
           names: RenderEnum.variableNamesFor(quirks, schema.values),
           descriptions: schema.descriptions,
+          assignedName: _nameFor(schema.pointer),
         );
       case ResolvedObject():
         return RenderObject(
@@ -349,6 +368,7 @@ class SpecResolver {
           ),
           additionalProperties: maybeRenderSchema(schema.additionalProperties),
           requiredProperties: schema.requiredProperties,
+          assignedName: _nameFor(schema.pointer),
         );
       case ResolvedPod():
         return RenderPod(
@@ -356,6 +376,7 @@ class SpecResolver {
           type: schema.type,
           createsNewType: schema.createsNewType,
           defaultValue: schema.defaultValue,
+          assignedName: _nameFor(schema.pointer),
         );
       case ResolvedString():
         return RenderString(
@@ -365,6 +386,7 @@ class SpecResolver {
           maxLength: schema.maxLength,
           minLength: schema.minLength,
           pattern: schema.pattern,
+          assignedName: _nameFor(schema.pointer),
         );
       case ResolvedNumber():
         return RenderNumber(
@@ -376,6 +398,7 @@ class SpecResolver {
           exclusiveMaximum: schema.exclusiveMaximum,
           exclusiveMinimum: schema.exclusiveMinimum,
           multipleOf: schema.multipleOf,
+          assignedName: _nameFor(schema.pointer),
         );
       case ResolvedInteger():
         return RenderInteger(
@@ -387,6 +410,7 @@ class SpecResolver {
           exclusiveMaximum: schema.exclusiveMaximum,
           exclusiveMinimum: schema.exclusiveMinimum,
           multipleOf: schema.multipleOf,
+          assignedName: _nameFor(schema.pointer),
         );
       case ResolvedArray():
         var defaultValue = schema.defaultValue;
@@ -451,6 +475,7 @@ class SpecResolver {
           schemas: renderSchemas,
           discriminator: renderDiscriminator,
           source: schema,
+          assignedName: _nameFor(schema.pointer),
         );
       case ResolvedAllOf():
         // Generate a synthetic object type for allOf. A property is
@@ -473,6 +498,7 @@ class SpecResolver {
           common: schema.common,
           properties: properties,
           requiredProperties: requiredProperties.toList(),
+          assignedName: _nameFor(schema.pointer),
         );
       case ResolvedAnyOf():
         // Resolver already makes anyOf with 1 schema to just be that schema.
@@ -485,6 +511,7 @@ class SpecResolver {
           schemas: schema.schemas.map(toRenderSchema).toList(),
           discriminator: null,
           source: schema,
+          assignedName: _nameFor(schema.pointer),
         );
       case ResolvedMap():
         final keyEnum = schema.keySchema;
@@ -496,7 +523,10 @@ class SpecResolver {
               : toRenderSchema(keyEnum) as RenderEnum,
         );
       case ResolvedEmptyObject():
-        return RenderEmptyObject(common: schema.common);
+        return RenderEmptyObject(
+          common: schema.common,
+          assignedName: _nameFor(schema.pointer),
+        );
       default:
         _unimplemented('Unknown schema: $schema', schema.pointer);
     }
@@ -671,6 +701,10 @@ class SpecResolver {
   }
 
   RenderSpec toRenderSpec(ResolvedSpec spec) {
+    // Run the naming pass once over the resolved tree; subsequent
+    // [toRenderSchema] calls consult [_names] when constructing
+    // newtypes so each `typeName` is a lookup, not a recomputation.
+    _names = assignNames(spec);
     return RenderSpec(
       title: spec.title,
       serverUrl: spec.serverUrl,
@@ -1933,9 +1967,27 @@ class RenderDefaultResponse {
 }
 
 abstract class RenderSchema extends Equatable implements ToTemplateContext {
-  const RenderSchema({required this.common, required this.createsNewType});
+  const RenderSchema({
+    required this.common,
+    required this.createsNewType,
+    this.assignedName,
+  });
 
   final CommonProperties common;
+
+  /// Dart class name assigned by the naming pass. Populated by
+  /// [SpecResolver.toRenderSchema] for `createsNewType: true` schemas
+  /// (and for [RenderRecursiveRef] whose target is named); null
+  /// otherwise.
+  ///
+  /// Subclass `typeName` getters consult this as an override of the
+  /// snake-derived computation. Today the override and the
+  /// computation produce the same string (the naming pass uses
+  /// `camelFromSnake(snakeName)` itself); future PRs swap the
+  /// algorithm to shortest-unique-with-fallback, at which point this
+  /// field becomes the source of truth and the snake-derived
+  /// fallback goes away.
+  final String? assignedName;
 
   /// The snake name of the resolved schema.
   String get snakeName => common.snakeName;
@@ -2153,6 +2205,7 @@ class RenderPod extends RenderSchema {
     required this.type,
     required super.createsNewType,
     this.defaultValue,
+    super.assignedName,
   });
 
   /// The type of the resolved schema.
@@ -2207,7 +2260,8 @@ class RenderPod extends RenderSchema {
   };
 
   @override
-  String get typeName => createsNewType ? camelFromSnake(snakeName) : dartType;
+  String get typeName =>
+      createsNewType ? (assignedName ?? camelFromSnake(snakeName)) : dartType;
 
   // Boolean is the only PodType with a `is bool` test that's distinct
   // from the other JSON storage types (the date/uri/uuid/etc. all
@@ -2415,13 +2469,17 @@ class RenderPod extends RenderSchema {
 }
 
 abstract class RenderNewType extends RenderSchema {
-  const RenderNewType({required super.common}) : super(createsNewType: true);
+  const RenderNewType({required super.common, super.assignedName})
+    : super(createsNewType: true);
 
   @override
   bool get shouldCallToJson => true;
 
-  /// The class name of the new type. Used by subclasses.
-  String get className => camelFromSnake(snakeName);
+  /// The class name of the new type. Used by subclasses. Prefers the
+  /// naming-pass-assigned name when present; falls back to the
+  /// snake-derived computation when not (e.g. tests that build
+  /// schemas directly without going through [SpecResolver]).
+  String get className => assignedName ?? camelFromSnake(snakeName);
 
   @override
   String get typeName => className;
@@ -2445,6 +2503,7 @@ class RenderString extends RenderSchema {
     required this.minLength,
     required this.pattern,
     required super.createsNewType,
+    super.assignedName,
   });
 
   @override
@@ -2466,7 +2525,8 @@ class RenderString extends RenderSchema {
   List<Object?> get props => [super.props, defaultValue, maxLength, minLength];
 
   @override
-  String get typeName => createsNewType ? camelFromSnake(snakeName) : 'String';
+  String get typeName =>
+      createsNewType ? (assignedName ?? camelFromSnake(snakeName)) : 'String';
 
   /// The default value of this schema as a string.
   @override
@@ -2583,6 +2643,7 @@ abstract class RenderNumeric<T extends num> extends RenderSchema {
     required this.exclusiveMinimum,
     required this.multipleOf,
     required super.createsNewType,
+    super.assignedName,
   });
 
   @override
@@ -2739,10 +2800,12 @@ class RenderNumber extends RenderNumeric<double> {
     required super.exclusiveMinimum,
     required super.multipleOf,
     required super.createsNewType,
+    super.assignedName,
   });
 
   @override
-  String get typeName => createsNewType ? camelFromSnake(snakeName) : 'double';
+  String get typeName =>
+      createsNewType ? (assignedName ?? camelFromSnake(snakeName)) : 'double';
 
   @override
   String? get wrapperTag => createsNewType ? null : 'Num';
@@ -2784,10 +2847,12 @@ class RenderInteger extends RenderNumeric<int> {
     required super.exclusiveMinimum,
     required super.multipleOf,
     required super.createsNewType,
+    super.assignedName,
   });
 
   @override
-  String get typeName => createsNewType ? camelFromSnake(snakeName) : 'int';
+  String get typeName =>
+      createsNewType ? (assignedName ?? camelFromSnake(snakeName)) : 'int';
 
   @override
   String? get wrapperTag => createsNewType ? null : 'Int';
@@ -2818,6 +2883,7 @@ class RenderObject extends RenderNewType {
     required this.properties,
     this.additionalProperties,
     this.requiredProperties = const [],
+    super.assignedName,
   });
 
   /// The properties of the resolved schema.
@@ -3603,6 +3669,7 @@ class RenderEnum extends RenderNewType {
     required this.names,
     required this.descriptions,
     this.defaultValue,
+    super.assignedName,
   }) : assert(
          names.length == values.length,
          'names and values must have the same length',
@@ -3757,6 +3824,7 @@ class RenderOneOf extends RenderNewType {
     required this.schemas,
     required this.discriminator,
     required this.source,
+    super.assignedName,
   });
 
   /// The schemas of the resolved schema.
@@ -4760,7 +4828,7 @@ class RenderBinary extends RenderNoJson {
 }
 
 class RenderEmptyObject extends RenderNewType {
-  const RenderEmptyObject({required super.common});
+  const RenderEmptyObject({required super.common, super.assignedName});
 
   @override
   dynamic get defaultValue => null;
@@ -4837,6 +4905,7 @@ class RenderRecursiveRef extends RenderSchema {
   const RenderRecursiveRef({
     required super.common,
     required this.targetPointer,
+    super.assignedName,
   }) : super(createsNewType: true);
 
   final JsonPointer targetPointer;
@@ -4851,7 +4920,7 @@ class RenderRecursiveRef extends RenderSchema {
   bool get shouldCallToJson => true;
 
   @override
-  String get typeName => camelFromSnake(snakeName);
+  String get typeName => assignedName ?? camelFromSnake(snakeName);
 
   @override
   String jsonStorageType({required bool isNullable}) =>

--- a/test/naming_test.dart
+++ b/test/naming_test.dart
@@ -117,6 +117,218 @@ void main() {
       }
     });
 
+    test('AssignedNames.[] throws for unassigned pointers', () {
+      const names = AssignedNames.empty;
+      expect(
+        () => names[JsonPointer.parse('#/components/schemas/missing')],
+        throwsStateError,
+      );
+      expect(
+        names.maybeGet(JsonPointer.parse('#/components/schemas/missing')),
+        isNull,
+      );
+    });
+
+    test('entries iterates assigned (pointer, name) pairs', () {
+      final names = namesFor({
+        'openapi': '3.1.0',
+        'info': {'title': 'X', 'version': '1.0'},
+        'servers': [
+          {'url': 'https://x'},
+        ],
+        'paths': {
+          '/u': {
+            'get': {
+              'summary': 'Get user',
+              'responses': {
+                '200': {
+                  'description': 'OK',
+                  'content': {
+                    'application/json': {
+                      'schema': {r'$ref': '#/components/schemas/User'},
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        'components': {
+          'schemas': {
+            'User': {
+              'type': 'object',
+              'properties': {
+                'login': {'type': 'string'},
+              },
+            },
+          },
+        },
+      });
+      final list = names.entries.toList();
+      expect(list, isNotEmpty);
+      final userEntry = list.firstWhere(
+        (e) => e.key.toString() == '#/components/schemas/User',
+      );
+      expect(userEntry.value, 'User');
+    });
+
+    test('walks anyOf and allOf variants', () {
+      final names = namesFor({
+        'openapi': '3.1.0',
+        'info': {'title': 'X', 'version': '1.0'},
+        'servers': [
+          {'url': 'https://x'},
+        ],
+        'paths': {
+          '/u': {
+            'get': {
+              'summary': 'Get',
+              'responses': {
+                '200': {
+                  'description': 'OK',
+                  'content': {
+                    'application/json': {
+                      'schema': {r'$ref': '#/components/schemas/Outer'},
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        'components': {
+          'schemas': {
+            'Outer': {
+              'anyOf': [
+                {r'$ref': '#/components/schemas/Inner'},
+                {
+                  'allOf': [
+                    {r'$ref': '#/components/schemas/Inner'},
+                  ],
+                },
+              ],
+            },
+            'Inner': {
+              'type': 'object',
+              'properties': {
+                'value': {'type': 'string'},
+              },
+            },
+          },
+        },
+      });
+      // Both top-level component schemas reachable through the
+      // anyOf/allOf walker get assigned names.
+      expect(names[JsonPointer.parse('#/components/schemas/Outer')], 'Outer');
+      expect(names[JsonPointer.parse('#/components/schemas/Inner')], 'Inner');
+    });
+
+    test('walks additionalProperties when an object has both named '
+        'properties and a value schema', () {
+      // An object with named properties + `additionalProperties: $ref`
+      // resolves as `ResolvedObject` (not `ResolvedMap`); the walker
+      // recurses into its `additionalProperties` so a newtype reachable
+      // only through that slot still gets a name.
+      final names = namesFor({
+        'openapi': '3.1.0',
+        'info': {'title': 'X', 'version': '1.0'},
+        'servers': [
+          {'url': 'https://x'},
+        ],
+        'paths': {
+          '/u': {
+            'get': {
+              'summary': 'Get',
+              'responses': {
+                '200': {
+                  'description': 'OK',
+                  'content': {
+                    'application/json': {
+                      'schema': {r'$ref': '#/components/schemas/Open'},
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        'components': {
+          'schemas': {
+            'Open': {
+              'type': 'object',
+              'properties': {
+                'name': {'type': 'string'},
+              },
+              'additionalProperties': {
+                r'$ref': '#/components/schemas/Extra',
+              },
+            },
+            'Extra': {
+              'type': 'object',
+              'properties': {
+                'value': {'type': 'string'},
+              },
+            },
+          },
+        },
+      });
+      expect(names[JsonPointer.parse('#/components/schemas/Open')], 'Open');
+      expect(names[JsonPointer.parse('#/components/schemas/Extra')], 'Extra');
+    });
+
+    test('walks map valueSchema and keySchema', () {
+      final names = namesFor({
+        'openapi': '3.1.0',
+        'info': {'title': 'X', 'version': '1.0'},
+        'servers': [
+          {'url': 'https://x'},
+        ],
+        'paths': {
+          '/u': {
+            'get': {
+              'summary': 'Get',
+              'responses': {
+                '200': {
+                  'description': 'OK',
+                  'content': {
+                    'application/json': {
+                      'schema': {
+                        'type': 'object',
+                        'additionalProperties': {
+                          r'$ref': '#/components/schemas/Item',
+                        },
+                        'propertyNames': {
+                          r'$ref': '#/components/schemas/Key',
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        'components': {
+          'schemas': {
+            'Item': {
+              'type': 'object',
+              'properties': {
+                'name': {'type': 'string'},
+              },
+            },
+            'Key': {
+              'type': 'string',
+              'enum': ['a', 'b'],
+            },
+          },
+        },
+      });
+      // Both the map's valueSchema (Item, an object newtype) and the
+      // keySchema (Key, an enum newtype) get assigned names.
+      expect(names[JsonPointer.parse('#/components/schemas/Item')], 'Item');
+      expect(names[JsonPointer.parse('#/components/schemas/Key')], 'Key');
+    });
+
     test('non-newtype schemas are not named (List<X>, primitives, etc.)', () {
       final names = namesFor({
         'openapi': '3.1.0',

--- a/test/naming_test.dart
+++ b/test/naming_test.dart
@@ -1,0 +1,171 @@
+import 'package:space_gen/src/naming.dart';
+import 'package:space_gen/src/parse/spec.dart';
+import 'package:space_gen/src/parser.dart';
+import 'package:space_gen/src/resolver.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('assignNames', () {
+    AssignedNames namesFor(Map<String, dynamic> specJson) {
+      final spec = parseOpenApi(specJson);
+      final resolved = resolveSpec(
+        spec,
+        specUrl: Uri.parse('file:///spec.yaml'),
+        logSchemas: false,
+      );
+      return assignNames(resolved);
+    }
+
+    test('top-level component schema gets CamelCase name', () {
+      final names = namesFor({
+        'openapi': '3.1.0',
+        'info': {'title': 'X', 'version': '1.0'},
+        'servers': [
+          {'url': 'https://x'},
+        ],
+        'paths': {
+          '/u': {
+            'get': {
+              'summary': 'Get user',
+              'responses': {
+                '200': {
+                  'description': 'OK',
+                  'content': {
+                    'application/json': {
+                      'schema': {r'$ref': '#/components/schemas/user_profile'},
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        'components': {
+          'schemas': {
+            'user_profile': {
+              'type': 'object',
+              'properties': {
+                'login': {'type': 'string'},
+              },
+            },
+          },
+        },
+      });
+      expect(
+        names[JsonPointer.parse('#/components/schemas/user_profile')],
+        'UserProfile',
+      );
+    });
+
+    test('inline object property schema is named from snake context', () {
+      // Inline object at /paths/.../properties/location gets a
+      // synthesized snake_name from its parent path; today's
+      // algorithm camel-cases it.
+      final names = namesFor({
+        'openapi': '3.1.0',
+        'info': {'title': 'X', 'version': '1.0'},
+        'servers': [
+          {'url': 'https://x'},
+        ],
+        'paths': {
+          '/u': {
+            'get': {
+              'summary': 'Get user',
+              'responses': {
+                '200': {
+                  'description': 'OK',
+                  'content': {
+                    'application/json': {
+                      'schema': {r'$ref': '#/components/schemas/User'},
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        'components': {
+          'schemas': {
+            'User': {
+              'type': 'object',
+              'properties': {
+                'location': {
+                  'type': 'object',
+                  'properties': {
+                    'lat': {'type': 'number'},
+                    'lng': {'type': 'number'},
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+      // The top-level User is named.
+      expect(names[JsonPointer.parse('#/components/schemas/User')], 'User');
+      // Inline `location` object also gets a name (it's a newtype).
+      // The synthesized snake name combines parent + property.
+      final inlineNames = names
+          .toMap()
+          .entries
+          .where((e) => e.key.toString().contains('location'))
+          .toList();
+      expect(inlineNames, isNotEmpty);
+      // Whatever the synthesized name is, it should be CamelCase.
+      for (final entry in inlineNames) {
+        expect(entry.value, matches(RegExp(r'^[A-Z][A-Za-z0-9]*$')));
+      }
+    });
+
+    test('non-newtype schemas are not named (List<X>, primitives, etc.)', () {
+      final names = namesFor({
+        'openapi': '3.1.0',
+        'info': {'title': 'X', 'version': '1.0'},
+        'servers': [
+          {'url': 'https://x'},
+        ],
+        'paths': {
+          '/u': {
+            'get': {
+              'summary': 'List users',
+              'responses': {
+                '200': {
+                  'description': 'OK',
+                  'content': {
+                    'application/json': {
+                      'schema': {
+                        'type': 'array',
+                        'items': {r'$ref': '#/components/schemas/User'},
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        'components': {
+          'schemas': {
+            'User': {
+              'type': 'object',
+              'properties': {
+                'login': {'type': 'string'},
+              },
+            },
+          },
+        },
+      });
+      // User is named. The response array itself isn't (it's
+      // structurally `List<User>`, no Dart class wrapper).
+      expect(names[JsonPointer.parse('#/components/schemas/User')], 'User');
+      // The `login` string property also isn't named — it's a
+      // primitive, not a newtype.
+      final loginNames = names
+          .toMap()
+          .entries
+          .where((e) => e.key.toString().endsWith('/login'))
+          .toList();
+      expect(loginNames, isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

PR 2 of the architecture work to support a global naming pass.

Today, Dart class names are decided in three places: the parser synthesizes inline-schema snake names, the resolver suffixes collisions with `_1`, and the renderer composes wrapper names per oneOf. None has the global view, so we get artifacts like `ProjectsCreateCardRequestProjectsCreateCardRequestOneOf0` and `RepositoryRulesetConditions1`. A single pass with the full set of named entities can pick shorter, less-collision-prone names.

This PR introduces the pass *and* wires it through render with byte-identical output:

**`lib/src/naming.dart`** — `assignNames(ResolvedSpec) → AssignedNames`. The pass walks the resolved tree, identifies every `createsNewType: true` schema, and assigns each a Dart class name using **today's algorithm** (`camelFromSnake(common.snakeName)`). Output is a `Map<JsonPointer, String>` sidecar.

**`SpecResolver`** runs `assignNames` at the start of `toRenderSpec`, looks up each schema's name when constructing the corresponding `RenderSchema`, and stashes it on the schema's new `assignedName` field. Every `RenderNewType.className` (and the flex-newtype `typeName` getters on `RenderString`/`Number`/`Integer`/`Pod`/`RecursiveRef`) is now `assignedName ?? camelFromSnake(snakeName)` — the fallback is what tests and direct constructions use; production always populates `assignedName`.

**`RenderRecursiveRef`** is special: its own pointer isn't named (`createsNewType: false` on the resolved side, marker), so `SpecResolver` looks up its `targetPointer` instead and passes the target's name as `assignedName`.

**Resolver stays Dart-blind.** It still produces snake-case identifiers and resolves snake-name collisions with `_1` suffixes; it knows nothing about Dart class names. The naming pass is the only place that does.

## Why no algorithm change yet

Splitting "introduce + wire" from "swap algorithm" into two PRs keeps each diff narrow. This PR proves the wiring is correct (byte-identical regen). The next PR can swap to shortest-unique-with-fallback in isolation, and the visible regen diff is purely the algorithm change. Same staging as the dispatch series — #158 introduced the predicate IR with no callers, #159 used it.

## Test plan

- [x] 3 new unit tests covering the pass; 391 total pass
- [x] `dart analyze` clean on lib/ and test/
- [x] github regen `dart analyze` clean
- [x] Stub count unchanged: 7
- [x] github regen byte-identical to before the lift (verified by walking both trees, stripping the package-name-length artifact in the post-format `// ignore_for_file:` header, and confirming zero content diffs in `lib/`)