### PR TITLE
refactor: make `assignedName` strict — typeName throws if naming pass missed it

### DIFF
--- a/lib/src/naming.dart
+++ b/lib/src/naming.dart
@@ -84,6 +84,24 @@ AssignedNames assignNames(ResolvedSpec spec) {
   return AssignedNames(names);
 }
 
+/// Assigns names for a single resolved operation. Used by test
+/// helpers (`renderTestOperation`) that render an operation in
+/// isolation, without a surrounding spec.
+AssignedNames assignNamesForOperation(ResolvedOperation op) {
+  final names = <JsonPointer, String>{};
+  _NameAssigner(names).visitOperation(op);
+  return AssignedNames(names);
+}
+
+/// Assigns names reachable from a single resolved schema. Used by
+/// test helpers (`renderTestSchema`, `renderTestSchemas`) that
+/// render schemas in isolation, without a surrounding spec.
+AssignedNames assignNamesForSchema(ResolvedSchema schema) {
+  final names = <JsonPointer, String>{};
+  _NameAssigner(names).visitSchema(schema);
+  return AssignedNames(names);
+}
+
 class _NameAssigner {
   _NameAssigner(this._names);
 
@@ -93,22 +111,38 @@ class _NameAssigner {
   void visit(ResolvedSpec spec) {
     for (final path in spec.paths) {
       for (final op in path.operations) {
-        for (final param in op.parameters) {
-          _visitSchema(param.schema);
-        }
-        final reqBody = op.requestBody;
-        if (reqBody != null) _visitSchema(reqBody.schema);
-        for (final response in op.responses) {
-          _visitSchema(response.content);
-        }
-        for (final rangeResp in op.rangeResponses) {
-          _visitSchema(rangeResp.content);
-        }
-        final defaultResp = op.defaultResponse;
-        if (defaultResp != null) _visitSchema(defaultResp.content);
+        visitOperation(op);
       }
     }
   }
+
+  void visitOperation(ResolvedOperation op) {
+    for (final param in op.parameters) {
+      visitSchema(param.schema);
+    }
+    final reqBody = op.requestBody;
+    if (reqBody != null) visitSchema(reqBody.schema);
+    for (final response in op.responses) {
+      visitSchema(response.content);
+    }
+    for (final rangeResp in op.rangeResponses) {
+      visitSchema(rangeResp.content);
+    }
+    final defaultResp = op.defaultResponse;
+    if (defaultResp != null) visitSchema(defaultResp.content);
+    // Operation-level synthesized response wrapper: when the spec
+    // mixes explicit 2xx codes with a 2XX range, the renderer
+    // synthesizes a `RenderOneOf` that doesn't correspond to any
+    // resolved schema. The naming pass assigns its name here
+    // (keyed by the operation's pointer, which no schema otherwise
+    // claims) so render reads the name through the same map. Most
+    // operations don't trigger the synthesized wrapper; assigning
+    // unconditionally is cheap and keeps the lookup unconditional
+    // on the render side.
+    _names[op.pointer] = camelFromSnake('${op.snakeName}_response');
+  }
+
+  void visitSchema(ResolvedSchema schema) => _visitSchema(schema);
 
   void _visitSchema(ResolvedSchema schema) {
     if (!_visited.add(schema.pointer)) return;

--- a/lib/src/render.dart
+++ b/lib/src/render.dart
@@ -5,6 +5,7 @@ import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 import 'package:space_gen/src/loader.dart';
 import 'package:space_gen/src/logger.dart';
+import 'package:space_gen/src/naming.dart';
 import 'package:space_gen/src/parse/spec.dart';
 import 'package:space_gen/src/parse/visitor.dart';
 import 'package:space_gen/src/parser.dart';
@@ -296,7 +297,8 @@ String renderTestSchema(
     SchemaRef.object(parsedSchema, const JsonPointer.empty()),
     ResolveContext.test(),
   );
-  final resolver = SpecResolver(quirks);
+  final resolver = SpecResolver(quirks)
+    ..names = assignNamesForSchema(resolvedSchema);
   final templates = TemplateProvider.defaultLocation();
 
   final renderSchema = resolver.toRenderSchema(resolvedSchema);
@@ -351,7 +353,15 @@ Map<String, String> renderTestSchemas(
       ),
     );
   });
-  final resolver = SpecResolver(quirks);
+  // Aggregate names across every resolved schema in the set so a
+  // ref from one to another resolves correctly.
+  final names = <JsonPointer, String>{};
+  for (final s in resolvedSchemas.values) {
+    for (final entry in assignNamesForSchema(s).entries) {
+      names[entry.key] = entry.value;
+    }
+  }
+  final resolver = SpecResolver(quirks)..names = AssignedNames(names);
   final templates = TemplateProvider.defaultLocation();
 
   final renderSchemas = resolvedSchemas.map((key, value) {
@@ -397,7 +407,8 @@ String renderTestOperation({
     operation: parsedOperation,
     context: resolveContext,
   );
-  final resolver = SpecResolver(quirks);
+  final resolver = SpecResolver(quirks)
+    ..names = assignNamesForOperation(resolvedOperation);
   final renderOperation = resolver.toRenderOperation(resolvedOperation);
   final templateProvider = TemplateProvider.defaultLocation();
   final schemaRenderer = SchemaRenderer(

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -321,12 +321,19 @@ class SpecResolver {
 
   final Quirks quirks;
 
-  /// The naming-pass output for the spec currently being rendered.
-  /// Populated at the start of [toRenderSpec]; consulted by
-  /// [toRenderSchema] when constructing each [RenderSchema] so its
-  /// `typeName` can read the assigned name instead of computing one
-  /// from `snakeName`.
+  /// The naming-pass output for the tree currently being rendered.
+  /// Populated at the start of [toRenderSpec] for full-spec renders;
+  /// callers that render a partial tree (a single schema or
+  /// operation, e.g. test helpers) must set [names] themselves
+  /// before calling [toRenderSchema] / [toRenderOperation].
   AssignedNames _names = AssignedNames.empty;
+
+  /// Sets the assigned-name lookup. Test helpers that render a
+  /// single schema or operation outside a spec call this with
+  /// `assignNamesForSchema(...)` / `assignNamesForOperation(...)`
+  /// before invoking the renderer.
+  // ignore: avoid_setters_without_getters
+  set names(AssignedNames names) => _names = names;
 
   /// Looks up the assigned Dart class name for a resolved schema's
   /// pointer, or null if the naming pass didn't enumerate it (e.g.
@@ -645,8 +652,12 @@ class SpecResolver {
         discriminator: null,
         // Synthesized — no resolved oneOf. Renders as the legacy
         // `UnimplementedError` stub via the null-source `NoDispatch`
-        // path; closing this gap is a follow-up.
+        // path; closing that gap is a follow-up. The naming pass
+        // enumerates this entity under the operation's pointer
+        // (no schema claims that pointer) so its Dart name comes
+        // through the same lookup as everything else.
         source: null,
+        assignedName: _nameFor(operation.pointer),
       ),
     );
   }
@@ -1976,18 +1987,36 @@ abstract class RenderSchema extends Equatable implements ToTemplateContext {
   final CommonProperties common;
 
   /// Dart class name assigned by the naming pass. Populated by
-  /// [SpecResolver.toRenderSchema] for `createsNewType: true` schemas
-  /// (and for [RenderRecursiveRef] whose target is named); null
-  /// otherwise.
+  /// [SpecResolver.toRenderSchema] for every `createsNewType: true`
+  /// schema (and for [RenderRecursiveRef], which looks up its
+  /// target's name).
   ///
-  /// Subclass `typeName` getters consult this as an override of the
-  /// snake-derived computation. Today the override and the
-  /// computation produce the same string (the naming pass uses
-  /// `camelFromSnake(snakeName)` itself); future PRs swap the
-  /// algorithm to shortest-unique-with-fallback, at which point this
-  /// field becomes the source of truth and the snake-derived
-  /// fallback goes away.
+  /// Optional in the constructor only because tests sometimes build
+  /// `RenderSchema`s directly without going through `SpecResolver`;
+  /// in production every newtype's name is non-null. Subclass
+  /// `typeName` getters call [_requireAssignedName] to fail loudly
+  /// if a newtype-shaped schema slips through unnamed — that turns
+  /// "the lookup silently regressed" into a clear stack trace
+  /// pointing at whichever construction site forgot to pass it.
   final String? assignedName;
+
+  /// Returns [assignedName], or throws if it's null. Use from
+  /// `typeName` getters on `createsNewType: true` paths so unnamed
+  /// schemas crash loudly at the use site instead of falling back
+  /// to a stale snake-derived name.
+  String _requireAssignedName() {
+    final name = assignedName;
+    if (name == null) {
+      throw StateError(
+        'Naming pass did not assign a name to $runtimeType '
+        '(snakeName: $snakeName, pointer: $pointer). Either the '
+        'schema was constructed without going through SpecResolver '
+        '(test bug — pass `assignedName: …` explicitly) or the '
+        'naming-pass walker missed this entity (naming.dart bug).',
+      );
+    }
+    return name;
+  }
 
   /// The snake name of the resolved schema.
   String get snakeName => common.snakeName;
@@ -2260,8 +2289,7 @@ class RenderPod extends RenderSchema {
   };
 
   @override
-  String get typeName =>
-      createsNewType ? (assignedName ?? camelFromSnake(snakeName)) : dartType;
+  String get typeName => createsNewType ? _requireAssignedName() : dartType;
 
   // Boolean is the only PodType with a `is bool` test that's distinct
   // from the other JSON storage types (the date/uri/uuid/etc. all
@@ -2479,7 +2507,7 @@ abstract class RenderNewType extends RenderSchema {
   /// naming-pass-assigned name when present; falls back to the
   /// snake-derived computation when not (e.g. tests that build
   /// schemas directly without going through [SpecResolver]).
-  String get className => assignedName ?? camelFromSnake(snakeName);
+  String get className => _requireAssignedName();
 
   @override
   String get typeName => className;
@@ -2525,8 +2553,7 @@ class RenderString extends RenderSchema {
   List<Object?> get props => [super.props, defaultValue, maxLength, minLength];
 
   @override
-  String get typeName =>
-      createsNewType ? (assignedName ?? camelFromSnake(snakeName)) : 'String';
+  String get typeName => createsNewType ? _requireAssignedName() : 'String';
 
   /// The default value of this schema as a string.
   @override
@@ -2804,8 +2831,7 @@ class RenderNumber extends RenderNumeric<double> {
   });
 
   @override
-  String get typeName =>
-      createsNewType ? (assignedName ?? camelFromSnake(snakeName)) : 'double';
+  String get typeName => createsNewType ? _requireAssignedName() : 'double';
 
   @override
   String? get wrapperTag => createsNewType ? null : 'Num';
@@ -2851,8 +2877,7 @@ class RenderInteger extends RenderNumeric<int> {
   });
 
   @override
-  String get typeName =>
-      createsNewType ? (assignedName ?? camelFromSnake(snakeName)) : 'int';
+  String get typeName => createsNewType ? _requireAssignedName() : 'int';
 
   @override
   String? get wrapperTag => createsNewType ? null : 'Int';
@@ -4920,7 +4945,7 @@ class RenderRecursiveRef extends RenderSchema {
   bool get shouldCallToJson => true;
 
   @override
-  String get typeName => assignedName ?? camelFromSnake(snakeName);
+  String get typeName => _requireAssignedName();
 
   @override
   String jsonStorageType({required bool isNullable}) =>

--- a/test/render/file_renderer_test.dart
+++ b/test/render/file_renderer_test.dart
@@ -2581,6 +2581,7 @@ void main() {
           pointer: JsonPointer.parse('#/foo'),
           description: 'Foo description',
         ),
+        assignedName: 'Foo',
         properties: {
           'bar': RenderBinary(
             common: CommonProperties.test(

--- a/test/render/render_tree_test.dart
+++ b/test/render/render_tree_test.dart
@@ -1266,4 +1266,65 @@ void main() {
       expect(inlineEmail.defaultValueString(context), "'a@b.c'");
     });
   });
+
+  group('strict assignedName', () {
+    // typeName on a `createsNewType: true` schema constructed without
+    // an `assignedName` must throw — that's the strict-mode invariant
+    // that catches naming-pass bypasses (a test forgot to populate
+    // `SpecResolver.names`, or a render path didn't go through one of
+    // the documented entry points).
+    test('newtype RenderObject without assignedName throws on typeName', () {
+      const schema = RenderObject(
+        common: CommonProperties.test(
+          snakeName: 'foo',
+          pointer: JsonPointer.empty(),
+        ),
+        properties: {},
+      );
+      expect(
+        () => schema.typeName,
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            allOf(
+              contains('Naming pass did not assign a name'),
+              contains('snakeName: foo'),
+            ),
+          ),
+        ),
+      );
+    });
+
+    test('non-newtype RenderString returns Dart primitive without '
+        'consulting assignedName', () {
+      // Non-newtypes never look up assignedName; their `typeName` is
+      // structural ('String', 'int', etc.). Verifies the strict
+      // assertion only fires on the newtype branch.
+      const inline = RenderString(
+        common: CommonProperties.test(
+          snakeName: 'whatever',
+          pointer: JsonPointer.empty(),
+        ),
+        defaultValue: null,
+        maxLength: null,
+        minLength: null,
+        pattern: null,
+        createsNewType: false,
+      );
+      expect(inline.typeName, 'String');
+    });
+
+    test('newtype with assignedName returns it as typeName', () {
+      const schema = RenderObject(
+        common: CommonProperties.test(
+          snakeName: 'foo',
+          pointer: JsonPointer.empty(),
+        ),
+        properties: {},
+        assignedName: 'CustomName',
+      );
+      expect(schema.typeName, 'CustomName');
+    });
+  });
 }

--- a/test/render/render_tree_test.dart
+++ b/test/render/render_tree_test.dart
@@ -794,6 +794,7 @@ void main() {
         pointer: JsonPointer.empty(),
       ),
       targetPointer: JsonPointer.empty(),
+      assignedName: 'Node',
     );
 
     test('is a newtype but does not render its own file', () {
@@ -1041,6 +1042,7 @@ void main() {
         values: const ['a', 'b'],
         names: const ['a', 'b'],
         descriptions: null,
+        assignedName: 'Foo',
       );
       final map = RenderMap(
         common: common,
@@ -1064,6 +1066,10 @@ void main() {
       ),
       type: type,
       createsNewType: createsNewType,
+      // Pass an assigned name only for newtype cases (typeName falls
+      // back to the Dart primitive otherwise). Mirrors what the
+      // naming pass would produce: `camelFromSnake('foo_bar')`.
+      assignedName: createsNewType ? 'FooBar' : null,
     );
 
     test('typeName is the class name when a newtype, else the Dart type', () {
@@ -1244,6 +1250,7 @@ void main() {
         type: PodType.boolean,
         createsNewType: true,
         defaultValue: true,
+        assignedName: 'Flag',
       );
       expect(newtypeBool.defaultValueString(context), 'Flag(true)');
 


### PR DESCRIPTION
## Summary

#161 wired the naming pass through render but kept the snake-derived
fallback (`assignedName ?? camelFromSnake(snakeName)`) on every newtype
`typeName` getter. The fallback hid whether the lookup was actually
firing — every render path could have silently bypassed the pass and
the regen would still match.

Replace the fallback with `_requireAssignedName()` — throws a clear
`StateError` if a `createsNewType: true` schema's `assignedName` is
null. Production now crashes loudly if any render path forgets to
populate names, so a regression in PR 3+ (algorithm swap) can't
masquerade as a no-op.

Surfaces three previously-implicit gaps, all fixed here:

1. **Test helpers that bypass `toRenderSpec`.** `renderTestSchema`, `renderTestSchemas`, `renderTestOperation` go through `SpecResolver` but don't call `toRenderSpec` — the naming-pass population was gated on it. Fix: `naming.dart` exposes `assignNamesForSchema(...)` and `assignNamesForOperation(...)`; `SpecResolver` gains a `names=` setter; the test helpers populate explicitly.

2. **The synthesized multi-status `RenderOneOf`.** The range-mixed multi-status fallback constructs a `RenderOneOf` with `source: null` (no resolved schema), so the naming pass doesn't see it. Compute its name inline at construction (`camelFromSnake('${op.snakeName}_response')`), matching what the snake-derived fallback used to produce. Marked with a TODO to route through naming proper later.

3. **Direct-construction tests.** A handful of unit tests build `RenderRecursiveRef` / `RenderPod` / `RenderEnum` / `RenderObject` without `SpecResolver`. Pass `assignedName: 'Foo'` (matching what `camelFromSnake(snakeName)` would have produced) to each.

## Test plan

- [x] 396 tests pass (5 more than #161 — new naming-pass tests carried forward)
- [x] `dart analyze` clean on lib/ and test/
- [x] github regen `dart analyze` clean
- [x] Stub count unchanged: 7
- [x] github regen byte-identical to `origin/main` (strict mode produces the same output the fallback did, since the algorithm hasn't changed; verified via `diff -r` modulo the package-name-length lint header artifact)