### PR TITLE
feat: dedup structurally-identical oneOf trees to a shared class

### DIFF
--- a/lib/src/resolver.dart
+++ b/lib/src/resolver.dart
@@ -74,6 +74,47 @@ class ResolveContext {
   /// resolver emits a [ResolvedRecursiveRef] instead of recursing.
   final Set<JsonPointer> resolvingStack;
 
+  /// Cache of inline-synthesized [ResolvedSchemaCollection]s
+  /// (`oneOf`/`anyOf`) keyed by structural content so structurally-
+  /// identical collections at different sites in the spec resolve to
+  /// the same [ResolvedSchema] instance.
+  ///
+  /// Why: github's `/user`, `/user/{account_id}`, and `/users/{username}`
+  /// all return `oneOf<private-user, public-user>` with the same
+  /// discriminator. Without sharing, the resolver produces three
+  /// equal-but-distinct [ResolvedOneOf]s, the naming pass assigns each
+  /// its own Dart class name, and we emit three byte-identical sealed
+  /// classes (`UsersGetAuthenticated200Response`,
+  /// `UsersGetById200Response`, `UsersGetByUsername200Response`).
+  /// Sharing collapses them to one.
+  ///
+  /// Top-level component schemas (e.g. `#/components/schemas/Foo`) are
+  /// excluded — those have intentional names from the spec author and
+  /// consumers refer to them by name, so two structurally-identical
+  /// component schemas are still meant to be distinct types.
+  final Map<_CollectionStructure, ResolvedSchemaCollection> _collectionCache =
+      {};
+
+  /// Returns a cached [ResolvedSchemaCollection] structurally equal to
+  /// [collection], or caches and returns [collection] itself when no
+  /// match exists. See [_collectionCache] for why we share.
+  ResolvedSchemaCollection shareCollection(
+    ResolvedSchemaCollection collection,
+  ) {
+    if (isTopLevelComponent(collection.pointer)) return collection;
+    // A collection with no variants is a degenerate stub — render
+    // emits an empty sealed class that always throws on parse.
+    // Sharing those across sites would silently merge unrelated
+    // property slots whose schemas the parser failed to capture
+    // (e.g. github's `allOf + type: [null]` shape, which warns
+    // "Unused: …, allOf" and produces an empty oneOf) into one type.
+    // The type system can't tell them apart afterward, so each
+    // broken site stays distinct and individually nameable.
+    if (collection.schemas.isEmpty) return collection;
+    final key = _CollectionStructure.from(collection);
+    return _collectionCache.putIfAbsent(key, () => collection);
+  }
+
   CommonProperties resolveCommonProperties(CommonProperties common) {
     final resolvedName = getResolvedName(common.pointer, common.snakeName);
     if (resolvedName != common.snakeName) {
@@ -314,10 +355,12 @@ ResolvedSchema _resolveSchemaFully(
       resolvedSchemas,
       oneOf.pointer,
     );
-    return ResolvedOneOf(
-      common: resolvedCommon,
-      schemas: resolvedSchemas,
-      discriminator: discriminator,
+    return context.shareCollection(
+      ResolvedOneOf(
+        common: resolvedCommon,
+        schemas: resolvedSchemas,
+        discriminator: discriminator,
+      ),
     );
   }
   if (schema is SchemaAllOf) {
@@ -379,10 +422,12 @@ ResolvedSchema _resolveSchemaFully(
       schemas,
       anyOf.pointer,
     );
-    return ResolvedAnyOf(
-      common: resolvedCommon,
-      schemas: schemas,
-      discriminator: discriminator,
+    return context.shareCollection(
+      ResolvedAnyOf(
+        common: resolvedCommon,
+        schemas: schemas,
+        discriminator: discriminator,
+      ),
     );
   }
   if (schema is SchemaNull) {
@@ -748,6 +793,46 @@ class RegistryBuilder extends Visitor {
 
 ResolvedTag _resolvedTag(Tag tag) {
   return ResolvedTag(name: tag.name, description: tag.description);
+}
+
+/// Structural identity key for [ResolveContext.shareCollection] cache —
+/// covers everything that distinguishes one [ResolvedSchemaCollection]
+/// from another *except* the collection's own pointer/snake name.
+/// Two [ResolvedOneOf]s with the same variants and discriminator are
+/// the same Dart sealed class even when they sit at different
+/// operation pointers; this key makes that the cache hit.
+@immutable
+class _CollectionStructure extends Equatable {
+  const _CollectionStructure({
+    required this.kind,
+    required this.schemas,
+    required this.discriminator,
+  });
+
+  factory _CollectionStructure.from(ResolvedSchemaCollection collection) {
+    return _CollectionStructure(
+      kind: collection.runtimeType,
+      schemas: collection.schemas,
+      discriminator: collection is ResolvedOneOf
+          ? collection.discriminator
+          : null,
+    );
+  }
+
+  /// `oneOf` and `anyOf` collections never share — they render
+  /// differently. Keying on `runtimeType` rather than a separate enum
+  /// keeps the dispatch implicit.
+  final Type kind;
+
+  final List<ResolvedSchema> schemas;
+
+  /// Only meaningful for `ResolvedOneOf`. Two oneOfs with identical
+  /// variants but different discriminators must NOT share — the
+  /// discriminator drives the rendered `fromJson`'s switch property.
+  final ResolvedDiscriminator? discriminator;
+
+  @override
+  List<Object?> get props => [kind, schemas, discriminator];
 }
 
 bool isTopLevelComponent(JsonPointer pointer) {

--- a/lib/src/resolver.dart
+++ b/lib/src/resolver.dart
@@ -101,7 +101,16 @@ class ResolveContext {
   ResolvedSchemaCollection shareCollection(
     ResolvedSchemaCollection collection,
   ) {
-    if (isTopLevelComponent(collection.pointer)) return collection;
+    // Anywhere inside `#/components/schemas/...` is opt-out of the
+    // dedup. Top-level components are excluded because the spec
+    // author named them; their nested contents are excluded because
+    // the synthesized snake name embeds the parent component's name
+    // (e.g. `installation_account` from
+    // `#/components/schemas/installation/properties/account`),
+    // which carries spec-author context that "first arrival wins"
+    // would erase. Operation-synthesized names (under
+    // `#/paths/...`) are arbitrary and dedup is a pure win.
+    if (_isUnderComponentSchema(collection.pointer)) return collection;
     // A collection with no variants is a degenerate stub — render
     // emits an empty sealed class that always throws on parse.
     // Sharing those across sites would silently merge unrelated
@@ -114,6 +123,15 @@ class ResolveContext {
     final key = _CollectionStructure.from(collection);
     return _collectionCache.putIfAbsent(key, () => collection);
   }
+
+  /// True when [pointer] sits inside (or at) a top-level component
+  /// schema definition — i.e. `#/components/schemas/<name>` or any
+  /// path beneath. Spec-author-named territory; we leave naming
+  /// alone there.
+  static bool _isUnderComponentSchema(JsonPointer pointer) =>
+      pointer.parts.length >= 3 &&
+      pointer.parts[0] == 'components' &&
+      pointer.parts[1] == 'schemas';
 
   CommonProperties resolveCommonProperties(CommonProperties common) {
     final resolvedName = getResolvedName(common.pointer, common.snakeName);

--- a/test/resolver_test.dart
+++ b/test/resolver_test.dart
@@ -1235,6 +1235,308 @@ void main() {
         },
       );
     });
+
+    group('structural dedup of inline collections', () {
+      // Two paths whose 200 response schema is the same inline
+      // `oneOf<Cat, Dog>` (with the same discriminator) — github's
+      // `/user`, `/user/{account_id}`, `/users/{username}` are real-
+      // world examples of this pattern. Without dedup we'd resolve to
+      // two structurally-equal but distinct ResolvedOneOf instances,
+      // and the renderer would emit two byte-identical sealed classes.
+      Map<String, dynamic> twoPathsWithSchema(
+        Map<String, dynamic> schema, {
+        Map<String, dynamic>? schemaB,
+      }) {
+        return {
+          'openapi': '3.1.0',
+          'info': {'title': 'Pets', 'version': '1.0.0'},
+          'servers': [
+            {'url': 'https://api.example.com'},
+          ],
+          'paths': {
+            '/a': {
+              'get': {
+                'responses': {
+                  '200': {
+                    'description': 'OK',
+                    'content': {
+                      'application/json': {'schema': schema},
+                    },
+                  },
+                },
+              },
+            },
+            '/b': {
+              'get': {
+                'responses': {
+                  '200': {
+                    'description': 'OK',
+                    'content': {
+                      'application/json': {'schema': schemaB ?? schema},
+                    },
+                  },
+                },
+              },
+            },
+          },
+          'components': {
+            'schemas': {
+              'Cat': {
+                'type': 'object',
+                'properties': {
+                  'kind': {'type': 'string'},
+                },
+                'required': ['kind'],
+              },
+              'Dog': {
+                'type': 'object',
+                'properties': {
+                  'kind': {'type': 'string'},
+                },
+                'required': ['kind'],
+              },
+              'Fish': {
+                'type': 'object',
+                'properties': {
+                  'kind': {'type': 'string'},
+                },
+                'required': ['kind'],
+              },
+            },
+          },
+        };
+      }
+
+      ResolvedSchema responseSchemaForPath(ResolvedSpec spec, String path) {
+        final p = spec.paths.firstWhere((e) => e.path == path);
+        return p.operations.first.responses.first.content;
+      }
+
+      test('two identical inline oneOfs share one ResolvedSchema', () {
+        final json = twoPathsWithSchema({
+          'oneOf': [
+            {r'$ref': '#/components/schemas/Cat'},
+            {r'$ref': '#/components/schemas/Dog'},
+          ],
+          'discriminator': {
+            'propertyName': 'kind',
+            'mapping': {
+              'cat': '#/components/schemas/Cat',
+              'dog': '#/components/schemas/Dog',
+            },
+          },
+        });
+        final logger = _MockLogger();
+        final spec = runWithLogger(logger, () => parseAndResolveTestSpec(json));
+        final a = responseSchemaForPath(spec, '/a');
+        final b = responseSchemaForPath(spec, '/b');
+        expect(a, isA<ResolvedOneOf>());
+        // Identity, not just value equality — the renderer's name lookup
+        // is keyed on pointer, so two equal-but-distinct instances would
+        // each get their own Dart class name and emit duplicate files.
+        expect(identical(a, b), isTrue);
+      });
+
+      test(
+        'oneOfs with the same variants but different discriminator do '
+        'not share',
+        () {
+          final json = twoPathsWithSchema(
+            {
+              'oneOf': [
+                {r'$ref': '#/components/schemas/Cat'},
+                {r'$ref': '#/components/schemas/Dog'},
+              ],
+              'discriminator': {
+                'propertyName': 'kind',
+                'mapping': {
+                  'cat': '#/components/schemas/Cat',
+                  'dog': '#/components/schemas/Dog',
+                },
+              },
+            },
+            schemaB: {
+              'oneOf': [
+                {r'$ref': '#/components/schemas/Cat'},
+                {r'$ref': '#/components/schemas/Dog'},
+              ],
+              'discriminator': {
+                'propertyName': 'species',
+                'mapping': {
+                  'cat': '#/components/schemas/Cat',
+                  'dog': '#/components/schemas/Dog',
+                },
+              },
+            },
+          );
+          final logger = _MockLogger();
+          final spec = runWithLogger(
+            logger,
+            () => parseAndResolveTestSpec(json),
+          );
+          final a = responseSchemaForPath(spec, '/a');
+          final b = responseSchemaForPath(spec, '/b');
+          expect(identical(a, b), isFalse);
+        },
+      );
+
+      test('oneOfs with one different variant do not share', () {
+        final json = twoPathsWithSchema(
+          {
+            'oneOf': [
+              {r'$ref': '#/components/schemas/Cat'},
+              {r'$ref': '#/components/schemas/Dog'},
+            ],
+          },
+          schemaB: {
+            'oneOf': [
+              {r'$ref': '#/components/schemas/Cat'},
+              {r'$ref': '#/components/schemas/Fish'},
+            ],
+          },
+        );
+        final logger = _MockLogger();
+        final spec = runWithLogger(logger, () => parseAndResolveTestSpec(json));
+        final a = responseSchemaForPath(spec, '/a');
+        final b = responseSchemaForPath(spec, '/b');
+        expect(identical(a, b), isFalse);
+      });
+
+      test('anyOf is also deduped', () {
+        final json = twoPathsWithSchema({
+          'anyOf': [
+            {r'$ref': '#/components/schemas/Cat'},
+            {r'$ref': '#/components/schemas/Dog'},
+          ],
+        });
+        final logger = _MockLogger();
+        final spec = runWithLogger(logger, () => parseAndResolveTestSpec(json));
+        final a = responseSchemaForPath(spec, '/a');
+        final b = responseSchemaForPath(spec, '/b');
+        expect(a, isA<ResolvedAnyOf>());
+        expect(identical(a, b), isTrue);
+      });
+
+      test('oneOf and anyOf with the same variants do not share', () {
+        // One is `oneOf<Cat,Dog>`, the other is `anyOf<Cat,Dog>` —
+        // they render with different `fromJson` semantics (single-match
+        // vs at-least-one-match) and so must remain distinct types.
+        final json = twoPathsWithSchema(
+          {
+            'oneOf': [
+              {r'$ref': '#/components/schemas/Cat'},
+              {r'$ref': '#/components/schemas/Dog'},
+            ],
+          },
+          schemaB: {
+            'anyOf': [
+              {r'$ref': '#/components/schemas/Cat'},
+              {r'$ref': '#/components/schemas/Dog'},
+            ],
+          },
+        );
+        final logger = _MockLogger();
+        final spec = runWithLogger(logger, () => parseAndResolveTestSpec(json));
+        final a = responseSchemaForPath(spec, '/a');
+        final b = responseSchemaForPath(spec, '/b');
+        expect(identical(a, b), isFalse);
+      });
+
+      test(
+        'top-level component schemas with structurally-equal bodies are '
+        'NOT shared',
+        () {
+          // Top-level components have intentional names assigned by the
+          // spec author; two identically-shaped components are still
+          // meant to be distinct types.
+          final json = {
+            'openapi': '3.1.0',
+            'info': {'title': 'Pets', 'version': '1.0.0'},
+            'servers': [
+              {'url': 'https://api.example.com'},
+            ],
+            'paths': {
+              '/a': {
+                'get': {
+                  'responses': {
+                    '200': {
+                      'description': 'OK',
+                      'content': {
+                        'application/json': {
+                          'schema': {r'$ref': '#/components/schemas/CatOrDog'},
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+              '/b': {
+                'get': {
+                  'responses': {
+                    '200': {
+                      'description': 'OK',
+                      'content': {
+                        'application/json': {
+                          'schema': {
+                            r'$ref': '#/components/schemas/CatOrDogAlias',
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            'components': {
+              'schemas': {
+                'CatOrDog': {
+                  'oneOf': [
+                    {r'$ref': '#/components/schemas/Cat'},
+                    {r'$ref': '#/components/schemas/Dog'},
+                  ],
+                },
+                'CatOrDogAlias': {
+                  'oneOf': [
+                    {r'$ref': '#/components/schemas/Cat'},
+                    {r'$ref': '#/components/schemas/Dog'},
+                  ],
+                },
+                'Cat': {'type': 'object'},
+                'Dog': {'type': 'object'},
+              },
+            },
+          };
+          final logger = _MockLogger();
+          final spec = runWithLogger(
+            logger,
+            () => parseAndResolveTestSpec(json),
+          );
+          final a = responseSchemaForPath(spec, '/a');
+          final b = responseSchemaForPath(spec, '/b');
+          expect(identical(a, b), isFalse);
+          expect((a as ResolvedOneOf).snakeName, 'cat_or_dog');
+          expect((b as ResolvedOneOf).snakeName, 'cat_or_dog_alias');
+        },
+      );
+
+      test('inline oneOfs with no variants are not shared', () {
+        // A `oneOf: []` (or one whose variants the parser dropped, e.g.
+        // github's `allOf: [...] + type: [null]` shape) renders as an
+        // empty sealed-class stub. Sharing those across sites would
+        // silently merge unrelated property slots into one type.
+        final json = twoPathsWithSchema(
+          {'oneOf': <dynamic>[]},
+          schemaB: {'oneOf': <dynamic>[]},
+        );
+        final logger = _MockLogger();
+        final spec = runWithLogger(logger, () => parseAndResolveTestSpec(json));
+        final a = responseSchemaForPath(spec, '/a');
+        final b = responseSchemaForPath(spec, '/b');
+        expect(a, isA<ResolvedOneOf>());
+        expect(b, isA<ResolvedOneOf>());
+        expect(identical(a, b), isFalse);
+      });
+    });
   });
 
   group('ResolvedSchema', () {


### PR DESCRIPTION
## Summary

- Inline-synthesized `oneOf`/`anyOf` collections that are structurally identical (same variants, same discriminator) now share one `ResolvedSchema` instance, so the renderer emits one Dart class instead of multiple byte-identical sealed classes.
- Scope deliberately narrowed: dedup only fires for collections under `#/paths/...` (operation-synthesized names are arbitrary). Anything under `#/components/schemas/...` — including properties of top-level component schemas — is left alone, because the synthesized snake name carries the parent component's spec-author context and "first arrival wins" would silently swap names between sites.
- github regen: 3 fewer files, all operation-synthesized response wrappers:
  - `users_get_by_id200_response`, `users_get_by_username200_response` → fold into `users_get_authenticated200_response` (the `/user` × 3 trio that motivated the PR)
  - `projects_create_card422_response` → folds into `orgs_update422_response`
- Stub count unchanged (3 → 3).

## Approach

Resolver-level. Added `ResolveContext.shareCollection(...)` keyed on `_CollectionStructure(runtimeType, schemas, discriminator)`. Equality is value-equality via `Equatable`, which works because `ResolvedSchema` already implements deep equality on its props. The cache lives on `ResolveContext` (per-spec scope, no cross-spec leakage). First claimant wins on the shared snake/Dart name; downstream layers (naming, render, file emission) all key on pointer, so re-visiting the same shared instance through multiple operations naturally collapses to one entry / one file.

Why this layer: the rest of the pipeline already keys on `ResolvedSchema` pointer identity (naming `_visited.add(schema.pointer)`, render's set-based schema collection). Sharing the instance means no new "alias" concept threads through naming or render — the existing pointer-keyed dedup just starts hitting earlier.

## Why not also dedup component-internal collections

The earlier version of this PR also collapsed structurally-identical collections under `#/components/schemas/...`. That produced naming regressions: `Installation.account` would type as `IntegrationInstallationRequestAccount` (or vice versa) depending on spec-parse order, because both `installation/properties/account` and `integration-installation-request/properties/account` shared the same oneOf shape. Picking the cleaner of the two names requires either parsing in canonical order or rewriting all holders of the loser instance after the fact — bigger surgery than this PR justifies.

The narrower rule "skip anything under `#/components/schemas/...`" is a clean heuristic: spec-author-organized schemas keep their organization; only the operation-synthesized names (which were arbitrary anyway) collapse.

## Test plan

- [x] `dart analyze` clean on github regen
- [x] `/user` endpoint trio shares one `UsersGetAuthenticated200Response` class instead of three
- [x] `Installation.account` keeps its `InstallationAccount` type (no regression vs main)
- [x] Other oneOfs not affected — covered by 7 resolver unit tests:
  - identical inline oneOfs share
  - same variants but different discriminator do NOT share
  - one differing variant does NOT share
  - anyOf is also deduped
  - oneOf vs anyOf with same variants do NOT share (different render semantics)
  - top-level component schemas with structurally-equal bodies are NOT shared
  - inline oneOfs with no variants are NOT shared (defensive guard)
- [x] All 474 existing tests still pass