### PR TITLE
feat: smoosh top-level $ref variants used by exactly one parent

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -26,6 +26,7 @@ words:
   - unioned
   - watchcrunch
   - dedup
+  - dedups
   - enumless
   - worktree
   - worktrees

--- a/lib/src/naming.dart
+++ b/lib/src/naming.dart
@@ -172,22 +172,23 @@ class _NameAssigner {
   // this through [AssignedNames.parentSealedTypeFor] and emits the
   // variant with `extends <Parent>` instead of a wrapper subclass.
   final Map<JsonPointer, String> _smooshedParentSnake = {};
-  // How many times each schema pointer is referenced as a oneOf/anyOf
-  // variant slot during the walk. AllOf members do *not* count —
-  // `ResolvedAllOf` collapses to a synthesized merged `RenderObject`
-  // at render time, so a $ref inside an allOf contributes structurally
-  // (its fields merge in) without emitting a typed Dart reference to
-  // the source class. Counts are total occurrences (not deduped on
-  // pointer); recursion is still deduped via [_visited].
-  final Map<JsonPointer, int> _variantUseCounts = {};
-  // How many times each schema pointer is referenced from a slot that
-  // emits a typed Dart reference to it: object property types,
-  // additionalProperties, array items, map values, parameter / request
-  // body / response schemas. AllOf-member uses don't count (see
-  // [_variantUseCounts]). Used together with [_variantUseCounts] to
-  // detect "exclusive-use" top-level schemas — a top-level component
-  // whose only typed reference site is one oneOf/anyOf variant slot.
-  final Map<JsonPointer, int> _otherUseCounts = {};
+  // Pointers seen at least once as a oneOf/anyOf variant. The
+  // smoosh predicate also needs to know "more than once", which
+  // [_seenAsVariantAgain] tracks separately so the on-encounter
+  // logic is a single set-`add` test instead of a counter compare.
+  // AllOf members are deliberately excluded — `ResolvedAllOf`
+  // collapses to a synthesized merged `RenderObject` at render
+  // time, so an `$ref` inside an allOf contributes structurally
+  // (its fields merge in) without emitting a typed Dart reference
+  // to the source class.
+  final Set<JsonPointer> _seenAsVariant = {};
+  final Set<JsonPointer> _seenAsVariantAgain = {};
+  // Pointers reached from at least one slot that emits a typed Dart
+  // reference: object properties, additionalProperties, array items,
+  // map values, parameter / request body / response schemas. The
+  // exact count doesn't matter — we only need to know whether *any*
+  // such use exists. AllOf members don't count (see [_seenAsVariant]).
+  final Set<JsonPointer> _hasOtherUse = {};
 
   /// Run the allocator over both phases and return the final
   /// pointer → Dart name map. The assigner is single-use; calling
@@ -332,13 +333,14 @@ class _NameAssigner {
 
   /// True when [variant] is a top-level component schema referenced
   /// from exactly one oneOf/anyOf variant slot and from no other
-  /// typed-reference slot. Reads the per-pointer counters tabulated
-  /// during the phase-1 walk; safe to call once that walk is done
-  /// (i.e. from phase 2's [_claimWrapperNames]).
+  /// typed-reference slot. Reads the per-pointer presence sets
+  /// populated during the phase-1 walk; safe to call once that walk
+  /// is done (i.e. from phase 2's [_claimWrapperNames]).
   bool _isExclusiveUseTopLevel(ResolvedSchema variant) {
-    final variantUses = _variantUseCounts[variant.pointer] ?? 0;
-    final otherUses = _otherUseCounts[variant.pointer] ?? 0;
-    return variantUses == 1 && otherUses == 0;
+    final p = variant.pointer;
+    return _seenAsVariant.contains(p) &&
+        !_seenAsVariantAgain.contains(p) &&
+        !_hasOtherUse.contains(p);
   }
 
   /// Whether [decision]'s render-layer template can emit a smooshed
@@ -491,22 +493,19 @@ class _NameAssigner {
   }
 
   void _visitSchema(ResolvedSchema schema, _SlotKind slot) {
-    // Tally every encounter (not just first-visit) so the use counters
-    // reflect total references. Recursion below still dedups via
-    // [_visited], so the tree walk is bounded.
+    // Record the encounter (not just first-visit) so the presence
+    // sets reflect total references. Recursion below still dedups
+    // via [_visited], so the tree walk is bounded.
     switch (slot) {
       case _SlotKind.variant:
-        _variantUseCounts.update(
-          schema.pointer,
-          (n) => n + 1,
-          ifAbsent: () => 1,
-        );
+        // First variant encounter goes into [_seenAsVariant];
+        // subsequent encounters spill into [_seenAsVariantAgain],
+        // which the smoosh predicate uses to reject "exactly once".
+        if (!_seenAsVariant.add(schema.pointer)) {
+          _seenAsVariantAgain.add(schema.pointer);
+        }
       case _SlotKind.other:
-        _otherUseCounts.update(
-          schema.pointer,
-          (n) => n + 1,
-          ifAbsent: () => 1,
-        );
+        _hasOtherUse.add(schema.pointer);
       case _SlotKind.allOfMember:
         // AllOf members aren't typed Dart references — `ResolvedAllOf`
         // collapses into a synthesized merged `RenderObject` whose

--- a/lib/src/naming.dart
+++ b/lib/src/naming.dart
@@ -164,11 +164,30 @@ class _NameAssigner {
   // their variants' Dart names have been resolved.
   final List<ResolvedSchemaCollection> _collectionsForWrappers = [];
   // Variant pointer → parent's snake name, populated during phase 2
-  // for inline-exclusive object variants whose dispatch lets the
-  // variant class extend the sealed parent directly (smoosh). Render
-  // reads this through [AssignedNames.parentSealedTypeFor] and emits
-  // the variant with `extends <Parent>` instead of a wrapper subclass.
+  // for object variants whose dispatch lets the variant class extend
+  // the sealed parent directly (smoosh). Two paths feed in: inline
+  // variants (`<parent>/oneOf/<i>`) and exclusive-by-use top-level
+  // schemas (a top-level component referenced by exactly one
+  // oneOf/anyOf variant slot and from nowhere else). Render reads
+  // this through [AssignedNames.parentSealedTypeFor] and emits the
+  // variant with `extends <Parent>` instead of a wrapper subclass.
   final Map<JsonPointer, String> _smooshedParentSnake = {};
+  // How many times each schema pointer is referenced as a oneOf/anyOf
+  // variant slot during the walk. AllOf members do *not* count —
+  // `ResolvedAllOf` collapses to a synthesized merged `RenderObject`
+  // at render time, so a $ref inside an allOf contributes structurally
+  // (its fields merge in) without emitting a typed Dart reference to
+  // the source class. Counts are total occurrences (not deduped on
+  // pointer); recursion is still deduped via [_visited].
+  final Map<JsonPointer, int> _variantUseCounts = {};
+  // How many times each schema pointer is referenced from a slot that
+  // emits a typed Dart reference to it: object property types,
+  // additionalProperties, array items, map values, parameter / request
+  // body / response schemas. AllOf-member uses don't count (see
+  // [_variantUseCounts]). Used together with [_variantUseCounts] to
+  // detect "exclusive-use" top-level schemas — a top-level component
+  // whose only typed reference site is one oneOf/anyOf variant slot.
+  final Map<JsonPointer, int> _otherUseCounts = {};
 
   /// Run the allocator over both phases and return the final
   /// pointer → Dart name map. The assigner is single-use; calling
@@ -241,20 +260,29 @@ class _NameAssigner {
     _allocator.claim(op.pointer, ['${op.snakeName}_response']);
   }
 
-  void visitSchema(ResolvedSchema schema) => _visitSchema(schema);
+  /// Visit a schema reached from a slot that emits a typed Dart
+  /// reference to it (operation parameter / request / response,
+  /// object property, additionalProperties, array items, map value).
+  /// Variant-slot visits dispatch through `_visitSchema` directly
+  /// with `_SlotKind.variant`; this entry point is for the "other"
+  /// (non-variant) slots so per-pointer use counters can distinguish
+  /// the two.
+  void visitSchema(ResolvedSchema schema) =>
+      _visitSchema(schema, _SlotKind.other);
 
   /// Phase-2 wrapper-subclass name claims. Reads the resolved variant
   /// names produced by phase 1 and submits one claim per dispatch-
   /// emitted wrapper. Variant identity is by index in
   /// [collection]`.schemas` — matches `AssignedNames.wrapperPointer`.
   ///
-  /// Smooshable variants (inline `ResolvedObject` under a
-  /// dispatch where the variant class can extend the sealed parent
-  /// directly — predicate-required for now) skip the wrapper claim
-  /// entirely. Render reads the parent's snake name from
-  /// [_smooshedParentSnake] and emits the variant class with
-  /// `extends <Parent>` instead of generating a separate wrapper
-  /// subclass + `value:` indirection.
+  /// Smooshable variants (inline `ResolvedObject` or exclusive-by-use
+  /// top-level `ResolvedObject`, under a dispatch whose template
+  /// knows how to skip the wrapper) skip the wrapper claim entirely
+  /// and instead record the parent's snake name in
+  /// [_smooshedParentSnake]. Render reads it through
+  /// [AssignedNames.parentSealedTypeFor] and emits the variant with
+  /// `extends <Parent>` directly, eliminating the wrapper subclass
+  /// + `value:` indirection.
   void _claimWrapperNames(ResolvedSchemaCollection collection) {
     final decision = decideDispatch(collection);
     if (decision is NoDispatch) return;
@@ -281,12 +309,37 @@ class _NameAssigner {
       _isStructurallySmooshable(variant) && _dispatchEmitsSmooshed(decision);
 
   /// Whether [variant] *could* be a direct subclass of a sealed
-  /// parent in idiomatic Dart. Holds when it's an inline (so
-  /// exclusive to one parent by construction) `ResolvedObject` (so
-  /// it has a class body to extend with). Independent of any
-  /// dispatch — purely a structural property of the variant.
-  bool _isStructurallySmooshable(ResolvedSchema variant) =>
-      variant is ResolvedObject && _isInlineCollectionVariant(variant);
+  /// parent in idiomatic Dart. Two paths:
+  ///
+  /// - Inline `ResolvedObject` variant — the variant lives at
+  ///   `<parent>/oneOf/<i>` (or `/anyOf/<i>`), so it's exclusive to
+  ///   one parent by construction.
+  /// - Top-level `ResolvedObject` referenced by exactly one
+  ///   oneOf/anyOf variant slot, with no other typed-reference uses
+  ///   — "exclusive-by-use." `ResolvedAllOf` member uses don't
+  ///   count (they don't emit a typed Dart reference to the source
+  ///   class), which lets `RepositoryRule`-style families fold even
+  ///   when their detailed twin re-uses the same components inside
+  ///   an allOf.
+  ///
+  /// Independent of any dispatch — purely a structural / reachability
+  /// property of the variant.
+  bool _isStructurallySmooshable(ResolvedSchema variant) {
+    if (variant is! ResolvedObject) return false;
+    if (_isInlineCollectionVariant(variant)) return true;
+    return _isExclusiveUseTopLevel(variant);
+  }
+
+  /// True when [variant] is a top-level component schema referenced
+  /// from exactly one oneOf/anyOf variant slot and from no other
+  /// typed-reference slot. Reads the per-pointer counters tabulated
+  /// during the phase-1 walk; safe to call once that walk is done
+  /// (i.e. from phase 2's [_claimWrapperNames]).
+  bool _isExclusiveUseTopLevel(ResolvedSchema variant) {
+    final variantUses = _variantUseCounts[variant.pointer] ?? 0;
+    final otherUses = _otherUseCounts[variant.pointer] ?? 0;
+    return variantUses == 1 && otherUses == 0;
+  }
 
   /// Whether [decision]'s render-layer template can emit a smooshed
   /// variant — i.e. skip the wrapper subclass and emit
@@ -437,7 +490,31 @@ class _NameAssigner {
     return secondToLast == 'oneOf' || secondToLast == 'anyOf';
   }
 
-  void _visitSchema(ResolvedSchema schema) {
+  void _visitSchema(ResolvedSchema schema, _SlotKind slot) {
+    // Tally every encounter (not just first-visit) so the use counters
+    // reflect total references. Recursion below still dedups via
+    // [_visited], so the tree walk is bounded.
+    switch (slot) {
+      case _SlotKind.variant:
+        _variantUseCounts.update(
+          schema.pointer,
+          (n) => n + 1,
+          ifAbsent: () => 1,
+        );
+      case _SlotKind.other:
+        _otherUseCounts.update(
+          schema.pointer,
+          (n) => n + 1,
+          ifAbsent: () => 1,
+        );
+      case _SlotKind.allOfMember:
+        // AllOf members aren't typed Dart references — `ResolvedAllOf`
+        // collapses into a synthesized merged `RenderObject` whose
+        // fields come from each member, but no member's class name is
+        // emitted at the use site. Skip the counters; we still recurse
+        // below for nested newtypes inside the member.
+        break;
+    }
     if (!_visited.add(schema.pointer)) return;
     if (schema.createsNewType) {
       _allocator.claim(schema.pointer, _preferencesFor(schema));
@@ -446,29 +523,34 @@ class _NameAssigner {
     switch (schema) {
       case ResolvedObject():
         for (final prop in schema.properties.values) {
-          _visitSchema(prop);
+          _visitSchema(prop, _SlotKind.other);
         }
         final extraProps = schema.additionalProperties;
-        if (extraProps != null) _visitSchema(extraProps);
+        if (extraProps != null) _visitSchema(extraProps, _SlotKind.other);
       case ResolvedArray():
-        _visitSchema(schema.items);
+        _visitSchema(schema.items, _SlotKind.other);
       case ResolvedMap():
-        _visitSchema(schema.valueSchema);
+        _visitSchema(schema.valueSchema, _SlotKind.other);
         final keyEnum = schema.keySchema;
-        if (keyEnum != null) _visitSchema(keyEnum);
+        if (keyEnum != null) _visitSchema(keyEnum, _SlotKind.other);
       case ResolvedOneOf():
       case ResolvedAnyOf():
-      case ResolvedAllOf():
         final collection = schema as ResolvedSchemaCollection;
         for (final variant in collection.schemas) {
-          _visitSchema(variant);
+          _visitSchema(variant, _SlotKind.variant);
         }
         // Defer wrapper-name claims to phase 2 — they need the
-        // resolved variant names. AllOf gets `NoDispatch` from
-        // [decideDispatch] (it collapses to a synthetic object), so
-        // no wrappers will actually be claimed for it; queueing it
-        // is harmless and keeps the gate in one place.
+        // resolved variant names.
         _collectionsForWrappers.add(collection);
+      case ResolvedAllOf():
+        for (final member in schema.schemas) {
+          _visitSchema(member, _SlotKind.allOfMember);
+        }
+        // AllOf gets `NoDispatch` from [decideDispatch] (it collapses
+        // to a synthetic object), so no wrappers are actually claimed.
+        // We still queue it for symmetry with the other collection
+        // kinds so the gate lives in one place.
+        _collectionsForWrappers.add(schema);
       case ResolvedString():
       case ResolvedInteger():
       case ResolvedNumber():
@@ -484,6 +566,28 @@ class _NameAssigner {
         break;
     }
   }
+}
+
+/// What kind of slot a [ResolvedSchema] was reached from. Drives the
+/// per-pointer use counters in [_NameAssigner] that detect "exclusive-
+/// use" top-level schemas — top-level components whose only typed
+/// reference site is one oneOf/anyOf variant slot, making them
+/// candidates to smoosh into the parent's sealed class.
+enum _SlotKind {
+  /// Reached as a oneOf/anyOf variant.
+  variant,
+
+  /// Reached as a typed reference: object property, additional
+  /// property, array items, map value, or operation parameter /
+  /// request body / response.
+  other,
+
+  /// Reached as a member of an `allOf`. `ResolvedAllOf` collapses to
+  /// a synthesized merged `RenderObject` at render time, so members
+  /// contribute fields without emitting a typed reference to the
+  /// source class — these don't count as "uses" for the smoosh
+  /// eligibility check.
+  allOfMember,
 }
 
 /// Collision-aware Dart name allocator. Each entity submits a

--- a/test/naming_test.dart
+++ b/test/naming_test.dart
@@ -172,11 +172,15 @@ void main() {
       expect(userEntry.value, 'User');
     });
 
-    test('oneOf with discriminator gets one wrapper name per variant '
-        'under the synthesized wrapper pointer', () {
-      // Discriminator dispatch emits a `<Parent><Variant>` wrapper
-      // per variant. Naming pass stores each under
-      // `AssignedNames.wrapperPointer(parent, i)`.
+    test(r'oneOf with discriminator: top-level $ref variants used '
+        'exclusively by one parent smoosh into the sealed parent', () {
+      // `Cat` and `Dog` are top-level component schemas referenced
+      // only as variants of `Pet` (no other property / param /
+      // response uses them). That makes them exclusive-by-use, so
+      // the smoosh predicate flips on: no wrapper subclass is
+      // claimed for either, and each variant pointer maps to
+      // `Pet`'s snake name (so render emits `class Cat extends Pet`
+      // inline in pet.dart).
       final names = namesFor({
         'openapi': '3.1.0',
         'info': {'title': 'X', 'version': '1.0'},
@@ -239,13 +243,372 @@ void main() {
         },
       });
       final pet = JsonPointer.parse('#/components/schemas/Pet');
+      // No wrapper subclass for either variant — both smoosh.
+      expect(names.maybeGet(AssignedNames.wrapperPointer(pet, 0)), isNull);
+      expect(names.maybeGet(AssignedNames.wrapperPointer(pet, 1)), isNull);
+      // Variant pointers carry the parent's sealed class name.
       expect(
-        names[AssignedNames.wrapperPointer(pet, 0)],
-        'PetCat',
+        names.parentSealedTypeFor(
+          JsonPointer.parse('#/components/schemas/Cat'),
+        ),
+        'Pet',
       );
       expect(
-        names[AssignedNames.wrapperPointer(pet, 1)],
-        'PetDog',
+        names.parentSealedTypeFor(
+          JsonPointer.parse('#/components/schemas/Dog'),
+        ),
+        'Pet',
+      );
+    });
+
+    test('top-level variant referenced by one oneOf parent + one '
+        'property keeps its wrapper (not exclusive-use)', () {
+      // `Cat` is a variant of `Pet` AND a property type on
+      // `Owner.favorite`. Two typed-reference uses → not
+      // exclusive-use → wrapper subclass survives, no smoosh.
+      final names = namesFor({
+        'openapi': '3.1.0',
+        'info': {'title': 'X', 'version': '1.0'},
+        'servers': [
+          {'url': 'https://x'},
+        ],
+        'paths': {
+          '/u': {
+            'get': {
+              'summary': 'Get',
+              'responses': {
+                '200': {
+                  'description': 'OK',
+                  'content': {
+                    'application/json': {
+                      'schema': {r'$ref': '#/components/schemas/Owner'},
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        'components': {
+          'schemas': {
+            'Owner': {
+              'type': 'object',
+              'required': ['pet', 'favorite'],
+              'properties': {
+                'pet': {r'$ref': '#/components/schemas/Pet'},
+                'favorite': {r'$ref': '#/components/schemas/Cat'},
+              },
+            },
+            'Pet': {
+              'oneOf': [
+                {r'$ref': '#/components/schemas/Cat'},
+                {r'$ref': '#/components/schemas/Dog'},
+              ],
+              'discriminator': {
+                'propertyName': 'kind',
+                'mapping': {
+                  'cat': '#/components/schemas/Cat',
+                  'dog': '#/components/schemas/Dog',
+                },
+              },
+            },
+            'Cat': {
+              'type': 'object',
+              'required': ['kind'],
+              'properties': {
+                'kind': {
+                  'type': 'string',
+                  'enum': ['cat'],
+                },
+              },
+            },
+            'Dog': {
+              'type': 'object',
+              'required': ['kind'],
+              'properties': {
+                'kind': {
+                  'type': 'string',
+                  'enum': ['dog'],
+                },
+              },
+            },
+          },
+        },
+      });
+      final pet = JsonPointer.parse('#/components/schemas/Pet');
+      // `Cat` keeps its wrapper because it's also a property type.
+      expect(names[AssignedNames.wrapperPointer(pet, 0)], 'PetCat');
+      expect(
+        names.parentSealedTypeFor(
+          JsonPointer.parse('#/components/schemas/Cat'),
+        ),
+        isNull,
+      );
+      // `Dog` is exclusive-use, so it still smooshes.
+      expect(names.maybeGet(AssignedNames.wrapperPointer(pet, 1)), isNull);
+      expect(
+        names.parentSealedTypeFor(
+          JsonPointer.parse('#/components/schemas/Dog'),
+        ),
+        'Pet',
+      );
+    });
+
+    test('top-level variant referenced by two oneOf parents keeps '
+        'its wrapper (variant_count > 1)', () {
+      // `Cat` is a variant of both `Pet1` and `Pet2`. Two variant
+      // references → not exclusive-use → wrapper subclasses survive
+      // in both parents, no smoosh.
+      final names = namesFor({
+        'openapi': '3.1.0',
+        'info': {'title': 'X', 'version': '1.0'},
+        'servers': [
+          {'url': 'https://x'},
+        ],
+        'paths': {
+          '/p1': {
+            'get': {
+              'summary': 'Get pet1',
+              'responses': {
+                '200': {
+                  'description': 'OK',
+                  'content': {
+                    'application/json': {
+                      'schema': {r'$ref': '#/components/schemas/Pet1'},
+                    },
+                  },
+                },
+              },
+            },
+          },
+          '/p2': {
+            'get': {
+              'summary': 'Get pet2',
+              'responses': {
+                '200': {
+                  'description': 'OK',
+                  'content': {
+                    'application/json': {
+                      'schema': {r'$ref': '#/components/schemas/Pet2'},
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        'components': {
+          'schemas': {
+            'Pet1': {
+              'oneOf': [
+                {r'$ref': '#/components/schemas/Cat'},
+                {r'$ref': '#/components/schemas/Dog'},
+              ],
+              'discriminator': {
+                'propertyName': 'kind',
+                'mapping': {
+                  'cat': '#/components/schemas/Cat',
+                  'dog': '#/components/schemas/Dog',
+                },
+              },
+            },
+            'Pet2': {
+              'oneOf': [
+                {r'$ref': '#/components/schemas/Cat'},
+                {r'$ref': '#/components/schemas/Bird'},
+              ],
+              'discriminator': {
+                'propertyName': 'kind',
+                'mapping': {
+                  'cat': '#/components/schemas/Cat',
+                  'bird': '#/components/schemas/Bird',
+                },
+              },
+            },
+            'Cat': {
+              'type': 'object',
+              'required': ['kind'],
+              'properties': {
+                'kind': {
+                  'type': 'string',
+                  'enum': ['cat'],
+                },
+              },
+            },
+            'Dog': {
+              'type': 'object',
+              'required': ['kind'],
+              'properties': {
+                'kind': {
+                  'type': 'string',
+                  'enum': ['dog'],
+                },
+              },
+            },
+            'Bird': {
+              'type': 'object',
+              'required': ['kind'],
+              'properties': {
+                'kind': {
+                  'type': 'string',
+                  'enum': ['bird'],
+                },
+              },
+            },
+          },
+        },
+      });
+      final pet1 = JsonPointer.parse('#/components/schemas/Pet1');
+      final pet2 = JsonPointer.parse('#/components/schemas/Pet2');
+      // `Cat` keeps its wrapper in both parents.
+      expect(names[AssignedNames.wrapperPointer(pet1, 0)], 'Pet1Cat');
+      expect(names[AssignedNames.wrapperPointer(pet2, 0)], 'Pet2Cat');
+      // `Cat` doesn't smoosh — would conflict (which parent?).
+      expect(
+        names.parentSealedTypeFor(
+          JsonPointer.parse('#/components/schemas/Cat'),
+        ),
+        isNull,
+      );
+      // `Dog` and `Bird` each have exactly one variant ref →
+      // exclusive-use, smooshed into their respective parents.
+      expect(names.maybeGet(AssignedNames.wrapperPointer(pet1, 1)), isNull);
+      expect(
+        names.parentSealedTypeFor(
+          JsonPointer.parse('#/components/schemas/Dog'),
+        ),
+        'Pet1',
+      );
+      expect(names.maybeGet(AssignedNames.wrapperPointer(pet2, 1)), isNull);
+      expect(
+        names.parentSealedTypeFor(
+          JsonPointer.parse('#/components/schemas/Bird'),
+        ),
+        'Pet2',
+      );
+    });
+
+    test('top-level variant referenced by one oneOf parent and '
+        'inside an allOf member smooshes (allOf is structural-only)', () {
+      // `Cat` is a variant of `Pet` and is also embedded in an
+      // `allOf` member of `PetDetailed`'s oneOf. The allOf-member
+      // use isn't a typed Dart reference (the merged class doesn't
+      // emit `Cat`'s name) — so `Cat` stays exclusive-by-use and
+      // smooshes into `Pet`. Mirrors the github `RepositoryRule` /
+      // `RepositoryRuleDetailed` family.
+      final names = namesFor({
+        'openapi': '3.1.0',
+        'info': {'title': 'X', 'version': '1.0'},
+        'servers': [
+          {'url': 'https://x'},
+        ],
+        'paths': {
+          '/p': {
+            'get': {
+              'summary': 'Get pet',
+              'responses': {
+                '200': {
+                  'description': 'OK',
+                  'content': {
+                    'application/json': {
+                      'schema': {r'$ref': '#/components/schemas/Pet'},
+                    },
+                  },
+                },
+              },
+            },
+          },
+          '/d': {
+            'get': {
+              'summary': 'Get detailed pet',
+              'responses': {
+                '200': {
+                  'description': 'OK',
+                  'content': {
+                    'application/json': {
+                      'schema': {
+                        r'$ref': '#/components/schemas/PetDetailed',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        'components': {
+          'schemas': {
+            'Pet': {
+              'oneOf': [
+                {r'$ref': '#/components/schemas/Cat'},
+                {r'$ref': '#/components/schemas/Dog'},
+              ],
+              'discriminator': {
+                'propertyName': 'kind',
+                'mapping': {
+                  'cat': '#/components/schemas/Cat',
+                  'dog': '#/components/schemas/Dog',
+                },
+              },
+            },
+            'PetDetailed': {
+              'oneOf': [
+                {
+                  'allOf': [
+                    {r'$ref': '#/components/schemas/Cat'},
+                    {r'$ref': '#/components/schemas/PetMeta'},
+                  ],
+                },
+                {
+                  'allOf': [
+                    {r'$ref': '#/components/schemas/Dog'},
+                    {r'$ref': '#/components/schemas/PetMeta'},
+                  ],
+                },
+              ],
+            },
+            'Cat': {
+              'type': 'object',
+              'required': ['kind'],
+              'properties': {
+                'kind': {
+                  'type': 'string',
+                  'enum': ['cat'],
+                },
+              },
+            },
+            'Dog': {
+              'type': 'object',
+              'required': ['kind'],
+              'properties': {
+                'kind': {
+                  'type': 'string',
+                  'enum': ['dog'],
+                },
+              },
+            },
+            'PetMeta': {
+              'type': 'object',
+              'required': ['updated_at'],
+              'properties': {
+                'updated_at': {'type': 'string'},
+              },
+            },
+          },
+        },
+      });
+      // `Cat` and `Dog` smoosh into `Pet` despite the allOf re-use.
+      expect(
+        names.parentSealedTypeFor(
+          JsonPointer.parse('#/components/schemas/Cat'),
+        ),
+        'Pet',
+      );
+      expect(
+        names.parentSealedTypeFor(
+          JsonPointer.parse('#/components/schemas/Dog'),
+        ),
+        'Pet',
       );
     });
 

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -1444,9 +1444,15 @@ void main() {
           ),
         ),
       );
-      // Wrappers, not smooshed (top-level $ref variants).
-      expect(result, contains('class RespDetailed extends Resp'));
-      expect(result, contains('class RespSimple extends Resp'));
+      // `Detailed` and `Simple` are top-level `$ref` variants
+      // referenced only by `Resp`, with no other typed-reference
+      // uses → exclusive-by-use → smooshed: variant data classes
+      // extend `Resp` directly, no `RespDetailed`/`RespSimple`
+      // wrapper classes survive.
+      expect(result, contains('final class Detailed extends Resp'));
+      expect(result, contains('final class Simple extends Resp'));
+      expect(result, isNot(contains('class RespDetailed ')));
+      expect(result, isNot(contains('class RespSimple ')));
       // No FormatException-on-fall-through: the Always fallback means
       // any input shape gets routed to a variant.
       expect(result, isNot(contains('throw UnimplementedError')));

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -1014,7 +1014,8 @@ void main() {
       expect(result, isNot(contains('throw UnimplementedError')));
     });
 
-    test('oneOf with discriminator + mapping renders sealed dispatch', () {
+    test('oneOf with discriminator + mapping renders sealed dispatch '
+        'with exclusive-use top-level variants smooshed', () {
       final results = renderTestSchemas(
         {
           'Pet': {
@@ -1054,16 +1055,25 @@ void main() {
       expect(pet, contains('sealed class Pet'));
       expect(pet, contains('factory Pet.fromJson(Map<String, dynamic> json)'));
       expect(pet, contains("final discriminator = json['pet_type']"));
-      expect(pet, contains("'cat' => PetCat(Cat.fromJson(json))"));
-      expect(pet, contains("'dog' => PetDog(Dog.fromJson(json))"));
+      // `Cat` and `Dog` are top-level component schemas referenced
+      // only as variants of `Pet` (no other property / param /
+      // response slot uses them). They're exclusive-by-use, so they
+      // smoosh: the case arms construct each variant directly (no
+      // `PetCat` / `PetDog` wrapper) and the variant data classes
+      // themselves are rendered inline in `pet.dart` as direct
+      // sealed subclasses.
+      expect(pet, contains("'cat' => Cat.fromJson(json)"));
+      expect(pet, contains("'dog' => Dog.fromJson(json)"));
       expect(pet, contains(r"Unknown pet_type '$discriminator' for Pet"));
-      // Wrapper subclasses with @immutable + structural equality.
-      expect(pet, contains('@immutable'));
-      expect(pet, contains('final class PetCat extends Pet'));
-      expect(pet, contains('final Cat value;'));
-      expect(pet, contains('final class PetDog extends Pet'));
-      expect(pet, contains('final Dog value;'));
-      expect(pet, contains('Map<String, dynamic> toJson() => value.toJson()'));
+      // Variant data classes inlined as direct sealed subclasses.
+      expect(pet, contains('final class Cat extends Pet'));
+      expect(pet, contains('final class Dog extends Pet'));
+      expect(pet, contains('@override'));
+      // No wrapper subclasses (`PetCat`/`PetDog`) survive.
+      expect(pet, isNot(contains('class PetCat ')));
+      expect(pet, isNot(contains('class PetDog ')));
+      expect(pet, isNot(contains('final Cat value;')));
+      expect(pet, isNot(contains('final Dog value;')));
     });
 
     test(
@@ -1097,10 +1107,17 @@ void main() {
         );
         final mixed = results['Mixed'];
         expect(mixed, isNotNull);
-        // Distinct shapes (Map vs String) → shape dispatch.
+        // Distinct shapes (Map vs String) → shape dispatch. `Cat` is
+        // exclusive-by-use (only referenced as a variant of `Mixed`),
+        // so it smooshes — the Map arm constructs `Cat` directly, no
+        // `MixedCat` wrapper. The non-object string variant keeps its
+        // `MixedString` wrapper (primitives can't extend a sealed
+        // class).
         expect(mixed, contains('factory Mixed.fromJson(dynamic json)'));
-        expect(mixed, contains('Map<String, dynamic> v => MixedCat'));
+        expect(mixed, contains('Map<String, dynamic> v => Cat.fromJson(v)'));
         expect(mixed, contains('String v => MixedString'));
+        expect(mixed, contains('final class Cat extends Mixed'));
+        expect(mixed, isNot(contains('class MixedCat ')));
         expect(mixed, isNot(contains('UnimplementedError')));
       },
     );
@@ -1580,11 +1597,17 @@ void main() {
       final result = results['Result'];
       expect(result, isNotNull);
       expect(result, contains('factory Result.fromJson(dynamic json)'));
+      // `Status` is an enum (can't extend a sealed class) so it keeps
+      // its `ResultStatus` wrapper. `Detail` is exclusive-by-use and
+      // smooshes — the Map arm constructs `Detail` directly, no
+      // wrapper.
       expect(result, contains('String v => ResultStatus(Status.fromJson(v))'));
       expect(
         result,
-        contains('Map<String, dynamic> v => ResultDetail(Detail.fromJson(v))'),
+        contains('Map<String, dynamic> v => Detail.fromJson(v)'),
       );
+      expect(result, contains('final class Detail extends Result'));
+      expect(result, isNot(contains('class ResultDetail ')));
       expect(result, contains('final Status value;'));
       expect(result, contains('value.toJson()'));
     });
@@ -1658,13 +1681,19 @@ void main() {
       final pet = results['Pet'];
       expect(pet, isNotNull);
       expect(pet, contains('factory Pet.fromJson(Map<String, dynamic> json)'));
+      // `Cat`/`Dog` are exclusive-by-use top-level variants → smooshed.
+      // The if-arms construct each variant directly; the variant data
+      // classes are inlined into `pet.dart` as direct sealed
+      // subclasses (no `PetCat`/`PetDog` wrappers).
       expect(pet, contains("if (json.containsKey('meow'))"));
-      expect(pet, contains('return PetCat(Cat.fromJson(json))'));
+      expect(pet, contains('return Cat.fromJson(json)'));
       expect(pet, contains("if (json.containsKey('bark'))"));
-      expect(pet, contains('return PetDog(Dog.fromJson(json))'));
+      expect(pet, contains('return Dog.fromJson(json)'));
       expect(pet, contains('No variant of Pet matched json keys'));
-      expect(pet, contains('final class PetCat extends Pet'));
-      expect(pet, contains('final class PetDog extends Pet'));
+      expect(pet, contains('final class Cat extends Pet'));
+      expect(pet, contains('final class Dog extends Pet'));
+      expect(pet, isNot(contains('class PetCat ')));
+      expect(pet, isNot(contains('class PetDog ')));
     });
 
     test('wrapper subclass uses position-based name when the variant '
@@ -1951,16 +1980,21 @@ void main() {
       );
       final author = results['Author'];
       expect(author, isNotNull);
-      // Checked arm fires when the unique required field is present.
+      // `SimpleUser` is `ResolvedObject` and exclusive-by-use →
+      // smooshed; the checked arm constructs it directly.
+      // `EmptyAuthor` (no properties) parses as `SchemaEmptyObject`
+      // → `ResolvedEmptyObject`, which the smoosh predicate excludes
+      // (only `ResolvedObject` has a class body to extend). It keeps
+      // its `AuthorEmptyAuthor` wrapper as the fallback arm.
       expect(author, contains("if (json.containsKey('id'))"));
-      expect(author, contains('return AuthorSimpleUser(SimpleUser.fromJson'));
-      // Fallback arm has no `containsKey` guard — emitted as a
-      // bare `return …`.
+      expect(author, contains('return SimpleUser.fromJson(json)'));
+      expect(author, contains('final class SimpleUser extends Author'));
+      expect(author, isNot(contains('class AuthorSimpleUser ')));
       expect(
         author,
         contains('return AuthorEmptyAuthor(EmptyAuthor.fromJson(json));'),
       );
-      // No throw — the fallback always matches.
+      expect(author, contains('final class AuthorEmptyAuthor extends Author'));
       expect(author, isNot(contains('throw FormatException')));
       expect(author, isNot(contains('throw UnimplementedError')));
     });
@@ -2190,14 +2224,18 @@ void main() {
       );
       final rule = results['Rule'];
       expect(rule, isNotNull);
+      // All three variants are exclusive-by-use top-level → smooshed.
       expect(rule, contains("if (json.containsKey('wait_timer'))"));
-      expect(rule, contains('return RuleWaitTimer(WaitTimer.fromJson'));
+      expect(rule, contains('return WaitTimer.fromJson(json)'));
       expect(rule, contains("if (json.containsKey('reviewers'))"));
-      expect(rule, contains('return RuleReviewersRule(ReviewersRule.fromJson'));
-      expect(
-        rule,
-        contains('return RuleBranchPolicy(BranchPolicy.fromJson(json));'),
-      );
+      expect(rule, contains('return ReviewersRule.fromJson(json)'));
+      expect(rule, contains('return BranchPolicy.fromJson(json);'));
+      expect(rule, contains('final class WaitTimer extends Rule'));
+      expect(rule, contains('final class ReviewersRule extends Rule'));
+      expect(rule, contains('final class BranchPolicy extends Rule'));
+      expect(rule, isNot(contains('class RuleWaitTimer ')));
+      expect(rule, isNot(contains('class RuleReviewersRule ')));
+      expect(rule, isNot(contains('class RuleBranchPolicy ')));
       expect(rule, isNot(contains('throw UnimplementedError')));
       expect(rule, isNot(contains('throw FormatException')));
     });
@@ -2323,7 +2361,11 @@ void main() {
       );
       final pet = results['Pet'];
       expect(pet, contains('factory Pet.fromJson(dynamic json)'));
-      expect(pet, contains('Map<String, dynamic> v => PetCat'));
+      // `Cat` is exclusive-by-use → smooshed; the Map case arm
+      // constructs `Cat` directly, no `PetCat` wrapper.
+      expect(pet, contains('Map<String, dynamic> v => Cat.fromJson(v)'));
+      expect(pet, contains('final class Cat extends Pet'));
+      expect(pet, isNot(contains('class PetCat ')));
       expect(pet, isNot(contains('UnimplementedError')));
     });
 
@@ -2373,16 +2415,15 @@ void main() {
         contains('factory Rule.fromJson(Map<String, dynamic> json)'),
       );
       expect(rule, contains("final discriminator = json['type']"));
-      expect(
-        rule,
-        contains("'creation' => RuleCreation(Creation.fromJson(json))"),
-      );
-      expect(
-        rule,
-        contains("'deletion' => RuleDeletion(Deletion.fromJson(json))"),
-      );
-      expect(rule, contains('final class RuleCreation extends Rule'));
-      expect(rule, contains('final class RuleDeletion extends Rule'));
+      // `Creation` and `Deletion` are exclusive-by-use top-level
+      // variants — they smoosh into `Rule` (no wrapper class, case
+      // arms construct each variant directly).
+      expect(rule, contains("'creation' => Creation.fromJson(json)"));
+      expect(rule, contains("'deletion' => Deletion.fromJson(json)"));
+      expect(rule, contains('final class Creation extends Rule'));
+      expect(rule, contains('final class Deletion extends Rule'));
+      expect(rule, isNot(contains('class RuleCreation ')));
+      expect(rule, isNot(contains('class RuleDeletion ')));
       expect(rule, isNot(contains('UnimplementedError')));
     });
 
@@ -2394,9 +2435,10 @@ void main() {
       // parent by construction (their pointer is `<parent>/oneOf/<i>`),
       // so they smoosh: the variant data class itself extends the
       // sealed parent, eliminating the wrapper-class shim and the
-      // `value:` indirection. Top-level `$ref` variants (the existing
-      // test above) continue to use wrappers because they could be
-      // referenced from multiple parents.
+      // `value:` indirection. Top-level `$ref` variants smoosh too
+      // when they're "exclusive-by-use" (referenced as a variant of
+      // exactly one parent and from no other slot) — covered by the
+      // implicit-discriminator test above.
       final result = renderTestSchema({
         'oneOf': [
           {


### PR DESCRIPTION
## Summary

- Widen the smoosh predicate to also accept top-level component schemas referenced as a variant of exactly one parent and from no other typed-reference slot ("exclusive-by-use"). The smoosh mechanism (variant data class extends sealed parent, inlined in parent's file, case arm calls Variant directly) was already built; this PR plumbs the new eligibility through.
- AllOf-member uses don't count against exclusivity — `allOf` collapses to a synthesized merged `RenderObject`, so a `$ref` inside an `allOf` contributes structurally (its fields merge in) without emitting a typed Dart reference. This is what lets `RepositoryRule` fold even though each variant is re-used inside `RepositoryRuleDetailed`'s `allOf` arms.
- github regen impact: 25 model files removed (`RepositoryRule*` family ~22, `ContentSymlink`, `ContentSubmodule`, `EnterpriseTeam`, `ReviewCustomGates*`); 21 wrapper subclasses eliminated (`Variant<i>` count: 43 → 22); 24 new direct sealed subclasses like `final class RepositoryRuleCreation extends RepositoryRule`. `dart analyze` stays clean.

## Test plan

- [x] `dart analyze` clean on github regen
- [x] `<Parent>Variant<i>` wrapper count: 43 → 22 (drops by 21)
- [x] `RepositoryRule` family folds into `repository_rule.dart`; `ContentSymlink`/`ContentSubmodule` fold into `repos_get_content200_response.dart`; `EnterpriseTeam` folds into `copilot_seat_details_assigning_team.dart`
- [x] `dart test` passes (3 new naming-test cases for the predicate's three branches: smoosh / blocked-by-property / blocked-by-multiple-variant-refs / smoosh-despite-allOf-reuse)
- [x] Existing render-schema tests updated to reflect that exclusive-by-use top-level variants now smoosh (instead of getting `<Parent><Variant>` wrapper subclasses)