### PR TITLE
refactor: stop doubling the parent prefix in inline oneOf wrapper names

### DIFF
--- a/lib/src/naming.dart
+++ b/lib/src/naming.dart
@@ -168,7 +168,7 @@ class _NameAssigner {
     if (parentName == null) return;
     for (var i = 0; i < collection.schemas.length; i++) {
       final variant = collection.schemas[i];
-      final wrapperName = _wrapperNameFor(parentName, variant, decision);
+      final wrapperName = _wrapperNameFor(parentName, variant, decision, i);
       if (wrapperName == null) continue;
       _names[AssignedNames.wrapperPointer(collection.pointer, i)] = wrapperName;
     }
@@ -184,6 +184,7 @@ class _NameAssigner {
     String parentName,
     ResolvedSchema variant,
     DispatchDecision decision,
+    int variantIndex,
   ) {
     if (decision is PredicateDispatch &&
         decision.kind == PredicateDispatchKind.arrayElement) {
@@ -198,6 +199,18 @@ class _NameAssigner {
     }
     final tag = _wrapperTagOf(variant);
     if (tag == null) return null;
+    // For object-like variants, the tag is the variant's own typeName.
+    // When the variant was synthesized inline by the parser
+    // (`<parent>OneOf<i>`), that name already contains the parent —
+    // composing `<parent><tag>` then doubles the prefix
+    // (`ProjectsCreateCardRequestProjectsCreateCardRequestOneOf0`).
+    // Fall back to a position-based name to keep wrappers readable.
+    // Top-level $ref variants (e.g. `PrivateUser` under
+    // `UsersGetAuthenticated200Response`) don't trip this and keep
+    // their descriptive `<parent><variant>` form.
+    if (tag.startsWith(parentName)) {
+      return '${parentName}Variant$variantIndex';
+    }
     return '$parentName$tag';
   }
 

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -813,7 +813,7 @@ void main() {
       };
       final result = renderTestSchema(schema);
       expect(result, contains('num v => TestNum(v)'));
-      expect(result, contains('Map<String, dynamic> v => TestTestOneOf1'));
+      expect(result, contains('Map<String, dynamic> v => TestVariant1'));
       expect(result, isNot(contains('throw UnimplementedError')));
     });
 
@@ -1453,6 +1453,43 @@ void main() {
       expect(pet, contains('final class PetDog extends Pet'));
     });
 
+    test('wrapper subclass uses position-based name when the variant '
+        'tag would double the parent prefix', () {
+      // Inline oneOf variants get parser-synthesized names that already
+      // contain the parent (`<Parent>OneOf<i>`). Composing the wrapper
+      // as `<Parent><variantTypeName>` would then double the prefix
+      // (e.g. `RequestRequestOneOf0`). The naming pass detects this and
+      // falls back to a position-based name — `RequestVariant0` —
+      // keeping the wrapper readable. Top-level `$ref` variants (whose
+      // names never start with the parent) are unaffected; see the Pet
+      // test above.
+      final result = renderTestSchema({
+        'oneOf': [
+          {
+            'type': 'object',
+            'required': ['note'],
+            'properties': {
+              'note': {'type': 'string'},
+            },
+          },
+          {
+            'type': 'object',
+            'required': ['content_id'],
+            'properties': {
+              'content_id': {'type': 'integer'},
+            },
+          },
+        ],
+      });
+      expect(result, contains('final class TestVariant0 extends Test'));
+      expect(result, contains('final class TestVariant1 extends Test'));
+      // Variant data classes still use their parser-synthesized names.
+      expect(result, contains('final TestOneOf0 value;'));
+      expect(result, contains('final TestOneOf1 value;'));
+      // No doubled prefix anywhere.
+      expect(result, isNot(contains('TestTestOneOf')));
+    });
+
     test('property-presence dispatch falls back to legacy when one '
         'variant has nothing unique at all', () {
       // Cat requires {a, b}; Dog requires {a, b} too with the same
@@ -1603,9 +1640,9 @@ void main() {
       // class's own fromJson/toJson.
       expect(result, contains('final class TestList extends Test'));
       expect(result, contains('final List<String> value;'));
-      expect(result, contains('final class TestTestOneOf1 extends Test'));
-      expect(result, contains('final class TestTestOneOf2 extends Test'));
-      expect(result, contains('final class TestTestOneOf3 extends Test'));
+      expect(result, contains('final class TestVariant1 extends Test'));
+      expect(result, contains('final class TestVariant2 extends Test'));
+      expect(result, contains('final class TestVariant3 extends Test'));
     });
 
     test('hybrid dispatch: Map sub-arms include a fallback when one '


### PR DESCRIPTION
## Summary

Wrapper subclasses for inline oneOf/anyOf variants currently come out
double-prefixed —
`ProjectsCreateCardRequestProjectsCreateCardRequestOneOf0`,
`ChecksUpdateRequestChecksUpdateRequestAnyOf1`, and 73 others in the
github regen. The parser synthesizes inline variants as
\`<parent>OneOf<i>\` (already including the parent), and the naming
pass composes the wrapper as \`<parent><variantName>\` — which then
doubles the prefix.

When the variant's tag already starts with the parent name, fall back
to a position-based wrapper name (\`<parent>Variant<i>\`). Top-level
\`\$ref\` variants — whose names don't start with the parent — are
unaffected and keep their descriptive form
(\`UsersGetAuthenticated200ResponsePrivateUser\`).

Cleans up 75 wrappers in the github regen (75 → 0 doubled); `dart
analyze` stays clean. This is one step on the wrapper-naming thread —
the variant data classes themselves (\`<parent>OneOf<i>\`) still
exist as separate files; collapsing them into the sealed-class
subclass directly is the natural follow-up.

## Test plan

- [x] `dart test` passes; new focused test covers the doubling case
- [x] `dart analyze` clean on github regen (`No issues found!`)
- [x] github regen: 75 doubled-prefix wrappers → 0
- [x] `UnimplementedError` stub count unchanged at 7 (orthogonal)
- [x] Verbose run surfaces no new warnings vs. baseline