### PR TITLE
feat: surface spec `example:` values in generated doc comments

### DIFF
--- a/lib/src/parse/spec.dart
+++ b/lib/src/parse/spec.dart
@@ -26,6 +26,8 @@ class Parameter extends Equatable implements HasPointer, Parseable {
     required this.inLocation,
     required this.isDeprecated,
     required this.pointer,
+    required this.example,
+    required this.examples,
   });
 
   /// The name of the parameter.
@@ -47,6 +49,16 @@ class Parameter extends Equatable implements HasPointer, Parseable {
   /// The type of the parameter.
   final SchemaRef type;
 
+  /// A single example value for this parameter, taken from the OpenAPI
+  /// `example` keyword. Surfaced in the endpoint's doc comment.
+  final dynamic example;
+
+  /// Multiple example values for this parameter, taken from the OpenAPI
+  /// `examples` keyword (a map of `Example` objects). Each entry's
+  /// `value` field is extracted into this list, in declaration order.
+  /// Surfaced in the endpoint's doc comment.
+  final List<dynamic>? examples;
+
   /// Where this parameter is located in the spec.
   @override
   final JsonPointer pointer;
@@ -59,6 +71,8 @@ class Parameter extends Equatable implements HasPointer, Parseable {
     inLocation,
     type,
     pointer,
+    example,
+    examples,
   ];
 }
 
@@ -68,6 +82,8 @@ class Header extends Equatable implements HasPointer, Parseable {
     required this.description,
     required this.schema,
     required this.pointer,
+    required this.example,
+    required this.examples,
   });
 
   /// The description of the header.
@@ -76,12 +92,30 @@ class Header extends Equatable implements HasPointer, Parseable {
   /// The type of the header.
   final SchemaRef? schema;
 
+  /// A single example value for this header, taken from the OpenAPI
+  /// `example` keyword. Captured at parse time but not yet surfaced —
+  /// response Header objects do not currently flow through to render.
+  final dynamic example;
+
+  /// Multiple example values for this header, taken from the OpenAPI
+  /// `examples` keyword (a map of `Example` objects). Each entry's
+  /// `value` field is extracted into this list, in declaration order.
+  /// Captured at parse time but not yet surfaced — response Header
+  /// objects do not currently flow through to render.
+  final List<dynamic>? examples;
+
   /// Where this header is located in the spec.
   @override
   final JsonPointer pointer;
 
   @override
-  List<Object?> get props => [description, schema, pointer];
+  List<Object?> get props => [
+    description,
+    schema,
+    pointer,
+    example,
+    examples,
+  ];
 }
 
 abstract class Parseable {}

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -261,12 +261,14 @@ Parameter parseParameter(MapContext json) {
   _ignored<bool>(json, 'allowEmptyValue');
 
   final SchemaRef type;
+  dynamic example;
+  List<dynamic>? examples;
   if (hasSchema && !hasContent) {
     // Schema fields.
     type = parseSchemaOrRef(schema);
     _warnUnsupportedSerialization(json, inLocation);
-    _ignored<dynamic>(json, 'example');
-    _ignored<dynamic>(json, 'examples');
+    example = _optional<dynamic>(json, 'example');
+    examples = _parseExamplesMap(json);
   } else if (!hasSchema && hasContent) {
     // Content values (Map<String, MediaType>) are not supported.
     _unimplemented(json, "'content'");
@@ -293,6 +295,8 @@ Parameter parseParameter(MapContext json) {
     isDeprecated: deprecated,
     inLocation: inLocation,
     type: type,
+    example: example,
+    examples: examples,
   );
 }
 
@@ -310,8 +314,8 @@ Header parseHeader(MapContext json) {
   _ignored<bool>(json, 'deprecated');
   _ignored<bool>(json, 'allowEmptyValue');
   _warnUnsupportedSerialization(json, ParameterLocation.header);
-  _ignored<dynamic>(json, 'example');
-  _ignored<Map<String, dynamic>>(json, 'examples');
+  final example = _optional<dynamic>(json, 'example');
+  final examples = _parseExamplesMap(json);
 
   final schema = _maybeSchemaOrRef(_optionalMap(json, 'schema'));
   _warnUnused(json);
@@ -319,7 +323,42 @@ Header parseHeader(MapContext json) {
     pointer: json.pointer,
     description: description,
     schema: schema,
+    example: example,
+    examples: examples,
   );
+}
+
+/// Parse an OpenAPI `examples` map (used on parameters and headers) into
+/// a flat list of example values, in declaration order. Each entry in
+/// the map is an Example object whose `value` field carries the actual
+/// example payload; sibling fields like `summary`/`description`/
+/// `externalValue` are not yet surfaced.
+///
+/// Returns null when no `examples` key is present so the absence is
+/// preserved through the pipeline (vs. an empty list, which would
+/// suggest the spec author wrote `examples: {}`).
+List<dynamic>? _parseExamplesMap(MapContext json) {
+  final examples = _optionalMap(json, 'examples');
+  if (examples == null) {
+    return null;
+  }
+  final values = <dynamic>[];
+  for (final key in examples.keys) {
+    final entry = examples.childAsMap(key);
+    final value = _optional<dynamic>(entry, 'value');
+    // The Example object has optional `summary`, `description`,
+    // `externalValue` siblings — consume them quietly so `_warnUnused`
+    // doesn't fire for spec-legal fields the generator just doesn't
+    // surface in doc comments yet.
+    _ignored<String>(entry, 'summary');
+    _ignored<String>(entry, 'description');
+    _ignored<String>(entry, 'externalValue');
+    _warnUnused(entry);
+    if (value != null) {
+      values.add(value);
+    }
+  }
+  return values;
 }
 
 RefOr<Header> parseHeaderOrRef(MapContext json) {

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:collection/collection.dart';
 import 'package:equatable/equatable.dart';
 import 'package:meta/meta.dart';
@@ -196,19 +198,17 @@ String? createDocCommentFromParts({
   String? body,
   dynamic example,
   List<dynamic>? examples,
+  List<ParameterExampleDoc> parameterExamples = const [],
   int indent = 0,
   String? templateName,
 }) {
-  if (title == null && body == null && example == null && examples == null) {
+  if (title == null &&
+      body == null &&
+      example == null &&
+      examples == null &&
+      parameterExamples.isEmpty) {
     return null;
   }
-  String quoteIfNeeded(dynamic value) {
-    if (value is String) {
-      return quoteString(value);
-    }
-    return value.toString();
-  }
-
   final indentStr = ' ' * indent;
   final hasTemplateContent = title != null || body != null;
   final wrapWithTemplate = templateName != null && hasTemplateContent;
@@ -217,11 +217,16 @@ String? createDocCommentFromParts({
     if (title != null) ...wrapDocComment(title, indent: indent),
     if (body != null) ...wrapDocComment(body, indent: indent),
     if (wrapWithTemplate) '$indentStr/// {@endtemplate}',
-    if (example != null)
-      ...wrapDocComment('example: `${quoteIfNeeded(example)}`', indent: indent),
+    if (example != null) ...exampleDocCommentLines(example, indent: indent),
     if (examples != null)
-      ...examples.expand(
-        (e) => wrapDocComment('example: `${quoteIfNeeded(e)}`', indent: indent),
+      ...examples.expand((e) => exampleDocCommentLines(e, indent: indent)),
+    for (final p in parameterExamples)
+      ...p.examples.expand(
+        (value) => exampleDocCommentLines(
+          value,
+          indent: indent,
+          prefix: '[${p.dartName}] example',
+        ),
       ),
   ];
   if (lines.isEmpty) {
@@ -232,6 +237,85 @@ String? createDocCommentFromParts({
   lines[0] = lines[0].trimLeft();
   // Re-indent the next line after the comment.
   return '${lines.join('\n')}\n${' ' * indent}';
+}
+
+/// Per-parameter example bundle threaded into an endpoint's doc
+/// comment. The Dart-side parameter name (rather than the wire name) is
+/// used so dartdoc renders the surrounding `[name]` as a cross-link to
+/// the method's parameter, not as a broken reference.
+class ParameterExampleDoc {
+  const ParameterExampleDoc({required this.dartName, required this.examples});
+
+  /// The Dart-side parameter name (camelCased, reserved-word-safe).
+  final String dartName;
+
+  /// All example values declared on the parameter, scalar or complex.
+  final List<dynamic> examples;
+}
+
+/// Renders an example [value] as one or more dartdoc lines, fully
+/// indented and prefixed with `///`, ready to be joined into a doc
+/// comment.
+///
+/// Scalars (String, num, bool) render inline as `` /// <prefix>: `<v>` ``.
+/// String values use Dart-source quoting so the rendered backtick span
+/// matches the shape callers would type in real code.
+///
+/// Complex values (Map / List) render as a fenced JSON code block —
+/// `/// <prefix>:`, then `/// ```json`, the pretty-printed payload split
+/// across lines, then a closing `/// ```. This keeps the doc comment
+/// readable even when the example is a multi-line object, and lets
+/// dartdoc/IDEs syntax-highlight the body.
+///
+/// [prefix] defaults to `Example`; pass e.g. `[paramName] example` to
+/// scope the example to a specific parameter.
+@visibleForTesting
+Iterable<String> exampleDocCommentLines(
+  dynamic value, {
+  int indent = 0,
+  String prefix = 'Example',
+}) {
+  if (value == null) return const [];
+  final indentStr = ' ' * indent;
+  if (value is Map || value is List) {
+    final pretty = _prettyPrintJson(value);
+    return <String>[
+      '$indentStr/// $prefix:',
+      '$indentStr/// ```json',
+      ...pretty.split('\n').map((line) => '$indentStr/// $line'),
+      '$indentStr/// ```',
+    ];
+  }
+  final formatted = value is String ? quoteString(value) : value.toString();
+  return wrapDocComment('$prefix: `$formatted`', indent: indent);
+}
+
+/// Pretty-print a JSON-shaped value with 2-space indentation. Coerces
+/// any non-JSON-encodable element (DateTime, class instance, etc.) to
+/// its `toString()` form before encoding so the encode never throws —
+/// doc-comment generation must always produce *something*, even if a
+/// spec author dropped a non-JSON value into an `example:` field.
+String _prettyPrintJson(dynamic value) {
+  const encoder = JsonEncoder.withIndent('  ');
+  return encoder.convert(_coerceToJson(value));
+}
+
+/// Walk [value] turning anything `jsonEncode` would reject into its
+/// `toString()` form. Maps and Lists are recursed into; JSON scalars
+/// (null, num, bool, String) pass through unchanged.
+dynamic _coerceToJson(dynamic value) {
+  if (value == null || value is num || value is bool || value is String) {
+    return value;
+  }
+  if (value is Map) {
+    return value.map<String, dynamic>(
+      (key, v) => MapEntry(key.toString(), _coerceToJson(v)),
+    );
+  }
+  if (value is List) {
+    return value.map(_coerceToJson).toList();
+  }
+  return value.toString();
 }
 
 /// Returns a dartdoc `/// {@macro <templateName>}` line, matching the
@@ -576,6 +660,8 @@ class SpecResolver {
       isRequired: parameter.isRequired,
       isDeprecated: parameter.isDeprecated,
       type: toRenderSchema(parameter.schema),
+      example: parameter.example,
+      examples: parameter.examples,
     );
   }
 
@@ -919,6 +1005,25 @@ class Endpoint implements ToTemplateContext {
       }
     }
     return statements;
+  }
+
+  /// Per-parameter example doc lines for this endpoint, ready to be
+  /// appended after the summary/description. Each entry refers to the
+  /// parameter by its Dart-side name in `[brackets]` so dartdoc renders
+  /// it as a cross-reference into the method signature.
+  List<ParameterExampleDoc> _parameterExampleLines(Quirks quirks) {
+    final out = <ParameterExampleDoc>[];
+    for (final parameter in parameters) {
+      final examples = parameter.allExamples.toList();
+      if (examples.isEmpty) continue;
+      out.add(
+        ParameterExampleDoc(
+          dartName: parameter.dartParameterName(quirks),
+          examples: examples,
+        ),
+      );
+    }
+    return out;
   }
 
   /// Turn the SecurityRequirements into AuthRequest subclasses to be
@@ -1440,6 +1545,7 @@ class Endpoint implements ToTemplateContext {
       'endpoint_doc_comment': createDocCommentFromParts(
         title: summary,
         body: description,
+        parameterExamples: _parameterExampleLines(context.quirks),
         indent: 4,
       ),
       'methodName': methodName,
@@ -4982,6 +5088,8 @@ class RenderParameter implements CanBeParameter {
     required this.isRequired,
     required this.isDeprecated,
     required this.inLocation,
+    required this.example,
+    required this.examples,
   });
 
   /// The name of the parameter.
@@ -5005,6 +5113,23 @@ class RenderParameter implements CanBeParameter {
 
   /// Whether the parameter is deprecated.
   final bool isDeprecated;
+
+  /// A single example value for this parameter, from the spec's
+  /// `example` keyword. Surfaced in the endpoint's doc comment.
+  final dynamic example;
+
+  /// Multiple example values for this parameter, from the spec's
+  /// `examples` keyword. Surfaced in the endpoint's doc comment.
+  final List<dynamic>? examples;
+
+  /// All example values declared for this parameter, in the order they
+  /// will be surfaced in the endpoint's doc comment. Combines the
+  /// singular [example] (if any) with each entry of [examples].
+  Iterable<dynamic> get allExamples sync* {
+    if (example != null) yield example;
+    final examples = this.examples;
+    if (examples != null) yield* examples;
+  }
 
   /// Whether the Dart storage for this parameter is nullable — the
   /// inverse of [isRequired]. Named for the use site rather than the

--- a/lib/src/resolver.dart
+++ b/lib/src/resolver.dart
@@ -488,6 +488,8 @@ List<ResolvedParameter> _resolveParameters(
         isRequired: resolved.isRequired,
         isDeprecated: resolved.isDeprecated,
         schema: type,
+        example: resolved.example,
+        examples: resolved.examples,
       );
     });
   }).toList();
@@ -938,6 +940,8 @@ class ResolvedParameter {
     required this.isRequired,
     required this.isDeprecated,
     required this.schema,
+    required this.example,
+    required this.examples,
   });
 
   /// The name of the resolved parameter.
@@ -957,6 +961,12 @@ class ResolvedParameter {
 
   /// The schema of the resolved parameter.
   final ResolvedSchema schema;
+
+  /// A single example value, from the spec's `example` keyword.
+  final dynamic example;
+
+  /// Multiple example values, from the spec's `examples` keyword.
+  final List<dynamic>? examples;
 }
 
 class ResolvedRequestBody {

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -965,6 +965,54 @@ void main() {
         ).called(1);
       });
 
+      test('parameter `example` is captured and `examples` map flattened', () {
+        // OpenAPI 3.x lets a parameter declare `example: <scalar>` *or*
+        // `examples: { name: { value: <scalar> } }` (the second form is
+        // a map of full Example objects). Both should land on the
+        // parsed Parameter so render can surface them in the endpoint
+        // doc comment instead of dropping them as `Ignoring: example`.
+        final logger = _MockLogger();
+        final spec = runWithLogger(
+          logger,
+          () => parseOpenApi(
+            specWithQueryParam({
+              'example': 'foo',
+              'examples': {
+                'first': {'value': 'one', 'summary': 'first example'},
+                'second': {'value': 'two'},
+              },
+            }),
+          ),
+        );
+        final operation = spec.paths['/users'].operations[Method.get];
+        if (operation == null) fail('expected /users get operation');
+        final parameter = operation.parameters.single.object;
+        if (parameter == null) fail('expected inline parameter');
+        expect(parameter.example, 'foo');
+        expect(parameter.examples, ['one', 'two']);
+        verifyNever(() => logger.warn(any()));
+      });
+
+      test(
+        'header `example` and `examples` map are captured (silent — headers '
+        'do not yet flow to render but the parser must not warn)',
+        () {
+          final logger = _MockLogger();
+          runWithLogger(
+            logger,
+            () => parseOpenApi(
+              specWithHeader({
+                'example': 'https://example.com/x',
+                'examples': {
+                  'redirect': {'value': 'https://example.com/y'},
+                },
+              }),
+            ),
+          );
+          verifyNever(() => logger.warn(any()));
+        },
+      );
+
       test('allowReserved=true on query warns', () {
         final logger = _MockLogger();
         runWithLogger(

--- a/test/render/file_renderer_test.dart
+++ b/test/render/file_renderer_test.dart
@@ -2660,6 +2660,8 @@ void main() {
                   isRequired: true,
                   isDeprecated: false,
                   inLocation: ParameterLocation.query,
+                  example: null,
+                  examples: null,
                 ),
               ],
               requestBody: null,

--- a/test/render/render_operation_test.dart
+++ b/test/render/render_operation_test.dart
@@ -842,6 +842,74 @@ void main() {
   });
 
   group('parameters', () {
+    test('parameter `example` surfaces in the endpoint doc comment', () {
+      // Real-world driver: github's `git-ref-only` parameter declares
+      // `example: 'heads/feature-a'`. Before, that was dropped on the
+      // floor (`Ignoring: example`); now it should land in the
+      // endpoint's doc comment, scoped to the parameter via `[name]`.
+      final json = {
+        'summary': 'Get a ref',
+        'parameters': [
+          {
+            'name': 'ref',
+            'in': 'query',
+            'required': true,
+            'schema': {'type': 'string'},
+            'example': 'heads/feature-a',
+          },
+        ],
+        'responses': {
+          '200': {'description': 'OK'},
+        },
+      };
+      final result = renderTestOperation(
+        path: '/refs',
+        operationJson: json,
+        serverUrl: Uri.parse('https://api.spacetraders.io/v2'),
+      );
+      expect(result, contains('/// Get a ref'));
+      expect(result, contains("/// [ref] example: `'heads/feature-a'`"));
+    });
+
+    test(
+      'parameter `examples` (OAS 3 plural map) surfaces every value in the '
+      'endpoint doc comment',
+      () {
+        // OpenAPI 3 `examples` is a map of named Example objects; each
+        // entry has its own `value`. We surface every one, in
+        // declaration order, so the doc is faithful to the spec.
+        // Sibling `summary`/`description`/`externalValue` fields go
+        // through `_ignored`, which needs a logger scope.
+        final json = {
+          'parameters': [
+            {
+              'name': 'installation_id',
+              'in': 'query',
+              'required': true,
+              'schema': {'type': 'integer'},
+              'examples': {
+                'first': {'value': 1, 'summary': 'first'},
+                'second': {'value': 42},
+              },
+            },
+          ],
+          'responses': {
+            '200': {'description': 'OK'},
+          },
+        };
+        final result = runWithLogger(
+          _MockLogger(),
+          () => renderTestOperation(
+            path: '/installs',
+            operationJson: json,
+            serverUrl: Uri.parse('https://api.spacetraders.io/v2'),
+          ),
+        );
+        expect(result, contains('/// [installationId] example: `1`'));
+        expect(result, contains('/// [installationId] example: `42`'));
+      },
+    );
+
     test('string with default', () {
       final json = {
         'summary': 'Get user',

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -3403,9 +3403,9 @@ void main() {
           renderTestSchema(json, asComponent: true),
           '/// Title\n'
           '/// Description\n'
-          "/// example: `'example'`\n"
-          "/// example: `'example1'`\n"
-          "/// example: `'example2'`\n"
+          "/// Example: `'example'`\n"
+          "/// Example: `'example1'`\n"
+          "/// Example: `'example2'`\n"
           'extension type const Test._(String value) {\n'
           '    const Test(this.value);\n'
           '\n'
@@ -3469,9 +3469,9 @@ void main() {
           renderTestSchema(json, asComponent: true),
           '/// Title\n'
           '/// Description\n'
-          '/// example: `1.2`\n'
-          '/// example: `1.2`\n'
-          '/// example: `1.3`\n'
+          '/// Example: `1.2`\n'
+          '/// Example: `1.2`\n'
+          '/// Example: `1.3`\n'
           'extension type const Test._(double value) {\n'
           '    const Test(this.value);\n'
           '\n'
@@ -3511,9 +3511,27 @@ void main() {
           '/// Title\n'
           '/// Description\n'
           '/// {@endtemplate}\n'
-          '/// example: `{a: example, b: example}`\n'
-          '/// example: `{a: example1, b: example1}`\n'
-          '/// example: `{a: example2, b: example2}`\n'
+          '/// Example:\n'
+          '/// ```json\n'
+          '/// {\n'
+          '///   "a": "example",\n'
+          '///   "b": "example"\n'
+          '/// }\n'
+          '/// ```\n'
+          '/// Example:\n'
+          '/// ```json\n'
+          '/// {\n'
+          '///   "a": "example1",\n'
+          '///   "b": "example1"\n'
+          '/// }\n'
+          '/// ```\n'
+          '/// Example:\n'
+          '/// ```json\n'
+          '/// {\n'
+          '///   "a": "example2",\n'
+          '///   "b": "example2"\n'
+          '/// }\n'
+          '/// ```\n'
           '@immutable\n'
           'class Test {\n'
           '    /// {@macro test}\n'

--- a/test/render/render_tree_test.dart
+++ b/test/render/render_tree_test.dart
@@ -77,6 +77,8 @@ void main() {
         isRequired: true,
         isDeprecated: false,
         inLocation: ParameterLocation.query,
+        example: null,
+        examples: null,
       );
       expect(parameter.dartParameterName(quirks), 'aB');
     });
@@ -99,6 +101,8 @@ void main() {
         isRequired: false,
         isDeprecated: false,
         inLocation: ParameterLocation.header,
+        example: null,
+        examples: null,
       );
       expect(parameter.dartParameterName(quirks), 'apiKey');
     });
@@ -134,6 +138,8 @@ void main() {
         isRequired: true,
         isDeprecated: false,
         inLocation: ParameterLocation.query,
+        example: null,
+        examples: null,
       );
       // The Dart-visible identifier gets `_` appended so it compiles;
       // the spec-side name and its bracketed form keep the original
@@ -207,6 +213,96 @@ void main() {
           reason: 'unbalanced backticks in line: $line',
         );
       }
+    });
+
+    test(r'parameter examples render as `[name] example: \`value\`` lines', () {
+      expect(
+        createDocCommentFromParts(
+          body: 'List the things.',
+          parameterExamples: const [
+            ParameterExampleDoc(
+              dartName: 'ref',
+              examples: <dynamic>['heads/feature-a'],
+            ),
+            ParameterExampleDoc(
+              dartName: 'installationId',
+              examples: <dynamic>[1],
+            ),
+          ],
+          indent: 4,
+        ),
+        '/// List the things.\n'
+        "    /// [ref] example: `'heads/feature-a'`\n"
+        '    /// [installationId] example: `1`\n'
+        '    ',
+      );
+    });
+  });
+
+  group('exampleDocCommentLines', () {
+    test('string scalar renders inline with Dart-source quoting', () {
+      expect(exampleDocCommentLines('hello'), const ["/// Example: `'hello'`"]);
+    });
+
+    test('numeric and boolean scalars render bare in backticks', () {
+      expect(exampleDocCommentLines(42), const ['/// Example: `42`']);
+      expect(exampleDocCommentLines(true), const ['/// Example: `true`']);
+    });
+
+    test('null is dropped (caller can pass `example` unconditionally)', () {
+      expect(exampleDocCommentLines(null), isEmpty);
+    });
+
+    test('Map values render as a fenced JSON block', () {
+      expect(exampleDocCommentLines(<String, dynamic>{'a': 1, 'b': 'two'}), [
+        '/// Example:',
+        '/// ```json',
+        '/// {',
+        '///   "a": 1,',
+        '///   "b": "two"',
+        '/// }',
+        '/// ```',
+      ]);
+    });
+
+    test('List values render as a fenced JSON block', () {
+      expect(exampleDocCommentLines(<dynamic>['a', 'b']), const [
+        '/// Example:',
+        '/// ```json',
+        '/// [',
+        '///   "a",',
+        '///   "b"',
+        '/// ]',
+        '/// ```',
+      ]);
+    });
+
+    test('nested complex values pretty-print with two-space indent', () {
+      expect(
+        exampleDocCommentLines(<String, dynamic>{
+          'name': 'octocat',
+          'tags': <dynamic>['admin', 'user'],
+        }),
+        const [
+          '/// Example:',
+          '/// ```json',
+          '/// {',
+          '///   "name": "octocat",',
+          '///   "tags": [',
+          '///     "admin",',
+          '///     "user"',
+          '///   ]',
+          '/// }',
+          '/// ```',
+        ],
+      );
+    });
+
+    test('custom prefix scopes the example to a parameter', () {
+      expect(
+        exampleDocCommentLines('a', prefix: '[ref] example'),
+        const ["/// [ref] example: `'a'`"],
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

- Threads OpenAPI `example` and `examples` keywords on parameters and headers through parse → resolve → render so they land in generated Dart doc comments instead of being dropped (`Ignoring: example` warning count on github regen: **51 → 0**).
- Per-parameter examples surface in the endpoint's doc comment as `/// [paramName] example: \`value\``; the Dart-side parameter name keeps the dartdoc cross-link valid. Schema examples (already supported) keep the same emission point.
- Uniformly upgrades example formatting: scalars (String/num/bool) render inline in backticks; Map/List values render in a fenced ` ```json ` block so multi-line objects stay readable.
- Parses the OpenAPI 3 plural `examples:` map (each entry an Example object with a nested `value:`) in a shared helper that flattens to a list and quietly consumes sibling `summary`/`description`/`externalValue` fields.
- Headers carry the new fields too; response headers do not yet flow to render, so the parser surfacing is dormant for now (it lights up automatically the day headers are emitted).

## Test plan

- [x] `dart analyze` clean on github regen (`/tmp/g_example_after`)
- [x] 51 sites previously dropping `example:` now emit `/// Example:` doc comments (parameters in `lib/api/`, schemas already in `lib/messages/`)
- [x] `Ignoring: example` warning count: 51 → 0
- [x] `dart test` — all 431 tests pass (4 new render-side, 2 new parser-side)
- [x] `dart format` clean