### PR TITLE
feat: handle inline oneOf/anyOf at property schema slots

### DIFF
--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -757,6 +757,27 @@ Schema _createCorrectSchemaSubtype(MapContext json) {
     examples: _optional<List<dynamic>>(json, 'examples'),
   );
 
+  // An explicit oneOf/anyOf wins over the multi-type type-array
+  // expansion below. Real specs (notably github) write *both* on the
+  // same property — `type: [null, string, integer]` alongside an
+  // `oneOf: [{type:string}, {type:integer, description:...}]` — and
+  // the explicit union carries strictly more semantic info (per-
+  // variant `format`, `description`, `items`, `enum`, ...). If the
+  // type-array expansion wins, the explicit union is dropped as
+  // `Unused: oneOf` and details like `format: date-time` on a
+  // `pushed_at` variant get flattened to plain `String`.
+  //
+  // allOf is intentionally not short-circuited here. It's AND, not
+  // OR, so it doesn't compose with the multi-type union the same
+  // way; the existing fallback below still routes it through
+  // `_handleCollectionTypes`.
+  if (json.containsKey('oneOf') || json.containsKey('anyOf')) {
+    final union = _handleCollectionTypes(json, common: common);
+    if (union != null) {
+      return union;
+    }
+  }
+
   if (typeAndFormat.types != null) {
     // Multiple types are treated as a oneOf schema, just parsing the same
     // root scheme object multiple times.
@@ -781,6 +802,12 @@ Schema _createCorrectSchemaSubtype(MapContext json) {
     );
   }
 
+  // Fallback handling for the rare allOf-only / oneOf-with-no-result
+  // shapes that didn't take the early branch above. The early gate
+  // covers the common case (oneOf/anyOf at any slot, with or without
+  // a parallel `type:` array); this catches allOf, plus the
+  // constraint-only oneOf/anyOf shapes that return null and fall
+  // through to plain object parsing.
   final collectionType = _handleCollectionTypes(json, common: common);
   if (collectionType != null) {
     return collectionType;

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -757,19 +757,18 @@ Schema _createCorrectSchemaSubtype(MapContext json) {
     examples: _optional<List<dynamic>>(json, 'examples'),
   );
 
-  // An explicit oneOf/anyOf wins over the multi-type type-array
-  // expansion below. Real specs (notably github) write *both* on the
-  // same property — `type: [null, string, integer]` alongside an
-  // `oneOf: [{type:string}, {type:integer, description:...}]` — and
-  // the explicit union carries strictly more semantic info (per-
-  // variant `format`, `description`, `items`, `enum`, ...). If the
-  // type-array expansion wins, the explicit union is dropped as
-  // `Unused: oneOf` and details like `format: date-time` on a
-  // `pushed_at` variant get flattened to plain `String`.
+  // An explicit `oneOf`/`anyOf` wins over the multi-type type-array
+  // expansion below. When a schema declares both — `type: [a, b]`
+  // alongside an `oneOf: [...]` — the explicit union is strictly
+  // more specific: it can carry per-variant `format`, `description`,
+  // `items`, `enum`, etc., and OpenAPI semantics treat the type-array
+  // as shorthand for a structurally-equivalent union. If the type-
+  // array path wins, the explicit union is silently dropped along
+  // with all its per-variant detail.
   //
-  // allOf is intentionally not short-circuited here. It's AND, not
-  // OR, so it doesn't compose with the multi-type union the same
-  // way; the existing fallback below still routes it through
+  // `allOf` is intentionally not short-circuited here: it's AND, not
+  // OR, so it doesn't substitute for a multi-type union the way
+  // `oneOf`/`anyOf` do. The fallback below still routes it through
   // `_handleCollectionTypes`.
   if (json.containsKey('oneOf') || json.containsKey('anyOf')) {
     final union = _handleCollectionTypes(json, common: common);

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -1749,6 +1749,114 @@ void main() {
         expect(oneOf.schemas[1].object, isA<SchemaNumber>());
         expect(oneOf.common.nullable, isTrue);
       });
+
+      test('explicit oneOf wins over multi-type', () {
+        // Github writes both `type: [null, string, integer]` AND
+        // `oneOf: [{string}, {integer with description}]` on the
+        // same property. The explicit `oneOf` carries strictly more
+        // info (the integer variant's description, formats, items)
+        // and should win — otherwise it gets logged as `Unused:
+        // oneOf` and dropped on the floor.
+        final json = {
+          'type': ['null', 'string', 'integer'],
+          'oneOf': [
+            {'type': 'string'},
+            {'type': 'integer', 'description': 'milestone number'},
+          ],
+        };
+        final schema = parseTestSchema(json);
+        if (schema is! SchemaOneOf) {
+          fail('Expected SchemaOneOf, got ${schema.runtimeType}');
+        }
+        expect(schema.schemas.length, 2);
+        expect(schema.schemas[0].object, isA<SchemaString>());
+        final intVariant = schema.schemas[1].object;
+        if (intVariant is! SchemaInteger) {
+          fail('Expected SchemaInteger, got ${intVariant.runtimeType}');
+        }
+        // Description from the explicit oneOf variant survives.
+        expect(intVariant.common.description, 'milestone number');
+        // The parent's `type: [null, ...]` still propagates the
+        // nullable bit through `common`.
+        expect(schema.common.nullable, isTrue);
+      });
+
+      test('explicit anyOf wins over multi-type', () {
+        // Same gap as oneOf above; github uses `anyOf` in a few
+        // property slots too (e.g. `metadata.additionalProperties`
+        // in webhooks).
+        final json = {
+          'type': ['null', 'string', 'integer'],
+          'anyOf': [
+            {'type': 'string', 'format': 'date-time'},
+            {'type': 'integer'},
+          ],
+        };
+        final schema = parseTestSchema(json);
+        if (schema is! SchemaAnyOf) {
+          fail('Expected SchemaAnyOf, got ${schema.runtimeType}');
+        }
+        expect(schema.schemas.length, 2);
+        // The string variant carries `format: date-time` from the
+        // explicit anyOf, which the type-array expansion would drop.
+        final strVariant = schema.schemas[0].object;
+        if (strVariant is! SchemaPod) {
+          fail('Expected SchemaPod, got ${strVariant.runtimeType}');
+        }
+        expect(strVariant.type, PodType.dateTime);
+        expect(schema.common.nullable, isTrue);
+      });
+
+      test('property-slot oneOf without parallel type also parses', () {
+        // The slot-coverage check: schemas with only `oneOf` (no
+        // `type:` array sibling) keep working as before — this case
+        // already worked, we just want a regression guard.
+        final json = {
+          'type': 'object',
+          'properties': {
+            'value': {
+              'oneOf': [
+                {'type': 'string'},
+                {'type': 'integer'},
+              ],
+            },
+          },
+        };
+        final schema = parseTestSchema(json);
+        if (schema is! SchemaObject) {
+          fail('Expected SchemaObject, got ${schema.runtimeType}');
+        }
+        expect(schema.properties['value']?.object, isA<SchemaOneOf>());
+      });
+
+      test('property-slot oneOf with parallel type', () {
+        // End-to-end shape mirroring github's `issues.post.milestone`
+        // — oneOf at a property slot with the redundant multi-type
+        // sibling. The property's schema is parsed as an explicit
+        // oneOf, not a type-array-derived synthetic one.
+        final json = {
+          'type': 'object',
+          'properties': {
+            'milestone': {
+              'type': ['null', 'string', 'integer'],
+              'oneOf': [
+                {'type': 'string'},
+                {'type': 'integer'},
+              ],
+            },
+          },
+        };
+        final schema = parseTestSchema(json);
+        if (schema is! SchemaObject) {
+          fail('Expected SchemaObject, got ${schema.runtimeType}');
+        }
+        final milestone = schema.properties['milestone']?.object;
+        if (milestone is! SchemaOneOf) {
+          fail('Expected SchemaOneOf, got ${milestone.runtimeType}');
+        }
+        expect(milestone.schemas.length, 2);
+        expect(milestone.common.nullable, isTrue);
+      });
     });
 
     group('security requirements', () {


### PR DESCRIPTION
## Summary

- Real specs (notably github) write both `type: [null, string, integer]` AND `oneOf: [{type:string}, {type:integer, description:...}]` on the same property. Today the multi-type-array expansion takes first dibs and the explicit `oneOf` is dropped as `Unused: oneOf` (~72 sites in github), losing per-variant detail like `format: date-time`, `items`, `description`.
- Short-circuit `_handleCollectionTypes` ahead of the multi-type expansion when the schema declares an explicit `oneOf` or `anyOf` at any slot. allOf is intentionally left to the existing fallback — it's AND, not OR, and shouldn't override the type-array union.
- Net github regen impact: `Unused: oneOf` 72 -> 0, `Unused: anyOf` 1 -> 0. Three property models (`custom_property_*_default_value`, `custom_property_value_value`) flip from `List<dynamic>` to `List<String>` because the explicit oneOf carries the array variant's `items: {type: string}`.

## Test plan

- [x] dart analyze clean on github regen (`No issues found!`)
- [x] `Unused: oneOf in .../properties/...` warning count: 72 -> 0
- [x] `Unused: anyOf` warning count: 1 -> 0
- [x] new parser unit tests cover (a) explicit oneOf wins over multi-type, (b) explicit anyOf wins (preserves `format: date-time` on string variant), (c) property-slot oneOf without parallel `type:` still parses (regression guard), (d) end-to-end milestone-shape regression test
- [x] `dart test` — all 423 tests pass