### PR TITLE
feat: surface readOnly=true as a doc-comment marker

### DIFF
--- a/lib/src/parse/spec.dart
+++ b/lib/src/parse/spec.dart
@@ -389,6 +389,7 @@ class SchemaObject extends SchemaObjectBase {
     required super.common,
     required this.properties,
     required this.requiredProperties,
+    required this.readOnlyProperties,
     required this.additionalProperties,
     required this.defaultValue,
   }) {
@@ -407,6 +408,14 @@ class SchemaObject extends SchemaObjectBase {
   /// The required properties of this schema.
   final List<String> requiredProperties;
 
+  /// Properties marked `readOnly: true` in the spec — server-set
+  /// fields that are returned in responses but not accepted in
+  /// requests. Today we surface these as a doc-comment marker on the
+  /// field so spec authors / consumers can see the signal; we do not
+  /// (yet) split request/response classes or omit the field from the
+  /// constructor.
+  final Set<String> readOnlyProperties;
+
   /// The additional properties of this schema.
   /// Used for specifying T for Map\<String, T\>.
   final SchemaRef? additionalProperties;
@@ -419,6 +428,7 @@ class SchemaObject extends SchemaObjectBase {
     super.props,
     properties,
     requiredProperties,
+    readOnlyProperties,
     additionalProperties,
     defaultValue,
   ];

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -875,11 +875,22 @@ Schema _createCorrectSchemaSubtype(MapContext json) {
   }
 
   final properties = <String, SchemaRef>{};
+  final readOnlyProperties = <String>{};
   for (final name in propertiesJson.json.keys) {
     final snakeName = snakeFromCamel(name);
     final childContext = propertiesJson
         .childAsMap(name)
         .addSnakeName(snakeName);
+    // Per OpenAPI 3.x, `readOnly: true` on a property means the field
+    // is server-set: present in responses, omitted from requests.
+    // Capture it from the property's json (this also marks the key
+    // used so it doesn't surface as `Unused: readOnly=true`). Only
+    // honored at a property slot — `readOnly` at a schema root falls
+    // through to the existing `_ignored` call below.
+    final isReadOnly = _optional<bool>(childContext, 'readOnly') ?? false;
+    if (isReadOnly) {
+      readOnlyProperties.add(name);
+    }
     properties[name] = parseSchemaOrRef(childContext);
   }
 
@@ -896,6 +907,7 @@ Schema _createCorrectSchemaSubtype(MapContext json) {
     common: common,
     properties: properties,
     requiredProperties: requiredProperties.cast<String>(),
+    readOnlyProperties: readOnlyProperties,
     additionalProperties: additionalPropertiesSchema,
     defaultValue: defaultValue,
   );

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -176,6 +176,7 @@ String? createDocComment({
   required CommonProperties common,
   int indent = 0,
   String? templateName,
+  bool readOnly = false,
 }) {
   final title = common.title;
   final body = common.description;
@@ -188,8 +189,16 @@ String? createDocComment({
     examples: examples,
     indent: indent,
     templateName: templateName,
+    readOnly: readOnly,
   );
 }
+
+/// Marker line appended to a property's doc comment when the spec
+/// marked it `readOnly: true`. Constructor / request-vs-response
+/// separation is a separate design call; today we only surface the
+/// signal so consumers can see it in the IDE.
+@visibleForTesting
+const readOnlyDocLine = 'Read-only: server-assigned.';
 
 String? createDocCommentFromParts({
   String? title,
@@ -198,8 +207,13 @@ String? createDocCommentFromParts({
   List<dynamic>? examples,
   int indent = 0,
   String? templateName,
+  bool readOnly = false,
 }) {
-  if (title == null && body == null && example == null && examples == null) {
+  if (title == null &&
+      body == null &&
+      example == null &&
+      examples == null &&
+      !readOnly) {
     return null;
   }
   String quoteIfNeeded(dynamic value) {
@@ -212,6 +226,8 @@ String? createDocCommentFromParts({
   final indentStr = ' ' * indent;
   final hasTemplateContent = title != null || body != null;
   final wrapWithTemplate = templateName != null && hasTemplateContent;
+  final hasPriorContent =
+      title != null || body != null || example != null || examples != null;
   final lines = <String>[
     if (wrapWithTemplate) '$indentStr/// {@template $templateName}',
     if (title != null) ...wrapDocComment(title, indent: indent),
@@ -223,6 +239,12 @@ String? createDocCommentFromParts({
       ...examples.expand(
         (e) => wrapDocComment('example: `${quoteIfNeeded(e)}`', indent: indent),
       ),
+    if (readOnly) ...[
+      // Blank dartdoc line acts as a paragraph break in dartdoc when
+      // there's prior prose; when standalone, just emit the marker.
+      if (hasPriorContent) '$indentStr///',
+      ...wrapDocComment(readOnlyDocLine, indent: indent),
+    ],
   ];
   if (lines.isEmpty) {
     return null;
@@ -392,6 +414,7 @@ class SpecResolver {
           ),
           additionalProperties: maybeRenderSchema(schema.additionalProperties),
           requiredProperties: schema.requiredProperties,
+          readOnlyProperties: schema.readOnlyProperties,
           parentSealedTypeName: _names.parentSealedTypeFor(schema.pointer),
           assignedName: _nameFor(schema.pointer),
           assignedSnakeName: _snakeFor(schema.pointer),
@@ -519,17 +542,20 @@ class SpecResolver {
         // dispatch detection (allOf-shaped variants).
         final properties = <String, RenderSchema>{};
         final requiredProperties = <String>{};
+        final readOnlyProperties = <String>{};
         for (final schema in schema.schemas) {
           final renderSchema = toRenderSchema(schema);
           if (renderSchema is RenderObject) {
             properties.addAll(renderSchema.properties);
             requiredProperties.addAll(renderSchema.requiredProperties);
+            readOnlyProperties.addAll(renderSchema.readOnlyProperties);
           }
         }
         return RenderObject(
           common: schema.common,
           properties: properties,
           requiredProperties: requiredProperties.toList(),
+          readOnlyProperties: readOnlyProperties,
           assignedName: _nameFor(schema.pointer),
           assignedSnakeName: _snakeFor(schema.pointer),
         );
@@ -2978,6 +3004,7 @@ class RenderObject extends RenderNewType {
     required this.properties,
     this.additionalProperties,
     this.requiredProperties = const [],
+    this.readOnlyProperties = const {},
     this.parentSealedTypeName,
     super.assignedName,
     super.assignedSnakeName,
@@ -2991,6 +3018,12 @@ class RenderObject extends RenderNewType {
 
   /// The required properties of the resolved schema.
   final List<String> requiredProperties;
+
+  /// Names of properties marked `readOnly: true` in the spec —
+  /// server-set fields. Used to surface a doc-comment marker on the
+  /// property field. Matches the `readOnlyProperties` carried by the
+  /// upstream parse and resolve types.
+  final Set<String> readOnlyProperties;
 
   /// Camel-case Dart class name of the sealed parent this object
   /// should extend, or null when the object stands alone. Set by the
@@ -3021,6 +3054,7 @@ class RenderObject extends RenderNewType {
     properties,
     additionalProperties,
     requiredProperties,
+    readOnlyProperties,
   ];
 
   @override
@@ -3159,6 +3193,7 @@ class RenderObject extends RenderNewType {
       'property_doc_comment': createDocComment(
         common: property.common,
         indent: 4,
+        readOnly: readOnlyProperties.contains(jsonName),
       ),
       'argumentLine': argumentLine(
         jsonName,

--- a/lib/src/resolver.dart
+++ b/lib/src/resolver.dart
@@ -230,6 +230,7 @@ ResolvedSchema _resolveSchemaFully(
         context,
       ),
       requiredProperties: schema.requiredProperties,
+      readOnlyProperties: schema.readOnlyProperties,
     );
   }
   if (schema is SchemaEnum) {
@@ -1393,6 +1394,7 @@ class ResolvedObject extends ResolvedSchema {
     required this.properties,
     required this.additionalProperties,
     required this.requiredProperties,
+    required this.readOnlyProperties,
   }) : super(createsNewType: true);
 
   /// The properties of the resolved schema.
@@ -1405,6 +1407,10 @@ class ResolvedObject extends ResolvedSchema {
   /// The required properties of the resolved schema.
   final List<String> requiredProperties;
 
+  /// Names of properties marked `readOnly: true` in the spec.
+  /// See [SchemaObject.readOnlyProperties] for semantics.
+  final Set<String> readOnlyProperties;
+
   @override
   ResolvedObject copyWith({CommonProperties? common}) {
     return ResolvedObject(
@@ -1412,6 +1418,7 @@ class ResolvedObject extends ResolvedSchema {
       properties: properties,
       additionalProperties: additionalProperties,
       requiredProperties: requiredProperties,
+      readOnlyProperties: readOnlyProperties,
     );
   }
 
@@ -1421,6 +1428,7 @@ class ResolvedObject extends ResolvedSchema {
     properties,
     additionalProperties,
     requiredProperties,
+    readOnlyProperties,
   ];
 }
 

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -440,6 +440,34 @@ void main() {
       expect(obj.requiredProperties, ['a']);
     });
 
+    test('readOnly: true on a property is captured', () {
+      // OpenAPI marks server-set fields with `readOnly: true` on the
+      // *property* slot. The parser should capture it on
+      // `SchemaObject.readOnlyProperties` so the render layer can
+      // surface it. Properties without `readOnly` stay out of the set;
+      // `readOnly: false` (just spec noise) also stays out. Capturing
+      // on the property side also kills `Unused: readOnly=true`
+      // warnings — readOnly is not consumed by the property's own
+      // schema parse (e.g. on a string property).
+      final json = {
+        'type': 'object',
+        'required': ['id'],
+        'properties': {
+          'id': {
+            'type': 'string',
+            'description': 'The advisory ID.',
+            'readOnly': true,
+          },
+          'name': {'type': 'string'},
+          'count': {'type': 'integer', 'readOnly': false},
+        },
+      };
+      final schema = parseTestSchema(json);
+      expect(schema, isA<SchemaObject>());
+      final obj = schema as SchemaObject;
+      expect(obj.readOnlyProperties, {'id'});
+    });
+
     test('oneOf with a real polymorphic variant stays a oneOf', () {
       // A oneOf where any variant brings its own shape (here, a
       // `type: string` variant) is a real polymorphic schema — the

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -108,6 +108,56 @@ void main() {
       );
     });
 
+    test('readOnly: true on a property emits a doc-comment marker', () {
+      // OpenAPI marks server-set fields with `readOnly: true` on the
+      // property slot. We surface this as a dartdoc paragraph so the
+      // signal is visible to consumers — the constructor / request-vs-
+      // response separation is a separate (larger) design call.
+      // Indent of the `///` lines themselves is supplied by the
+      // template + post-render `dart format`; the raw template output
+      // checked here only enforces the relative structure.
+      final schema = {
+        'type': 'object',
+        'required': ['id'],
+        'properties': {
+          'id': {
+            'type': 'string',
+            'description': 'The advisory ID.',
+            'readOnly': true,
+          },
+          'name': {'type': 'string', 'readOnly': true},
+          'count': {'type': 'integer'},
+        },
+      };
+      final result = renderTestSchema(schema);
+      // With prior prose, marker is separated by a paragraph break
+      // (`///` empty line) before the marker line.
+      expect(
+        result,
+        contains(
+          '/// The advisory ID.\n'
+          '    ///\n'
+          '    /// Read-only: server-assigned.\n'
+          '    final String id;',
+        ),
+      );
+      // Without prior prose, marker stands alone (no leading blank).
+      expect(
+        result,
+        contains(
+          '/// Read-only: server-assigned.\n'
+          '    final String? name;',
+        ),
+      );
+      // Properties without `readOnly` get no marker — the marker line
+      // does not appear directly before `count`'s declaration.
+      expect(result, contains('final int? count;'));
+      expect(
+        result,
+        isNot(contains('Read-only: server-assigned.\nfinal int? count;')),
+      );
+    });
+
     test('long property description wraps to 80 cols at 4-space indent', () {
       final schema = {
         'type': 'object',

--- a/test/resolver_test.dart
+++ b/test/resolver_test.dart
@@ -1251,6 +1251,7 @@ void main() {
           properties: const {},
           additionalProperties: null,
           requiredProperties: const [],
+          readOnlyProperties: const {},
         );
         final schema2 = ResolvedObject(
           common: CommonProperties.test(
@@ -1263,6 +1264,7 @@ void main() {
           properties: const {},
           additionalProperties: null,
           requiredProperties: const [],
+          readOnlyProperties: const {},
         );
         expect(schema1, equals(schema1));
         // Different pointer.
@@ -1531,6 +1533,7 @@ void main() {
           properties: const {},
           additionalProperties: null,
           requiredProperties: const [],
+          readOnlyProperties: const {},
         );
         testCopyWith(schema, (schema, copy) {
           expect(copy.properties, equals(schema.properties));
@@ -1539,6 +1542,7 @@ void main() {
             equals(schema.additionalProperties),
           );
           expect(copy.requiredProperties, equals(schema.requiredProperties));
+          expect(copy.readOnlyProperties, equals(schema.readOnlyProperties));
         });
       });
       test('ResolvedEnum', () {


### PR DESCRIPTION
## Summary

- Thread `readOnlyProperties: Set<String>` through the parse → resolve → render chain on the object schema.
- When a property is `readOnly: true`, append a `/// Read-only: server-assigned.` paragraph to its dartdoc.
- Captured in the property-loop only — `readOnly` at a non-property schema root still falls through to the existing `_ignored` path; `readOnly: false` is silently dropped.

Real-world example from `global-advisory`:

```dart
/// The GitHub Security Advisory ID.
///
/// Read-only: server-assigned.
final String ghsaId;
```

`Unused: readOnly=true` on the github regen: **84 → 12** (all 72 property-slot cases now consume the marker; 12 non-property roots remain by design and keep firing under the existing `Ignoring: readOnly` path).

## Test plan

- [x] `dart analyze` clean on the github regen
- [x] 77 read-only properties now annotated in the github regen (`grep -rE "/// Read-only" /tmp/g_readonly_after/lib | wc -l` → 77; the 5 above 72 reflect allOf-merged copies of the same source property)
- [x] `Unused: readOnly=true` warning count: 84 → 12 (12 remaining are non-property roots, scope-deferred)
- [x] Parser unit test: captures `readOnly: true`, ignores `readOnly: false`
- [x] Render unit test: emits the marker with paragraph break when there's prior prose; standalone when there's no description; no marker when unset
- [ ] Constructor / request-vs-response separation deferred to a follow-up PR