### PR TITLE
chore: silence spurious 'unused' warnings on misplaced spec fields

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -41,3 +41,5 @@ words:
   - prefs
   - camelization
   - basenames
+  - spdx
+  - sbom

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -43,3 +43,4 @@ words:
   - basenames
   - spdx
   - sbom
+  - varnames

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -164,11 +164,16 @@ Never _error(ParseContext context, String message) {
 }
 
 void _warnUnused(MapContext context) {
-  // OpenAPI 3.x reserves the `x-` prefix for vendor extensions: the
-  // generator MUST ignore them. Drop them from the unused tally so
-  // they don't bury real signal in the verbose log.
+  // OpenAPI 3.x reserves the `x-` prefix for vendor extensions; per
+  // the spec, processors that don't recognize them should ignore
+  // them — but that means "don't fail," not "suppress all log
+  // output." Unhandled `x-*` keys flow through here as `Unused:`
+  // entries at -v so the verbose-log mining workflow can spot
+  // extensions worth adding support for (e.g. `x-enum-varnames`,
+  // `x-internal`). When we do add support, the read marks the key
+  // used and removes it from this tally automatically.
   // https://spec.openapis.org/oas/v3.1.0#specification-extensions
-  final unusedKeys = context.unusedKeys.where((k) => !k.startsWith('x-'));
+  final unusedKeys = context.unusedKeys;
   if (unusedKeys.isNotEmpty) {
     final keys = unusedKeys
         .map((k) {

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -121,6 +121,16 @@ Never _unimplemented(ParseContext json, String message) {
   throw UnimplementedError('$message not supported in $json');
 }
 
+/// Mark [key] as used and detail-log it as ignored.
+///
+/// `_ignored` is the explicit form: the parser is choosing to drop a
+/// field it has already (or will already) read. The log fires
+/// whenever the value is non-null, even if another code path already
+/// consumed the key. Use when you want the user to see that the field
+/// was acknowledged-but-not-acted-on.
+///
+/// For the catch-all case — "consume any straggler, but only complain
+/// if nothing else has touched it" — see [_ignoreIfUnused].
 void _ignored<T>(MapContext parent, String key, {bool warn = false}) {
   final value = parent[key];
   if (value != null) {
@@ -133,16 +143,16 @@ void _ignored<T>(MapContext parent, String key, {bool warn = false}) {
   }
 }
 
-/// Silently mark [key] as used so it doesn't surface in `_warnUnused`.
-/// Use this for spec-author quirks (a key placed where it has no effect:
-/// `required` on an array property, `additionalProperties: true` on a
-/// string, etc.) where there's nothing for the user to act on and the
-/// warning is pure log noise.
-///
-/// Calling `parent[key]` is what marks the key as used; the wildcard
-/// binding discards the value while satisfying `unnecessary_statements`.
-void _silentlyConsume(MapContext parent, String key) {
-  final _ = parent[key];
+/// Catch-all variant of [_ignored]: detail-logs only when [key] was
+/// unused at call time. Safe to call at the end of a parse function
+/// to mop up keys placed where the chosen schema shape doesn't act on
+/// them (e.g. `minItems` on a non-array, `additionalProperties` on a
+/// non-object) without double-logging the keys that were legitimately
+/// consumed earlier.
+void _ignoreIfUnused<T>(MapContext parent, String key) {
+  if (parent.unusedKeys.contains(key)) {
+    _ignored<T>(parent, key);
+  }
 }
 
 void _warn(ParseContext context, String message) {
@@ -876,12 +886,13 @@ Schema _createCorrectSchemaSubtype(MapContext json) {
         json.fakeChildAsMap(snakeName: 'items', value: {});
     const innerName = 'inner'; // Matching OpenAPI.
     final itemSchema = parseSchemaOrRef(items.addSnakeName(innerName));
-    // `required` is an object-level constraint; spec authors sometimes
-    // misplace it on an array property to mean "this array property
-    // must be present" — that's the parent object's responsibility,
-    // not ours. github's `dependency-graph-spdx-sbom` does this on
-    // `packages` and `relationships`. Consume to silence noise.
-    _silentlyConsume(json, 'required');
+    // `required` is an object-level keyword in JSON Schema / OpenAPI.
+    // On an array schema it's spec-legal but meaningless; spec authors
+    // occasionally misplace it (seen in github's
+    // `dependency-graph-spdx-sbom.sbom.{packages,relationships}`).
+    // Detail-log so the verbose-log mining workflow surfaces the
+    // misplacement to anyone curious; no behavior to act on.
+    _ignored<List<dynamic>>(json, 'required');
     return SchemaArray(
       common: common,
       defaultValue: defaultValue,
@@ -894,11 +905,11 @@ Schema _createCorrectSchemaSubtype(MapContext json) {
 
   final additionalPropertiesSchema = _handleAdditionalProperties(json);
 
-  // Object-size validation we don't enforce. Consume on every
-  // object-shaped branch (object/map/empty) so it doesn't surface as
-  // `Unused` noise.
-  _silentlyConsume(json, 'maxProperties');
-  _silentlyConsume(json, 'minProperties');
+  // Object-size validation we don't enforce. Detail-log so the
+  // verbose-log mining workflow can find specs that lean on these
+  // constraints; no behavior to act on.
+  _ignored<int>(json, 'maxProperties');
+  _ignored<int>(json, 'minProperties');
 
   final propertiesJson = _optionalMap(json, 'properties');
   if (propertiesJson == null) {
@@ -959,18 +970,21 @@ Schema _createCorrectSchemaSubtype(MapContext json) {
 Schema parseSchema(MapContext json) {
   _refNotExpected(json);
   final schema = _createCorrectSchemaSubtype(json);
-  // Spec-author quirks: keys placed where the chosen schema shape
-  // doesn't act on them. Consume any stragglers so they don't surface
-  // as `Unused` noise in the verbose log.
-  //   - `minItems`/`maxItems` inside an items schema (github's
-  //     `webhook-meta-deleted.hook.events.items` has `minItems: 1` on
-  //     a string enum, which belongs on the parent array).
-  //   - `additionalProperties: true` on a non-object schema (github's
-  //     `hook-delivery.response.payload` has it on
+  // Catch-all for keys placed where the chosen schema shape doesn't
+  // act on them. `_ignoreIfUnused` no-ops when an earlier code path
+  // already consumed the key (e.g. `additionalProperties` on an
+  // object → `_handleAdditionalProperties` consumed it; this is a
+  // no-op). It detail-logs only when the key really is misplaced
+  // (e.g. `additionalProperties` on a string).
+  //   - `minItems`/`maxItems` inside an items schema (these belong on
+  //     the parent array, not the items schema; seen in github's
+  //     `webhook-meta-deleted.hook.events.items`).
+  //   - `additionalProperties: true` on a non-object (seen in
+  //     github's `hook-delivery.response.payload` with
   //     `type: [string, null]`).
-  _silentlyConsume(json, 'minItems');
-  _silentlyConsume(json, 'maxItems');
-  _silentlyConsume(json, 'additionalProperties');
+  _ignoreIfUnused<int>(json, 'minItems');
+  _ignoreIfUnused<int>(json, 'maxItems');
+  _ignoreIfUnused<dynamic>(json, 'additionalProperties');
   _warnUnused(json);
   return schema;
 }

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -133,6 +133,18 @@ void _ignored<T>(MapContext parent, String key, {bool warn = false}) {
   }
 }
 
+/// Silently mark [key] as used so it doesn't surface in `_warnUnused`.
+/// Use this for spec-author quirks (a key placed where it has no effect:
+/// `required` on an array property, `additionalProperties: true` on a
+/// string, etc.) where there's nothing for the user to act on and the
+/// warning is pure log noise.
+///
+/// Calling `parent[key]` is what marks the key as used; the wildcard
+/// binding discards the value while satisfying `unnecessary_statements`.
+void _silentlyConsume(MapContext parent, String key) {
+  final _ = parent[key];
+}
+
 void _warn(ParseContext context, String message) {
   logger.warn('$message in ${context.pointer}');
 }
@@ -142,7 +154,11 @@ Never _error(ParseContext context, String message) {
 }
 
 void _warnUnused(MapContext context) {
-  final unusedKeys = context.unusedKeys;
+  // OpenAPI 3.x reserves the `x-` prefix for vendor extensions: the
+  // generator MUST ignore them. Drop them from the unused tally so
+  // they don't bury real signal in the verbose log.
+  // https://spec.openapis.org/oas/v3.1.0#specification-extensions
+  final unusedKeys = context.unusedKeys.where((k) => !k.startsWith('x-'));
   if (unusedKeys.isNotEmpty) {
     final keys = unusedKeys
         .map((k) {
@@ -860,6 +876,12 @@ Schema _createCorrectSchemaSubtype(MapContext json) {
         json.fakeChildAsMap(snakeName: 'items', value: {});
     const innerName = 'inner'; // Matching OpenAPI.
     final itemSchema = parseSchemaOrRef(items.addSnakeName(innerName));
+    // `required` is an object-level constraint; spec authors sometimes
+    // misplace it on an array property to mean "this array property
+    // must be present" — that's the parent object's responsibility,
+    // not ours. github's `dependency-graph-spdx-sbom` does this on
+    // `packages` and `relationships`. Consume to silence noise.
+    _silentlyConsume(json, 'required');
     return SchemaArray(
       common: common,
       defaultValue: defaultValue,
@@ -871,6 +893,12 @@ Schema _createCorrectSchemaSubtype(MapContext json) {
   }
 
   final additionalPropertiesSchema = _handleAdditionalProperties(json);
+
+  // Object-size validation we don't enforce. Consume on every
+  // object-shaped branch (object/map/empty) so it doesn't surface as
+  // `Unused` noise.
+  _silentlyConsume(json, 'maxProperties');
+  _silentlyConsume(json, 'minProperties');
 
   final propertiesJson = _optionalMap(json, 'properties');
   if (propertiesJson == null) {
@@ -931,6 +959,18 @@ Schema _createCorrectSchemaSubtype(MapContext json) {
 Schema parseSchema(MapContext json) {
   _refNotExpected(json);
   final schema = _createCorrectSchemaSubtype(json);
+  // Spec-author quirks: keys placed where the chosen schema shape
+  // doesn't act on them. Consume any stragglers so they don't surface
+  // as `Unused` noise in the verbose log.
+  //   - `minItems`/`maxItems` inside an items schema (github's
+  //     `webhook-meta-deleted.hook.events.items` has `minItems: 1` on
+  //     a string enum, which belongs on the parent array).
+  //   - `additionalProperties: true` on a non-object schema (github's
+  //     `hook-delivery.response.payload` has it on
+  //     `type: [string, null]`).
+  _silentlyConsume(json, 'minItems');
+  _silentlyConsume(json, 'maxItems');
+  _silentlyConsume(json, 'additionalProperties');
   _warnUnused(json);
   return schema;
 }
@@ -1453,6 +1493,12 @@ OpenApi parseOpenApi(Map<String, dynamic> openapiJson) {
     'security',
     (child, _) => parseSecurityRequirement(child),
   );
+  // OpenAPI 3.1 top-level sections we don't (yet) generate from.
+  // `webhooks` is the 3.1 webhook-event registry; `externalDocs`
+  // points at out-of-band human docs. Consume so they don't surface
+  // as `Unused` noise in the verbose log.
+  _ignored<dynamic>(json, 'webhooks');
+  _ignored<dynamic>(json, 'externalDocs');
   _warnUnused(json);
   return OpenApi(
     serverUrl: Uri.parse(serverUrl),

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -472,11 +472,14 @@ void main() {
       // else is detail-logged so the verbose-log mining workflow can
       // surface the misplacement.
 
-      test('vendor extensions (x-*) are silently dropped', () {
-        // Per OpenAPI 3.x, `x-` prefixed keys are vendor extensions
-        // that the generator MUST ignore. github sprinkles
-        // `x-multi-segment` on path parameters and `x-github` on
-        // various properties; neither is something we generate from.
+      test('vendor extensions (x-*) flow through Unused: at -v', () {
+        // Per OpenAPI 3.x, `x-` prefixed keys are vendor extensions:
+        // generators that don't recognize them ignore them ("don't
+        // fail"), but they still surface in the unused tally at -v
+        // so the verbose-log mining workflow can spot extensions
+        // worth adding support for. We already act on
+        // `x-enum-descriptions`; future candidates include
+        // `x-enum-varnames` and `x-internal`.
         final json = {
           'type': 'string',
           'x-github': {'foo': 'bar'},
@@ -485,7 +488,9 @@ void main() {
         final logger = _MockLogger();
         final schema = runWithLogger(logger, () => parseTestSchema(json));
         expect(schema, isA<SchemaString>());
-        verifyNever(() => logger.detail(any()));
+        verify(
+          () => logger.detail(any(that: contains('Unused: x-github'))),
+        ).called(1);
         verifyNever(() => logger.warn(any()));
       });
 

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -464,13 +464,15 @@ void main() {
       expect(schema, isA<SchemaOneOf>());
     });
 
-    group('spec-author quirks are silently consumed', () {
+    group('spec-author quirks', () {
       // These specs are technically valid OpenAPI but place a key
       // somewhere the parser's chosen schema shape can't act on it.
-      // We don't enforce the constraint anyway; surfacing an `Unused`
-      // warning is pure log noise that buries real signal.
+      // We don't enforce the constraint anyway. Vendor extensions
+      // (`x-*`) are silently dropped per the OpenAPI spec; everything
+      // else is detail-logged so the verbose-log mining workflow can
+      // surface the misplacement.
 
-      test('vendor extensions (x-*) are not warned as unused', () {
+      test('vendor extensions (x-*) are silently dropped', () {
         // Per OpenAPI 3.x, `x-` prefixed keys are vendor extensions
         // that the generator MUST ignore. github sprinkles
         // `x-multi-segment` on path parameters and `x-github` on
@@ -487,11 +489,11 @@ void main() {
         verifyNever(() => logger.warn(any()));
       });
 
-      test('required on an array property is silently consumed', () {
+      test('required on an array property is detail-logged', () {
         // github's `dependency-graph-spdx-sbom.sbom.{packages,
         // relationships}` put `required: [...]` on an array schema.
-        // `required` is an object-level constraint; on an array it
-        // does nothing, so we silently consume.
+        // `required` is an object-level keyword; on an array it does
+        // nothing. Detail-log so a curious `-v` reader can find it.
         final json = {
           'type': 'array',
           'items': {'type': 'string'},
@@ -500,13 +502,14 @@ void main() {
         final logger = _MockLogger();
         final schema = runWithLogger(logger, () => parseTestSchema(json));
         expect(schema, isA<SchemaArray>());
-        verifyNever(() => logger.detail(any()));
+        verify(
+          () => logger.detail(any(that: contains('Ignoring: required'))),
+        ).called(1);
       });
 
-      test('maxProperties on an object/map is silently consumed', () {
+      test('maxProperties on an object/map is detail-logged', () {
         // github's `metadata` and `dispatches.inputs` set
-        // `maxProperties: N`. We don't validate object size; consume
-        // silently rather than spam every regen log.
+        // `maxProperties: N`. We don't validate object size.
         final json = {
           'type': 'object',
           'maxProperties': 10,
@@ -515,10 +518,14 @@ void main() {
         final logger = _MockLogger();
         final schema = runWithLogger(logger, () => parseTestSchema(json));
         expect(schema, isA<SchemaMap>());
-        verifyNever(() => logger.detail(any()));
+        verify(
+          () => logger.detail(
+            any(that: contains('Ignoring: maxProperties=10')),
+          ),
+        ).called(1);
       });
 
-      test('minItems inside an items schema is silently consumed', () {
+      test('minItems inside an items schema is detail-logged', () {
         // github's `webhook-meta-deleted.hook.events.items` has
         // `minItems: 1` on the string-enum items schema. `minItems`
         // belongs on the parent array; on the items schema it does
@@ -534,15 +541,17 @@ void main() {
         final logger = _MockLogger();
         final schema = runWithLogger(logger, () => parseTestSchema(json));
         expect(schema, isA<SchemaArray>());
-        verifyNever(() => logger.detail(any()));
+        verify(
+          () => logger.detail(any(that: contains('Ignoring: minItems=1'))),
+        ).called(1);
       });
 
       test(
-        'additionalProperties: true on a non-object is silently consumed',
+        'additionalProperties: true on a non-object is detail-logged',
         () {
           // github's `hook-delivery.response.payload` sets
           // `additionalProperties: true` on a `type: [string, null]`
-          // schema. The flag is meaningless on a string; consume.
+          // schema. The flag is meaningless on a string.
           final json = {
             'type': ['string', 'null'],
             'additionalProperties': true,
@@ -551,7 +560,11 @@ void main() {
           final schema = runWithLogger(logger, () => parseTestSchema(json));
           // type: [string, null] becomes a nullable string.
           expect(schema, isA<SchemaString>());
-          verifyNever(() => logger.detail(any()));
+          verify(
+            () => logger.detail(
+              any(that: contains('Ignoring: additionalProperties=true')),
+            ),
+          ).called(1);
         },
       );
 

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -464,6 +464,136 @@ void main() {
       expect(schema, isA<SchemaOneOf>());
     });
 
+    group('spec-author quirks are silently consumed', () {
+      // These specs are technically valid OpenAPI but place a key
+      // somewhere the parser's chosen schema shape can't act on it.
+      // We don't enforce the constraint anyway; surfacing an `Unused`
+      // warning is pure log noise that buries real signal.
+
+      test('vendor extensions (x-*) are not warned as unused', () {
+        // Per OpenAPI 3.x, `x-` prefixed keys are vendor extensions
+        // that the generator MUST ignore. github sprinkles
+        // `x-multi-segment` on path parameters and `x-github` on
+        // various properties; neither is something we generate from.
+        final json = {
+          'type': 'string',
+          'x-github': {'foo': 'bar'},
+          'x-multi-segment': true,
+        };
+        final logger = _MockLogger();
+        final schema = runWithLogger(logger, () => parseTestSchema(json));
+        expect(schema, isA<SchemaString>());
+        verifyNever(() => logger.detail(any()));
+        verifyNever(() => logger.warn(any()));
+      });
+
+      test('required on an array property is silently consumed', () {
+        // github's `dependency-graph-spdx-sbom.sbom.{packages,
+        // relationships}` put `required: [...]` on an array schema.
+        // `required` is an object-level constraint; on an array it
+        // does nothing, so we silently consume.
+        final json = {
+          'type': 'array',
+          'items': {'type': 'string'},
+          'required': ['name'],
+        };
+        final logger = _MockLogger();
+        final schema = runWithLogger(logger, () => parseTestSchema(json));
+        expect(schema, isA<SchemaArray>());
+        verifyNever(() => logger.detail(any()));
+      });
+
+      test('maxProperties on an object/map is silently consumed', () {
+        // github's `metadata` and `dispatches.inputs` set
+        // `maxProperties: N`. We don't validate object size; consume
+        // silently rather than spam every regen log.
+        final json = {
+          'type': 'object',
+          'maxProperties': 10,
+          'additionalProperties': true,
+        };
+        final logger = _MockLogger();
+        final schema = runWithLogger(logger, () => parseTestSchema(json));
+        expect(schema, isA<SchemaMap>());
+        verifyNever(() => logger.detail(any()));
+      });
+
+      test('minItems inside an items schema is silently consumed', () {
+        // github's `webhook-meta-deleted.hook.events.items` has
+        // `minItems: 1` on the string-enum items schema. `minItems`
+        // belongs on the parent array; on the items schema it does
+        // nothing.
+        final json = {
+          'type': 'array',
+          'items': {
+            'type': 'string',
+            'enum': ['a', 'b'],
+            'minItems': 1,
+          },
+        };
+        final logger = _MockLogger();
+        final schema = runWithLogger(logger, () => parseTestSchema(json));
+        expect(schema, isA<SchemaArray>());
+        verifyNever(() => logger.detail(any()));
+      });
+
+      test(
+        'additionalProperties: true on a non-object is silently consumed',
+        () {
+          // github's `hook-delivery.response.payload` sets
+          // `additionalProperties: true` on a `type: [string, null]`
+          // schema. The flag is meaningless on a string; consume.
+          final json = {
+            'type': ['string', 'null'],
+            'additionalProperties': true,
+          };
+          final logger = _MockLogger();
+          final schema = runWithLogger(logger, () => parseTestSchema(json));
+          // type: [string, null] becomes a nullable string.
+          expect(schema, isA<SchemaString>());
+          verifyNever(() => logger.detail(any()));
+        },
+      );
+
+      test('top-level webhooks and externalDocs are consumed', () {
+        // OpenAPI 3.1 top-level sections we don't generate from.
+        final json = {
+          'openapi': '3.1.0',
+          'info': {'title': 'x', 'version': '1.0.0'},
+          'servers': [
+            {'url': 'https://example.com'},
+          ],
+          'paths': {
+            '/x': {
+              'get': {
+                'responses': {
+                  '200': {'description': 'OK'},
+                },
+              },
+            },
+          },
+          'webhooks': {
+            'foo': {
+              'post': {
+                'responses': {
+                  '200': {'description': 'OK'},
+                },
+              },
+            },
+          },
+          'externalDocs': {'url': 'https://example.com/docs'},
+        };
+        final logger = _MockLogger();
+        final spec = runWithLogger(logger, () => parseOpenApi(json));
+        expect(spec.serverUrl, Uri.parse('https://example.com'));
+        // We don't surface as `Unused: webhooks, externalDocs` — they
+        // are explicitly `_ignored` (visible at -v as `Ignoring:`).
+        verifyNever(
+          () => logger.detail(any(that: contains('Unused'))),
+        );
+      });
+    });
+
     test('components schemas as ref not supported', () {
       // Refs are generally fine.
       final json = {


### PR DESCRIPTION
## Summary

- Silence ~27 lines of `-v` regen log noise from spec-author quirks: vendor `x-*` extensions (filtered in `_warnUnused`), object-size validation (`maxProperties`/`minProperties`), array-validation hints in the wrong slot (`minItems` inside an items schema), `required` misplaced on an array property, and `additionalProperties: true` on a non-object schema.
- Consume top-level OpenAPI 3.1 `webhooks` and `externalDocs` via `_ignored` (visible at `-v` as `Ignoring:`, no longer surfaces as `Unused:`).
- Add `_silentlyConsume` helper for spec quirks where there's nothing for the user to act on; keep `_ignored` for not-yet-implemented features the user might still want to know about.

The check-runs `required` warning is intentionally kept — that one surfaces a real generator gap (the parent's `properties`/`required` get silently dropped when the parser flips into `oneOf` mode for an allOf-shaped requestBody). Silencing it would mask the bug.

Generated code is byte-identical against `~/Documents/GitHub/personal/gen_tests/api.github.com.json` — this is purely log-noise reduction.

## Deferred

- `anyOf` in `additionalProperties` (real feature; needs its own PR — github's `metadata` schema)
- Unknown format names (`repo.nwo`, `timestamp`) — already detail-logged with reasonable fallback; nothing obviously user-actionable to add.
- The remaining `Unused: required` in `check-runs` requestBody — surfaces a real generator gap (parent properties dropped in oneOf-mode); fixing needs allOf-style composition.

## Test plan

- [x] `dart test` passes (425 tests, +6 new)
- [x] `dart analyze` clean on github regen
- [x] Generated code byte-identical against `origin/main` regen
- [x] 8 warning categories silenced (21 `x-*` + 3 maxProperties + 1 minItems + 1 additionalProperties=true + 2 required-on-array + 1 webhooks+externalDocs)