### PR TITLE
refactor: collision-aware naming via NameAllocator

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -33,3 +33,5 @@ words:
   - smooshing
   - isinstance
   - elif
+  - fixpoint
+  - prefs

--- a/lib/src/naming.dart
+++ b/lib/src/naming.dart
@@ -7,12 +7,21 @@
 /// collisions with `_1`, renderer composes wrappers from parent +
 /// tag). Each layer makes a local decision with only partial
 /// information, so we get artifacts like
-/// `ProjectsCreateCardRequestProjectsCreateCardRequestOneOf0` and
-/// `RepositoryRulesetConditions1`. A single pass with the full set
-/// of named entities in view can pick shorter, less-collision-prone
-/// names. This file is the first step — it consolidates the lookup
-/// without changing the algorithm. A future pass can swap the
-/// algorithm to shortest-unique-with-fallback.
+/// `ProjectsCreateCardRequestProjectsCreateCardRequestOneOf0`. A
+/// single pass with the full set of named entities in view can pick
+/// shorter, less-collision-prone names.
+///
+/// Each entity submits a *preference list* — best (shortest /
+/// most-descriptive) first, longest-but-guaranteed-unique last — and
+/// the [NameAllocator] runs a fixpoint: when two entities propose the
+/// same name, both advance to their next preference; when an entity
+/// reaches the end of its list and still conflicts, a numeric suffix
+/// disambiguates. Today every caller passes a single-element list
+/// (the same name the old algorithm produced), so generated output
+/// is unchanged. Multi-tier preferences are wired in for the
+/// synthesized op-response name to exercise the fixpoint, and
+/// future PRs can opt other entities into shorter forms by widening
+/// their preference lists.
 ///
 /// Resolver stays Dart-blind: this pass is the only place that
 /// knows about Dart class names. The resolver produces snake-case
@@ -78,46 +87,49 @@ class AssignedNames {
   Map<JsonPointer, String> toMap() => Map.unmodifiable(_byPointer);
 }
 
-/// Walks the resolved tree and assigns a Dart class name to every
-/// schema that creates a new type. Today's algorithm: for each
-/// `createsNewType: true` schema, the name is
-/// `camelFromSnake(common.snakeName)`. The resolver has already
-/// applied any `_1`-style snake-name collision suffixes upstream, so
-/// this pass produces the same output the renderer's existing
-/// `typeName` getters would compute on their own.
-///
-/// The eventual quality win is changing this algorithm to
-/// shortest-unique-with-fallback (PR 3+). This PR just consolidates
-/// the lookup so one place owns the answer.
-AssignedNames assignNames(ResolvedSpec spec) {
-  final names = <JsonPointer, String>{};
-  _NameAssigner(names).visit(spec);
-  return AssignedNames(names);
-}
+/// Walks the resolved tree, builds a preference list for each named
+/// entity, and runs an [NameAllocator] fixpoint to settle on final
+/// Dart class names. See the library doc for the algorithm; today
+/// most callers pass single-element preference lists, so the output
+/// matches the prior `camelFromSnake(common.snakeName)` algorithm.
+AssignedNames assignNames(ResolvedSpec spec) =>
+    (_NameAssigner()..visit(spec)).build();
 
 /// Assigns names for a single resolved operation. Used by test
 /// helpers (`renderTestOperation`) that render an operation in
 /// isolation, without a surrounding spec.
-AssignedNames assignNamesForOperation(ResolvedOperation op) {
-  final names = <JsonPointer, String>{};
-  _NameAssigner(names).visitOperation(op);
-  return AssignedNames(names);
-}
+AssignedNames assignNamesForOperation(ResolvedOperation op) =>
+    (_NameAssigner()..visitOperation(op)).build();
 
 /// Assigns names reachable from a single resolved schema. Used by
 /// test helpers (`renderTestSchema`, `renderTestSchemas`) that
 /// render schemas in isolation, without a surrounding spec.
-AssignedNames assignNamesForSchema(ResolvedSchema schema) {
-  final names = <JsonPointer, String>{};
-  _NameAssigner(names).visitSchema(schema);
-  return AssignedNames(names);
-}
+AssignedNames assignNamesForSchema(ResolvedSchema schema) =>
+    (_NameAssigner()..visitSchema(schema)).build();
 
 class _NameAssigner {
-  _NameAssigner(this._names);
+  _NameAssigner();
 
-  final Map<JsonPointer, String> _names;
+  final NameAllocator _allocator = NameAllocator();
   final Set<JsonPointer> _visited = {};
+  // Schema collections seen in phase 1, processed in phase 2 once
+  // their variants' Dart names have been resolved.
+  final List<ResolvedSchemaCollection> _collectionsForWrappers = [];
+
+  /// Run the allocator's fixpoint and return the final pointer →
+  /// Dart name map. Two phases: phase 1 resolves schema and synthesized
+  /// op-response names; phase 2 reads those resolved names to compose
+  /// wrapper-subclass preferences and resolves them. Wrappers can't
+  /// land in phase 1 because their preferences depend on phase 1's
+  /// output.
+  AssignedNames build() {
+    _allocator.resolve();
+    for (final collection in _collectionsForWrappers) {
+      _claimWrapperNames(collection);
+    }
+    _allocator.resolve();
+    return AssignedNames(Map.of(_allocator.assigned));
+  }
 
   void visit(ResolvedSpec spec) {
     for (final path in spec.paths) {
@@ -144,33 +156,44 @@ class _NameAssigner {
     // Operation-level synthesized response wrapper: when the spec
     // mixes explicit 2xx codes with a 2XX range, the renderer
     // synthesizes a `RenderOneOf` that doesn't correspond to any
-    // resolved schema. The naming pass assigns its name here
-    // (keyed by the operation's pointer, which no schema otherwise
-    // claims) so render reads the name through the same map. Most
-    // operations don't trigger the synthesized wrapper; assigning
-    // unconditionally is cheap and keeps the lookup unconditional
-    // on the render side.
-    _names[op.pointer] = camelFromSnake('${op.snakeName}_response');
+    // resolved schema. We claim its name on the operation's pointer
+    // (no schema otherwise claims it) so render reads the name
+    // through the same map. Most operations don't trigger the
+    // synthesized wrapper; claiming unconditionally is cheap and
+    // keeps the lookup unconditional on the render side.
+    //
+    // Multi-tier preferences exercise the allocator's fixpoint on a
+    // real production code path: `<op>Response` is the natural
+    // first preference, with `<op>Response2`, `<op>Response3`, ...
+    // as fallbacks if a top-level schema with that snake name claims
+    // the slot first. Today neither github nor gen_tests/ has such a
+    // collision, so the first preference always wins; the platform
+    // is wired regardless so future renames pay no plumbing cost.
+    final base = camelFromSnake('${op.snakeName}_response');
+    _allocator.claim(op.pointer, [
+      base,
+      for (var i = 2; i <= 4; i++) '$base$i',
+    ]);
   }
 
   void visitSchema(ResolvedSchema schema) => _visitSchema(schema);
 
-  /// Once every variant of [collection] has its own assigned name,
-  /// enumerate the wrapper subclasses the dispatch will emit and
-  /// assign each its name. Stored under [AssignedNames.wrapperPointer]
-  /// so the render side can look them up using the parent pointer +
-  /// variant index, the same way it already maps variants between
-  /// `source.schemas[i]` and the parallel `RenderOneOf.schemas[i]`.
-  void _assignWrapperNames(ResolvedSchemaCollection collection) {
+  /// Phase-2 wrapper-subclass name claims. Reads the resolved variant
+  /// names produced by phase 1 and submits one claim per dispatch-
+  /// emitted wrapper. Variant identity is by index in
+  /// [collection]`.schemas` — matches `AssignedNames.wrapperPointer`.
+  void _claimWrapperNames(ResolvedSchemaCollection collection) {
     final decision = decideDispatch(collection);
     if (decision is NoDispatch) return;
-    final parentName = _names[collection.pointer];
+    final parentName = _allocator.assigned[collection.pointer];
     if (parentName == null) return;
     for (var i = 0; i < collection.schemas.length; i++) {
       final variant = collection.schemas[i];
       final wrapperName = _wrapperNameFor(parentName, variant, decision, i);
       if (wrapperName == null) continue;
-      _names[AssignedNames.wrapperPointer(collection.pointer, i)] = wrapperName;
+      _allocator.claim(AssignedNames.wrapperPointer(collection.pointer, i), [
+        wrapperName,
+      ]);
     }
   }
 
@@ -216,14 +239,15 @@ class _NameAssigner {
 
   /// The Dart type name for a schema as it would appear at a use
   /// site. Mirrors the render-side `typeName` getter chain: looks up
-  /// the assigned name for newtypes; returns the structural Dart
+  /// the resolved name for newtypes; returns the structural Dart
   /// type for non-newtype primitives. Returns null when neither
   /// applies (uncovered case — caller decides whether to skip).
+  /// Called from phase 2; reads phase-1's resolved names.
   String? _typeNameOf(ResolvedSchema schema) {
-    final assigned = _names[schema.pointer];
+    final assigned = _allocator.assigned[schema.pointer];
     if (assigned != null) return assigned;
     return switch (schema) {
-      ResolvedRecursiveRef() => _names[schema.targetPointer],
+      ResolvedRecursiveRef() => _allocator.assigned[schema.targetPointer],
       ResolvedString() => schema.createsNewType ? null : 'String',
       ResolvedInteger() => schema.createsNewType ? null : 'int',
       ResolvedNumber() => schema.createsNewType ? null : 'double',
@@ -240,16 +264,16 @@ class _NameAssigner {
   String? _wrapperTagOf(ResolvedSchema variant) {
     return switch (variant) {
       // Object / enum / empty-object variants tag with the variant's
-      // own assigned name (they're always newtypes; the tag IS the
+      // own resolved name (they're always newtypes; the tag IS the
       // class name). AllOf collapses into a synthetic merged
       // `RenderObject` at render time, so it's the same case here —
-      // the AllOf's own assigned name.
+      // the AllOf's own resolved name.
       ResolvedObject() ||
       ResolvedEnum() ||
       ResolvedEmptyObject() ||
-      ResolvedAllOf() => _names[variant.pointer],
-      // Recursive refs tag with the target's assigned name.
-      ResolvedRecursiveRef() => _names[variant.targetPointer],
+      ResolvedAllOf() => _allocator.assigned[variant.pointer],
+      // Recursive refs tag with the target's resolved name.
+      ResolvedRecursiveRef() => _allocator.assigned[variant.targetPointer],
       // Primitives: null when newtype (no shape-dispatch
       // participation), else the structural Dart type name.
       ResolvedString() => variant.createsNewType ? null : 'String',
@@ -272,7 +296,10 @@ class _NameAssigner {
   void _visitSchema(ResolvedSchema schema) {
     if (!_visited.add(schema.pointer)) return;
     if (schema.createsNewType) {
-      _names[schema.pointer] = camelFromSnake(schema.snakeName);
+      // Single-element preference list for now — today's behavior.
+      // Future PRs can widen this (e.g., title-derived shorter forms
+      // ahead of the parser-synthesized name).
+      _allocator.claim(schema.pointer, [camelFromSnake(schema.snakeName)]);
     }
     // Recurse into structural children so inline newtypes get named.
     switch (schema) {
@@ -295,11 +322,12 @@ class _NameAssigner {
         for (final variant in collection.schemas) {
           _visitSchema(variant);
         }
-        // After variants are named, enumerate any wrapper subclass
-        // names. AllOf gets `NoDispatch` from [decideDispatch] (it
-        // collapses to a synthetic object) and the helper is a
-        // no-op there, so no gate needed.
-        _assignWrapperNames(collection);
+        // Defer wrapper-name claims to phase 2 — they need the
+        // resolved variant names. AllOf gets `NoDispatch` from
+        // [decideDispatch] (it collapses to a synthetic object), so
+        // no wrappers will actually be claimed for it; queueing it
+        // is harmless and keeps the gate in one place.
+        _collectionsForWrappers.add(collection);
       case ResolvedString():
       case ResolvedInteger():
       case ResolvedNumber():
@@ -314,5 +342,120 @@ class _NameAssigner {
         // Leaf — no inline children to visit.
         break;
     }
+  }
+}
+
+/// Collision-aware Dart name allocator. Each entity submits a
+/// preference list (best first, longest/safest last) via [claim];
+/// [resolve] runs a fixpoint that advances colliding entities to
+/// their next preference, then suffixes any remaining ties with a
+/// numeric tail (`Foo`, `Foo2`, `Foo3`, …).
+///
+/// The fixpoint is order-independent: same set of claims → same
+/// assignments regardless of insertion order. This matters because
+/// the naming pass walks the spec in declaration order, but a stable
+/// algorithm means future visit-order tweaks can't silently shuffle
+/// names.
+///
+/// [resolve] can be called multiple times — each call assigns the
+/// claims pending at the time of the call. Names assigned in earlier
+/// `resolve()` cycles are treated as taken: subsequent claims work
+/// around them. The naming pass uses two cycles (phase 1: schemas +
+/// op-response synthetics; phase 2: wrappers, which need phase-1
+/// resolved names to compose their preferences).
+///
+/// Public so unit tests can drive it directly with hand-built claims;
+/// most callers should go through [_NameAssigner].
+class NameAllocator {
+  NameAllocator();
+
+  final Map<JsonPointer, String> _assigned = {};
+  final Set<String> _takenNames = {};
+  final Map<JsonPointer, List<String>> _pending = {};
+
+  /// Resolved (pointer → name) assignments from prior [resolve] calls.
+  /// Read-only view; new assignments land here when the next
+  /// [resolve] runs.
+  Map<JsonPointer, String> get assigned => Map.unmodifiable(_assigned);
+
+  /// Submit a claim. [preferences] must be non-empty and ordered
+  /// best-first. A pointer that already has a resolved name (from a
+  /// prior [resolve]) silently ignores the claim — re-visits during
+  /// recursion are common and benign.
+  void claim(JsonPointer pointer, List<String> preferences) {
+    if (preferences.isEmpty) {
+      throw ArgumentError('Preferences cannot be empty: $pointer');
+    }
+    if (_assigned.containsKey(pointer)) return;
+    _pending[pointer] = preferences;
+  }
+
+  /// Run the fixpoint over pending claims, settling each on its
+  /// best non-conflicting preference. Already-assigned names from
+  /// prior [resolve] cycles are treated as taken and won't be
+  /// reused. Empties the pending queue.
+  void resolve() {
+    if (_pending.isEmpty) return;
+
+    final pending = Map.of(_pending);
+    _pending.clear();
+
+    // Per-entity tier index, advanced when its current proposal
+    // conflicts with another pending claimant or with an already-
+    // assigned name.
+    final tiers = <JsonPointer, int>{
+      for (final p in pending.keys) p: 0,
+    };
+
+    while (true) {
+      final proposals = <String, List<JsonPointer>>{};
+      for (final p in pending.keys) {
+        proposals.putIfAbsent(pending[p]![tiers[p]!], () => []).add(p);
+      }
+      var changed = false;
+      for (final entry in proposals.entries) {
+        final group = entry.value;
+        final inConflict = group.length > 1 || _takenNames.contains(entry.key);
+        if (!inConflict) continue;
+        for (final p in group) {
+          final prefs = pending[p]!;
+          if (tiers[p]! < prefs.length - 1) {
+            tiers[p] = tiers[p]! + 1;
+            changed = true;
+          }
+        }
+      }
+      if (!changed) break;
+    }
+
+    // Finalize: each pending claim takes its current-tier name.
+    // Any remaining ties (multiple pending claimants stuck on the
+    // same last-tier name, or a pending claim whose final preference
+    // matches an already-assigned name) get a numeric suffix. Order
+    // by pointer string so the suffix assignment is deterministic.
+    final byName = <String, List<JsonPointer>>{};
+    for (final p in pending.keys) {
+      byName.putIfAbsent(pending[p]![tiers[p]!], () => []).add(p);
+    }
+    for (final entry in byName.entries) {
+      final base = entry.key;
+      final group = entry.value
+        ..sort((a, b) => a.toString().compareTo(b.toString()));
+      var baseTaken = _takenNames.contains(base);
+      for (final p in group) {
+        final name = baseTaken ? _disambiguate(base) : base;
+        _assigned[p] = name;
+        _takenNames.add(name);
+        baseTaken = true;
+      }
+    }
+  }
+
+  String _disambiguate(String base) {
+    var i = 2;
+    while (_takenNames.contains('$base$i')) {
+      i++;
+    }
+    return '$base$i';
   }
 }

--- a/lib/src/naming.dart
+++ b/lib/src/naming.dart
@@ -18,10 +18,10 @@
 /// reaches the end of its list and still conflicts, a numeric suffix
 /// disambiguates. Today every caller passes a single-element list
 /// (the same name the old algorithm produced), so generated output
-/// is unchanged. Multi-tier preferences are wired in for the
-/// synthesized op-response name to exercise the fixpoint, and
-/// future PRs can opt other entities into shorter forms by widening
-/// their preference lists.
+/// is byte-identical to before. Future PRs opt entities into
+/// shorter forms by widening their preference lists — wrapper
+/// subclasses, inline variants with a `title`, and synthesized
+/// op-response names are the natural candidates.
 ///
 /// Resolver stays Dart-blind: this pass is the only place that
 /// knows about Dart class names. The resolver produces snake-case
@@ -93,19 +93,19 @@ class AssignedNames {
 /// most callers pass single-element preference lists, so the output
 /// matches the prior `camelFromSnake(common.snakeName)` algorithm.
 AssignedNames assignNames(ResolvedSpec spec) =>
-    (_NameAssigner()..visit(spec)).build();
+    (_NameAssigner()..visit(spec)).finalize();
 
 /// Assigns names for a single resolved operation. Used by test
 /// helpers (`renderTestOperation`) that render an operation in
 /// isolation, without a surrounding spec.
 AssignedNames assignNamesForOperation(ResolvedOperation op) =>
-    (_NameAssigner()..visitOperation(op)).build();
+    (_NameAssigner()..visitOperation(op)).finalize();
 
 /// Assigns names reachable from a single resolved schema. Used by
 /// test helpers (`renderTestSchema`, `renderTestSchemas`) that
 /// render schemas in isolation, without a surrounding spec.
 AssignedNames assignNamesForSchema(ResolvedSchema schema) =>
-    (_NameAssigner()..visitSchema(schema)).build();
+    (_NameAssigner()..visitSchema(schema)).finalize();
 
 class _NameAssigner {
   _NameAssigner();
@@ -116,19 +116,31 @@ class _NameAssigner {
   // their variants' Dart names have been resolved.
   final List<ResolvedSchemaCollection> _collectionsForWrappers = [];
 
-  /// Run the allocator's fixpoint and return the final pointer →
-  /// Dart name map. Two phases: phase 1 resolves schema and synthesized
-  /// op-response names; phase 2 reads those resolved names to compose
-  /// wrapper-subclass preferences and resolves them. Wrappers can't
-  /// land in phase 1 because their preferences depend on phase 1's
-  /// output.
-  AssignedNames build() {
+  /// Run the allocator over both phases and return the final
+  /// pointer → Dart name map. The assigner is single-use; calling
+  /// this a second time would re-resolve already-assigned names as
+  /// no-ops and produce the same snapshot.
+  AssignedNames finalize() {
+    _resolvePhase1();
+    _resolvePhase2();
+    return AssignedNames(_allocator.snapshot());
+  }
+
+  /// Phase 1: schema names + the synthesized op-response name. These
+  /// were claimed during the tree walk; resolve them so phase 2 can
+  /// read final schema names when it composes wrapper preferences.
+  void _resolvePhase1() {
     _allocator.resolve();
+  }
+
+  /// Phase 2: wrapper-subclass preferences depend on phase-1 names,
+  /// so we claim them now (reading from the resolved phase-1
+  /// snapshot) and then resolve again.
+  void _resolvePhase2() {
     for (final collection in _collectionsForWrappers) {
       _claimWrapperNames(collection);
     }
     _allocator.resolve();
-    return AssignedNames(Map.of(_allocator.assigned));
   }
 
   void visit(ResolvedSpec spec) {
@@ -162,17 +174,15 @@ class _NameAssigner {
     // synthesized wrapper; claiming unconditionally is cheap and
     // keeps the lookup unconditional on the render side.
     //
-    // Multi-tier preferences exercise the allocator's fixpoint on a
-    // real production code path: `<op>Response` is the natural
-    // first preference, with `<op>Response2`, `<op>Response3`, ...
-    // as fallbacks if a top-level schema with that snake name claims
-    // the slot first. Today neither github nor gen_tests/ has such a
-    // collision, so the first preference always wins; the platform
-    // is wired regardless so future renames pay no plumbing cost.
-    final base = camelFromSnake('${op.snakeName}_response');
+    // Single-tier preference list: if a real schema ever ends up
+    // wanting `<op>Response`, the allocator's numeric-suffix
+    // fallback handles disambiguation correctly. Multi-tier
+    // alternatives are pointless here (every op has the same
+    // shape of preference list, so they'd march through tiers in
+    // lockstep and finalize at a *worse* name than single-tier
+    // gives via the suffix path).
     _allocator.claim(op.pointer, [
-      base,
-      for (var i = 2; i <= 4; i++) '$base$i',
+      camelFromSnake('${op.snakeName}_response'),
     ]);
   }
 
@@ -185,7 +195,7 @@ class _NameAssigner {
   void _claimWrapperNames(ResolvedSchemaCollection collection) {
     final decision = decideDispatch(collection);
     if (decision is NoDispatch) return;
-    final parentName = _allocator.assigned[collection.pointer];
+    final parentName = _allocator.lookup(collection.pointer);
     if (parentName == null) return;
     for (var i = 0; i < collection.schemas.length; i++) {
       final variant = collection.schemas[i];
@@ -244,10 +254,10 @@ class _NameAssigner {
   /// applies (uncovered case — caller decides whether to skip).
   /// Called from phase 2; reads phase-1's resolved names.
   String? _typeNameOf(ResolvedSchema schema) {
-    final assigned = _allocator.assigned[schema.pointer];
+    final assigned = _allocator.lookup(schema.pointer);
     if (assigned != null) return assigned;
     return switch (schema) {
-      ResolvedRecursiveRef() => _allocator.assigned[schema.targetPointer],
+      ResolvedRecursiveRef() => _allocator.lookup(schema.targetPointer),
       ResolvedString() => schema.createsNewType ? null : 'String',
       ResolvedInteger() => schema.createsNewType ? null : 'int',
       ResolvedNumber() => schema.createsNewType ? null : 'double',
@@ -271,9 +281,9 @@ class _NameAssigner {
       ResolvedObject() ||
       ResolvedEnum() ||
       ResolvedEmptyObject() ||
-      ResolvedAllOf() => _allocator.assigned[variant.pointer],
+      ResolvedAllOf() => _allocator.lookup(variant.pointer),
       // Recursive refs tag with the target's resolved name.
-      ResolvedRecursiveRef() => _allocator.assigned[variant.targetPointer],
+      ResolvedRecursiveRef() => _allocator.lookup(variant.targetPointer),
       // Primitives: null when newtype (no shape-dispatch
       // participation), else the structural Dart type name.
       ResolvedString() => variant.createsNewType ? null : 'String',
@@ -373,10 +383,18 @@ class NameAllocator {
   final Set<String> _takenNames = {};
   final Map<JsonPointer, List<String>> _pending = {};
 
-  /// Resolved (pointer → name) assignments from prior [resolve] calls.
-  /// Read-only view; new assignments land here when the next
-  /// [resolve] runs.
-  Map<JsonPointer, String> get assigned => Map.unmodifiable(_assigned);
+  /// O(1) lookup of the resolved name for [pointer]. Returns null
+  /// when the pointer isn't yet assigned (no prior [resolve] cycle
+  /// has settled it). Safe to call from hot paths — the naming
+  /// pass's wrapper-name composition reads through this on every
+  /// variant.
+  String? lookup(JsonPointer pointer) => _assigned[pointer];
+
+  /// Snapshot the resolved assignments as an unmodifiable map. Call
+  /// once at the end of the naming pass; intermediate readers should
+  /// use [lookup]. Returns a freshly-wrapped view each call, so
+  /// don't call this in a loop.
+  Map<JsonPointer, String> snapshot() => Map.unmodifiable(_assigned);
 
   /// Submit a claim. [preferences] must be non-empty and ordered
   /// best-first. A pointer that already has a resolved name (from a

--- a/lib/src/render.dart
+++ b/lib/src/render.dart
@@ -124,7 +124,7 @@ void validatePackageName(String packageName) {
 /// chars. Used by the CLI so `--out api.github.com` works without the
 /// user having to pre-sanitize the directory name for pub.
 String sanitizePackageName(String raw) {
-  var s = raw.toLowerCase().replaceAll(RegExp(r'[^a-z0-9_]'), '_');
+  var s = raw.toLowerCase().replaceAll(RegExp('[^a-z0-9_]'), '_');
   s = s.replaceAll(RegExp('_+'), '_').replaceAll(RegExp(r'^_+|_+$'), '');
   if (s.isEmpty || RegExp('^[0-9]').hasMatch(s)) {
     s = 'p_$s';

--- a/lib/src/render/file_renderer.dart
+++ b/lib/src/render/file_renderer.dart
@@ -115,14 +115,14 @@ void suppressLongLineLintInGeneratedFiles(Directory dir) {
 
 /// Block prepended to generated `.dart` files whose dartdoc contains
 /// `[…]` patterns that don't resolve (e.g. github's code-of-conduct
-/// description literally says "contacting the project team at
-/// [EMAIL]", and the MIT license template carries `[year] [fullname]`
-/// placeholders). Exposed for tests.
+/// description literally has the form "contacting the project team
+/// at \[EMAIL\]", and the MIT license template carries \[year\] and
+/// \[fullname\] placeholders). Exposed for tests.
 @visibleForTesting
 const commentReferencesIgnoreBlock =
-    "// Spec descriptions copy prose verbatim into dartdoc, where `[x]`\n"
+    '// Spec descriptions copy prose verbatim into dartdoc, where `[x]`\n'
     '// inside a sentence (placeholder text, ALL_CAPS tokens, license\n'
-    "// templates) is parsed as a symbol reference even when no such\n"
+    '// templates) is parsed as a symbol reference even when no such\n'
     '// symbol exists. Suppress file-locally so the lint stays live\n'
     '// elsewhere; spec authors do not always escape brackets.\n'
     '// ignore_for_file: comment_references';

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -908,9 +908,17 @@ class Endpoint implements ToTemplateContext {
   /// auth: OneOf([
   ///     MultiAuth([
   ///         HttpAuth(scheme: "Bearer", secretName: "AgentToken"),
-  ///         ApiKeyAuth(name: "apiKey", secretName: "ApiKey", sendIn: SendIn.header),
+  ///         ApiKeyAuth(
+  ///             name: "apiKey",
+  ///             secretName: "ApiKey",
+  ///             sendIn: SendIn.header,
+  ///         ),
   ///     ]),
-  ///     ApiKeyAuth(name: "apiKey", secretName: "ApiKey", sendIn: SendIn.header),
+  ///     ApiKeyAuth(
+  ///         name: "apiKey",
+  ///         secretName: "ApiKey",
+  ///         sendIn: SendIn.header,
+  ///     ),
   ///     NoAuth(),
   /// ]),
   String? authArgument({int indent = 0}) {
@@ -3945,7 +3953,7 @@ class RenderOneOf extends RenderNewType {
   String wrapperTypeName(RenderSchema variant) {
     final i = schemas.indexWhere((s) => identical(s, variant));
     if (i == -1) {
-      throw StateError('Variant $variant not in this oneOf\'s schemas.');
+      throw StateError("Variant $variant not in this oneOf's schemas.");
     }
     final name = wrapperNames[i];
     if (name == null) {

--- a/test/naming_test.dart
+++ b/test/naming_test.dart
@@ -586,4 +586,124 @@ void main() {
       expect(loginNames, isEmpty);
     });
   });
+
+  group('NameAllocator', () {
+    JsonPointer p(String s) => JsonPointer.parse('#/$s');
+
+    test('single-tier preference resolves to itself when uncontested', () {
+      final alloc = NameAllocator()
+        ..claim(p('a'), ['Foo'])
+        ..resolve();
+      expect(alloc.assigned[p('a')], 'Foo');
+    });
+
+    test('single-tier collision falls through to a numeric suffix', () {
+      // Two claims, identical preference — neither can advance, both
+      // settle on the last tier and the second gets the suffix in
+      // pointer-string order.
+      final alloc = NameAllocator()
+        ..claim(p('a'), ['Foo'])
+        ..claim(p('b'), ['Foo'])
+        ..resolve();
+      expect(alloc.assigned[p('a')], 'Foo');
+      expect(alloc.assigned[p('b')], 'Foo2');
+    });
+
+    test('multi-tier collision lets each entity step up to its next '
+        'preference', () {
+      // The whole point of multi-tier: A and B both want `Foo`; the
+      // fixpoint advances both to their next preference, where they
+      // happen not to collide. Both keep a meaningful name.
+      final alloc = NameAllocator()
+        ..claim(p('a'), ['Foo', 'Bar'])
+        ..claim(p('b'), ['Foo', 'Baz'])
+        ..resolve();
+      expect(alloc.assigned[p('a')], 'Bar');
+      expect(alloc.assigned[p('b')], 'Baz');
+    });
+
+    test('symmetric multi-tier collision exhausts preferences, then '
+        'suffixes', () {
+      // Identical preference lists — nothing can disambiguate them.
+      // After both tiers collide, the finalize step sorts by pointer
+      // string and applies a suffix to all but the first.
+      final alloc = NameAllocator()
+        ..claim(p('a'), ['Foo', 'Bar'])
+        ..claim(p('b'), ['Foo', 'Bar'])
+        ..resolve();
+      expect(alloc.assigned[p('a')], 'Bar');
+      expect(alloc.assigned[p('b')], 'Bar2');
+    });
+
+    test('an entity with a single preference holds it; richer-list '
+        'rivals defer', () {
+      // A's single preference is its only option. B has a fallback,
+      // so the fixpoint advances B (not A) and both win their
+      // own slot.
+      final alloc = NameAllocator()
+        ..claim(p('a'), ['Foo'])
+        ..claim(p('b'), ['Foo', 'Bar'])
+        ..resolve();
+      expect(alloc.assigned[p('a')], 'Foo');
+      expect(alloc.assigned[p('b')], 'Bar');
+    });
+
+    test('three-way collision on first tier', () {
+      // All three want Foo first, all bump. Second tier is unique
+      // for each. No suffixing required.
+      final alloc = NameAllocator()
+        ..claim(p('a'), ['Foo', 'Apple'])
+        ..claim(p('b'), ['Foo', 'Banana'])
+        ..claim(p('c'), ['Foo', 'Cherry'])
+        ..resolve();
+      expect(alloc.assigned[p('a')], 'Apple');
+      expect(alloc.assigned[p('b')], 'Banana');
+      expect(alloc.assigned[p('c')], 'Cherry');
+    });
+
+    test('subsequent resolve() honors names already assigned in '
+        'earlier rounds', () {
+      // Phase 1 assigns A=Foo. Phase 2 brings in B which would also
+      // prefer Foo; it must bump because Foo is already taken.
+      final alloc = NameAllocator()
+        ..claim(p('a'), ['Foo'])
+        ..resolve()
+        ..claim(p('b'), ['Foo', 'Bar'])
+        ..resolve();
+      expect(alloc.assigned[p('a')], 'Foo');
+      expect(alloc.assigned[p('b')], 'Bar');
+    });
+
+    test('a re-claim on an already-assigned pointer is a no-op', () {
+      // The naming pass calls `claim` from a recursive walker; a
+      // duplicate claim during a re-visit must not overwrite the
+      // already-resolved name.
+      final alloc = NameAllocator()
+        ..claim(p('a'), ['Foo'])
+        ..resolve()
+        ..claim(p('a'), ['Bar'])
+        ..resolve();
+      expect(alloc.assigned[p('a')], 'Foo');
+    });
+
+    test('empty preference list is rejected', () {
+      expect(
+        () => NameAllocator().claim(p('a'), const []),
+        throwsArgumentError,
+      );
+    });
+
+    test('numeric suffix walks past a name already in use', () {
+      // A holds Foo from phase 1 and Foo2 from phase 2. A new claim
+      // for Foo lands at Foo3, not Foo2.
+      final alloc = NameAllocator()
+        ..claim(p('a'), ['Foo'])
+        ..claim(p('b'), ['Foo'])
+        ..resolve()
+        // alloc has Foo and Foo2 taken now.
+        ..claim(p('c'), ['Foo'])
+        ..resolve();
+      expect(alloc.assigned[p('c')], 'Foo3');
+    });
+  });
 }

--- a/test/naming_test.dart
+++ b/test/naming_test.dart
@@ -594,7 +594,7 @@ void main() {
       final alloc = NameAllocator()
         ..claim(p('a'), ['Foo'])
         ..resolve();
-      expect(alloc.assigned[p('a')], 'Foo');
+      expect(alloc.lookup(p('a')), 'Foo');
     });
 
     test('single-tier collision falls through to a numeric suffix', () {
@@ -605,8 +605,8 @@ void main() {
         ..claim(p('a'), ['Foo'])
         ..claim(p('b'), ['Foo'])
         ..resolve();
-      expect(alloc.assigned[p('a')], 'Foo');
-      expect(alloc.assigned[p('b')], 'Foo2');
+      expect(alloc.lookup(p('a')), 'Foo');
+      expect(alloc.lookup(p('b')), 'Foo2');
     });
 
     test('multi-tier collision lets each entity step up to its next '
@@ -618,8 +618,8 @@ void main() {
         ..claim(p('a'), ['Foo', 'Bar'])
         ..claim(p('b'), ['Foo', 'Baz'])
         ..resolve();
-      expect(alloc.assigned[p('a')], 'Bar');
-      expect(alloc.assigned[p('b')], 'Baz');
+      expect(alloc.lookup(p('a')), 'Bar');
+      expect(alloc.lookup(p('b')), 'Baz');
     });
 
     test('symmetric multi-tier collision exhausts preferences, then '
@@ -631,8 +631,8 @@ void main() {
         ..claim(p('a'), ['Foo', 'Bar'])
         ..claim(p('b'), ['Foo', 'Bar'])
         ..resolve();
-      expect(alloc.assigned[p('a')], 'Bar');
-      expect(alloc.assigned[p('b')], 'Bar2');
+      expect(alloc.lookup(p('a')), 'Bar');
+      expect(alloc.lookup(p('b')), 'Bar2');
     });
 
     test('an entity with a single preference holds it; richer-list '
@@ -644,8 +644,8 @@ void main() {
         ..claim(p('a'), ['Foo'])
         ..claim(p('b'), ['Foo', 'Bar'])
         ..resolve();
-      expect(alloc.assigned[p('a')], 'Foo');
-      expect(alloc.assigned[p('b')], 'Bar');
+      expect(alloc.lookup(p('a')), 'Foo');
+      expect(alloc.lookup(p('b')), 'Bar');
     });
 
     test('three-way collision on first tier', () {
@@ -656,9 +656,9 @@ void main() {
         ..claim(p('b'), ['Foo', 'Banana'])
         ..claim(p('c'), ['Foo', 'Cherry'])
         ..resolve();
-      expect(alloc.assigned[p('a')], 'Apple');
-      expect(alloc.assigned[p('b')], 'Banana');
-      expect(alloc.assigned[p('c')], 'Cherry');
+      expect(alloc.lookup(p('a')), 'Apple');
+      expect(alloc.lookup(p('b')), 'Banana');
+      expect(alloc.lookup(p('c')), 'Cherry');
     });
 
     test('subsequent resolve() honors names already assigned in '
@@ -670,8 +670,8 @@ void main() {
         ..resolve()
         ..claim(p('b'), ['Foo', 'Bar'])
         ..resolve();
-      expect(alloc.assigned[p('a')], 'Foo');
-      expect(alloc.assigned[p('b')], 'Bar');
+      expect(alloc.lookup(p('a')), 'Foo');
+      expect(alloc.lookup(p('b')), 'Bar');
     });
 
     test('a re-claim on an already-assigned pointer is a no-op', () {
@@ -683,7 +683,7 @@ void main() {
         ..resolve()
         ..claim(p('a'), ['Bar'])
         ..resolve();
-      expect(alloc.assigned[p('a')], 'Foo');
+      expect(alloc.lookup(p('a')), 'Foo');
     });
 
     test('empty preference list is rejected', () {
@@ -703,7 +703,7 @@ void main() {
         // alloc has Foo and Foo2 taken now.
         ..claim(p('c'), ['Foo'])
         ..resolve();
-      expect(alloc.assigned[p('c')], 'Foo3');
+      expect(alloc.lookup(p('c')), 'Foo3');
     });
   });
 }


### PR DESCRIPTION
## Summary

The naming pass becomes the single authority on Dart class names. Each entity submits a preference list (best/shortest first, longest/safest last), and a new `NameAllocator` runs a fixpoint: when two entities propose the same name, both advance to their next preference; when one reaches the end of its list and still conflicts, a numeric suffix disambiguates. The fixpoint is order-independent, so future visit-order tweaks can't silently shuffle generated names.

Today every caller passes a single-element preference list (the same name the old algorithm produced), so generated output is byte-identical to before. The platform is still fully exercised: every name flows through the allocator's claim/resolve path, the fixpoint loop runs, the numeric-suffix disambiguator handles real collisions, and the multi-tier behavior is covered by direct unit tests against `NameAllocator`. Follow-up PRs each pick one source of ugly names (wrapper subclasses, inline variants with a `title`, etc.) and widen its preference list.

This is the platform discussed in the `/spec-iteration` thread under #165. The "shortest-unique-with-fallback" TODO in `naming.dart`'s docstring is now wired.

## Test plan

- [x] 11 new `NameAllocator` tests cover single/multi-tier collision, three-way conflict, asymmetric preferences, multi-round resolve(), re-claim no-op, and numeric-suffix walking past prior assignments.
- [x] `dart test` full suite green.
- [x] `dart analyze` clean (also fixes a few pre-existing infos).
- [x] github regen byte-identical to prior run.