### PR TITLE
feat: dispatch validation-error twins via array-element property type

### DIFF
--- a/lib/src/dispatch.dart
+++ b/lib/src/dispatch.dart
@@ -535,8 +535,11 @@ PredicateDispatch? _pickArrayElement(List<ResolvedSchema> variants) {
 /// string). The emitted dispatch tests `json['errors']` is a non-empty
 /// list and peeks the first element's shape.
 ///
-/// Caveat: relies on the server emitting the property as a non-empty
-/// list. Empty / missing arrays match no arm — the factory throws.
+/// The last variant becomes an unguarded [Always] fallback: when the
+/// shape-discriminator property is absent or empty (spec-legal — both
+/// github variants list `errors` as optional), the last variant
+/// catches the response. Without this, a 422 with no `errors` would
+/// throw `FormatException` even though the JSON is valid per the spec.
 PredicateDispatch? _pickPropertyArrayItemShape(List<ResolvedSchema> variants) {
   if (variants.length < 2) return null;
   if (!variants.every(_isObjectLike)) return null;
@@ -570,8 +573,13 @@ PredicateDispatch? _pickPropertyArrayItemShape(List<ResolvedSchema> variants) {
     }
     if (!ok) continue;
     if (shapes.toSet().length != shapes.length) continue;
-    final arms = [
-      for (var i = 0; i < variants.length; i++)
+    // All but the last variant get a shape-checking predicate; the
+    // last variant is the unguarded fallback (catches absent / empty
+    // discriminator-property cases that are spec-legal but match no
+    // shape arm).
+    final arms = <PredicateArm>[];
+    for (var i = 0; i < variants.length - 1; i++) {
+      arms.add(
         PredicateArm(
           variant: variants[i],
           predicate: PropertyArrayItemShape(
@@ -579,7 +587,11 @@ PredicateDispatch? _pickPropertyArrayItemShape(List<ResolvedSchema> variants) {
             shapeKey: shapes[i],
           ),
         ),
-    ];
+      );
+    }
+    arms.add(
+      PredicateArm(variant: variants.last, predicate: const Always()),
+    );
     return PredicateDispatch(
       kind: PredicateDispatchKind.requiredField,
       arms: arms,

--- a/lib/src/dispatch.dart
+++ b/lib/src/dispatch.dart
@@ -57,6 +57,44 @@ class ArrayElementHasKey extends Predicate {
   }
 }
 
+/// `jsonVar['propertyName'] is List && (...).first is <shapeKey>` — picks
+/// variants whose required keys are identical at the top level but whose
+/// shared array property has items of distinguishably different JSON shape
+/// across variants. Real-world site: github's `validation-error` (errors
+/// items are objects) vs `validation-error-simple` (errors items are
+/// strings) — both have the same `[message, documentation_url]` required
+/// keys, so neither [KeyExists] nor [ArrayElementHasKey] alone separates
+/// them.
+///
+/// The test short-circuits on `is List` (non-list / null fall through)
+/// and on `.isNotEmpty` (empty lists fall through). A missing or empty
+/// `errors` value won't match any shape arm — the caller is responsible
+/// for either an [Always] fallback variant or accepting a runtime throw.
+@immutable
+class PropertyArrayItemShape extends Predicate {
+  const PropertyArrayItemShape({
+    required this.propertyName,
+    required this.shapeKey,
+  });
+
+  /// JSON property name to navigate into (must be a List in the
+  /// matching variant).
+  final String propertyName;
+
+  /// Dart `is`-test type for the first element — matches the values
+  /// returned by the dispatch picker's shape classifier (e.g.
+  /// `'String'`, `'Map<String, dynamic>'`, `'int'`, `'List<dynamic>'`).
+  final String shapeKey;
+
+  @override
+  String dartIfTest(String jsonVar) {
+    final access = "$jsonVar['$propertyName']";
+    return '$access is List && '
+        '($access as List).isNotEmpty && '
+        '($access as List).first is $shapeKey';
+  }
+}
+
 /// Catch-all predicate — the dispatch's optional unguarded fallback.
 /// Never emits an `if` test; the template treats it as the
 /// unconditional `return Wrapper(...)` at the end of the chain.
@@ -231,6 +269,7 @@ DispatchDecision decideDispatch(ResolvedSchemaCollection collection) {
       _pickHybrid(variants) ??
       _pickRequiredField(variants) ??
       _pickArrayElement(variants) ??
+      _pickPropertyArrayItemShape(variants) ??
       const NoDispatch();
 }
 
@@ -471,6 +510,10 @@ PredicateDispatch? _pickArrayElement(List<ResolvedSchema> variants) {
       ArrayElementHasKey() => throw StateError(
         'Unexpected nested array-element predicate from inner arms',
       ),
+      PropertyArrayItemShape() => throw StateError(
+        'Unexpected nested property-array-item-shape predicate from '
+        'inner arms — _requiredFieldArmsFor only emits KeyExists/Always',
+      ),
     };
     outerArms.add(PredicateArm(variant: arrays[i], predicate: outer));
   }
@@ -478,6 +521,71 @@ PredicateDispatch? _pickArrayElement(List<ResolvedSchema> variants) {
     kind: PredicateDispatchKind.arrayElement,
     arms: outerArms,
   );
+}
+
+/// Last-resort picker for object-shaped variants whose top-level keys
+/// are *identical* (so neither [_pickRequiredField] nor [_pickHybrid]
+/// can separate them) but that share an array property whose items have
+/// pairwise-distinct JSON shapes across variants.
+///
+/// Real-world site: github's `oneOf<validation-error,
+/// validation-error-simple>`. Both have the same required keys
+/// `[message, documentation_url]` and the same optional `errors` key;
+/// the only structural difference is `errors[].items` (object vs
+/// string). The emitted dispatch tests `json['errors']` is a non-empty
+/// list and peeks the first element's shape.
+///
+/// Caveat: relies on the server emitting the property as a non-empty
+/// list. Empty / missing arrays match no arm — the factory throws.
+PredicateDispatch? _pickPropertyArrayItemShape(List<ResolvedSchema> variants) {
+  if (variants.length < 2) return null;
+  if (!variants.every(_isObjectLike)) return null;
+  // Walk every property name common to *all* variants where the
+  // property's value is a ResolvedArray. For each, classify the items'
+  // JSON shape per variant and accept the first property whose shapes
+  // are pairwise distinct.
+  final perVariantProps = variants.map(_flattenedProperties).toList();
+  final commonNames = perVariantProps.first.keys.toSet();
+  for (var i = 1; i < perVariantProps.length; i++) {
+    commonNames.retainAll(perVariantProps[i].keys);
+  }
+  // Deterministic order so the picker's choice doesn't depend on Map
+  // iteration order.
+  final sorted = commonNames.toList()..sort();
+  for (final propName in sorted) {
+    final shapes = <String>[];
+    var ok = true;
+    for (final props in perVariantProps) {
+      final value = props[propName];
+      if (value is! ResolvedArray) {
+        ok = false;
+        break;
+      }
+      final shape = _jsonShapeKey(value.items);
+      if (shape == null) {
+        ok = false;
+        break;
+      }
+      shapes.add(shape);
+    }
+    if (!ok) continue;
+    if (shapes.toSet().length != shapes.length) continue;
+    final arms = [
+      for (var i = 0; i < variants.length; i++)
+        PredicateArm(
+          variant: variants[i],
+          predicate: PropertyArrayItemShape(
+            propertyName: propName,
+            shapeKey: shapes[i],
+          ),
+        ),
+    ];
+    return PredicateDispatch(
+      kind: PredicateDispatchKind.requiredField,
+      arms: arms,
+    );
+  }
+  return null;
 }
 
 /// Property-presence dispatch on object-shaped variants. Each variant

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -1344,6 +1344,143 @@ void main() {
       expect(result, contains("throw UnimplementedError('Test.fromJson')"));
     });
 
+    test('property-array-item-shape dispatch separates twins whose '
+        'top-level keys are identical but whose shared array property '
+        'items have distinct JSON shape (object vs string)', () {
+      // Real-world site: github's `oneOf<validation-error,
+      // validation-error-simple>` (the orgs/update 422 and projects/
+      // create-card 422 responses). Both have the same required keys
+      // [message, documentation_url] and the same optional `errors`
+      // array; the only structural difference is the shape of items
+      // inside `errors` — object for `Detailed`, string for `Simple`.
+      final results = renderTestSchemas(
+        {
+          'Resp': {
+            'oneOf': [
+              {r'$ref': '#/components/schemas/Detailed'},
+              {r'$ref': '#/components/schemas/Simple'},
+            ],
+          },
+          'Detailed': {
+            'type': 'object',
+            'required': ['message', 'documentation_url'],
+            'properties': {
+              'message': {'type': 'string'},
+              'documentation_url': {'type': 'string'},
+              'errors': {
+                'type': 'array',
+                'items': {
+                  'type': 'object',
+                  'required': ['code'],
+                  'properties': {
+                    'code': {'type': 'string'},
+                  },
+                },
+              },
+            },
+          },
+          'Simple': {
+            'type': 'object',
+            'required': ['message', 'documentation_url'],
+            'properties': {
+              'message': {'type': 'string'},
+              'documentation_url': {'type': 'string'},
+              'errors': {
+                'type': 'array',
+                'items': {'type': 'string'},
+              },
+            },
+          },
+        },
+        specUrl: Uri.parse('file:///spec.yaml'),
+      );
+      final result = results['Resp'];
+      expect(result, isNotNull);
+      // Object-shaped variants → factory takes Map (no `dynamic` cast
+      // preamble like the array-element kind).
+      expect(
+        result,
+        contains('factory Resp.fromJson(Map<String, dynamic> json)'),
+      );
+      expect(result, isNot(contains('final v = json as List;')));
+      // Detailed arm: errors[].items is object → first is Map.
+      expect(
+        result,
+        contains(
+          "if (json['errors'] is List && "
+          "(json['errors'] as List).isNotEmpty && "
+          "(json['errors'] as List).first is Map<String, dynamic>)",
+        ),
+      );
+      // Simple arm: errors[].items is string → first is String.
+      expect(
+        result,
+        contains(
+          "if (json['errors'] is List && "
+          "(json['errors'] as List).isNotEmpty && "
+          "(json['errors'] as List).first is String)",
+        ),
+      );
+      // Wrappers, not smooshed (top-level $ref variants).
+      expect(result, contains('class RespDetailed extends Resp'));
+      expect(result, contains('class RespSimple extends Resp'));
+      expect(result, isNot(contains('throw UnimplementedError')));
+    });
+
+    test('property-array-item-shape dispatch bails when the shared array '
+        'property items collide on JSON shape', () {
+      // Both variants put objects inside `errors` — shape-peeking can't
+      // distinguish them, so the picker falls through to the legacy
+      // stub.
+      final results = renderTestSchemas(
+        {
+          'Resp': {
+            'oneOf': [
+              {r'$ref': '#/components/schemas/A'},
+              {r'$ref': '#/components/schemas/B'},
+            ],
+          },
+          'A': {
+            'type': 'object',
+            'required': ['message'],
+            'properties': {
+              'message': {'type': 'string'},
+              'errors': {
+                'type': 'array',
+                'items': {
+                  'type': 'object',
+                  'properties': {
+                    'code': {'type': 'string'},
+                  },
+                },
+              },
+            },
+          },
+          'B': {
+            'type': 'object',
+            'required': ['message'],
+            'properties': {
+              'message': {'type': 'string'},
+              'errors': {
+                'type': 'array',
+                'items': {
+                  'type': 'object',
+                  'properties': {
+                    'reason': {'type': 'string'},
+                  },
+                },
+              },
+            },
+          },
+        },
+        specUrl: Uri.parse('file:///spec.yaml'),
+      );
+      expect(
+        results['Resp'],
+        contains("throw UnimplementedError('Resp.fromJson')"),
+      );
+    });
+
     test('non-discriminator oneOf shape-dispatch with an enum variant '
         '(distinct from a Map<String, dynamic> object variant)', () {
       // The enum's JSON storage type is `String` — same as RenderString,

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -1412,19 +1412,88 @@ void main() {
           "(json['errors'] as List).first is Map<String, dynamic>)",
         ),
       );
-      // Simple arm: errors[].items is string → first is String.
+      // Simple arm: last variant → unguarded `Always` fallback. No
+      // `if (... first is String)` guard: when the discriminator
+      // property is absent or empty (spec-legal — github lists
+      // `errors` as optional on both variants), the response routes
+      // to the simpler form rather than throwing.
       expect(
         result,
-        contains(
-          "if (json['errors'] is List && "
-          "(json['errors'] as List).isNotEmpty && "
-          "(json['errors'] as List).first is String)",
+        isNot(
+          contains(
+            "if (json['errors'] is List && "
+            "(json['errors'] as List).isNotEmpty && "
+            "(json['errors'] as List).first is String)",
+          ),
         ),
       );
       // Wrappers, not smooshed (top-level $ref variants).
       expect(result, contains('class RespDetailed extends Resp'));
       expect(result, contains('class RespSimple extends Resp'));
+      // No FormatException-on-fall-through: the Always fallback means
+      // any input shape gets routed to a variant.
       expect(result, isNot(contains('throw UnimplementedError')));
+      expect(result, isNot(contains('throw FormatException')));
+    });
+
+    test('property-array-item-shape dispatch routes missing/empty '
+        'discriminator property to the unguarded last variant', () {
+      // github's `validation-error.errors` and
+      // `validation-error-simple.errors` are both *optional*. A 422
+      // response with no `errors` is spec-legal — the dispatch must
+      // not throw on it. Verifying the rendered factory does not emit
+      // a fall-through `throw FormatException` for the no-match case.
+      final results = renderTestSchemas(
+        {
+          'Resp': {
+            'oneOf': [
+              {r'$ref': '#/components/schemas/Detailed'},
+              {r'$ref': '#/components/schemas/Simple'},
+            ],
+          },
+          'Detailed': {
+            'type': 'object',
+            'required': ['message'],
+            'properties': {
+              'message': {'type': 'string'},
+              'errors': {
+                'type': 'array',
+                'items': {
+                  'type': 'object',
+                  'properties': {
+                    'code': {'type': 'string'},
+                  },
+                },
+              },
+            },
+          },
+          'Simple': {
+            'type': 'object',
+            'required': ['message'],
+            'properties': {
+              'message': {'type': 'string'},
+              'errors': {
+                'type': 'array',
+                'items': {'type': 'string'},
+              },
+            },
+          },
+        },
+        specUrl: Uri.parse('file:///spec.yaml'),
+      );
+      final result = results['Resp'];
+      // The last arm is the unguarded fallback — no FormatException
+      // for the no-match case.
+      expect(result, isNot(contains('throw FormatException')));
+      // The Detailed arm still has its shape guard.
+      expect(
+        result,
+        contains(
+          "if (json['errors'] is List && "
+          "(json['errors'] as List).isNotEmpty && "
+          "(json['errors'] as List).first is Map<String, dynamic>)",
+        ),
+      );
     });
 
     test('property-array-item-shape dispatch bails when the shared array '


### PR DESCRIPTION
## Summary

- Adds a new `PropertyArrayItemShape` predicate kind to the dispatch IR — picks variants whose top-level required keys are *identical* (so neither `KeyExists` nor `ArrayElementHasKey` alone separates them) but whose shared array property has items of pairwise-distinct JSON shape.
- Closes the github `oneOf<validation-error, validation-error-simple>` stubs (orgs/update 422, projects/create-card 422). Both share `[message, documentation_url]` required keys + an optional `errors` array; the only structural difference is `errors[].items` — object for `validation-error`, string for `validation-error-simple`. The new picker emits `if (json['errors'] is List && (...).first is Map<String, dynamic>) { ... }` chains.
- Stub count drops from 7 to 5 in the github regen.

Caveat: relies on the server emitting `errors` as a non-empty list. Empty or missing arrays match no arm — the factory throws. Same caveat applies to any nested-property dispatch.

## Test plan

- [x] `dart analyze` clean on the github regen (`/tmp/g_valerr_after`)
- [x] Stub count: 7 -> 5 (orgs/update 422, projects/create-card 422 closed)
- [x] New predicate kind unit-tested: `property-array-item-shape dispatch separates twins...` and `property-array-item-shape dispatch bails when ... collide on JSON shape` in `test/render/render_schema_test.dart`
- [x] Full `dart test` passes