### PR TITLE
docs: update spec-iteration skill for naming + smoosh series

### DIFF
--- a/.claude/skills/spec-iteration/SKILL.md
+++ b/.claude/skills/spec-iteration/SKILL.md
@@ -14,7 +14,7 @@ description: |
   any spec-driven follow-up.
 ---
 
-# State as of 2026-04-28
+# State as of 2026-04-29
 
 ## What this is
 
@@ -44,14 +44,17 @@ A "gap" can be any of:
   `prefer_single_quotes`, `lines_longer_than_80_chars`).
 - A real-spec author hits a snag and reports it.
 
-**Current status:** **7 stubs remain** on github. The dispatch
-series has settled into a clean architecture; the visible quality
-wins (96 double-prefix wrappers, 8 `_1` suffixes) are now an
-algorithm-swap PR away — see "Next steps" below.
+**Current status:** **7 stubs remain** on github (unchanged — same
+hard cases as before). The naming + smoosh series has shipped: 96
+double-prefix wrappers fixed, ~25 wrapper subclasses eliminated
+entirely (variant data class IS the sealed subclass now), and 3
+inline variants flipped to title-derived names. The next leverage
+is the conceptual shift to **exclusive-by-use** smoosh — see "Open
+gaps" below.
 
 ## Architecture
 
-The pipeline has been pulled apart over the last several PRs:
+The pipeline:
 
 ```
 Load → Parse → Resolve → Dispatch → Naming → Render
@@ -65,21 +68,33 @@ Load → Parse → Resolve → Dispatch → Naming → Render
   (`Discriminator` / `Shape` / `Hybrid` / `Predicate` / `NoDispatch`).
   Variants are referenced as `ResolvedSchema`, no Dart names.
   `Predicate` IR (`KeyExists`, `ArrayElementHasKey`, `Always`) —
-  adding a new predicate is a subtype, not a new mode. The
-  `_PredicateDispatchMode` consolidation (#159) collapsed
-  required-field + array-element into one mode with five knobs.
-- **`lib/src/naming.dart`** (#161, #162, #163). Walks the resolved
-  tree (and dispatch decisions) to assign every Dart class name in
-  one pass:
-  - Top-level + inline newtype schemas (keyed by their pointer).
-  - Operation-level synthesized response wrappers (keyed by op
-    pointer, used by the multi-status range-mixed fallback).
-  - oneOf/anyOf wrapper subclasses (keyed by
-    `AssignedNames.wrapperPointer(parent, variantIndex)`).
-  Today's algorithm is `camelFromSnake(snakeName)` — same answer
-  the snake-derived render code used to compute. The next PR
-  swaps to shortest-unique-with-fallback for the visible quality
-  wins.
+  adding a new predicate is a subtype, not a new mode.
+
+- **`lib/src/naming.dart`** (#161–#163, #165, #166, #167). The
+  source of truth for every Dart class name *and* every file
+  basename. Single `NameAllocator` keyed by snake names; camel is
+  derived via `camelFromSnake` on read. Each entity submits a
+  *preference list* (best/shortest first, longest/safest last);
+  the allocator runs a fixpoint that advances colliding entities to
+  their next preference, then numeric-suffix-disambiguates any
+  remaining ties. Order-independent.
+
+  - **Two-phase resolution**: phase 1 claims schemas + synthesized
+    op-response names; phase 2 claims wrapper subclass names (which
+    depend on phase-1 resolved variant names). `AssignedNames`
+    exposes both `snakeFor(pointer)` and `[]`/`maybeGet` (camel,
+    derived).
+  - **Title-derived names** (#167): inline oneOf/anyOf variants
+    with a spec `title:` opt into a multi-tier preference list
+    `[<title-snake>, <parent>_one_of_<i>]`. When the title is
+    unique, the variant gets the descriptive name (file + class
+    paired). github example: `org-ruleset-conditions` variants
+    flip to `RepositoryNameAndRefName` etc.
+  - **Doubling fallback** (#165): when a wrapper's
+    `<parent><variantTag>` would double the parent prefix (because
+    the parser-synthesized inline variant name already starts with
+    the parent), the wrapper falls back to `<parent>Variant<i>`.
+
 - **`SpecResolver`** (in `render_tree.dart`) consults both pre-
   passes: `decideDispatch(source)` per oneOf, and a `names=` field
   populated from `assignNames(spec)` at the start of `toRenderSpec`.
@@ -90,117 +105,202 @@ Load → Parse → Resolve → Dispatch → Naming → Render
 **Strict-mode invariant** (#162): `RenderSchema.typeName` and
 `RenderOneOf.wrapperTypeName` throw `StateError` if the lookup is
 missing. Production crashes loudly if any render path forgets to
-populate names — no silent fallback. Tests that build schemas
-directly without going through `SpecResolver` must pass
-`assignedName: 'Foo'` explicitly.
+populate names. Tests that build schemas directly without going
+through `SpecResolver` must pass `assignedName: 'Foo'` explicitly.
 
 **Resolver stays Dart-blind.** It carries `snakeName` (parser-
 level) and resolves snake-name collisions with `_1` suffixes; it
-knows nothing about Dart class names. Naming sits between resolve
-and render so the resolver can be reused for any non-Dart consumer.
+knows nothing about Dart class names.
+
+### Smoosh (the structural matrix)
+
+For an inline `ResolvedObject` variant of a oneOf/anyOf, today's
+output is **smooshed** (#168, #169, #170): the variant data class
+itself extends the sealed parent, inlined in the parent's `.dart`
+file, with no separate wrapper subclass and no `value:` shim.
+
+Pattern matching destructures fields directly:
+
+```dart
+switch (req) {
+  case ProjectsCreateCardRequestOneOf0(:final note):  // direct
+    print(note);
+}
+```
+
+instead of unwrapping `value:`:
+
+```dart
+case ProjectsCreateCardRequestVariant0(value: final v):
+  print(v.note);  // pre-smoosh
+```
+
+Smoosh applies when:
+
+1. **Structural eligibility** (`_isStructurallySmooshable`): variant
+   is `ResolvedObject` AND its pointer is a child of the
+   collection's pointer (so it's inline-exclusive by construction).
+   `ResolvedAllOf` is excluded — it collapses to a synthesized
+   `RenderObject` at render but isn't a `ResolvedObject` upstream.
+2. **Render support** (`_dispatchEmitsSmooshed`): the parent
+   dispatch's render template emits the smooshed form. Today this
+   is exhaustive — every `DispatchDecision` kind capable of smoosh
+   does it (predicate-required, discriminator, shape, hybrid Map
+   sub-arms). Array-element predicate is excluded structurally
+   (variants are arrays, not objects); `NoDispatch` doesn't claim
+   wrappers at all.
+
+Sealed subclasses must live in the same library — Dart's `sealed`
+modifier restricts cross-library extension — so smooshed variants
+are emitted **inline in the parent's `.dart` file**, not their
+own. `RenderObject.parentSealedTypeName: String?` carries the
+parent's class name; `RenderSchema.isSmooshed` is the check used
+by the dispatch builders and `file_renderer`.
+
+### Render-side dispatch builders
+
+Each dispatch kind has a `_buildXMode(...)` helper on `RenderOneOf`
+that splits variants into `dispatch` (per-arm `caseExpression`s),
+`variants` (non-smooshed wrapper subclass declarations), and
+`smooshedVariants` (full `toTemplateContext`s rendered inline via
+the `schema_object` partial). The four builders follow the same
+shape:
+
+- `_buildDiscriminatorMode` — `switch (json[propertyName])`.
+- `_buildShapeMode` — `switch (json) { T v => ... }`.
+- `_buildHybridMode` — non-Map shape arms + Map sub-dispatch with
+  optional unguarded fallback.
+- `_buildPredicateMode` — if-chain (required-field or array-
+  element).
+
+Each `caseExpression` is the full Dart expression to `return` from
+its switch arm — pre-composed in render code so the template just
+splices it. Smooshed: `<Variant>.fromJson(<arg>)`. Non-smooshed:
+`<Wrapper>(<Variant>.fromJson(<arg>))`.
 
 ## Recent PRs
 
-The dispatch / naming arc since the older state:
-
 | PR | What |
 |---|---|
-| #154 | Required-field dispatch generalizes to property-presence on object oneOfs |
-| #155 | Parse object schemas with required-only oneOf/anyOf as plain objects |
-| #156 | Hybrid shape+required-field dispatch for mixed-shape oneOfs |
 | #157 | Lift dispatch-mode bools into a sealed `_DispatchMode` |
 | #158 | `_Predicate` IR for if-chain dispatch arms |
-| #159 | Array-element dispatch (`anyOf<array<X>, array<Y>>`) via consolidated `_PredicateDispatchMode` |
-| #160 | Lift dispatch picking into `decideDispatch` phase on the resolved tree |
+| #159 | Array-element dispatch via consolidated `_PredicateDispatchMode` |
+| #160 | Lift dispatch picking into `decideDispatch` phase |
 | #161 | Introduce naming pass and wire it through render |
 | #162 | Make `assignedName` strict — `typeName` throws if missed |
 | #163 | Bring oneOf wrapper subclass names under the naming pass |
+| #165 | Stop doubling the parent prefix in inline oneOf wrapper names |
+| #166 | Collision-aware naming via `NameAllocator` (multi-tier prefs + fixpoint) |
+| #167 | Title-derived names for inline oneOf/anyOf variants; allocator stores snake |
+| #168 | Smoosh inline-object variants under predicate dispatch (~13 sites) |
+| #169 | Smoosh under discriminator dispatch (platform; github uses top-level refs) |
+| #170 | Smoosh under shape + hybrid dispatch (~12 sites; structural matrix complete) |
 
-Stub count moved 9 → 7 along the way. The last four are pure
-architecture (no algorithm changes, byte-identical regen).
+Stub count remained at 7 throughout. Smoosh net: ~25 inline-object
+variants flipped from wrapper-subclass to direct sealed subclass
+in the github regen.
 
 ## Open gaps (pick from here)
 
-### Next: shortest-unique-with-fallback (the visible quality win)
+### Next: smoosh by exclusive-use (the big remaining lever)
 
-The naming pass owns every Dart class name. Today it computes
-`camelFromSnake(snakeName)` per entity — same as before. Swap to
-**shortest-unique-with-fallback**:
+Today's smoosh predicate is *structural* — variant is inline
+(pointer is `<parent>/oneOf/<i>`). That misses github's biggest
+wrapper-subclass families because they use **top-level `$ref`
+variants** referenced by exactly one parent:
 
-For each named entity, generate candidates in preference order:
-1. Property-derived bare name (for oneOf variants — pick a unique
-   required field; e.g., `Note` from `note`).
-2. Title-derived bare name (when the spec has a `title:`).
-3. Last-segment of synthesized snake (for `_one_of_<i>` cases —
-   `Variant0`).
-4. `camelFromSnake(snakeName)` — today's, as final fallback.
+- `RepositoryRule` family (~20 wrappers): `RepositoryRuleCreation`,
+  `RepositoryRuleDeletion`, etc. Each top-level schema is a
+  variant of `RepositoryRule` and (the more detailed)
+  `RepositoryRuleDetailed`. Likely also referenced from nowhere
+  else.
+- `/user` × 3 sites (`oneOf<private-user, public-user>`):
+  cross-cuts with the **structural-dedup** gap below — the three
+  endpoints generate three structurally-identical sealed classes.
+- `repos/get-content` 200 response (hybrid dispatch with
+  `ContentFile`/`ContentSymlink`/`ContentSubmodule`): top-level
+  refs.
 
-Greedy claim in stable order: top-level component schemas first
-(they already have good names from the spec), then inline schemas
-in pointer order, then wrappers. Numeric suffix only when truly
-collided after the candidate ladder.
+Extending smoosh-eligibility to "top-level schema referenced as a
+variant of exactly one parent, nowhere else" would catch all of
+these. The check is real reachability analysis on the resolved
+tree:
 
-**Expected regen diff:**
-- ~96 wrapper classes shed the double-prefix (e.g.
-  `ProjectsCreateCardRequestProjectsCreateCardRequestOneOf0` →
-  `ProjectsCreateCardRequestNote`).
-- ~8 schemas shed `_1` suffixes (e.g.
-  `RepositoryRulesetConditions1` → something cleaner).
+1. Walk the spec, count how many oneOf/anyOf collections include
+   each top-level schema as a variant.
+2. Walk again, count references *outside* of variant slots
+   (property types, parameter types, request/response bodies).
+3. A schema is exclusive-use iff it has exactly one variant
+   reference and zero other references.
 
-This is the PR that delivers user-visible quality. The strict-mode
-invariant from #162 + global naming view from #163 mean any
-algorithm bug shows up as a regen diff or crash — no silent
-regression.
+Implementation note: top-level `$ref`s resolve to the same
+`ResolvedSchema` instance (via the resolver's ref cache), so
+identity comparison works. Refs from one resolved schema to
+another are recorded; the count is a tree walk.
+
+The smoosh mechanism (RenderObject extends parent, inlined in
+parent's file, case arm calls Variant directly) is fully built —
+this PR is "widen the eligibility predicate + plumb the parent
+relationship through to top-level schemas." Probably bigger than
+one PR; could be:
+1. Reachability analysis + `_isStructurallySmooshable` extension.
+2. `parentSealedTypeName` plumbing for top-level smooshed schemas.
+3. Same-library inlining (top-level schemas would move *into* the
+   parent's file, eliminating their own files).
+
+Each step has a real github-regen impact.
 
 ### Long-tail stubs (lower leverage)
 
-7 stubs split into three groups (per regen on `origin/main`):
+7 stubs split into three groups:
 
-**Group A — validation-error twins** (2 sites:
-`orgs/update` 422, `projects/create-card` 422). `oneOf<validation-
-error, validation-error-simple>` — identical at top level
-(same required `[documentation_url, message]`, same props),
-distinguishable only by `errors[].type` (object vs string). Needs
-a new predicate kind that navigates into a property's array first-
-element type. Caveat: relies on server emitting `errors`.
+**Group A — validation-error twins** (2 sites: `orgs/update` 422,
+`projects/create-card` 422). `oneOf<validation-error, validation-
+error-simple>` — identical at top level, distinguishable only by
+`errors[].type` (object vs string). Needs a new predicate kind
+that navigates into a property's array first-element type.
 
 **Group B — labels requestBody mess** (2 sites: `issues/add-labels`,
 `issues/set-labels`). 5 variants: 2× literal-duplicate
 `{labels?}` object, `array<string>`, `array<object>`, `string`.
-Needs upstream structural dedup (the 2 identical objects are a
-spec-author bug) + hybrid composition extending to
+Needs upstream structural dedup + hybrid composition extending to
 "array-element sub-dispatch when the outer hybrid has multiple
-List variants." Two architectural changes.
+List variants."
 
 **Group C — big enumless anyOfs** (3 sites: `timeline-issue-events`
 22 variants, `issue-event-for-issue` 15, `repository-ruleset-
-conditions-1`). All variants share an `event: string` field but
-no `enum` to dispatch on. Probably right to skip — leave as stubs
-with a verbose warning. Inferring values from variant titles is
-fragile; try-each is order-dependent.
+conditions-1`). All variants share an `event: string` field but no
+`enum` to dispatch on. Probably right to skip — try-each is
+order-dependent.
 
-### Quality wins (lower priority once shortest-unique lands)
+### Quality wins (mid-priority)
 
-- **Structural dedup of identical oneOfs.** Three github `/user`
+- **Structural dedup of identical oneOfs**. Three github `/user`
   endpoints all return `oneOf: [private-user, public-user]` with
-  the same discriminator. Today they generate 3 structurally-equal
-  sealed classes (`UsersGetAuthenticated200Response`, etc.). Dedup
-  → one shared `User` type. Composes with shortest-unique once it
-  lands.
+  the same discriminator, generating 3 structurally-equal sealed
+  classes (`UsersGetAuthenticated200Response`, etc.). Dedup → one
+  shared `User` type. Composes with exclusive-use smoosh.
+
+- **Per-variant round-trip test coverage for smooshed variants.**
+  Smoosh removed 25 separate variant `.dart` files — and with them,
+  25 round-trip test files. The variant classes still exist
+  (inlined in parent), and their `fromJson`/`toJson` are unchanged,
+  but no test exercises them now. Could synthesize a per-variant
+  round-trip in the parent's test file.
 
 ### Tangentially related
 
 - **Synthesized typeName collisions.** `<op>_response` could
   collide with a schema named that way in the spec. The naming
-  pass enumerates both now (under different keys), so a future
-  collision-resolution pass over `AssignedNames` can detect and
-  resolve.
+  pass enumerates both now; multi-tier preferences + the allocator
+  would let the synthesized name fall back to `<op>_response_2`
+  on collision, but no caller currently passes that fallback list.
+  Tiny widening of the op-response claim list.
+
 - **Error-status response unions.** Multi-status dispatch only
   kicks in for 2xx variation. 4xx/5xx with structurally-different
-  bodies still falls back to untyped `ApiException<Object?>` when
-  the error schemas don't dedupe. Could extend `OperationReturn`
-  (or add a parallel `ErrorShape`) to dispatch on error status
-  too.
+  bodies still falls back to untyped `ApiException<Object?>`.
+
 - **Range-mixed multi-status fallback.** When 2XX range mixes with
   explicit 2xx codes, render synthesizes a `RenderOneOf` with
   `source: null` that always emits the legacy stub. Closing this
@@ -215,54 +315,69 @@ From the project's CLAUDE.md and saved memory:
 - **Validation target required**: pick the next PR by what real
   specs need. github is the primary punching bag.
 - **Don't add a new strategy when a new predicate / candidate /
-  knob will do.** The dispatch series taught this — see #156–#159
-  for the consolidation arc and #163 for naming. Adding a 6th
-  dispatch mode or a 5th `RenderOneOf` codepath is almost never
-  the right move; extend an existing structure with a new
-  variant.
+  knob will do.** The dispatch + naming + smoosh series taught
+  this. Adding a 6th dispatch mode or a 5th `RenderOneOf` codepath
+  is almost never the right move; extend an existing structure
+  with a new variant.
+- **Architectural changes ship as their own PRs first**, with
+  byte-identical regen, *before* the algorithm change that
+  motivated them. Pattern from the dispatch series (#158 → #159),
+  the naming series (#161 → #162 → #163 → #165 → #166), and the
+  smoosh series (the platform piece in each landed dispatch type
+  before the next). Introduce the abstraction without behavior
+  change, lock it in, then swap the algorithm in a focused diff.
+- **Snake-keyed allocator, camel derived.** A snake collision IS a
+  camel collision (and vice versa) — one allocator handles both.
+  No parallel allocator. File names and class names share storage.
+- **Sealed subclasses live in the same library** (Dart's `sealed`
+  modifier requires it). Smooshed variants are emitted inline in
+  the parent's `.dart` file, not their own file. The
+  `rendersToSeparateFile` predicate gates per-schema file emission;
+  smooshed `RenderObject`s return false.
 - **Byte-identical regen as verification gate.** When a refactor
-  claims no behavior change, prove it: regen `~/.../api.github.com.json`
-  before and after, normalize package names + strip the post-
-  format `// ignore_for_file: lines_longer_than_80_chars` lint
-  header (which is package-name-length sensitive), then `diff -r`.
-  Zero content diffs = clean lift.
+  claims no behavior change, prove it: regen
+  `~/.../api.github.com.json` before and after, normalize package
+  names + strip the post-format `// ignore_for_file:
+  lines_longer_than_80_chars` lint header (which is package-name-
+  length sensitive), then `diff -r`. Zero content diffs = clean
+  lift.
+- **Self-review before pushing**. Read the diff cold with two
+  questions: (1) is anything here doing nothing useful (dead gates,
+  speculative branches), (2) are there inline checks duplicated 3+
+  times that want a helper. Eric will ask if you don't.
 - **Unit tests over gen_tests**: each layer (parser, resolver,
-  dispatch, naming, render) has its own unit test file. Add
-  narrow unit tests on the layer changing; only add a `gen_tests/`
-  fixture for genuine end-to-end coverage (those run dart format
-  + dart fix on every CI).
+  dispatch, naming, render) has its own unit test file. Add narrow
+  unit tests on the layer changing; only add a `gen_tests/`
+  fixture for genuine end-to-end coverage.
 - **Don't use `!`**: bind nullable fields to a local, null-check
   the local. Same for tests — use `is` patterns or `if (x ==
   null) fail(...)` instead of postfix `!`.
 - **American English**. cspell catches British spellings — use the
   American form. For coined / informal words (`smooshing`,
-  `dispatchable`, `regen`, `unioned`), just add them to
-  `cspell.config.yaml`. Rephrase or rename for British spellings
-  and for abbreviations that aren't real words (rename the local
-  rather than dictionary-allowing the abbreviation).
+  `smooshable`, `smooshed`, `dispatchable`, `regen`, `unioned`,
+  `fixpoint`, `prefs`, `camelization`), just add them to
+  `cspell.config.yaml`. Rephrase or rename for British spellings.
 - **`required` on internal types**: every constructor parameter
   on `Schema*` / `Resolved*` / `Render*` classes is `required`,
-  including fields that default to null/[]. CLAUDE.md explains
-  why (silent drops in the pipeline).
+  including fields that default to null/[].
 - **Sealed types over nullable-pair encodings** when a field
   encodes "exactly one of N." Examples: `OperationReturn`,
-  `DispatchDecision`, `Predicate`.
+  `DispatchDecision`, `Predicate`, `_DispatchMode`.
+- **Exhaustive switches on sealed types**, not if-chains, when the
+  decision is mutually exclusive across known kinds. Adding a new
+  subtype becomes a compile-time prompt to decide. The
+  `_dispatchEmitsSmooshed` post-self-review change is the recent
+  example.
 - **80-col wrap** for code; loose for doc comments.
 - **Don't edit CHANGELOG.md** in regular PRs — the release skill
   generates it from PR bodies.
 - **Separate small PRs** ("one gap per PR") over bundled changes
   — keeps github regen diff crisp per PR.
 - **Every PR branches from `origin/main`.** Never stack a new gap
-  fix on top of an in-progress branch. If the worktree is sitting
-  on the previous PR's branch, start a fresh branch off
-  `origin/main` before touching code — even if that previous PR
-  hasn't merged yet.
-- **Architectural changes ship as their own PRs first**, with
-  byte-identical regen, *before* the algorithm change that
-  motivated them. Pattern from the dispatch series (#158 → #159)
-  and the naming series (#161 → #162 → #163 → next): introduce
-  the abstraction without behavior change, lock it in, then swap
-  the algorithm in a focused diff.
+  fix on top of an in-progress branch. If you accidentally stack
+  (forgot to branch fresh), the cleanest recovery is to combine
+  related work into one PR and update the title/description rather
+  than try to untangle the git history.
 
 ## Working rhythm
 
@@ -273,15 +388,15 @@ From the project's CLAUDE.md and saved memory:
    primary checkout owns `main`).
 2. Read the relevant layer (`lib/src/parse/`,
    `lib/src/resolver.dart`, `lib/src/dispatch.dart`,
-   `lib/src/naming.dart`, `lib/src/render/render_tree.dart`)
+   `lib/src/naming.dart`, `lib/src/render/render_tree.dart`,
+   `lib/src/render/file_renderer.dart`, `lib/templates/*.mustache`)
    for context.
 3. Add a unit test exercising the gap.
 4. Make the fix in the right layer.
-5. Render-layer unit tests in
-   `test/render/render_schema_test.dart` or
-   `test/render/render_operation_test.dart`. Don't snapshot full
-   template output — `contains()` checks read better and survive
-   whitespace tweaks.
+5. Render-layer unit tests in `test/render/render_schema_test.dart`,
+   `test/render/render_operation_test.dart`, or
+   `test/naming_test.dart`. Don't snapshot full template output —
+   `contains()` checks read better and survive whitespace tweaks.
 6. End-to-end smoke test (when warranted): write a small spec at
    `/tmp/<name>_repro/spec.json`, run `dart run space_gen -i ...
    -o ...`, verify generated code in a Dart test.
@@ -291,59 +406,34 @@ From the project's CLAUDE.md and saved memory:
      dart run space_gen -i ~/Documents/GitHub/personal/gen_tests/api.github.com.json -o /tmp/github_out && \
      (cd /tmp/github_out && dart analyze)
    ```
-   Should be `No issues found!`. If not, the new code is breaking
-   real specs — fix before pushing.
+   Should be `No issues found!`.
 
    **Add `-v` (`--verbose`) to surface detailed warnings** that
    the default run swallows — unsupported feature usage, name
    collisions resolved by renaming, schema-shape fallbacks, etc.
 
-8. **For "byte-identical" claims:** run the diff harness. Saves a
-   baseline regen on `origin/main`, regen with your branch,
-   normalize, strip the lint-header artifact, walk diffs:
-
-   ```sh
-   # baseline (on a clean tree of origin/main)
-   git stash && rm -rf /tmp/g_main && \
-     dart run space_gen -i ~/Documents/GitHub/personal/gen_tests/api.github.com.json -o /tmp/g_main && \
-     git stash pop
-
-   # your branch
-   rm -rf /tmp/g_branch && \
-     dart run space_gen -i ~/Documents/GitHub/personal/gen_tests/api.github.com.json -o /tmp/g_branch
-
-   # diff with normalization
-   mkdir -p /tmp/db /tmp/da
-   cp -r /tmp/g_main/. /tmp/db/
-   cp -r /tmp/g_branch/. /tmp/da/
-   find /tmp/db -type f \( -name '*.dart' -o -name '*.yaml' -o -name '*.json' \) -exec sed -i '' 's|g_main|GG|g' {} +
-   find /tmp/da -type f \( -name '*.dart' -o -name '*.yaml' -o -name '*.json' \) -exec sed -i '' 's|g_branch|GG|g' {} +
-   strip_header() { awk 'NR==1 && /^\/\/ Some OpenAPI specs flatten inline schemas/ { skip=4 } skip>0 { skip--; next } { print }' "$1"; }
-   real=0
-   for f in $(diff -rq /tmp/db /tmp/da 2>&1 | grep '^Files' | awk '{print $2}'); do
-     rel=${f#/tmp/db}
-     if ! diff <(strip_header /tmp/db$rel) <(strip_header /tmp/da$rel) > /dev/null 2>&1; then
-       echo "REAL: $rel"; real=$((real+1))
-     fi
-   done
-   echo "---real: $real---"
-   ```
-
-   The lint-header artifact is package-name-length sensitive; strip
-   it or normalize the package-name lengths to match.
+8. **For "byte-identical" claims:** baseline with `git stash`,
+   regen, restore, regen again, diff. The package-name-in-paths
+   problem only shows up if the two output dirs have different
+   names — keep the path identical (e.g. always `/tmp/github_out`)
+   to avoid that source of noise.
 
 9. Count newly-fixed sites if the PR closes a stub-emitting gap:
    ```sh
    grep -l "throw UnimplementedError" /tmp/github_out/lib -r | wc -l
    ```
 
-10. Push, open PR. CI will:
+10. **Self-review before pushing.** Read your diff cold. If
+    something is doing nothing (dead gate, speculative branch),
+    delete it. If a check is duplicated across 3+ files, extract
+    a helper. If a comment claims something that's no longer true
+    (`"this is a partial-rollout switch"`), update it. Eric will
+    ask "self-review please" and you should already have done it.
+
+11. Push, open PR. CI will:
     - cspell trips on coined words — add them to
       `cspell.config.yaml`. Rephrase only for British spellings.
-    - codecov/patch checks new-line coverage. New files often need
-      a few targeted unit tests — naming.dart was at ~88% before
-      adding 5 more tests to hit the throw / `entries` / map /
-      anyOf-allOf paths.
+    - codecov/patch checks new-line coverage.
     - codecov/project may fail with no-drop default — mostly an
       accounting artifact when adding lines that shift uncovered
       code's denominator. Address only if patch coverage is
@@ -357,19 +447,29 @@ From the project's CLAUDE.md and saved memory:
 - Don't use postfix `!` to silence Dart's flow analysis.
 - Don't bundle multiple gap fixes in one PR — separate PRs.
 - Don't merge without `dart analyze` clean on the github regen.
-- Don't touch the merge-conflict-prone CHANGELOG.md in feature
-  PRs.
-- Don't conflate operation-level constructs with schema-level
-  ones. (#148 made this lesson explicit: multi-status responses
-  look like a oneOf but aren't.)
+- Don't touch the merge-conflict-prone CHANGELOG.md in feature PRs.
+- Don't conflate operation-level constructs with schema-level ones.
+  (#148 made this lesson explicit: multi-status responses look
+  like a oneOf but aren't.)
 - Don't add a new dispatch mode / template branch / `_DispatchMode`
   subtype when a new predicate kind or new picker that builds the
-  existing mode will do. Strategy proliferation is the
-  anti-pattern.
+  existing mode will do.
 - Don't compute names in render. Naming is the source of truth;
   render reads. If a code path needs a name, it goes through
   `AssignedNames` (or a strict-mode `_requireAssignedName()`
   throws telling you why).
+- Don't ship infrastructure with no production user. The
+  NameAllocator multi-tier path was almost shipped untested in
+  production — the mistake (a multi-tier list that was *worse*
+  than single-tier in conflict) was caught in self-review. Today
+  every dispatch builder is the production user of `isSmooshed`;
+  multi-tier is the production user via title-based renaming. Hold
+  the line.
+- Don't add a smooshed-variant inline emission case for "future-
+  proofing" without a concrete trigger. Removed one such
+  speculative branch in #170 self-review — it would silently mis-
+  render if ever reached. Better to crash on missing-case than
+  silently produce wrong output.
 
 ## Helpful one-shots
 
@@ -384,11 +484,16 @@ grep -l "^sealed class " /tmp/github_out/lib/models/ -r | wc -l
 grep -c "switch (response.statusCode)" /tmp/github_out/lib/api/*.dart 2>/dev/null \
   | awk -F: '{ sum +=  } END { print sum }'
 
-# Double-prefix wrapper sites (the 96-class smoosh target)
-grep -rE "class [A-Z][a-zA-Z]+OneOf[0-9]" /tmp/github_out/lib | wc -l
+# Smoosh sites — variants that extend a sealed parent directly
+grep -E "^final class \w+ extends \w+" /tmp/github_out/lib/messages/*.dart | wc -l
 
-# Schemas with `_1` collision suffixes
-grep -rl "class [A-Z][a-zA-Z]*1 " /tmp/github_out/lib/models/ | wc -l
+# Wrappers still using the post-#165 `Variant<i>` doubling fallback
+grep -rE "class \w+Variant[0-9]+ extends \w+" /tmp/github_out/lib | wc -l
+
+# Top-level `$ref` variant wrappers (the next-PR target — these are
+# what exclusive-by-use smoosh would catch)
+grep -rE "^final class \w+(Creation|Deletion|Update|...) extends Repository" \
+  /tmp/github_out/lib/models/ | wc -l
 ```
 
 ```sh
@@ -409,24 +514,31 @@ walk(spec, '')
 
 ## Where to look
 
-- `lib/src/parser.dart`, `lib/src/parse/` — spec → Spec parse
-  tree.
+- `lib/src/parser.dart`, `lib/src/parse/` — spec → Spec parse tree.
 - `lib/src/resolver.dart` — Spec → ResolvedSpec, $ref + snake-name
   collision resolution. Stays Dart-blind.
 - `lib/src/dispatch.dart` — `decideDispatch(ResolvedSchemaCollection)`
   per oneOf/anyOf, sealed `DispatchDecision` family + `Predicate`
   IR.
 - `lib/src/naming.dart` — `assignNames(ResolvedSpec)` walks the
-  resolved tree (and dispatch decisions) to assign every Dart
-  class name. `assignNamesForSchema` / `assignNamesForOperation`
-  for partial trees. `AssignedNames.wrapperPointer(parent, i)`
-  for wrapper subclass keys.
+  resolved tree and dispatch decisions to assign every Dart class
+  name. `NameAllocator` is the multi-tier preference allocator.
+  `AssignedNames` exposes both `snakeFor(pointer)` and `[]`/
+  `maybeGet` (camel, derived). Smoosh metadata in
+  `smooshedParentSnakeByPointer` / `parentSealedTypeFor`.
 - `lib/src/render/render_tree.dart` — ResolvedSpec → RenderSpec.
-  `RenderOneOf` reads `decideDispatch(source)` and `wrapperNames`
-  (looked up from naming via `_wrapperNamesFor`). `typeName` /
-  `wrapperTypeName` are strict lookups, not computations.
-- `lib/templates/` — Mustache templates. Schema templates,
-  api.mustache, partials.
+  `RenderOneOf._buildXMode` per dispatch kind. `RenderObject.
+  parentSealedTypeName` carries the smoosh marker;
+  `RenderSchema.isSmooshed` is the predicate used by builders +
+  `file_renderer`.
+- `lib/src/render/file_renderer.dart` — `rendersToSeparateFile`
+  gates per-schema file emission (smooshed variants return false).
+  Per-schema and per-API import collection.
+- `lib/templates/` — Mustache templates. `schema_object.mustache`
+  emits `final class X extends Y` when `parentSealedTypeName` is
+  set. `schema_one_of.mustache` has four dispatch sections; each
+  reads `caseExpression` per arm and includes the `schema_object`
+  partial for `smooshedVariants`.
 - `test/render/render_schema_test.dart`,
   `test/render/render_operation_test.dart`,
   `test/naming_test.dart` — unit tests per layer.

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -34,6 +34,7 @@ words:
   - smooshed
   - smooshes
   - smooshing
+  - destructures
   - isinstance
   - elif
   - fixpoint


### PR DESCRIPTION
## Summary

The previous skill snapshot pointed at *shortest-unique-with-fallback* as the next move and described 96 double-prefix wrappers + 8 `_1` suffixes as the visible quality wins. All of that has shipped — the snapshot needs to catch up so a fresh-context iteration of the skill picks the right next move.

What landed since the prior snapshot:

- #165: stop the wrapper double-prefix.
- #166: `NameAllocator` with multi-tier preferences + fixpoint resolution; collision-aware naming as a platform.
- #167: title-derived names for inline oneOf/anyOf variants; `AssignedNames` switches to snake-keyed storage with camel derived (file + class names share one source of truth, no parallel allocator).
- #168 / #169 / #170: smoosh series — inline-object variants of a sealed parent become direct `final class X extends Y` subclasses inlined in the parent's file, eliminating the wrapper subclass + `value:` indirection. Structural matrix complete: predicate-required, discriminator, shape, hybrid Map sub-arms. ~25 sites flipped in the github regen.

What this PR rewrites in the skill:

- **Architecture** section adds `NameAllocator`, snake-keyed storage, two-phase resolution, the smoosh structural matrix (`_isStructurallySmooshable` + `_dispatchEmitsSmooshed`), and the shared shape of the four `_buildXMode` builders.
- **Recent PRs** table extends through #170.
- **Open gaps** reframed: the next big lever is *smoosh-by-exclusive-use* — extending eligibility from "structurally inline" to "top-level schema referenced as a variant of exactly one parent, nowhere else." Would unlock the `RepositoryRule` family (~20 wrappers), `/user` × 3, and `repos/get-content` hybrid sub-arms — sites today's structural predicate misses.
- New gap notes: per-variant round-trip test coverage loss for smooshed variants, structural dedup of identical oneOfs (composes with exclusive-use smoosh).
- **Conventions** add: snake-keyed allocator pairing collisions, sealed-subclass same-library rule, exhaustive switches over sealed `DispatchDecision` types, self-review-before-pushing.
- **Don'ts** add: no infrastructure without a production user (the `Response2/3/4` multi-tier near-miss caught in #166 self-review is the cautionary tale), no speculative future-proof branches without a concrete trigger (the shape-arm smoosh dead branch removed in #170 self-review).

## Test plan

- [x] No code changes.
- [x] Self-review pass: confirmed every "next" claim points at something not yet shipped (exclusive-use smoosh, dedup, round-trip-test recovery), every architecture claim matches a shipped PR.