### PR TITLE
feat: recognize int32/int64/float/double as known formats (drop spurious warning)

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -41,3 +41,4 @@ words:
   - prefs
   - camelization
   - basenames
+  - dart2js

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -611,6 +611,19 @@ TypeAndFormat parseTypeAndFormat(MapContext json) {
     if (format == null) {
       return null;
     }
+    // Formats we recognize as valid for a given base type. Some map to a
+    // richer `PodType` below (`date-time` → `DateTime`); the numeric
+    // formats (`int32`, `int64`, `float`, `double`) don't, because
+    // Dart's native `int` is 64-bit on the VM and `double` is IEEE 754
+    // double-precision — the same widths as the OpenAPI formats. There
+    // is no win to a `PodType.int64` that just maps back to `int`.
+    //
+    // Web/dart2js caveat: `int` becomes a JS Number above 2^53. JSON
+    // parsers on the web have the same limit before our types matter,
+    // so the type choice doesn't fix it. Real-world int64 IDs (github
+    // user/repo IDs, etc.) sit ~6 orders of magnitude below 2^53; if a
+    // user ever needs true 64-bit precision on the web, that's an opt-
+    // in `BigInt` flag, not a today-default.
     final expectedFormats = {
       'string': {
         'binary',
@@ -622,29 +635,21 @@ TypeAndFormat parseTypeAndFormat(MapContext json) {
         'date',
         'time',
       },
+      'integer': {'int32', 'int64'},
+      'number': {'float', 'double'},
     };
     final expected = expectedFormats[type];
     if (expected == null || !expected.contains(format)) {
-      final ignoredFormats = {
-        // We don't explicitly support any number formats yet.
-        'number': {'float', 'double'},
-        'integer': {'int32', 'int64'},
-      };
-      final ignored = ignoredFormats[type];
-      if (ignored != null && ignored.contains(format)) {
-        _ignored<String>(json, 'format');
-      } else {
-        // Unknown format on a recognized base type — generated code
-        // falls back to the plain Dart type (`int`/`String`/...) which
-        // is correct for almost every real-world non-standard format
-        // (`timestamp`, `repo.nwo`, ...). Log as detail rather than
-        // warn: there's nothing the user can act on, and surfacing
-        // every spec-author idiosyncrasy at WARN level buries the
-        // diagnostics that actually matter.
-        logger.detail(
-          'Ignoring unknown $type format: $format in ${json.pointer}',
-        );
-      }
+      // Unknown format on a recognized base type — generated code
+      // falls back to the plain Dart type (`int`/`String`/...) which
+      // is correct for almost every real-world non-standard format
+      // (`timestamp`, `repo.nwo`, ...). Log as detail rather than
+      // warn: there's nothing the user can act on, and surfacing
+      // every spec-author idiosyncrasy at WARN level buries the
+      // diagnostics that actually matter.
+      logger.detail(
+        'Ignoring unknown $type format: $format in ${json.pointer}',
+      );
     }
     return format;
   }

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -46,7 +46,19 @@ void main() {
         () => logger.detail('Ignoring unknown string format: foo in #/'),
       ).called(1);
       expect(parse('number'), isNull);
+      // Numeric formats are recognized as valid (no warn-log) but don't
+      // map to a richer PodType — Dart's `int` is 64-bit on the VM and
+      // `double` is IEEE 754, the same widths as the OpenAPI formats.
+      expect(parse('number', format: 'float'), isNull);
+      expect(parse('number', format: 'double'), isNull);
       expect(parse('integer'), isNull);
+      expect(parse('integer', format: 'int32'), isNull);
+      expect(parse('integer', format: 'int64'), isNull);
+      // Unknown integer/number formats still log at detail level.
+      expect(parse('integer', format: 'bogus', expectLogs: true), isNull);
+      verify(
+        () => logger.detail('Ignoring unknown integer format: bogus in #/'),
+      ).called(1);
       expect(parse('boolean'), PodType.boolean);
       expect(parse('array'), isNull);
       expect(parse('object'), isNull);

--- a/test/render/render_operation_test.dart
+++ b/test/render/render_operation_test.dart
@@ -44,11 +44,12 @@ void main() {
           serverUrl: Uri.parse('https://example.com'),
         ),
       );
-      verify(
-        () => logger.detail(
-          'Ignoring: format=int64 (String) in #/parameters/0/schema',
-        ),
-      ).called(1);
+      // `format: int64` on `type: integer` is recognized — Dart's `int`
+      // is 64-bit on the VM and is the correct base type, so we don't
+      // warn or detail-log it (used to log "Ignoring: format=int64").
+      verifyNever(
+        () => logger.detail(any(that: contains('format=int64'))),
+      );
       expect(
         result,
         '/// Test API\n'


### PR DESCRIPTION
## Summary

- Move `int32`, `int64`, `float`, `double` into the recognized-formats map alongside `date-time`/`uuid`/etc. They were previously detail-logged as `Ignoring: format=int64 (String)` even though `int` is already the correct Dart base type for them.
- 246 sites in the github spec regen go from "Ignoring: format=int64" detail-log noise to silent (the warning was the misleading thing — we weren't actually ignoring the format, just the format string itself, since Dart's native types already honor the widths).
- Output is byte-identical; `dart analyze` clean; full test suite passes.

## Design

The original gap framing was that `format: int64` on `type: string` is the JSON-precision dodge (large IDs sent as strings to dodge JSON's 2^53 limit). After investigating, **all 246 sites in github are `type: integer, format: int64`** — none on `type: string`. The `(String)` in the warning was the format-value's own Dart type, not the schema's wire type.

Given that, the question is: what should we do with `format: int64` on `type: integer`?

- **Dart VM**: `int` is 64-bit native. `format: int64` is fully precise. We were already correct.
- **dart2js / web**: `int` becomes a JS Number, which loses precision above 2^53. But the JSON parser on the web ALSO caps at 2^53 before our type choice matters — switching to `BigInt` doesn't help unless we also change deserialization to read JSON-as-text and parse manually (a much bigger change). And github IDs are ~2e8 today, ~6 orders of magnitude below 2^53.
- **`BigInt` everywhere**: would propagate `BigInt` math through every consumer — large API ripple for zero practical gain on the github spec.
- **`String` typedef / wrapper**: would force users to parse — net negative ergonomics for a problem they don't have.

So the right call today is: stop pretending we're ignoring the format. We're honoring it correctly with `int`. If a real user ever needs true 64-bit precision on the web, that's an opt-in `--big-int` flag in a future PR — backed by a concrete failing case, not speculation.

The same logic applies to `int32`, `float`, and `double`. The `Ignoring: format=` log was misleading on all four.

## Breaking change?

No. The generated Dart is byte-identical. Only the verbose-log output changed (246 detail-log lines disappear).

## Test plan

- [x] `dart analyze` clean on github regen
- [x] github regen byte-identical (only package-name path noise per the skill)
- [x] `Ignoring: format=int64` warning count: 246 → 0
- [x] new parser-layer unit assertions for `int32`/`int64`/`float`/`double` (recognized, no log) and an unknown integer format (still detail-logged)
- [x] stale `verify(... format=int64 ...)` in `render_operation_test.dart` flipped to `verifyNever`
- [x] full `dart test` passes