### PR TITLE
feat: smoosh inline-object variants into the sealed parent (predicate dispatch)

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -30,6 +30,9 @@ words:
   - worktree
   - worktrees
   - smoosh
+  - smooshable
+  - smooshed
+  - smooshes
   - smooshing
   - isinstance
   - elif

--- a/lib/src/naming.dart
+++ b/lib/src/naming.dart
@@ -49,9 +49,26 @@ import 'package:space_gen/src/string.dart';
 /// read.
 @immutable
 class AssignedNames {
-  const AssignedNames(this._snakeByPointer);
+  const AssignedNames(
+    this._snakeByPointer, {
+    this.smooshedParentSnakeByPointer = const {},
+  });
 
   final Map<JsonPointer, String> _snakeByPointer;
+
+  /// For variants the naming pass marked smooshable (today: inline
+  /// `ResolvedObject` variants under predicate-required dispatch),
+  /// maps the variant's pointer to the snake name of the sealed
+  /// parent it should extend. The render layer reads this to decide
+  /// whether to emit a separate wrapper subclass or have the variant
+  /// class extend the sealed parent directly.
+  final Map<JsonPointer, String> smooshedParentSnakeByPointer;
+
+  /// Snake name of the sealed parent that [pointer]'s variant
+  /// class should extend, or null when this variant isn't
+  /// smooshed (the wrapper subclass is emitted normally).
+  String? parentSealedSnakeFor(JsonPointer pointer) =>
+      smooshedParentSnakeByPointer[pointer];
 
   /// Looks up the snake-case name for [pointer]. Used as a file
   /// basename. Returns null when the entity at [pointer] doesn't
@@ -102,6 +119,13 @@ class AssignedNames {
         (e) => MapEntry(e.key, camelFromSnake(e.value)),
       );
 
+  /// All assigned (pointer, snake-name) pairs. Same iteration order
+  /// as [entries], but exposes the underlying snake form. Used by
+  /// test helpers that need to reconstruct an [AssignedNames] across
+  /// multiple resolved schemas without losing the snake key.
+  Iterable<MapEntry<JsonPointer, String>> get snakeEntries =>
+      _snakeByPointer.entries;
+
   /// Returns an unmodifiable view of the camel-name map. Test-only.
   Map<JsonPointer, String> toMap() => Map.unmodifiable({
     for (final e in _snakeByPointer.entries) e.key: camelFromSnake(e.value),
@@ -136,6 +160,12 @@ class _NameAssigner {
   // Schema collections seen in phase 1, processed in phase 2 once
   // their variants' Dart names have been resolved.
   final List<ResolvedSchemaCollection> _collectionsForWrappers = [];
+  // Variant pointer → parent's snake name, populated during phase 2
+  // for inline-exclusive object variants whose dispatch lets the
+  // variant class extend the sealed parent directly (smoosh). Render
+  // reads this through [AssignedNames.parentSealedSnakeFor] and emits
+  // the variant with `extends <Parent>` instead of a wrapper subclass.
+  final Map<JsonPointer, String> _smooshedParentSnake = {};
 
   /// Run the allocator over both phases and return the final
   /// pointer → Dart name map. The assigner is single-use; calling
@@ -144,7 +174,10 @@ class _NameAssigner {
   AssignedNames finalize() {
     _resolvePhase1();
     _resolvePhase2();
-    return AssignedNames(_allocator.snapshot());
+    return AssignedNames(
+      _allocator.snapshot(),
+      smooshedParentSnakeByPointer: Map.unmodifiable(_smooshedParentSnake),
+    );
   }
 
   /// Phase 1: schema names + the synthesized op-response name. These
@@ -211,6 +244,14 @@ class _NameAssigner {
   /// names produced by phase 1 and submits one claim per dispatch-
   /// emitted wrapper. Variant identity is by index in
   /// [collection]`.schemas` — matches `AssignedNames.wrapperPointer`.
+  ///
+  /// Smooshable variants (inline `ResolvedObject` under a
+  /// dispatch where the variant class can extend the sealed parent
+  /// directly — predicate-required for now) skip the wrapper claim
+  /// entirely. Render reads the parent's snake name from
+  /// [_smooshedParentSnake] and emits the variant class with
+  /// `extends <Parent>` instead of generating a separate wrapper
+  /// subclass + `value:` indirection.
   void _claimWrapperNames(ResolvedSchemaCollection collection) {
     final decision = decideDispatch(collection);
     if (decision is NoDispatch) return;
@@ -218,6 +259,10 @@ class _NameAssigner {
     if (parentName == null) return;
     for (var i = 0; i < collection.schemas.length; i++) {
       final variant = collection.schemas[i];
+      if (_isSmooshable(variant, decision)) {
+        _smooshedParentSnake[variant.common.pointer] = parentName;
+        continue;
+      }
       final wrapperName = _wrapperNameFor(parentName, variant, decision, i);
       if (wrapperName == null) continue;
       _allocator.claim(AssignedNames.wrapperPointer(collection.pointer, i), [
@@ -225,6 +270,31 @@ class _NameAssigner {
       ]);
     }
   }
+
+  /// True when [variant] should be rendered as a direct subclass of
+  /// its sealed parent (no separate wrapper class + `value:` shim).
+  /// Two parts: structural eligibility and render-layer support.
+  bool _isSmooshable(ResolvedSchema variant, DispatchDecision decision) =>
+      _isStructurallySmooshable(variant) && _dispatchEmitsSmooshed(decision);
+
+  /// Whether [variant] *could* be a direct subclass of a sealed
+  /// parent in idiomatic Dart. Holds when it's an inline (so
+  /// exclusive to one parent by construction) `ResolvedObject` (so
+  /// it has a class body to extend with). Independent of any
+  /// dispatch — purely a structural property of the variant.
+  bool _isStructurallySmooshable(ResolvedSchema variant) =>
+      variant is ResolvedObject && _isInlineCollectionVariant(variant);
+
+  /// Whether [decision]'s render-layer template can emit a smooshed
+  /// variant — i.e. skip the wrapper subclass and emit
+  /// `case … => Variant.fromJson(…)` directly. Other dispatch kinds
+  /// fall through to today's wrapper-based rendering until their
+  /// templates are taught to smoosh too. Expanding this is the
+  /// smoosh PR train: predicate-required first (this PR), then
+  /// discriminator, shape, hybrid Map sub-arms.
+  bool _dispatchEmitsSmooshed(DispatchDecision decision) =>
+      decision is PredicateDispatch &&
+      decision.kind == PredicateDispatchKind.requiredField;
 
   /// Computes the snake-case wrapper-subclass name for one variant.
   /// Mirrors the render-side `wrapperTypeName` / array-element logic

--- a/lib/src/naming.dart
+++ b/lib/src/naming.dart
@@ -59,16 +59,19 @@ class AssignedNames {
   /// For variants the naming pass marked smooshable (today: inline
   /// `ResolvedObject` variants under predicate-required dispatch),
   /// maps the variant's pointer to the snake name of the sealed
-  /// parent it should extend. The render layer reads this to decide
-  /// whether to emit a separate wrapper subclass or have the variant
-  /// class extend the sealed parent directly.
+  /// parent it should extend. Snake-keyed for symmetry with the
+  /// rest of the allocator's storage; readers that want a Dart class
+  /// name should call [parentSealedTypeFor] which derives the camel
+  /// form on read.
   final Map<JsonPointer, String> smooshedParentSnakeByPointer;
 
-  /// Snake name of the sealed parent that [pointer]'s variant
-  /// class should extend, or null when this variant isn't
+  /// Camel-case Dart class name of the sealed parent that [pointer]'s
+  /// variant class should extend, or null when this variant isn't
   /// smooshed (the wrapper subclass is emitted normally).
-  String? parentSealedSnakeFor(JsonPointer pointer) =>
-      smooshedParentSnakeByPointer[pointer];
+  String? parentSealedTypeFor(JsonPointer pointer) {
+    final snake = smooshedParentSnakeByPointer[pointer];
+    return snake == null ? null : camelFromSnake(snake);
+  }
 
   /// Looks up the snake-case name for [pointer]. Used as a file
   /// basename. Returns null when the entity at [pointer] doesn't
@@ -163,7 +166,7 @@ class _NameAssigner {
   // Variant pointer → parent's snake name, populated during phase 2
   // for inline-exclusive object variants whose dispatch lets the
   // variant class extend the sealed parent directly (smoosh). Render
-  // reads this through [AssignedNames.parentSealedSnakeFor] and emits
+  // reads this through [AssignedNames.parentSealedTypeFor] and emits
   // the variant with `extends <Parent>` instead of a wrapper subclass.
   final Map<JsonPointer, String> _smooshedParentSnake = {};
 

--- a/lib/src/render.dart
+++ b/lib/src/render.dart
@@ -354,14 +354,24 @@ Map<String, String> renderTestSchemas(
     );
   });
   // Aggregate names across every resolved schema in the set so a
-  // ref from one to another resolves correctly.
-  final names = <JsonPointer, String>{};
+  // ref from one to another resolves correctly. Also carry the
+  // smooshed-parent map across schemas — its data lives on the
+  // returned [AssignedNames] beside the snake-name map and would
+  // otherwise be dropped by a naive merge.
+  final snakeNames = <JsonPointer, String>{};
+  final smooshedParents = <JsonPointer, String>{};
   for (final s in resolvedSchemas.values) {
-    for (final entry in assignNamesForSchema(s).entries) {
-      names[entry.key] = entry.value;
+    final names = assignNamesForSchema(s);
+    for (final entry in names.snakeEntries) {
+      snakeNames[entry.key] = entry.value;
     }
+    smooshedParents.addAll(names.smooshedParentSnakeByPointer);
   }
-  final resolver = SpecResolver(quirks)..names = AssignedNames(names);
+  final resolver = SpecResolver(quirks)
+    ..names = AssignedNames(
+      snakeNames,
+      smooshedParentSnakeByPointer: smooshedParents,
+    );
   final templates = TemplateProvider.defaultLocation();
 
   final renderSchemas = resolvedSchemas.map((key, value) {

--- a/lib/src/render/file_renderer.dart
+++ b/lib/src/render/file_renderer.dart
@@ -729,7 +729,12 @@ class FileRenderer {
   }
 
   bool rendersToSeparateFile(RenderSchema schema) =>
-      schema.createsNewType && schema is! RenderRecursiveRef;
+      schema.createsNewType &&
+      schema is! RenderRecursiveRef &&
+      // Smooshed variants are emitted inline in their sealed
+      // parent's file (Dart's `sealed` modifier requires direct
+      // subclasses to live in the same library) — no separate file.
+      !(schema is RenderObject && schema.parentSealedSnakeName != null);
 
   @visibleForTesting
   Iterable<Import> importsForApi(Api api, ApiUsage usage) {
@@ -747,8 +752,15 @@ class FileRenderer {
     final apiSchemas = collectSchemasUnderApi(api);
     final inlineSchemas = apiSchemas.where((s) => !s.createsNewType);
     // Every newtype (including RenderRecursiveRef, which points at one)
-    // lives in its own file and needs an import at the use site.
-    final importedSchemas = apiSchemas.where((s) => s.createsNewType);
+    // lives in its own file and needs an import at the use site —
+    // except smooshed variants, which are emitted inline in their
+    // sealed parent's file. The sealed parent is itself imported
+    // here, so the variant's class name resolves through that import.
+    final importedSchemas = apiSchemas
+        .where((s) => s.createsNewType)
+        .where(
+          (s) => !(s is RenderObject && s.parentSealedSnakeName != null),
+        );
     final apiImports = importedSchemas
         .map((s) => Import(modelPackageImport(this, s)))
         .toList();
@@ -811,9 +823,14 @@ class FileRenderer {
     final localSchemas = referencedSchemas.where(
       (s) => !s.createsNewType,
     );
-    // Every newtype (including RenderRecursiveRef) imports the target's file.
+    // Every newtype (including RenderRecursiveRef) imports the target's
+    // file — except smooshed variants, which the sealed parent emits
+    // inline (same library, no separate file to import).
     final importedSchemas = referencedSchemas
         .where((s) => s.createsNewType)
+        .where(
+          (s) => !(s is RenderObject && s.parentSealedSnakeName != null),
+        )
         .toSet();
     final referencedImports = importedSchemas
         .map((s) => Import(modelPackageImport(this, s)))

--- a/lib/src/render/file_renderer.dart
+++ b/lib/src/render/file_renderer.dart
@@ -734,7 +734,7 @@ class FileRenderer {
       // Smooshed variants are emitted inline in their sealed
       // parent's file (Dart's `sealed` modifier requires direct
       // subclasses to live in the same library) — no separate file.
-      !(schema is RenderObject && schema.parentSealedSnakeName != null);
+      !(schema is RenderObject && schema.parentSealedTypeName != null);
 
   @visibleForTesting
   Iterable<Import> importsForApi(Api api, ApiUsage usage) {
@@ -759,7 +759,7 @@ class FileRenderer {
     final importedSchemas = apiSchemas
         .where((s) => s.createsNewType)
         .where(
-          (s) => !(s is RenderObject && s.parentSealedSnakeName != null),
+          (s) => !(s is RenderObject && s.parentSealedTypeName != null),
         );
     final apiImports = importedSchemas
         .map((s) => Import(modelPackageImport(this, s)))
@@ -829,7 +829,7 @@ class FileRenderer {
     final importedSchemas = referencedSchemas
         .where((s) => s.createsNewType)
         .where(
-          (s) => !(s is RenderObject && s.parentSealedSnakeName != null),
+          (s) => !(s is RenderObject && s.parentSealedTypeName != null),
         )
         .toSet();
     final referencedImports = importedSchemas

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -392,6 +392,7 @@ class SpecResolver {
           ),
           additionalProperties: maybeRenderSchema(schema.additionalProperties),
           requiredProperties: schema.requiredProperties,
+          parentSealedSnakeName: _names.parentSealedSnakeFor(schema.pointer),
           assignedName: _nameFor(schema.pointer),
           assignedSnakeName: _snakeFor(schema.pointer),
         );
@@ -2966,6 +2967,7 @@ class RenderObject extends RenderNewType {
     required this.properties,
     this.additionalProperties,
     this.requiredProperties = const [],
+    this.parentSealedSnakeName,
     super.assignedName,
     super.assignedSnakeName,
   });
@@ -2978,6 +2980,20 @@ class RenderObject extends RenderNewType {
 
   /// The required properties of the resolved schema.
   final List<String> requiredProperties;
+
+  /// Snake name of the sealed parent class this object should extend,
+  /// or null when the object stands alone. Set by the naming pass for
+  /// inline `ResolvedObject` variants of a oneOf/anyOf whose dispatch
+  /// supports smoosh — the variant class itself becomes the sealed-
+  /// parent's subclass, replacing the separate wrapper-subclass +
+  /// `value:` indirection. Drives both the `final class X extends Y`
+  /// declaration and the `import` to the parent's file.
+  final String? parentSealedSnakeName;
+
+  /// Camel form of [parentSealedSnakeName] — null when not smooshed.
+  String? get parentSealedTypeName => parentSealedSnakeName == null
+      ? null
+      : camelFromSnake(parentSealedSnakeName!);
 
   @override
   String? get wrapperTag => typeName;
@@ -3265,6 +3281,10 @@ class RenderObject extends RenderNewType {
       'castFromJsonArg': context.quirks.dynamicJson,
       'mutableModels': context.quirks.mutableModels,
       'isDeprecated': isDeprecated,
+      // When non-null, the template emits `final class X extends Y`
+      // and an `@override` on `toJson()`. Set by the naming pass for
+      // smooshable inline variants — see [parentSealedSnakeName].
+      'parentSealedTypeName': parentSealedTypeName,
     };
   }
 
@@ -4193,30 +4213,48 @@ class RenderOneOf extends RenderNewType {
     final dispatch = <Map<String, dynamic>>[];
     Map<String, dynamic>? fallback;
     final variants = <Map<String, dynamic>>[];
+    final smooshedVariants = <Map<String, dynamic>>[];
     for (final arm in arms) {
       final renderVariant = renderOf(arm.variant);
+      // Smooshed variants (today: only inline-object variants under
+      // required-field dispatch) are emitted as direct subclasses of
+      // the sealed parent, *inline* in the parent's file — Dart's
+      // `sealed` modifier requires direct subclasses to live in the
+      // same library. The dispatch case arm constructs the variant
+      // itself (no outer wrap call); the wrapper-subclass form is
+      // skipped entirely. Non-smooshed variants keep the wrapper
+      // form and continue to render to their own file.
+      final isSmooshed =
+          renderVariant is RenderObject &&
+          renderVariant.parentSealedSnakeName != null;
       final Map<String, dynamic> armCtx;
       switch (kind) {
         case PredicateDispatchKind.requiredField:
-          // Wrappers wrap the Map back as `value.toJson()`; per-arm
-          // construction is `<typeName>.fromJson(json)`.
+          final fromJson = '${renderVariant.typeName}.fromJson(json)';
           armCtx = {
-            'wrapperTypeName': wrapperTypeName(renderVariant),
-            'construction': '${renderVariant.typeName}.fromJson(json)',
+            'caseExpression': isSmooshed
+                ? fromJson
+                : '${wrapperTypeName(renderVariant)}($fromJson)',
           };
-          variants.add(objectWrapperContext(renderVariant));
+          if (isSmooshed) {
+            smooshedVariants.add(renderVariant.toTemplateContext(context));
+          } else {
+            variants.add(objectWrapperContext(renderVariant));
+          }
         case PredicateDispatchKind.arrayElement:
           // Each array variant wraps `List<X>` and serializes via
           // the items' own conversion. Wrapper class names splice
           // the items type so sibling array variants don't collide
           // on the shared `wrapperTag = 'List'`; the naming pass
           // composed the splice when it enumerated wrappers, and we
-          // read it back here through the standard lookup.
+          // read it back here through the standard lookup. Array-
+          // element variants are never smoosh-eligible (the variant
+          // is a list, not an object), so this path always emits a
+          // wrapper.
           final wrapperName = wrapperTypeName(renderVariant);
           final plan = _planVariant(renderVariant, context)!;
           armCtx = {
-            'wrapperTypeName': wrapperName,
-            'construction': plan.fromJson,
+            'caseExpression': '$wrapperName(${plan.fromJson})',
           };
           variants.add({
             'wrapperTypeName': wrapperName,
@@ -4256,6 +4294,7 @@ class RenderOneOf extends RenderNewType {
       dispatch: dispatch,
       fallback: fallback,
       variants: variants,
+      smooshedVariants: smooshedVariants,
       factoryParamType: factoryParamType,
       preamble: preamble,
       throwMessage: throwMessage,
@@ -4494,14 +4533,18 @@ class _PredicateDispatchMode extends _DispatchMode {
     required this.dispatch,
     required this.fallback,
     required this.variants,
+    required this.smooshedVariants,
     required this.factoryParamType,
     required this.preamble,
     required this.throwMessage,
     required this.toJsonReturnType,
   });
 
-  /// Per-arm contexts for each checked branch. Each entry has
-  /// `predicateTest`, `wrapperTypeName`, and `construction` keys.
+  /// Per-arm contexts for each checked branch. Each entry has a
+  /// `predicateTest` key and a `caseExpression` key (the full Dart
+  /// expression to `return` — already includes the wrapper-class
+  /// call when the variant has a wrapper, or just the variant's
+  /// `fromJson(json)` when the variant is smooshed).
   final List<Map<String, dynamic>> dispatch;
 
   /// Unguarded fallback at the end of the if-chain (no `if`).
@@ -4510,6 +4553,15 @@ class _PredicateDispatchMode extends _DispatchMode {
 
   /// Wrapper subclass declarations, in declaration order.
   final List<Map<String, dynamic>> variants;
+
+  /// Smooshed variants (today: only inline `RenderObject` variants
+  /// under required-field dispatch) — emitted *inline in the parent
+  /// file* as direct subclasses of the sealed class, with no wrapper
+  /// shim. Each entry is the variant's full `toTemplateContext` so
+  /// the schema_object partial can render the class body unchanged.
+  /// Sealed subclasses must live in the same library, which is why
+  /// these can't be separate files like non-smooshed variants are.
+  final List<Map<String, dynamic>> smooshedVariants;
 
   /// Type of the `fromJson(... json)` parameter — `Map<String, dynamic>`
   /// for object-shaped dispatches, `dynamic` for ones whose preamble
@@ -4583,6 +4635,7 @@ void _applyDispatchMode(_DispatchMode mode, Map<String, dynamic> ctx) {
       :final dispatch,
       :final fallback,
       :final variants,
+      :final smooshedVariants,
       :final factoryParamType,
       :final preamble,
       :final throwMessage,
@@ -4592,6 +4645,7 @@ void _applyDispatchMode(_DispatchMode mode, Map<String, dynamic> ctx) {
       ctx['dispatch'] = dispatch;
       ctx['fallback'] = fallback ?? false;
       ctx['variants'] = variants;
+      ctx['smooshedVariants'] = smooshedVariants;
       ctx['factoryParamType'] = factoryParamType;
       ctx['preamble'] = preamble;
       ctx['throwMessage'] = throwMessage;

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -392,7 +392,7 @@ class SpecResolver {
           ),
           additionalProperties: maybeRenderSchema(schema.additionalProperties),
           requiredProperties: schema.requiredProperties,
-          parentSealedSnakeName: _names.parentSealedSnakeFor(schema.pointer),
+          parentSealedTypeName: _names.parentSealedTypeFor(schema.pointer),
           assignedName: _nameFor(schema.pointer),
           assignedSnakeName: _snakeFor(schema.pointer),
         );
@@ -2967,7 +2967,7 @@ class RenderObject extends RenderNewType {
     required this.properties,
     this.additionalProperties,
     this.requiredProperties = const [],
-    this.parentSealedSnakeName,
+    this.parentSealedTypeName,
     super.assignedName,
     super.assignedSnakeName,
   });
@@ -2981,19 +2981,15 @@ class RenderObject extends RenderNewType {
   /// The required properties of the resolved schema.
   final List<String> requiredProperties;
 
-  /// Snake name of the sealed parent class this object should extend,
-  /// or null when the object stands alone. Set by the naming pass for
-  /// inline `ResolvedObject` variants of a oneOf/anyOf whose dispatch
-  /// supports smoosh — the variant class itself becomes the sealed-
-  /// parent's subclass, replacing the separate wrapper-subclass +
-  /// `value:` indirection. Drives both the `final class X extends Y`
-  /// declaration and the `import` to the parent's file.
-  final String? parentSealedSnakeName;
-
-  /// Camel form of [parentSealedSnakeName] — null when not smooshed.
-  String? get parentSealedTypeName => parentSealedSnakeName == null
-      ? null
-      : camelFromSnake(parentSealedSnakeName!);
+  /// Camel-case Dart class name of the sealed parent this object
+  /// should extend, or null when the object stands alone. Set by the
+  /// naming pass for inline `ResolvedObject` variants of a oneOf/anyOf
+  /// whose dispatch supports smoosh — the variant class itself
+  /// becomes the sealed-parent's subclass, replacing the separate
+  /// wrapper-subclass + `value:` indirection. The non-null state
+  /// drives the `final class X extends Y` declaration in the schema
+  /// template and the "skip my own file" gates in `file_renderer`.
+  final String? parentSealedTypeName;
 
   @override
   String? get wrapperTag => typeName;
@@ -3283,7 +3279,7 @@ class RenderObject extends RenderNewType {
       'isDeprecated': isDeprecated,
       // When non-null, the template emits `final class X extends Y`
       // and an `@override` on `toJson()`. Set by the naming pass for
-      // smooshable inline variants — see [parentSealedSnakeName].
+      // smooshable inline variants — see [parentSealedTypeName].
       'parentSealedTypeName': parentSealedTypeName,
     };
   }
@@ -4226,7 +4222,7 @@ class RenderOneOf extends RenderNewType {
       // form and continue to render to their own file.
       final isSmooshed =
           renderVariant is RenderObject &&
-          renderVariant.parentSealedSnakeName != null;
+          renderVariant.parentSealedTypeName != null;
       final Map<String, dynamic> armCtx;
       switch (kind) {
         case PredicateDispatchKind.requiredField:
@@ -4551,7 +4547,10 @@ class _PredicateDispatchMode extends _DispatchMode {
   /// Same per-arm shape as [dispatch] entries.
   final Map<String, dynamic>? fallback;
 
-  /// Wrapper subclass declarations, in declaration order.
+  /// Non-smooshed variants — wrapper subclass declarations, in
+  /// declaration order. Smooshed variants (those whose data class
+  /// extends the sealed parent directly) are in [smooshedVariants];
+  /// the union of the two preserves declaration order.
   final List<Map<String, dynamic>> variants;
 
   /// Smooshed variants (today: only inline `RenderObject` variants

--- a/lib/templates/schema_object.mustache
+++ b/lib/templates/schema_object.mustache
@@ -1,5 +1,5 @@
 {{{ doc_comment }}}{{^mutableModels}}@immutable{{/mutableModels}}
-class {{ typeName }} {
+{{#parentSealedTypeName}}final {{/parentSealedTypeName}}class {{ typeName }}{{#parentSealedTypeName}} extends {{ parentSealedTypeName }}{{/parentSealedTypeName}} {
     {{{ constructor_doc_comment }}}{{ typeName }}(
         {{#hasProperties}}
         { {{#properties}}{{{ argumentLine }}}, {{/properties}}
@@ -60,7 +60,8 @@ class {{ typeName }} {
     {{{ valueSchema }}}? operator [](String key) => {{additionalPropertiesName}}[key];
     {{/hasAdditionalProperties}}
 
-    {{{ to_json_doc_comment }}}Map<String, dynamic> toJson() {
+    {{{ to_json_doc_comment }}}{{#parentSealedTypeName}}@override
+    {{/parentSealedTypeName}}Map<String, dynamic> toJson() {
     {{#hasNoJsonProperty}}
         throw UnsupportedError(
           'Cannot encode {{ typeName }} as JSON (binary field present).',

--- a/lib/templates/schema_one_of.mustache
+++ b/lib/templates/schema_one_of.mustache
@@ -95,11 +95,11 @@
 {{/preamble}}
 {{#dispatch}}
         if ({{{ predicateTest }}}) {
-            return {{{ wrapperTypeName }}}({{{ construction }}});
+            return {{{ caseExpression }}};
         }
 {{/dispatch}}
 {{#fallback}}
-        return {{{ wrapperTypeName }}}({{{ construction }}});
+        return {{{ caseExpression }}};
 {{/fallback}}
 {{^fallback}}
         throw FormatException(
@@ -117,6 +117,9 @@
 {{#variants}}
 {{> _one_of_wrapper}}
 {{/variants}}
+{{#smooshedVariants}}
+{{> schema_object}}
+{{/smooshedVariants}}
 {{/has_predicate_dispatch}}
 {{#no_dispatch}}
 {{{ doc_comment }}}sealed class {{ typeName }} {

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -1454,15 +1454,49 @@ void main() {
     });
 
     test('wrapper subclass uses position-based name when the variant '
-        'tag would double the parent prefix', () {
+        'tag would double the parent prefix (non-smooshed path)', () {
       // Inline oneOf variants get parser-synthesized names that already
       // contain the parent (`<Parent>OneOf<i>`). Composing the wrapper
       // as `<Parent><variantTypeName>` would then double the prefix
-      // (e.g. `RequestRequestOneOf0`). The naming pass detects this and
-      // falls back to a position-based name — `RequestVariant0` —
-      // keeping the wrapper readable. Top-level `$ref` variants (whose
-      // names never start with the parent) are unaffected; see the Pet
-      // test above.
+      // (e.g. `TestTestOneOf0`). The naming pass detects this and
+      // falls back to a position-based wrapper name (`TestVariant0`).
+      //
+      // Predicate-required dispatch with inline objects would smoosh
+      // (no wrapper at all) — see the smoosh test below. To exercise
+      // the doubling-fallback path on its own, this test uses shape
+      // dispatch (a string variant + an inline object variant). Shape
+      // dispatch isn't yet smoosh-aware, so the inline object's
+      // wrapper is still emitted and the fallback name applies.
+      final result = renderTestSchema({
+        'oneOf': [
+          {'type': 'string'},
+          {
+            'type': 'object',
+            'properties': {
+              'note': {'type': 'string'},
+            },
+          },
+        ],
+      });
+      // The string variant gets the structural `TestString` wrapper.
+      expect(result, contains('final class TestString extends Test'));
+      // The inline object's wrapper would be `TestTestOneOf1` if we
+      // composed naively; the naming pass falls back to `TestVariant1`.
+      expect(result, contains('final class TestVariant1 extends Test'));
+      expect(result, contains('final TestOneOf1 value;'));
+      expect(result, isNot(contains('TestTestOneOf')));
+    });
+
+    test('predicate-required dispatch smooshes inline-object variants: '
+        'no wrapper class, case arm calls variant directly', () {
+      // Inline object variants of a oneOf that uses predicate-required
+      // dispatch are smooshed: no wrapper subclass is emitted in the
+      // sealed parent's file, and dispatch case arms construct the
+      // variant directly instead of wrapping it. The variant data
+      // class itself becomes the sealed subclass — that side of the
+      // change is rendered into a separate variant file and
+      // verified by the github regen integration check (and by file_
+      // renderer-level tests for the variant's `extends` clause).
       final result = renderTestSchema({
         'oneOf': [
           {
@@ -1481,13 +1515,28 @@ void main() {
           },
         ],
       });
-      expect(result, contains('final class TestVariant0 extends Test'));
-      expect(result, contains('final class TestVariant1 extends Test'));
-      // Variant data classes still use their parser-synthesized names.
-      expect(result, contains('final TestOneOf0 value;'));
-      expect(result, contains('final TestOneOf1 value;'));
-      // No doubled prefix anywhere.
-      expect(result, isNot(contains('TestTestOneOf')));
+      // Case arms call the variant data class directly — no outer
+      // wrapper-class call.
+      expect(
+        result,
+        contains(
+          "if (json.containsKey('note')) {\n            "
+          'return TestOneOf0.fromJson(json);',
+        ),
+      );
+      expect(
+        result,
+        contains(
+          "if (json.containsKey('content_id')) {\n            "
+          'return TestOneOf1.fromJson(json);',
+        ),
+      );
+      // No wrapper subclasses survive in the parent file: there's no
+      // `<Parent>Variant<i>`, and no `final <VariantClass> value;`
+      // (which would be the wrapper's `value` field).
+      expect(result, isNot(contains('class TestVariant0')));
+      expect(result, isNot(contains('TestOneOf0 value')));
+      expect(result, isNot(contains('TestOneOf1 value')));
     });
 
     test('property-presence dispatch falls back to legacy when one '

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -1531,6 +1531,13 @@ void main() {
           'return TestOneOf1.fromJson(json);',
         ),
       );
+      // Variant data classes are inlined into the parent's file as
+      // direct sealed subclasses (Dart's `sealed` modifier requires
+      // them in the same library). Their `toJson` is an `@override`
+      // of the sealed parent's abstract method.
+      expect(result, contains('final class TestOneOf0 extends Test'));
+      expect(result, contains('final class TestOneOf1 extends Test'));
+      expect(result, contains('@override'));
       // No wrapper subclasses survive in the parent file: there's no
       // `<Parent>Variant<i>`, and no `final <VariantClass> value;`
       // (which would be the wrapper's `value` field).


### PR DESCRIPTION
## Summary

OpenAPI's `oneOf` is a tagged union. The idiomatic Dart for a tagged union is a sealed class with each variant as a `final class` extending the sealed parent and the variant's data fields inline. Today's generator adds a layer handwritten Dart wouldn't:

- Sealed parent (`ProjectsCreateCardRequest`)
- Per-variant data class (`ProjectsCreateCardRequestOneOf0`) with the fields and `toJson`/`fromJson`
- Per-variant **wrapper subclass** (`ProjectsCreateCardRequestVariant0`) that extends the parent and holds `final value: <DataClass>`, forwarding `toJson()` to it

The wrapper layer is a workaround for cases where the variant *can't* be a direct sealed subclass — top-level `$ref` variants (shared across multiple oneOfs; a class can only extend one parent) and primitives (Dart's `String`/`int` can't extend anything). For an **inline object variant** — exclusive to one parent by construction — the wrapper adds zero information.

This PR teaches predicate-required dispatch to *smoosh*: emit the variant data class itself as the sealed subclass (`final class ProjectsCreateCardRequestOneOf0 extends ProjectsCreateCardRequest`), inline in the parent's file, and have the dispatch case arm construct it directly (`return ProjectsCreateCardRequestOneOf0.fromJson(json);`) without the outer wrapper call. Pattern matching at use sites destructures the variant's fields directly (`case ProjectsCreateCardRequestOneOf0(:final note)`) instead of unwrapping a `value`.

Sealed subclasses must live in the same library — Dart's `sealed` modifier restricts cross-library extension — so smooshed variants are emitted **inline in the parent's `.dart` file**, not their own.

## PR train framing

This is step 1 of the smoosh PR train. The smoosh predicate is split:

- `_isStructurallySmooshable(variant)` — variant is inline + `ResolvedObject`. Pure structural check, holds for any spec.
- `_dispatchEmitsSmooshed(decision)` — the dispatch's render templates know how to emit the smooshed form. Today only `PredicateDispatch.requiredField`. Discriminator, shape, and hybrid will land as follow-ups by widening this second predicate and teaching their templates the same.

## github regen impact

13 inline-object variants smooshed across 6 sealed parents:

```
ChecksCreateRequest
ChecksUpdateRequest
CodespacesCreateForAuthenticatedUserRequest
EnvironmentProtectionRulesInner
ProjectsCreateCardRequest
UsersDeleteAttestationsBulkRequest
```

13 separate variant `.dart` files (+ 13 round-trip test files) deleted; their classes now live in the parent's file as direct sealed subclasses. `dart analyze` clean.

## Test plan

- [x] Two new render-schema tests: smooshed predicate dispatch (no wrapper, case arm calls variant directly) and the doubling-prevention fallback for non-smooshed paths (shape dispatch with an inline object).
- [x] `dart test` full suite green.
- [x] `dart analyze` clean.
- [x] github regen `dart analyze` clean.
- [x] github regen diff: only the 6 sealed parents and `lib/api.dart` (export list) modified; 13 variant files + 13 tests removed; nothing else moved.