### PR TITLE
refactor: bring oneOf wrapper subclass names under the naming pass

### DIFF
--- a/lib/src/dispatch.dart
+++ b/lib/src/dispatch.dart
@@ -217,6 +217,14 @@ class NoDispatch extends DispatchDecision {
 /// schemas' shapes (required/optional properties, items types,
 /// discriminator). Returns [NoDispatch] when no strategy fits.
 DispatchDecision decideDispatch(ResolvedSchemaCollection collection) {
+  // AllOf isn't a polymorphic dispatch — every member must validate,
+  // so there's no "pick one variant" at runtime. Render flattens it
+  // into a synthetic merged object; dispatch is never consulted in
+  // that path. Returning NoDispatch unconditionally keeps the
+  // contract honest for callers that walk every collection (the
+  // naming pass enumerates wrappers from each `decideDispatch`
+  // result, and AllOf produces none).
+  if (collection is ResolvedAllOf) return const NoDispatch();
   final variants = collection.schemas;
   return _pickDiscriminator(collection, variants) ??
       _pickShape(variants) ??

--- a/lib/src/naming.dart
+++ b/lib/src/naming.dart
@@ -21,6 +21,7 @@
 library;
 
 import 'package:meta/meta.dart';
+import 'package:space_gen/src/dispatch.dart';
 import 'package:space_gen/src/parse/spec.dart';
 import 'package:space_gen/src/resolver.dart';
 import 'package:space_gen/src/string.dart';
@@ -58,6 +59,16 @@ class AssignedNames {
   /// going through the full pipeline. Schemas constructed this way
   /// fall back to their `common.snakeName`-derived computation.
   static const empty = AssignedNames({});
+
+  /// Synthesized pointer for a wrapper subclass of a sealed-class
+  /// dispatch. The wrapper itself isn't a [ResolvedSchema], so it has
+  /// no pointer of its own; we mint one from the parent oneOf's
+  /// pointer + variant index. The render side computes the same key
+  /// when it needs the wrapper's class name.
+  static JsonPointer wrapperPointer(
+    JsonPointer parentPointer,
+    int variantIndex,
+  ) => parentPointer.add('_wrapper').add('$variantIndex');
 
   /// All assigned (pointer, name) pairs. Iteration order matches the
   /// underlying map; use only for debugging / tests / metrics.
@@ -144,6 +155,107 @@ class _NameAssigner {
 
   void visitSchema(ResolvedSchema schema) => _visitSchema(schema);
 
+  /// Once every variant of [collection] has its own assigned name,
+  /// enumerate the wrapper subclasses the dispatch will emit and
+  /// assign each its name. Stored under [AssignedNames.wrapperPointer]
+  /// so the render side can look them up using the parent pointer +
+  /// variant index, the same way it already maps variants between
+  /// `source.schemas[i]` and the parallel `RenderOneOf.schemas[i]`.
+  void _assignWrapperNames(ResolvedSchemaCollection collection) {
+    final decision = decideDispatch(collection);
+    if (decision is NoDispatch) return;
+    final parentName = _names[collection.pointer];
+    if (parentName == null) return;
+    for (var i = 0; i < collection.schemas.length; i++) {
+      final variant = collection.schemas[i];
+      final wrapperName = _wrapperNameFor(parentName, variant, decision);
+      if (wrapperName == null) continue;
+      _names[AssignedNames.wrapperPointer(collection.pointer, i)] = wrapperName;
+    }
+  }
+
+  /// Computes the Dart class name for one wrapper subclass. Mirrors
+  /// the render-side `wrapperTypeName` / array-element logic, but
+  /// reads variant names from `_names` instead of the variant's own
+  /// `typeName` getter. Returns null for the rare case where the
+  /// dispatch doesn't actually emit a wrapper for this variant
+  /// (caller skips the assignment).
+  String? _wrapperNameFor(
+    String parentName,
+    ResolvedSchema variant,
+    DispatchDecision decision,
+  ) {
+    if (decision is PredicateDispatch &&
+        decision.kind == PredicateDispatchKind.arrayElement) {
+      // Array-element wrappers splice the items type so sibling
+      // arrays don't collide on the shared `wrapperTag = 'List'`.
+      // `_pickArrayElementMode` only fires when every variant is a
+      // `ResolvedArray`, so the cast is safe.
+      final array = variant as ResolvedArray;
+      final itemName = _typeNameOf(array.items);
+      if (itemName == null) return null;
+      return '$parentName${itemName}List';
+    }
+    final tag = _wrapperTagOf(variant);
+    if (tag == null) return null;
+    return '$parentName$tag';
+  }
+
+  /// The Dart type name for a schema as it would appear at a use
+  /// site. Mirrors the render-side `typeName` getter chain: looks up
+  /// the assigned name for newtypes; returns the structural Dart
+  /// type for non-newtype primitives. Returns null when neither
+  /// applies (uncovered case — caller decides whether to skip).
+  String? _typeNameOf(ResolvedSchema schema) {
+    final assigned = _names[schema.pointer];
+    if (assigned != null) return assigned;
+    return switch (schema) {
+      ResolvedRecursiveRef() => _names[schema.targetPointer],
+      ResolvedString() => schema.createsNewType ? null : 'String',
+      ResolvedInteger() => schema.createsNewType ? null : 'int',
+      ResolvedNumber() => schema.createsNewType ? null : 'double',
+      _ => null,
+    };
+  }
+
+  /// The wrapper-tag string used to compose a wrapper class name as
+  /// `<parent><tag>` for non-array-element dispatches. Mirrors each
+  /// `RenderSchema` subclass's `wrapperTag` getter exactly — see
+  /// those getters for why each case looks the way it does. Returns
+  /// null when the variant has no wrapperTag (e.g., a primitive
+  /// newtype that gates shape-dispatch out).
+  String? _wrapperTagOf(ResolvedSchema variant) {
+    return switch (variant) {
+      // Object / enum / empty-object variants tag with the variant's
+      // own assigned name (they're always newtypes; the tag IS the
+      // class name). AllOf collapses into a synthetic merged
+      // `RenderObject` at render time, so it's the same case here —
+      // the AllOf's own assigned name.
+      ResolvedObject() ||
+      ResolvedEnum() ||
+      ResolvedEmptyObject() ||
+      ResolvedAllOf() => _names[variant.pointer],
+      // Recursive refs tag with the target's assigned name.
+      ResolvedRecursiveRef() => _names[variant.targetPointer],
+      // Primitives: null when newtype (no shape-dispatch
+      // participation), else the structural Dart type name.
+      ResolvedString() => variant.createsNewType ? null : 'String',
+      ResolvedInteger() => variant.createsNewType ? null : 'Int',
+      ResolvedNumber() => variant.createsNewType ? null : 'Num',
+      ResolvedPod() =>
+        !variant.createsNewType && variant.type == PodType.boolean
+            ? 'Bool'
+            : null,
+      // Array / Map: always the structural literal, even when the
+      // variant is a top-level newtype. The variant's `typeName` for
+      // an array is `List<X>`; we can't splice that into a class
+      // name, so the wrapper uses just `'List'`.
+      ResolvedArray() => 'List',
+      ResolvedMap() => 'Map',
+      _ => null,
+    };
+  }
+
   void _visitSchema(ResolvedSchema schema) {
     if (!_visited.add(schema.pointer)) return;
     if (schema.createsNewType) {
@@ -170,6 +282,11 @@ class _NameAssigner {
         for (final variant in collection.schemas) {
           _visitSchema(variant);
         }
+        // After variants are named, enumerate any wrapper subclass
+        // names. AllOf gets `NoDispatch` from [decideDispatch] (it
+        // collapses to a synthetic object) and the helper is a
+        // no-op there, so no gate needed.
+        _assignWrapperNames(collection);
       case ResolvedString():
       case ResolvedInteger():
       case ResolvedNumber():

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -340,6 +340,16 @@ class SpecResolver {
   /// non-newtype schemas like inline arrays/maps).
   String? _nameFor(JsonPointer pointer) => _names.maybeGet(pointer);
 
+  /// Looks up the wrapper-subclass names assigned by the naming pass
+  /// for each variant of a oneOf/anyOf, in `coll.schemas` order.
+  /// Indexes that the naming pass didn't enumerate (e.g. NoDispatch)
+  /// land as null; render only reads the entries it needs (the
+  /// dispatch decision tells it which).
+  List<String?> _wrapperNamesFor(ResolvedSchemaCollection coll) => [
+    for (var i = 0; i < coll.schemas.length; i++)
+      _names.maybeGet(AssignedNames.wrapperPointer(coll.pointer, i)),
+  ];
+
   RenderSchema? maybeRenderSchema(ResolvedSchema? schema) {
     if (schema == null) {
       return null;
@@ -483,6 +493,7 @@ class SpecResolver {
           discriminator: renderDiscriminator,
           source: schema,
           assignedName: _nameFor(schema.pointer),
+          wrapperNames: _wrapperNamesFor(schema),
         );
       case ResolvedAllOf():
         // Generate a synthetic object type for allOf. A property is
@@ -519,6 +530,7 @@ class SpecResolver {
           discriminator: null,
           source: schema,
           assignedName: _nameFor(schema.pointer),
+          wrapperNames: _wrapperNamesFor(schema),
         );
       case ResolvedMap():
         final keyEnum = schema.keySchema;
@@ -3849,6 +3861,7 @@ class RenderOneOf extends RenderNewType {
     required this.schemas,
     required this.discriminator,
     required this.source,
+    this.wrapperNames = const [],
     super.assignedName,
   });
 
@@ -3875,6 +3888,13 @@ class RenderOneOf extends RenderNewType {
   /// multi-status responses. These always render as [NoDispatch] /
   /// the legacy `UnimplementedError` stub.
   final ResolvedSchemaCollection? source;
+
+  /// Wrapper subclass class name per variant — index parallel to
+  /// [schemas]. Populated by [SpecResolver.toRenderSchema] from the
+  /// naming pass's wrapper enumeration. Empty for synthesized
+  /// RenderOneOfs (no `source`) and for genuine [NoDispatch] oneOfs
+  /// (no wrappers emitted). [wrapperTypeName] looks up by index.
+  final List<String?> wrapperNames;
 
   /// We could do something smarter here, to determine if the oneOf has a
   /// const constructor, but it's not worth the complexity for now.
@@ -3911,24 +3931,30 @@ class RenderOneOf extends RenderNewType {
     return 'Map<String, dynamic>';
   }
 
-  /// Build the wrapper class name as `<ParentTypeName><wrapperTag>`.
-  /// We always prepend — even when the variant's tag already starts
-  /// with the parent's typeName — because stripping the duplicate
-  /// would collide with the variant's own standalone class (the
-  /// parser names inline variants `<parent_snake>_one_of_<i>`, so the
-  /// variant typeName equals the would-be deduped wrapper name). The
-  /// double-prefix is ugly but unambiguous; co-locating the inline
-  /// variant into the parent's file is a follow-up that fixes both
-  /// the ugliness and the duplicate emission.
+  /// Looks up the wrapper subclass class name assigned by the naming
+  /// pass for [variant]. Variant identity is by index in [schemas]
+  /// (which is parallel to `source.schemas`); the naming pass keyed
+  /// each wrapper name by `(parentPointer, variantIndex)` and stored
+  /// it under [AssignedNames.wrapperPointer]. We thread the resolved
+  /// names from there through [wrapperNames] at construction.
   ///
-  /// Caller must have established that [variant] has a non-null
-  /// [RenderSchema.wrapperTag] (e.g. via the dispatch gates).
+  /// Today's algorithm composes the wrapper name as
+  /// `<ParentTypeName><wrapperTag>` (computed in `naming.dart`). A
+  /// future PR will swap to shortest-unique-with-fallback; render
+  /// doesn't need to know.
   String wrapperTypeName(RenderSchema variant) {
-    final tag = variant.wrapperTag;
-    if (tag == null) {
-      throw StateError('No wrapper tag available for $variant');
+    final i = schemas.indexWhere((s) => identical(s, variant));
+    if (i == -1) {
+      throw StateError('Variant $variant not in this oneOf\'s schemas.');
     }
-    return '$typeName$tag';
+    final name = wrapperNames[i];
+    if (name == null) {
+      throw StateError(
+        'Naming pass did not assign a wrapper name for variant $i '
+        'of ${common.pointer}.',
+      );
+    }
+    return name;
   }
 
   /// Wrapper-variant context for the object-only dispatch paths
@@ -3953,14 +3979,18 @@ class RenderOneOf extends RenderNewType {
   /// [RenderSchema._variantConversion]; this method just composes the
   /// wrapper class name (parent + tag) and shape key around it.
   _VariantPlan? _planVariant(RenderSchema variant, SchemaRenderer context) {
-    final tag = variant.wrapperTag;
-    if (tag == null) return null;
+    // Gate on `wrapperTag != null` — variants with no tag don't
+    // participate in shape dispatch (and the naming pass also
+    // skipped them, so [wrapperTypeName] would throw). Treating
+    // "no tag" as "no plan" keeps the gate semantically the same as
+    // before the wrapper-name lift.
+    if (variant.wrapperTag == null) return null;
     final shapeKey = variant.jsonShapeKey;
     if (shapeKey == null) return null;
     final conversion = variant._variantConversion(context);
     if (conversion == null) return null;
     return _VariantPlan(
-      wrapperTypeName: '$typeName$tag',
+      wrapperTypeName: wrapperTypeName(variant),
       valueType: conversion.valueType,
       jsonTestType: shapeKey,
       fromJson: conversion.fromJson,
@@ -4128,15 +4158,12 @@ class RenderOneOf extends RenderNewType {
           variants.add(objectWrapperContext(renderVariant));
         case PredicateDispatchKind.arrayElement:
           // Each array variant wraps `List<X>` and serializes via
-          // the items' own conversion. Wrapper class name splices
+          // the items' own conversion. Wrapper class names splice
           // the items type so sibling array variants don't collide
-          // on the shared `wrapperTag = 'List'`. The items'
-          // RenderSchema is on the parallel render array (the
-          // resolved items aren't a direct member of source.schemas
-          // and so can't go through renderOf).
-          final renderArray = renderVariant as RenderArray;
-          final innerTypeName = renderArray.items.typeName;
-          final wrapperName = '$typeName${innerTypeName}List';
+          // on the shared `wrapperTag = 'List'`; the naming pass
+          // composed the splice when it enumerated wrappers, and we
+          // read it back here through the standard lookup.
+          final wrapperName = wrapperTypeName(renderVariant);
           final plan = _planVariant(renderVariant, context)!;
           armCtx = {
             'wrapperTypeName': wrapperName,

--- a/test/naming_test.dart
+++ b/test/naming_test.dart
@@ -172,6 +172,212 @@ void main() {
       expect(userEntry.value, 'User');
     });
 
+    test('oneOf with discriminator gets one wrapper name per variant '
+        'under the synthesized wrapper pointer', () {
+      // Discriminator dispatch emits a `<Parent><Variant>` wrapper
+      // per variant. Naming pass stores each under
+      // `AssignedNames.wrapperPointer(parent, i)`.
+      final names = namesFor({
+        'openapi': '3.1.0',
+        'info': {'title': 'X', 'version': '1.0'},
+        'servers': [
+          {'url': 'https://x'},
+        ],
+        'paths': {
+          '/u': {
+            'get': {
+              'summary': 'Get',
+              'responses': {
+                '200': {
+                  'description': 'OK',
+                  'content': {
+                    'application/json': {
+                      'schema': {r'$ref': '#/components/schemas/Pet'},
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        'components': {
+          'schemas': {
+            'Pet': {
+              'oneOf': [
+                {r'$ref': '#/components/schemas/Cat'},
+                {r'$ref': '#/components/schemas/Dog'},
+              ],
+              'discriminator': {
+                'propertyName': 'kind',
+                'mapping': {
+                  'cat': '#/components/schemas/Cat',
+                  'dog': '#/components/schemas/Dog',
+                },
+              },
+            },
+            'Cat': {
+              'type': 'object',
+              'required': ['kind'],
+              'properties': {
+                'kind': {
+                  'type': 'string',
+                  'enum': ['cat'],
+                },
+              },
+            },
+            'Dog': {
+              'type': 'object',
+              'required': ['kind'],
+              'properties': {
+                'kind': {
+                  'type': 'string',
+                  'enum': ['dog'],
+                },
+              },
+            },
+          },
+        },
+      });
+      final pet = JsonPointer.parse('#/components/schemas/Pet');
+      expect(
+        names[AssignedNames.wrapperPointer(pet, 0)],
+        'PetCat',
+      );
+      expect(
+        names[AssignedNames.wrapperPointer(pet, 1)],
+        'PetDog',
+      );
+    });
+
+    test('array-element dispatch wraps per-variant items with '
+        '`<Parent><Items>List`', () {
+      final names = namesFor({
+        'openapi': '3.1.0',
+        'info': {'title': 'X', 'version': '1.0'},
+        'servers': [
+          {'url': 'https://x'},
+        ],
+        'paths': {
+          '/u': {
+            'get': {
+              'summary': 'Get',
+              'responses': {
+                '200': {
+                  'description': 'OK',
+                  'content': {
+                    'application/json': {
+                      'schema': {
+                        'anyOf': [
+                          {
+                            'type': 'array',
+                            'items': {
+                              r'$ref': '#/components/schemas/Stargazer',
+                            },
+                          },
+                          {
+                            'type': 'array',
+                            'items': {r'$ref': '#/components/schemas/User'},
+                          },
+                        ],
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        'components': {
+          'schemas': {
+            'Stargazer': {
+              'type': 'object',
+              'required': ['starred_at'],
+              'properties': {
+                'starred_at': {'type': 'string'},
+              },
+            },
+            'User': {
+              'type': 'object',
+              'required': ['login'],
+              'properties': {
+                'login': {'type': 'string'},
+              },
+            },
+          },
+        },
+      });
+      // The synthesized anyOf gets a name (something like
+      // `Get200Response` — exact synthesized name is implementation-
+      // detail), and each wrapper splices the items type:
+      // `<Parent>StargazerList` and `<Parent>UserList`.
+      final wrappers = names.entries
+          .where((e) => e.key.toString().contains('_wrapper'))
+          .map((e) => e.value)
+          .toList();
+      expect(wrappers, hasLength(2));
+      expect(wrappers.any((w) => w.endsWith('StargazerList')), isTrue);
+      expect(wrappers.any((w) => w.endsWith('UserList')), isTrue);
+    });
+
+    test('allOf collapses (no wrappers, NoDispatch path)', () {
+      // allOf renders as a synthetic merged RenderObject — no oneOf
+      // wrapper subclasses. The naming pass walks it (recurses into
+      // members) but `_assignWrapperNames` returns early on
+      // NoDispatch, so no wrapper-pointer entries appear.
+      final names = namesFor({
+        'openapi': '3.1.0',
+        'info': {'title': 'X', 'version': '1.0'},
+        'servers': [
+          {'url': 'https://x'},
+        ],
+        'paths': {
+          '/u': {
+            'get': {
+              'summary': 'Get',
+              'responses': {
+                '200': {
+                  'description': 'OK',
+                  'content': {
+                    'application/json': {
+                      'schema': {r'$ref': '#/components/schemas/Both'},
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        'components': {
+          'schemas': {
+            'Both': {
+              'allOf': [
+                {r'$ref': '#/components/schemas/A'},
+                {r'$ref': '#/components/schemas/B'},
+              ],
+            },
+            'A': {
+              'type': 'object',
+              'properties': {
+                'a': {'type': 'string'},
+              },
+            },
+            'B': {
+              'type': 'object',
+              'properties': {
+                'b': {'type': 'string'},
+              },
+            },
+          },
+        },
+      });
+      // Components are still named; no wrapper-pointer entries.
+      expect(names[JsonPointer.parse('#/components/schemas/Both')], 'Both');
+      final wrappers = names.entries
+          .where((e) => e.key.toString().contains('_wrapper'))
+          .toList();
+      expect(wrappers, isEmpty);
+    });
+
     test('walks anyOf and allOf variants', () {
       final names = namesFor({
         'openapi': '3.1.0',


### PR DESCRIPTION
## Summary

The naming pass was missing wrapper subclasses — the `<Parent><wrapperTag>` classes that `RenderOneOf` emits for sealed dispatch. Render computed those locally from `parent.typeName + variant.wrapperTag`, which meant the pass didn't have the global view needed for collision detection across the whole emitted name set (e.g., a top-level schema `RequestNote` could collide with a wrapper `Request<Note>`'s composed name).

This PR moves wrapper-name composition into `naming.dart`. After the walker assigns names to every variant of a `ResolvedOneOf` / `ResolvedAnyOf`, `_assignWrapperNames` calls `decideDispatch` and — based on the dispatch kind — composes one wrapper name per variant:

- **Default** (discriminator / shape / hybrid / required-field): `<parent name><wrapperTag>`. The tag mirrors each `RenderSchema` subclass's `wrapperTag` getter — variant's assigned name for newtypes, structural string for primitives (`'String'`, `'Int'`, `'Bool'`, `'List'`, `'Map'`).
- **Array-element**: `<parent name><items name>List`. The items-type splice mirrors what `_pickArrayElementMode`'s render side used to compose inline (no longer needed).

Wrapper names are stored under a synthesized JSON pointer: `AssignedNames.wrapperPointer(parentPointer, variantIndex)`. Render threads them onto each `RenderOneOf` as `wrapperNames: List<String?>` (index parallel to `schemas`); `wrapperTypeName(variant)` is now a lookup by index.

Strict-mode invariant carries forward: `wrapperTypeName` throws if the requested wrapper isn't in the map. The `<Parent><items>List` inline composition in `_buildPredicateMode` is gone.

## Why this matters

The naming pass now owns *every* Dart class name the generator emits. The next PR (algorithm swap to shortest-unique-with-fallback) can reason about collisions across the whole emitted set, including wrappers — which is what made the user push back on shipping the algorithm change before this lift was complete.

## Test plan

- [x] 399 tests pass
- [x] `dart analyze` clean on lib/ and test/
- [x] github regen `dart analyze` clean
- [x] Stub count unchanged: 7
- [x] github regen byte-identical to `origin/main` (verified by walking both trees, stripping the package-name-length lint header artifact, and confirming zero content diffs in `lib/`)