### PR TITLE
feat: smoosh inline-object variants under shape and hybrid dispatch

### DIFF
--- a/lib/src/naming.dart
+++ b/lib/src/naming.dart
@@ -293,10 +293,11 @@ class _NameAssigner {
   /// `case … => Variant.fromJson(…)` directly. Other dispatch kinds
   /// fall through to today's wrapper-based rendering until their
   /// templates are taught to smoosh too. Expanding this is the
-  /// smoosh PR train: predicate-required and discriminator (today),
-  /// then shape, then hybrid Map sub-arms.
+  /// smoosh PR train: predicate-required, discriminator, and shape
+  /// (today), then hybrid Map sub-arms.
   bool _dispatchEmitsSmooshed(DispatchDecision decision) {
     if (decision is DiscriminatorDispatch) return true;
+    if (decision is ShapeDispatch) return true;
     if (decision is PredicateDispatch &&
         decision.kind == PredicateDispatchKind.requiredField) {
       return true;

--- a/lib/src/naming.dart
+++ b/lib/src/naming.dart
@@ -290,14 +290,16 @@ class _NameAssigner {
 
   /// Whether [decision]'s render-layer template can emit a smooshed
   /// variant — i.e. skip the wrapper subclass and emit
-  /// `case … => Variant.fromJson(…)` directly. Other dispatch kinds
-  /// fall through to today's wrapper-based rendering until their
-  /// templates are taught to smoosh too. Expanding this is the
-  /// smoosh PR train: predicate-required, discriminator, and shape
-  /// (today), then hybrid Map sub-arms.
+  /// `case … => Variant.fromJson(…)` directly. Today every dispatch
+  /// kind capable of smoosh emits the smooshed form; the only
+  /// remaining gate is structural eligibility
+  /// ([_isStructurallySmooshable]). Array-element predicate
+  /// dispatch is excluded because its variants are arrays, never
+  /// objects.
   bool _dispatchEmitsSmooshed(DispatchDecision decision) {
     if (decision is DiscriminatorDispatch) return true;
     if (decision is ShapeDispatch) return true;
+    if (decision is HybridDispatch) return true;
     if (decision is PredicateDispatch &&
         decision.kind == PredicateDispatchKind.requiredField) {
       return true;

--- a/lib/src/naming.dart
+++ b/lib/src/naming.dart
@@ -290,21 +290,27 @@ class _NameAssigner {
 
   /// Whether [decision]'s render-layer template can emit a smooshed
   /// variant — i.e. skip the wrapper subclass and emit
-  /// `case … => Variant.fromJson(…)` directly. Today every dispatch
-  /// kind capable of smoosh emits the smooshed form; the only
-  /// remaining gate is structural eligibility
-  /// ([_isStructurallySmooshable]). Array-element predicate
-  /// dispatch is excluded because its variants are arrays, never
-  /// objects.
+  /// `case … => Variant.fromJson(…)` directly. Every dispatch kind
+  /// whose variants can be `ResolvedObject`s supports smoosh today;
+  /// the dispatch gate exists alongside [_isStructurallySmooshable]
+  /// as a defensive guardrail. Adding a new [DispatchDecision]
+  /// subtype is a compile-time prompt (sealed-switch exhaustiveness)
+  /// to decide whether its template knows how to skip the wrapper
+  /// shim before its variants get marked smooshable.
+  ///
+  /// Array-element predicate dispatch's variants are arrays so it's
+  /// never reached via the structural check; [NoDispatch] doesn't
+  /// claim wrappers at all. Both are excluded here for the
+  /// guardrail's sake.
   bool _dispatchEmitsSmooshed(DispatchDecision decision) {
-    if (decision is DiscriminatorDispatch) return true;
-    if (decision is ShapeDispatch) return true;
-    if (decision is HybridDispatch) return true;
-    if (decision is PredicateDispatch &&
-        decision.kind == PredicateDispatchKind.requiredField) {
-      return true;
-    }
-    return false;
+    return switch (decision) {
+      DiscriminatorDispatch() => true,
+      ShapeDispatch() => true,
+      HybridDispatch() => true,
+      PredicateDispatch(kind: PredicateDispatchKind.requiredField) => true,
+      PredicateDispatch(kind: PredicateDispatchKind.arrayElement) => false,
+      NoDispatch() => false,
+    };
   }
 
   /// Computes the snake-case wrapper-subclass name for one variant.

--- a/lib/src/render/file_renderer.dart
+++ b/lib/src/render/file_renderer.dart
@@ -734,7 +734,7 @@ class FileRenderer {
       // Smooshed variants are emitted inline in their sealed
       // parent's file (Dart's `sealed` modifier requires direct
       // subclasses to live in the same library) — no separate file.
-      !(schema is RenderObject && schema.parentSealedTypeName != null);
+      !schema.isSmooshed;
 
   @visibleForTesting
   Iterable<Import> importsForApi(Api api, ApiUsage usage) {
@@ -759,7 +759,7 @@ class FileRenderer {
     final importedSchemas = apiSchemas
         .where((s) => s.createsNewType)
         .where(
-          (s) => !(s is RenderObject && s.parentSealedTypeName != null),
+          (s) => !s.isSmooshed,
         );
     final apiImports = importedSchemas
         .map((s) => Import(modelPackageImport(this, s)))
@@ -829,7 +829,7 @@ class FileRenderer {
     final importedSchemas = referencedSchemas
         .where((s) => s.createsNewType)
         .where(
-          (s) => !(s is RenderObject && s.parentSealedTypeName != null),
+          (s) => !s.isSmooshed,
         )
         .toSet();
     final referencedImports = importedSchemas

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -2072,6 +2072,17 @@ abstract class RenderSchema extends Equatable implements ToTemplateContext {
   /// over the parser-synthesized form on `common`.
   String get snakeName => assignedSnakeName ?? common.snakeName;
 
+  /// True when this schema is a smooshed inline-object variant of a
+  /// sealed parent — i.e. it'll be rendered as `final class X
+  /// extends Y` inline in the parent's file, with no wrapper
+  /// subclass. Subclasses other than [RenderObject] always return
+  /// false (only objects can extend a sealed class). Used by the
+  /// dispatch-mode builders (`_buildPredicateMode`,
+  /// `_buildDiscriminatorMode`, `_buildShapeMode`,
+  /// `_buildHybridMode`) and `file_renderer` to decide whether to
+  /// emit a wrapper / a separate file / a wrapping case-arm call.
+  bool get isSmooshed => false;
+
   /// The pointer of the resolved schema.
   JsonPointer get pointer => common.pointer;
 
@@ -2990,6 +3001,9 @@ class RenderObject extends RenderNewType {
   /// drives the `final class X extends Y` declaration in the schema
   /// template and the "skip my own file" gates in `file_renderer`.
   final String? parentSealedTypeName;
+
+  @override
+  bool get isSmooshed => parentSealedTypeName != null;
 
   @override
   String? get wrapperTag => typeName;
@@ -4182,13 +4196,10 @@ class RenderOneOf extends RenderNewType {
     final dispatch = <Map<String, dynamic>>[];
     for (final entry in mapping) {
       final renderVariant = renderOf(entry.variant);
-      final isSmooshed =
-          renderVariant is RenderObject &&
-          renderVariant.parentSealedTypeName != null;
       final fromJson = '${renderVariant.typeName}.fromJson(json)';
       dispatch.add({
         'value': entry.value,
-        'caseExpression': isSmooshed
+        'caseExpression': renderVariant.isSmooshed
             ? fromJson
             : '${wrapperTypeName(renderVariant)}($fromJson)',
       });
@@ -4197,8 +4208,7 @@ class RenderOneOf extends RenderNewType {
     final smooshedVariants = <Map<String, dynamic>>[];
     for (final v in declarationOrder) {
       final renderVariant = renderOf(v);
-      if (renderVariant is RenderObject &&
-          renderVariant.parentSealedTypeName != null) {
+      if (renderVariant.isSmooshed) {
         smooshedVariants.add(renderVariant.toTemplateContext(context));
       } else {
         variants.add(objectWrapperContext(renderVariant));
@@ -4227,10 +4237,7 @@ class RenderOneOf extends RenderNewType {
     final smooshedVariants = <Map<String, dynamic>>[];
     for (final arm in arms) {
       final renderVariant = renderOf(arm.variant);
-      final isSmooshed =
-          renderVariant is RenderObject &&
-          renderVariant.parentSealedTypeName != null;
-      if (isSmooshed) {
+      if (renderVariant.isSmooshed) {
         // Smooshed object variants are always Map-shaped; the case
         // arm constructs the variant directly. The wrapper subclass
         // is gone, the variant data class is inlined into the parent
@@ -4279,40 +4286,30 @@ class RenderOneOf extends RenderNewType {
     final variants = <Map<String, dynamic>>[];
     final smooshedVariants = <Map<String, dynamic>>[];
 
-    bool isSmooshedVariant(RenderSchema variant) =>
-        variant is RenderObject && variant.parentSealedTypeName != null;
+    String mapCaseExpression(RenderSchema variant) {
+      final fromJson = '${variant.typeName}.fromJson(v)';
+      return variant.isSmooshed
+          ? fromJson
+          : '${wrapperTypeName(variant)}($fromJson)';
+    }
 
-    String mapCaseExpression(RenderSchema variant) => isSmooshedVariant(variant)
-        ? '${variant.typeName}.fromJson(v)'
-        : '${wrapperTypeName(variant)}(${variant.typeName}.fromJson(v))';
-
+    // Non-Map shape arms always carry non-object variants today (the
+    // dispatcher routes Map-shaped objects to `mapArms`), so this
+    // path never sees a smooshable variant. `_planVariant` is fine.
     final renderedShapeArms = <Map<String, dynamic>>[];
     for (final arm in shapeArms) {
-      final renderVariant = renderOf(arm.variant);
-      if (isSmooshedVariant(renderVariant)) {
-        // Inline-object on a non-Map shape arm is unusual but
-        // possible (e.g. a future RenderObject whose jsonShapeKey
-        // isn't Map). Today Map-shaped objects always land in
-        // mapArms, but treating shapeArms uniformly future-proofs.
-        renderedShapeArms.add({
-          'jsonTestType': renderVariant.jsonShapeKey,
-          'caseExpression': '${renderVariant.typeName}.fromJson(v)',
-        });
-      } else {
-        final plan = _planVariant(renderVariant, context)!;
-        renderedShapeArms.add({
-          'jsonTestType': plan.jsonTestType,
-          'caseExpression': '${plan.wrapperTypeName}(${plan.fromJson})',
-        });
-      }
+      final plan = _planVariant(renderOf(arm.variant), context)!;
+      renderedShapeArms.add({
+        'jsonTestType': plan.jsonTestType,
+        'caseExpression': '${plan.wrapperTypeName}(${plan.fromJson})',
+      });
     }
 
     final renderedMapArms = <Map<String, dynamic>>[];
     for (final arm in mapArms) {
-      final renderVariant = renderOf(arm.variant);
       renderedMapArms.add({
         'predicateTest': arm.predicate.dartIfTest('v'),
-        'caseExpression': mapCaseExpression(renderVariant),
+        'caseExpression': mapCaseExpression(renderOf(arm.variant)),
       });
     }
 
@@ -4322,7 +4319,7 @@ class RenderOneOf extends RenderNewType {
 
     for (final v in declarationOrder) {
       final renderVariant = renderOf(v);
-      if (isSmooshedVariant(renderVariant)) {
+      if (renderVariant.isSmooshed) {
         smooshedVariants.add(renderVariant.toTemplateContext(context));
       } else if (mapArms.any((a) => identical(a.variant, v)) ||
           identical(v, mapFallback)) {
@@ -4361,19 +4358,16 @@ class RenderOneOf extends RenderNewType {
       // itself (no outer wrap call); the wrapper-subclass form is
       // skipped entirely. Non-smooshed variants keep the wrapper
       // form and continue to render to their own file.
-      final isSmooshed =
-          renderVariant is RenderObject &&
-          renderVariant.parentSealedTypeName != null;
       final Map<String, dynamic> armCtx;
       switch (kind) {
         case PredicateDispatchKind.requiredField:
           final fromJson = '${renderVariant.typeName}.fromJson(json)';
           armCtx = {
-            'caseExpression': isSmooshed
+            'caseExpression': renderVariant.isSmooshed
                 ? fromJson
                 : '${wrapperTypeName(renderVariant)}($fromJson)',
           };
-          if (isSmooshed) {
+          if (renderVariant.isSmooshed) {
             smooshedVariants.add(renderVariant.toTemplateContext(context));
           } else {
             variants.add(objectWrapperContext(renderVariant));

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -4148,35 +4148,13 @@ class RenderOneOf extends RenderNewType {
         :final mapFallback,
         :final declarationOrder,
       ) =>
-        _HybridMode(
-          shapeArms: [
-            for (final arm in shapeArms)
-              _shapeWrapperContext(
-                _planVariant(renderOf(arm.variant), context)!,
-              ),
-          ],
-          mapArms: [
-            for (final arm in mapArms)
-              {
-                'predicateTest': arm.predicate.dartIfTest('v'),
-                'wrapperTypeName': wrapperTypeName(renderOf(arm.variant)),
-                'valueType': renderOf(arm.variant).typeName,
-              },
-          ],
-          mapFallback: mapFallback == null
-              ? null
-              : {
-                  'wrapperTypeName': wrapperTypeName(renderOf(mapFallback)),
-                  'valueType': renderOf(mapFallback).typeName,
-                },
-          variants: [
-            for (final v in declarationOrder)
-              if (mapArms.any((a) => identical(a.variant, v)) ||
-                  identical(v, mapFallback))
-                objectWrapperContext(renderOf(v))
-              else
-                _shapeWrapperContext(_planVariant(renderOf(v), context)!),
-          ],
+        _buildHybridMode(
+          shapeArms,
+          mapArms,
+          mapFallback,
+          declarationOrder,
+          renderOf,
+          context,
         ),
       PredicateDispatch(:final kind, :final arms) => _buildPredicateMode(
         kind,
@@ -4276,6 +4254,88 @@ class RenderOneOf extends RenderNewType {
     }
     return _ShapeMode(
       dispatch: dispatch,
+      variants: variants,
+      smooshedVariants: smooshedVariants,
+    );
+  }
+
+  /// Build a [_HybridMode], splitting variants by smooshed/not.
+  /// Hybrid has three arm flavors — non-Map shape arms, predicate-
+  /// guarded Map arms, and an optional unguarded Map fallback —
+  /// each of which composes the same `caseExpression`: a direct
+  /// `<Variant>.fromJson(v)` for smooshed variants and the
+  /// wrapper-class call for the rest. Variants that get a wrapper
+  /// land in `variants`; smooshed ones in `smooshedVariants` and
+  /// are inlined into the parent's file by the schema_object
+  /// partial.
+  _HybridMode _buildHybridMode(
+    List<ShapeArm> shapeArms,
+    List<PredicateArm> mapArms,
+    ResolvedSchema? mapFallback,
+    List<ResolvedSchema> declarationOrder,
+    RenderSchema Function(ResolvedSchema) renderOf,
+    SchemaRenderer context,
+  ) {
+    final variants = <Map<String, dynamic>>[];
+    final smooshedVariants = <Map<String, dynamic>>[];
+
+    bool isSmooshedVariant(RenderSchema variant) =>
+        variant is RenderObject && variant.parentSealedTypeName != null;
+
+    String mapCaseExpression(RenderSchema variant) => isSmooshedVariant(variant)
+        ? '${variant.typeName}.fromJson(v)'
+        : '${wrapperTypeName(variant)}(${variant.typeName}.fromJson(v))';
+
+    final renderedShapeArms = <Map<String, dynamic>>[];
+    for (final arm in shapeArms) {
+      final renderVariant = renderOf(arm.variant);
+      if (isSmooshedVariant(renderVariant)) {
+        // Inline-object on a non-Map shape arm is unusual but
+        // possible (e.g. a future RenderObject whose jsonShapeKey
+        // isn't Map). Today Map-shaped objects always land in
+        // mapArms, but treating shapeArms uniformly future-proofs.
+        renderedShapeArms.add({
+          'jsonTestType': renderVariant.jsonShapeKey,
+          'caseExpression': '${renderVariant.typeName}.fromJson(v)',
+        });
+      } else {
+        final plan = _planVariant(renderVariant, context)!;
+        renderedShapeArms.add({
+          'jsonTestType': plan.jsonTestType,
+          'caseExpression': '${plan.wrapperTypeName}(${plan.fromJson})',
+        });
+      }
+    }
+
+    final renderedMapArms = <Map<String, dynamic>>[];
+    for (final arm in mapArms) {
+      final renderVariant = renderOf(arm.variant);
+      renderedMapArms.add({
+        'predicateTest': arm.predicate.dartIfTest('v'),
+        'caseExpression': mapCaseExpression(renderVariant),
+      });
+    }
+
+    final renderedMapFallback = mapFallback == null
+        ? null
+        : {'caseExpression': mapCaseExpression(renderOf(mapFallback))};
+
+    for (final v in declarationOrder) {
+      final renderVariant = renderOf(v);
+      if (isSmooshedVariant(renderVariant)) {
+        smooshedVariants.add(renderVariant.toTemplateContext(context));
+      } else if (mapArms.any((a) => identical(a.variant, v)) ||
+          identical(v, mapFallback)) {
+        variants.add(objectWrapperContext(renderVariant));
+      } else {
+        final plan = _planVariant(renderVariant, context)!;
+        variants.add(_shapeWrapperContext(plan));
+      }
+    }
+    return _HybridMode(
+      shapeArms: renderedShapeArms,
+      mapArms: renderedMapArms,
+      mapFallback: renderedMapFallback,
       variants: variants,
       smooshedVariants: smooshedVariants,
     );
@@ -4614,16 +4674,36 @@ class _HybridMode extends _DispatchMode {
     required this.mapArms,
     required this.mapFallback,
     required this.variants,
+    required this.smooshedVariants,
   });
 
+  /// Per-arm contexts for non-Map shape arms. Each entry has
+  /// `jsonTestType` and `caseExpression` (the full Dart expression
+  /// to `return`).
   final List<Map<String, dynamic>> shapeArms;
+
+  /// Per-arm contexts for predicate-guarded Map arms. Each entry has
+  /// `predicateTest` (the `v.containsKey('foo')` check) and
+  /// `caseExpression`.
   final List<Map<String, dynamic>> mapArms;
 
   /// `null` when no fallback applies (the Map sub-dispatch ends in a
-  /// throw). Projects to `false` at the template boundary; the
-  /// mustache inverted section fires on null/false alike.
+  /// throw). Otherwise has just `caseExpression`. Projects to `false`
+  /// at the template boundary; the mustache inverted section fires
+  /// on null/false alike.
   final Map<String, dynamic>? mapFallback;
+
+  /// Non-smooshed variants — wrapper subclass declarations, in
+  /// declaration order. Smooshed variants (those whose data class
+  /// extends the sealed parent directly) are in [smooshedVariants];
+  /// the union of the two preserves declaration order.
   final List<Map<String, dynamic>> variants;
+
+  /// Smooshed variants — emitted *inline in the parent's file* as
+  /// direct sealed subclasses, no wrapper shim. Each entry is the
+  /// variant's full `toTemplateContext` so the schema_object partial
+  /// can render the class body unchanged.
+  final List<Map<String, dynamic>> smooshedVariants;
 }
 
 /// Predicate-driven if-chain dispatch — covers every mode whose
@@ -4748,12 +4828,14 @@ void _applyDispatchMode(_DispatchMode mode, Map<String, dynamic> ctx) {
       :final mapArms,
       :final mapFallback,
       :final variants,
+      :final smooshedVariants,
     ):
       ctx['has_hybrid_dispatch'] = true;
       ctx['shapeArms'] = shapeArms;
       ctx['mapArms'] = mapArms;
       ctx['mapFallback'] = mapFallback ?? false;
       ctx['variants'] = variants;
+      ctx['smooshedVariants'] = smooshedVariants;
     case _PredicateDispatchMode(
       :final dispatch,
       :final fallback,

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -4141,12 +4141,7 @@ class RenderOneOf extends RenderNewType {
           renderOf,
           context,
         ),
-      ShapeDispatch(:final arms) => _ShapeMode(
-        variants: [
-          for (final arm in arms)
-            _shapeWrapperContext(_planVariant(renderOf(arm.variant), context)!),
-        ],
-      ),
+      ShapeDispatch(:final arms) => _buildShapeMode(arms, renderOf, context),
       HybridDispatch(
         :final shapeArms,
         :final mapArms,
@@ -4233,6 +4228,53 @@ class RenderOneOf extends RenderNewType {
     }
     return _DiscriminatorMode(
       discriminatorProperty: propertyName,
+      dispatch: dispatch,
+      variants: variants,
+      smooshedVariants: smooshedVariants,
+    );
+  }
+
+  /// Build a [_ShapeMode], splitting variants into smooshed (the
+  /// variant data class extends the sealed parent directly, inlined
+  /// in the parent's file) and non-smooshed (today's wrapper-subclass
+  /// + `value:` indirection). Each `dispatch` entry's `caseExpression`
+  /// is the full Dart expression to `return` from its switch arm.
+  _ShapeMode _buildShapeMode(
+    List<ShapeArm> arms,
+    RenderSchema Function(ResolvedSchema) renderOf,
+    SchemaRenderer context,
+  ) {
+    final dispatch = <Map<String, dynamic>>[];
+    final variants = <Map<String, dynamic>>[];
+    final smooshedVariants = <Map<String, dynamic>>[];
+    for (final arm in arms) {
+      final renderVariant = renderOf(arm.variant);
+      final isSmooshed =
+          renderVariant is RenderObject &&
+          renderVariant.parentSealedTypeName != null;
+      if (isSmooshed) {
+        // Smooshed object variants are always Map-shaped; the case
+        // arm constructs the variant directly. The wrapper subclass
+        // is gone, the variant data class is inlined into the parent
+        // file as a direct sealed subclass. We skip `_planVariant`
+        // here because its `wrapperTypeName(variant)` lookup would
+        // throw — the naming pass intentionally skipped the wrapper
+        // claim for smooshable variants.
+        dispatch.add({
+          'jsonTestType': _mapShapeKey,
+          'caseExpression': '${renderVariant.typeName}.fromJson(v)',
+        });
+        smooshedVariants.add(renderVariant.toTemplateContext(context));
+      } else {
+        final plan = _planVariant(renderVariant, context)!;
+        dispatch.add({
+          'jsonTestType': plan.jsonTestType,
+          'caseExpression': '${plan.wrapperTypeName}(${plan.fromJson})',
+        });
+        variants.add(_shapeWrapperContext(plan));
+      }
+    }
+    return _ShapeMode(
       dispatch: dispatch,
       variants: variants,
       smooshedVariants: smooshedVariants,
@@ -4535,11 +4577,32 @@ class _DiscriminatorMode extends _DispatchMode {
   final List<Map<String, dynamic>> smooshedVariants;
 }
 
-/// Pure shape dispatch — `switch (json) { final T v => ... }`.
+/// Pure shape dispatch — `switch (json) { T v => ... }`.
 class _ShapeMode extends _DispatchMode {
-  const _ShapeMode({required this.variants});
+  const _ShapeMode({
+    required this.dispatch,
+    required this.variants,
+    required this.smooshedVariants,
+  });
 
+  /// Per-arm contexts: each entry has `jsonTestType` (the case
+  /// pattern type, e.g. `int`, `Map<String, dynamic>`) and
+  /// `caseExpression` (the full Dart expression to `return` —
+  /// includes the wrapper-class call when the variant has a wrapper,
+  /// or just `Variant.fromJson(v)` when smooshed).
+  final List<Map<String, dynamic>> dispatch;
+
+  /// Non-smooshed variants — wrapper subclass declarations, in
+  /// declaration order. Smooshed variants (those whose data class
+  /// extends the sealed parent directly) are in [smooshedVariants];
+  /// the union of the two preserves declaration order.
   final List<Map<String, dynamic>> variants;
+
+  /// Smooshed variants — emitted *inline in the parent's file* as
+  /// direct sealed subclasses, no wrapper shim. Each entry is the
+  /// variant's full `toTemplateContext` so the schema_object partial
+  /// can render the class body unchanged.
+  final List<Map<String, dynamic>> smooshedVariants;
 }
 
 /// Hybrid dispatch — non-Map shape arms followed by a Map sub-
@@ -4675,9 +4738,11 @@ void _applyDispatchMode(_DispatchMode mode, Map<String, dynamic> ctx) {
       ctx['variants'] = variants;
       ctx['smooshedVariants'] = smooshedVariants;
       ctx['maybeFromJsonParamType'] = 'Map<String, dynamic>?';
-    case _ShapeMode(:final variants):
+    case _ShapeMode(:final dispatch, :final variants, :final smooshedVariants):
       ctx['has_shape_dispatch'] = true;
+      ctx['dispatch'] = dispatch;
       ctx['variants'] = variants;
+      ctx['smooshedVariants'] = smooshedVariants;
     case _HybridMode(
       :final shapeArms,
       :final mapArms,

--- a/lib/templates/schema_one_of.mustache
+++ b/lib/templates/schema_one_of.mustache
@@ -33,9 +33,9 @@
 
     factory {{ typeName }}.fromJson(dynamic json) {
         return switch (json) {
-{{#variants}}
-            {{{ jsonTestType }}} v => {{{ wrapperTypeName }}}({{{ fromJson }}}),
-{{/variants}}
+{{#dispatch}}
+            {{{ jsonTestType }}} v => {{{ caseExpression }}},
+{{/dispatch}}
             _ => throw FormatException(
                 'Unsupported shape for {{ typeName }}: ${json.runtimeType}',
             ),
@@ -51,6 +51,9 @@
 {{#variants}}
 {{> _one_of_wrapper}}
 {{/variants}}
+{{#smooshedVariants}}
+{{> schema_object}}
+{{/smooshedVariants}}
 {{/has_shape_dispatch}}
 {{#has_hybrid_dispatch}}
 {{{ doc_comment }}}sealed class {{ typeName }} {

--- a/lib/templates/schema_one_of.mustache
+++ b/lib/templates/schema_one_of.mustache
@@ -62,13 +62,13 @@
     factory {{ typeName }}.fromJson(dynamic json) {
         return switch (json) {
 {{#shapeArms}}
-            final {{{ jsonTestType }}} v => {{{ wrapperTypeName }}}({{{ fromJson }}}),
+            final {{{ jsonTestType }}} v => {{{ caseExpression }}},
 {{/shapeArms}}
 {{#mapArms}}
-            final Map<String, dynamic> v when {{{ predicateTest }}} => {{{ wrapperTypeName }}}({{{ valueType }}}.fromJson(v)),
+            final Map<String, dynamic> v when {{{ predicateTest }}} => {{{ caseExpression }}},
 {{/mapArms}}
 {{#mapFallback}}
-            final Map<String, dynamic> v => {{{ wrapperTypeName }}}({{{ valueType }}}.fromJson(v)),
+            final Map<String, dynamic> v => {{{ caseExpression }}},
 {{/mapFallback}}
 {{^mapFallback}}
             final Map<String, dynamic> v => throw FormatException(
@@ -90,6 +90,9 @@
 {{#variants}}
 {{> _one_of_wrapper}}
 {{/variants}}
+{{#smooshedVariants}}
+{{> schema_object}}
+{{/smooshedVariants}}
 {{/has_hybrid_dispatch}}
 {{#has_predicate_dispatch}}
 {{{ doc_comment }}}sealed class {{ typeName }} {

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -1470,42 +1470,53 @@ void main() {
       // this and falls back to a position-based wrapper name
       // (`TestVariant1`).
       //
-      // Predicate / discriminator / shape with inline objects all
-      // smoosh now, eliminating the wrapper entirely — those paths
-      // never reach the doubling-fallback. To exercise the fallback
-      // on its own, this test uses **hybrid** dispatch (a string
-      // variant + two map variants forced into a sub-dispatch), which
-      // isn't smoosh-aware yet. Both inline map variants keep their
-      // wrapper subclasses, and both trip the doubling check.
-      final result = renderTestSchema({
-        'oneOf': [
-          {'type': 'string'},
-          {
+      // Every dispatch kind now smooshes inline `ResolvedObject`
+      // variants, so the doubling-fallback never fires for plain
+      // inline objects anymore. To exercise the fallback we need an
+      // inline variant that *isn't* `ResolvedObject` — an inline
+      // multi-member `allOf` qualifies. The structural smoosh
+      // predicate excludes `ResolvedAllOf`, so the wrapper still
+      // gets emitted and trips the doubling check.
+      final results = renderTestSchemas(
+        {
+          'Test': {
+            'oneOf': [
+              {'type': 'string'},
+              {
+                'allOf': [
+                  {r'$ref': '#/components/schemas/A'},
+                  {r'$ref': '#/components/schemas/B'},
+                ],
+              },
+            ],
+          },
+          'A': {
             'type': 'object',
-            'required': ['tag_a'],
+            'required': ['a'],
             'properties': {
-              'tag_a': {'type': 'string'},
+              'a': {'type': 'string'},
             },
           },
-          {
+          'B': {
             'type': 'object',
-            'required': ['tag_b'],
+            'required': ['b'],
             'properties': {
-              'tag_b': {'type': 'string'},
+              'b': {'type': 'string'},
             },
           },
-        ],
-      });
+        },
+        specUrl: Uri.parse('file:///spec.yaml'),
+      );
+      final test = results['Test']!;
       // The string variant gets the structural `TestString` wrapper.
-      expect(result, contains('final class TestString extends Test'));
-      // The two inline-object wrappers would naively be
-      // `TestTestOneOf1` / `TestTestOneOf2`; the fallback collapses
-      // them to `TestVariant1` / `TestVariant2`.
-      expect(result, contains('final class TestVariant1 extends Test'));
-      expect(result, contains('final class TestVariant2 extends Test'));
-      expect(result, contains('final TestOneOf1 value;'));
-      expect(result, contains('final TestOneOf2 value;'));
-      expect(result, isNot(contains('TestTestOneOf')));
+      expect(test, contains('final class TestString extends Test'));
+      // The inline allOf variant's parser-synthesized name starts
+      // with the parent (`TestOneOf1`), so naive composition would
+      // give `TestTestOneOf1`; the fallback collapses to
+      // `TestVariant1`.
+      expect(test, contains('final class TestVariant1 extends Test'));
+      expect(test, contains('final TestOneOf1 value;'));
+      expect(test, isNot(contains('TestTestOneOf')));
     });
 
     test('predicate-required dispatch smooshes inline-object variants: '
@@ -1602,6 +1613,62 @@ void main() {
       // No wrapper subclass for the smooshed variant.
       expect(result, isNot(contains('class TestVariant1')));
       expect(result, isNot(contains('TestOneOf1 value')));
+    });
+
+    test('hybrid dispatch smooshes inline-object Map sub-arms: each '
+        'variant extends the sealed parent directly', () {
+      // String + 2 inline-object variants — hybrid dispatch (string
+      // shape arm + property-presence sub-dispatch on the Maps). Both
+      // map variants are inline-exclusive `ResolvedObject`s, so they
+      // smoosh: the Map case arms call the variant directly, the
+      // wrapper subclasses are gone, and the variant data classes
+      // are inlined into the parent's file.
+      final result = renderTestSchema({
+        'oneOf': [
+          {'type': 'string'},
+          {
+            'type': 'object',
+            'required': ['tag_a'],
+            'properties': {
+              'tag_a': {'type': 'string'},
+            },
+          },
+          {
+            'type': 'object',
+            'required': ['tag_b'],
+            'properties': {
+              'tag_b': {'type': 'string'},
+            },
+          },
+        ],
+      });
+      // String shape-arm keeps its wrapper (primitives can't extend
+      // a sealed class).
+      expect(result, contains('final class TestString extends Test'));
+      // Map sub-arms call the variant directly — no wrapper-class
+      // outer call.
+      expect(
+        result,
+        contains(
+          "final Map<String, dynamic> v when v.containsKey('tag_a') "
+          '=> TestOneOf1.fromJson(v)',
+        ),
+      );
+      expect(
+        result,
+        contains(
+          "final Map<String, dynamic> v when v.containsKey('tag_b') "
+          '=> TestOneOf2.fromJson(v)',
+        ),
+      );
+      // Variant data classes are sealed subclasses, inlined.
+      expect(result, contains('final class TestOneOf1 extends Test'));
+      expect(result, contains('final class TestOneOf2 extends Test'));
+      // No legacy `<Parent>Variant<i>` wrappers.
+      expect(result, isNot(contains('class TestVariant1')));
+      expect(result, isNot(contains('class TestVariant2')));
+      expect(result, isNot(contains('TestOneOf1 value')));
+      expect(result, isNot(contains('TestOneOf2 value')));
     });
 
     test('property-presence dispatch falls back to legacy when one '
@@ -1748,15 +1815,23 @@ void main() {
       );
       // No legacy stub.
       expect(result, isNot(contains('throw UnimplementedError')));
-      // Sealed subclass declarations land in spec order: array first,
-      // then the three objects. The List wrapper holds the parsed
-      // List<itemType>; the object wrappers delegate to the variant
-      // class's own fromJson/toJson.
+      // The List variant keeps its primitive wrapper. The three
+      // inline-object variants smoosh — they extend the sealed
+      // parent directly, no `<Parent>Variant<i>` wrapper, no
+      // `value:` indirection. Map case arms call the variant's
+      // `fromJson` directly.
       expect(result, contains('final class TestList extends Test'));
       expect(result, contains('final List<String> value;'));
-      expect(result, contains('final class TestVariant1 extends Test'));
-      expect(result, contains('final class TestVariant2 extends Test'));
-      expect(result, contains('final class TestVariant3 extends Test'));
+      expect(result, contains('final class TestOneOf1 extends Test'));
+      expect(result, contains('final class TestOneOf2 extends Test'));
+      expect(result, contains('final class TestOneOf3 extends Test'));
+      expect(
+        result,
+        contains(
+          "final Map<String, dynamic> v when v.containsKey('content') "
+          '=> TestOneOf1.fromJson(v)',
+        ),
+      );
     });
 
     test('hybrid dispatch: Map sub-arms include a fallback when one '

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -1477,6 +1477,11 @@ void main() {
       // multi-member `allOf` qualifies. The structural smoosh
       // predicate excludes `ResolvedAllOf`, so the wrapper still
       // gets emitted and trips the doubling check.
+      //
+      // Two members are deliberate: the resolver collapses a
+      // single-member `allOf` to its inner schema (eliding the
+      // allOf), which would defeat the test setup. Two members
+      // forces the `allOf` to survive resolution as `ResolvedAllOf`.
       final results = renderTestSchemas(
         {
           'Test': {

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -812,8 +812,16 @@ void main() {
         ],
       };
       final result = renderTestSchema(schema);
+      // Number variant keeps its primitive wrapper.
       expect(result, contains('num v => TestNum(v)'));
-      expect(result, contains('Map<String, dynamic> v => TestVariant1'));
+      // The inline-object variant smooshes — case arm constructs the
+      // variant directly, no wrapper-class call. Variant data class
+      // is inlined into the parent's file as a sealed subclass.
+      expect(
+        result,
+        contains('Map<String, dynamic> v => TestOneOf1.fromJson(v)'),
+      );
+      expect(result, contains('final class TestOneOf1 extends Test'));
       expect(result, isNot(contains('throw UnimplementedError')));
     });
 
@@ -1455,35 +1463,48 @@ void main() {
 
     test('wrapper subclass uses position-based name when the variant '
         'tag would double the parent prefix (non-smooshed path)', () {
-      // Inline oneOf variants get parser-synthesized names that already
-      // contain the parent (`<Parent>OneOf<i>`). Composing the wrapper
-      // as `<Parent><variantTypeName>` would then double the prefix
-      // (e.g. `TestTestOneOf0`). The naming pass detects this and
-      // falls back to a position-based wrapper name (`TestVariant0`).
+      // Inline oneOf variants get parser-synthesized names that
+      // already contain the parent (`<Parent>OneOf<i>`). Composing
+      // the wrapper as `<Parent><variantTypeName>` would then double
+      // the prefix (e.g. `TestTestOneOf1`). The naming pass detects
+      // this and falls back to a position-based wrapper name
+      // (`TestVariant1`).
       //
-      // Predicate-required dispatch with inline objects would smoosh
-      // (no wrapper at all) — see the smoosh test below. To exercise
-      // the doubling-fallback path on its own, this test uses shape
-      // dispatch (a string variant + an inline object variant). Shape
-      // dispatch isn't yet smoosh-aware, so the inline object's
-      // wrapper is still emitted and the fallback name applies.
+      // Predicate / discriminator / shape with inline objects all
+      // smoosh now, eliminating the wrapper entirely — those paths
+      // never reach the doubling-fallback. To exercise the fallback
+      // on its own, this test uses **hybrid** dispatch (a string
+      // variant + two map variants forced into a sub-dispatch), which
+      // isn't smoosh-aware yet. Both inline map variants keep their
+      // wrapper subclasses, and both trip the doubling check.
       final result = renderTestSchema({
         'oneOf': [
           {'type': 'string'},
           {
             'type': 'object',
+            'required': ['tag_a'],
             'properties': {
-              'note': {'type': 'string'},
+              'tag_a': {'type': 'string'},
+            },
+          },
+          {
+            'type': 'object',
+            'required': ['tag_b'],
+            'properties': {
+              'tag_b': {'type': 'string'},
             },
           },
         ],
       });
       // The string variant gets the structural `TestString` wrapper.
       expect(result, contains('final class TestString extends Test'));
-      // The inline object's wrapper would be `TestTestOneOf1` if we
-      // composed naively; the naming pass falls back to `TestVariant1`.
+      // The two inline-object wrappers would naively be
+      // `TestTestOneOf1` / `TestTestOneOf2`; the fallback collapses
+      // them to `TestVariant1` / `TestVariant2`.
       expect(result, contains('final class TestVariant1 extends Test'));
+      expect(result, contains('final class TestVariant2 extends Test'));
       expect(result, contains('final TestOneOf1 value;'));
+      expect(result, contains('final TestOneOf2 value;'));
       expect(result, isNot(contains('TestTestOneOf')));
     });
 
@@ -1543,6 +1564,43 @@ void main() {
       // (which would be the wrapper's `value` field).
       expect(result, isNot(contains('class TestVariant0')));
       expect(result, isNot(contains('TestOneOf0 value')));
+      expect(result, isNot(contains('TestOneOf1 value')));
+    });
+
+    test('shape dispatch smooshes the inline-object variant: case arm '
+        'calls variant directly, primitive variants keep wrappers', () {
+      // Mixed-shape `oneOf` where one variant is an inline object
+      // and the other is a primitive (e.g. github's
+      // `repos_*_team_access_restrictions_request`: object-or-array
+      // shape). The object variant is inline and exclusive — smoosh
+      // eligible; the primitive can't extend a sealed class so it
+      // keeps its wrapper. The mixed result demonstrates the per-arm
+      // smoosh decision.
+      final result = renderTestSchema({
+        'oneOf': [
+          {'type': 'string'},
+          {
+            'type': 'object',
+            'properties': {
+              'name': {'type': 'string'},
+            },
+          },
+        ],
+      });
+      // String variant keeps the structural wrapper.
+      expect(result, contains('final class TestString extends Test'));
+      expect(result, contains('String v => TestString(v)'));
+      // Inline-object variant smooshes — case arm constructs it
+      // directly, no wrapper-class call. Variant data class is the
+      // sealed subclass.
+      expect(
+        result,
+        contains('Map<String, dynamic> v => TestOneOf1.fromJson(v)'),
+      );
+      expect(result, contains('final class TestOneOf1 extends Test'));
+      expect(result, contains('@override'));
+      // No wrapper subclass for the smooshed variant.
+      expect(result, isNot(contains('class TestVariant1')));
       expect(result, isNot(contains('TestOneOf1 value')));
     });
 


### PR DESCRIPTION
## Summary

Final two stops on the smoosh PR train (after #168 predicate, #169 discriminator). Both shape and hybrid dispatch now know how to skip the wrapper subclass and emit a direct `<Variant>.fromJson(...)` case arm when the variant is an inline-exclusive `ResolvedObject`. With this PR the smoosh predicate `_dispatchEmitsSmooshed` is exhaustive — every dispatch kind capable of smoosh emits the smooshed form. The remaining gate is purely structural: `_isStructurallySmooshable` (inline + `ResolvedObject`).

Each mode (`_ShapeMode`, `_HybridMode`) now carries a `dispatch` list of per-arm `caseExpression`s plus parallel `variants` (non-smooshed wrappers) and `smooshedVariants` (full `toTemplateContext`s rendered inline via the schema_object partial) — same shape as `_DiscriminatorMode` and `_PredicateDispatchMode`.

## github regen impact

**12 inline-object variants smooshed across 12 sealed parents** in mixed-shape `oneOf`s:

```
Repos{Add,Remove,Set}StatusCheckContextsRequest
Repos{Add,Remove,Set}TeamAccessRestrictionsRequest
Users{Add,Delete}EmailForAuthenticatedUserRequest
Issue{,sCreate,sUpdate}LabelsInner...
ReposUpdateInformationAboutPagesSiteRequest.source
```

12 separate variant `.dart` files + 12 round-trip test files deleted. `dart analyze` clean.

Hybrid alone is byte-identical for github — the github sites that *use* hybrid dispatch (e.g., `repos/get-content` 200 response) all have top-level `$ref` variants, not inline ones. Like discriminator (#169), hybrid smoosh is platform-only on github; it'll fire on specs that have inline-object map sub-arms.

## Test plan

- [x] New focused tests: shape-smoosh (mixed object-or-primitive); hybrid-smoosh (string + 2 inline-object map sub-arms).
- [x] Three existing tests adjusted for the new smoosh: `oneOf with [number, object]`, `hybrid: array variant + multiple objects`, doubling-fallback test (now uses inline multi-member `allOf` — the only remaining non-smooshable inline shape).
- [x] `dart test` full suite green.
- [x] `dart analyze` clean.
- [x] github regen `dart analyze` clean.
- [x] github regen diff: 12 sealed parents modified + `lib/api.dart`; 12 variant files + 12 tests removed; nothing else moved.

## Train state after this lands

```
Predicate-required  ✅ #168
Discriminator       ✅ #169 (platform; github top-level refs)
Shape               ✅ this PR
Hybrid              ✅ this PR (platform; github top-level refs)
Array-element       N/A (variants are arrays, not objects)
```

Smoosh structural matrix complete. The next leverage on github is the conceptual shift to **exclusive top-level `$ref`-variant** smoosh, which would catch the `RepositoryRule` family and the discriminator/hybrid sites that use top-level refs whose target is referenced from exactly one parent. Separate PR.