### PR TITLE
feat: smoosh inline-object variants under discriminator dispatch

### DIFF
--- a/lib/src/naming.dart
+++ b/lib/src/naming.dart
@@ -293,11 +293,16 @@ class _NameAssigner {
   /// `case … => Variant.fromJson(…)` directly. Other dispatch kinds
   /// fall through to today's wrapper-based rendering until their
   /// templates are taught to smoosh too. Expanding this is the
-  /// smoosh PR train: predicate-required first (this PR), then
-  /// discriminator, shape, hybrid Map sub-arms.
-  bool _dispatchEmitsSmooshed(DispatchDecision decision) =>
-      decision is PredicateDispatch &&
-      decision.kind == PredicateDispatchKind.requiredField;
+  /// smoosh PR train: predicate-required and discriminator (today),
+  /// then shape, then hybrid Map sub-arms.
+  bool _dispatchEmitsSmooshed(DispatchDecision decision) {
+    if (decision is DiscriminatorDispatch) return true;
+    if (decision is PredicateDispatch &&
+        decision.kind == PredicateDispatchKind.requiredField) {
+      return true;
+    }
+    return false;
+  }
 
   /// Computes the snake-case wrapper-subclass name for one variant.
   /// Mirrors the render-side `wrapperTypeName` / array-element logic

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -4134,19 +4134,12 @@ class RenderOneOf extends RenderNewType {
         :final mapping,
         :final variants,
       ) =>
-        _DiscriminatorMode(
-          discriminatorProperty: propertyName,
-          dispatch: [
-            for (final entry in mapping)
-              {
-                'value': entry.value,
-                'wrapperTypeName': wrapperTypeName(renderOf(entry.variant)),
-                'valueType': renderOf(entry.variant).typeName,
-              },
-          ],
-          variants: [
-            for (final v in variants) objectWrapperContext(renderOf(v)),
-          ],
+        _buildDiscriminatorMode(
+          propertyName,
+          mapping,
+          variants,
+          renderOf,
+          context,
         ),
       ShapeDispatch(:final arms) => _ShapeMode(
         variants: [
@@ -4198,6 +4191,52 @@ class RenderOneOf extends RenderNewType {
       ),
       NoDispatch() => const _NoDispatchMode(),
     };
+  }
+
+  /// Build a [_DiscriminatorMode], splitting variants into smooshed
+  /// (the variant data class extends the sealed parent directly,
+  /// inlined in the parent's file) and non-smooshed (today's wrapper-
+  /// subclass + `value:` indirection). Each `dispatch` entry's
+  /// `caseExpression` already contains the full Dart expression to
+  /// `return`, so the template emits it directly.
+  _DiscriminatorMode _buildDiscriminatorMode(
+    String propertyName,
+    List<({String value, ResolvedSchema variant})> mapping,
+    List<ResolvedSchema> declarationOrder,
+    RenderSchema Function(ResolvedSchema) renderOf,
+    SchemaRenderer context,
+  ) {
+    final dispatch = <Map<String, dynamic>>[];
+    for (final entry in mapping) {
+      final renderVariant = renderOf(entry.variant);
+      final isSmooshed =
+          renderVariant is RenderObject &&
+          renderVariant.parentSealedTypeName != null;
+      final fromJson = '${renderVariant.typeName}.fromJson(json)';
+      dispatch.add({
+        'value': entry.value,
+        'caseExpression': isSmooshed
+            ? fromJson
+            : '${wrapperTypeName(renderVariant)}($fromJson)',
+      });
+    }
+    final variants = <Map<String, dynamic>>[];
+    final smooshedVariants = <Map<String, dynamic>>[];
+    for (final v in declarationOrder) {
+      final renderVariant = renderOf(v);
+      if (renderVariant is RenderObject &&
+          renderVariant.parentSealedTypeName != null) {
+        smooshedVariants.add(renderVariant.toTemplateContext(context));
+      } else {
+        variants.add(objectWrapperContext(renderVariant));
+      }
+    }
+    return _DiscriminatorMode(
+      discriminatorProperty: propertyName,
+      dispatch: dispatch,
+      variants: variants,
+      smooshedVariants: smooshedVariants,
+    );
   }
 
   _PredicateDispatchMode _buildPredicateMode(
@@ -4471,11 +4510,29 @@ class _DiscriminatorMode extends _DispatchMode {
     required this.discriminatorProperty,
     required this.dispatch,
     required this.variants,
+    required this.smooshedVariants,
   });
 
   final String discriminatorProperty;
+
+  /// Per-arm contexts: each entry has the discriminator string `value`
+  /// and a `caseExpression` (the full Dart expression to `return` —
+  /// already includes the wrapper-class call when the variant has a
+  /// wrapper, or just `Variant.fromJson(json)` when smooshed).
   final List<Map<String, dynamic>> dispatch;
+
+  /// Non-smooshed variants — wrapper subclass declarations, in
+  /// declaration order. Smooshed variants (those whose data class
+  /// extends the sealed parent directly) are in [smooshedVariants];
+  /// the union of the two preserves declaration order.
   final List<Map<String, dynamic>> variants;
+
+  /// Smooshed variants — emitted *inline in the parent's file* as
+  /// direct sealed subclasses, no wrapper shim. Each entry is the
+  /// variant's full `toTemplateContext` so the schema_object partial
+  /// can render the class body unchanged. Same shape as
+  /// [_PredicateDispatchMode.smooshedVariants].
+  final List<Map<String, dynamic>> smooshedVariants;
 }
 
 /// Pure shape dispatch — `switch (json) { final T v => ... }`.
@@ -4610,11 +4667,13 @@ void _applyDispatchMode(_DispatchMode mode, Map<String, dynamic> ctx) {
       :final discriminatorProperty,
       :final dispatch,
       :final variants,
+      :final smooshedVariants,
     ):
       ctx['has_discriminator_dispatch'] = true;
       ctx['discriminatorProperty'] = discriminatorProperty;
       ctx['dispatch'] = dispatch;
       ctx['variants'] = variants;
+      ctx['smooshedVariants'] = smooshedVariants;
       ctx['maybeFromJsonParamType'] = 'Map<String, dynamic>?';
     case _ShapeMode(:final variants):
       ctx['has_shape_dispatch'] = true;

--- a/lib/templates/schema_one_of.mustache
+++ b/lib/templates/schema_one_of.mustache
@@ -6,7 +6,7 @@
         final discriminator = json['{{ discriminatorProperty }}'];
         return switch (discriminator) {
 {{#dispatch}}
-            '{{ value }}' => {{{ wrapperTypeName }}}({{{ valueType }}}.fromJson(json)),
+            '{{ value }}' => {{{ caseExpression }}},
 {{/dispatch}}
             _ => throw FormatException(
                 "Unknown {{ discriminatorProperty }} '$discriminator' for {{ typeName }}",
@@ -23,6 +23,9 @@
 {{#variants}}
 {{> _one_of_wrapper}}
 {{/variants}}
+{{#smooshedVariants}}
+{{> schema_object}}
+{{/smooshedVariants}}
 {{/has_discriminator_dispatch}}
 {{#has_shape_dispatch}}
 {{{ doc_comment }}}sealed class {{ typeName }} {

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -2042,6 +2042,57 @@ void main() {
       expect(rule, isNot(contains('UnimplementedError')));
     });
 
+    test('discriminator dispatch smooshes inline-object variants: case '
+        'arms call the variant directly, no wrapper class', () {
+      // Same shape as the implicit-discriminator test above, but
+      // variants are *inline* under the parent's oneOf rather than
+      // top-level `$ref`s. Inline variants are exclusive to one
+      // parent by construction (their pointer is `<parent>/oneOf/<i>`),
+      // so they smoosh: the variant data class itself extends the
+      // sealed parent, eliminating the wrapper-class shim and the
+      // `value:` indirection. Top-level `$ref` variants (the existing
+      // test above) continue to use wrappers because they could be
+      // referenced from multiple parents.
+      final result = renderTestSchema({
+        'oneOf': [
+          {
+            'type': 'object',
+            'properties': {
+              'type': {
+                'type': 'string',
+                'enum': ['creation'],
+              },
+            },
+            'required': ['type'],
+          },
+          {
+            'type': 'object',
+            'properties': {
+              'type': {
+                'type': 'string',
+                'enum': ['deletion'],
+              },
+            },
+            'required': ['type'],
+          },
+        ],
+      });
+      // Discriminator dispatch with case arms calling the variant
+      // directly — no `<Wrapper>(<Variant>.fromJson(...))` outer call.
+      expect(result, contains("final discriminator = json['type']"));
+      expect(result, contains("'creation' => TestOneOf0.fromJson(json)"));
+      expect(result, contains("'deletion' => TestOneOf1.fromJson(json)"));
+      // Variant data classes are inlined into the parent's file as
+      // direct sealed subclasses with `@override` on `toJson`.
+      expect(result, contains('final class TestOneOf0 extends Test'));
+      expect(result, contains('final class TestOneOf1 extends Test'));
+      expect(result, contains('@override'));
+      // No wrapper subclasses survive in the parent file.
+      expect(result, isNot(contains('class TestVariant0')));
+      expect(result, isNot(contains('TestOneOf0 value')));
+      expect(result, isNot(contains('TestOneOf1 value')));
+    });
+
     test('implicit-discriminator dispatch falls back when the single-enum '
         'values collide across variants', () {
       // Both variants tag themselves `type: 'creation'` — no unique


### PR DESCRIPTION
## Summary

Extends the smoosh PR train started in #168 from predicate-required dispatch to discriminator dispatch. Same mechanism: when a variant is structurally smooshable (inline `ResolvedObject`) and the parent dispatch's render template knows how to emit the smooshed form, the variant data class becomes a direct subclass of the sealed parent (inlined in the parent's file), case arms call the variant directly (no `<Wrapper>(<Variant>.fromJson(json))`), and the wrapper-class shim is gone.

## github regen impact: none today

This is platform-only for github. All 5 of github's discriminator-dispatch sites (the `RepositoryRule` family + the three `/user` endpoints) use **top-level `$ref` variants**, not inline ones. Inline variants are exclusive to one parent by construction (their pointer is `<parent>/oneOf/<i>`); a top-level schema, by contrast, might be a variant of multiple parents and can only `extend` one. The structural smoosh predicate correctly excludes them.

Catching the github discriminator cases needs a separate eligibility extension — "top-level schema referenced as a variant of exactly one parent" — which is a follow-up. That's a meaningful conceptual shift (smoosh = "exclusive use" rather than "structurally inline") and gets its own PR.

## Test plan

- [x] New synthetic unit test in `render_schema_test.dart` exercises discriminator-smoosh on a hand-built `oneOf` with inline-object variants tagged by single-value enums.
- [x] The existing top-level-`$ref` discriminator test still asserts the non-smooshed wrapper form — demonstrates the branch picks the right path per variant.
- [x] `dart test` full suite green.
- [x] `dart analyze` clean.
- [x] github regen byte-identical to baseline.