### PR TITLE
feat: synthesize round-trip tests for smooshed oneOf variants

### DIFF
--- a/lib/src/render/file_renderer.dart
+++ b/lib/src/render/file_renderer.dart
@@ -872,6 +872,14 @@ class FileRenderer {
   /// example value. Skips schemas for which [testPath] returns null,
   /// or for which [RenderSchema.exampleValue] returns null (recursive
   /// types, no-JSON types).
+  ///
+  /// `RenderOneOf` parents take a separate path
+  /// ([_renderOneOfTest]): they don't have a single example value
+  /// (the sealed type isn't directly constructible), but each
+  /// smooshed inline-object variant does. Those variants used to
+  /// render to their own files (and got their own round-trip tests
+  /// per file); since smoosh inlined them into the parent's file, the
+  /// parent's test file now owns their coverage.
   void renderModelTests(Iterable<RenderSchema> schemas) {
     final schemaContext = schemaRenderer;
     for (final schema in schemas) {
@@ -879,6 +887,10 @@ class FileRenderer {
       final layoutContext = _contextFor(schema);
       final outPath = testPath(layoutContext);
       if (outPath == null) continue;
+      if (schema is RenderOneOf) {
+        _renderOneOfTest(schema, outPath: outPath, context: schemaContext);
+        continue;
+      }
       final example = schema.exampleValue(schemaContext);
       if (example == null) continue;
       final invalidJson = schema.invalidJsonExample(schemaContext);
@@ -895,6 +907,60 @@ class FileRenderer {
         },
       );
     }
+  }
+
+  /// Emit a round-trip test for [schema]'s smooshed variants — one
+  /// `test()` per variant — into the parent's test file. Each test
+  /// builds the variant directly, then round-trips it through the
+  /// variant's own `maybeFromJson` / `toJson`. We don't dispatch
+  /// through the parent's `fromJson` here for two reasons: (a) the
+  /// variant's example value is sometimes built from non-required
+  /// properties only, and the parent's predicate dispatch keys off
+  /// fields that may be absent from the example; (b) the variant's
+  /// own conversion is the unit under test.
+  ///
+  /// Skipped (no file emitted) when the oneOf has no smooshed
+  /// variants, or when no smooshed variant produces a usable
+  /// `exampleValue`. Non-smooshed wrapper subclasses (string/int/list
+  /// variants) aren't covered here — they live in the parent's file
+  /// too, but they predate smoosh and never had their own tests, so
+  /// adding coverage for them is out of scope for this pass.
+  ///
+  /// Variants whose object has `additionalProperties` are also
+  /// skipped: their example value carries an `entries: <String, …>{}`
+  /// map field, and Dart's `Map ==` is reference equality, so the
+  /// round-trip's equality assertion would fail spuriously. The same
+  /// pre-existing equality bug already affects the standard
+  /// per-schema round-trip test for top-level objects with
+  /// `additionalProperties`; this skip prevents the smoosh test pass
+  /// from regressing the github regen's pass count by the same
+  /// underlying issue.
+  void _renderOneOfTest(
+    RenderOneOf schema, {
+    required String outPath,
+    required SchemaRenderer context,
+  }) {
+    final variants = <Map<String, dynamic>>[];
+    for (final variant in schema.smooshedVariants) {
+      if (variant.additionalProperties != null) continue;
+      final example = variant.exampleValue(context);
+      if (example == null) continue;
+      variants.add({
+        'variantTypeName': variant.typeName,
+        'exampleValue': example,
+      });
+    }
+    if (variants.isEmpty) return;
+    _renderTemplate(
+      template: 'schema_oneof_round_trip_test',
+      outPath: outPath,
+      context: {
+        'packageName': packageName,
+        'barrelImportPath': testBarrelImport(),
+        'typeName': schema.typeName,
+        'variants': variants,
+      },
+    );
   }
 
   /// Render the entire spec.

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -3975,6 +3975,17 @@ class RenderOneOf extends RenderNewType {
   /// (no wrappers emitted). [wrapperTypeName] looks up by index.
   final List<String?> wrapperNames;
 
+  /// The smooshed inline-object variants of this oneOf — variant
+  /// classes that are emitted as `final class X extends Y` inline in
+  /// this oneOf's `.dart` file (rather than getting their own file).
+  /// Used by the test renderer to synthesize per-variant round-trip
+  /// tests in the parent's test file: with smoosh, the variants no
+  /// longer have their own `.dart` file and so no longer pick up an
+  /// auto-generated test file from the per-schema path. The parent
+  /// owns their coverage.
+  List<RenderObject> get smooshedVariants =>
+      schemas.whereType<RenderObject>().where((v) => v.isSmooshed).toList();
+
   /// We could do something smarter here, to determine if the oneOf has a
   /// const constructor, but it's not worth the complexity for now.
   @override

--- a/lib/templates/schema_oneof_round_trip_test.mustache
+++ b/lib/templates/schema_oneof_round_trip_test.mustache
@@ -1,0 +1,20 @@
+// GENERATED — do not hand-edit.
+import 'package:{{{ packageName }}}/{{{ barrelImportPath }}}';
+import 'package:test/test.dart';
+
+void main() {
+  group('{{{ typeName }}}', () {
+{{#variants}}
+    test('{{{ variantTypeName }}} round-trips via maybeFromJson/toJson', () {
+      final instance = {{{ exampleValue }}};
+      final parsed = {{{ variantTypeName }}}.maybeFromJson(instance.toJson())!;
+      expect(parsed, equals(instance));
+      expect(parsed.hashCode, equals(instance.hashCode));
+    });
+
+{{/variants}}
+    test('maybeFromJson returns null on null input', () {
+      expect({{{ typeName }}}.maybeFromJson(null), isNull);
+    });
+  });
+}

--- a/test/render/file_renderer_test.dart
+++ b/test/render/file_renderer_test.dart
@@ -527,6 +527,100 @@ void main() {
     });
 
     test(
+      'oneOf with smooshed inline-object variants gets a parent test '
+      'file with one round-trip per variant',
+      () async {
+        // Pre-smoosh, each inline variant rendered to its own `.dart`
+        // file and got its own auto-generated round-trip test. The
+        // smoosh series moved the variants inline into the parent's
+        // file, which dropped those tests on the floor — the variant
+        // classes still exist (and their `fromJson`/`toJson` are
+        // unchanged) but nothing exercised them anymore. This test
+        // pins the recovery: the parent's test file now carries a
+        // per-variant round-trip for every smooshed inline object.
+        final fs = MemoryFileSystem.test();
+        final spec = {
+          'openapi': '3.1.0',
+          'info': {'title': 'SmooshTest', 'version': '1.0.0'},
+          'servers': [
+            {'url': 'https://example.com'},
+          ],
+          'paths': {
+            '/cards': {
+              'post': {
+                'operationId': 'createCard',
+                'requestBody': {
+                  'required': true,
+                  'content': {
+                    'application/json': {
+                      'schema': {
+                        'oneOf': [
+                          {
+                            'type': 'object',
+                            'required': ['note'],
+                            'properties': {
+                              'note': {'type': 'string'},
+                            },
+                          },
+                          {
+                            'type': 'object',
+                            'required': ['contentId'],
+                            'properties': {
+                              'contentId': {'type': 'integer'},
+                            },
+                          },
+                        ],
+                      },
+                    },
+                  },
+                },
+                'responses': {
+                  '200': {'description': 'OK'},
+                },
+              },
+            },
+          },
+        };
+        final out = fs.directory('out');
+        await renderToDirectory(spec: spec, outDir: out);
+        final testFile = out.childFile(
+          'test/messages/create_card_request_test.dart',
+        );
+        expect(testFile.existsSync(), isTrue);
+        final body = testFile.readAsStringSync();
+        // Group is named after the parent oneOf type.
+        expect(body, contains("group('CreateCardRequest'"));
+        // One test per smooshed variant.
+        expect(
+          body,
+          contains(
+            'CreateCardRequestOneOf0 round-trips via maybeFromJson/toJson',
+          ),
+        );
+        expect(
+          body,
+          contains(
+            'CreateCardRequestOneOf1 round-trips via maybeFromJson/toJson',
+          ),
+        );
+        // Each variant round-trips through its own factory (not the
+        // parent's), so the test exercises the variant's conversion
+        // even when the parent's dispatch keys off properties absent
+        // from the example value.
+        expect(
+          body,
+          contains('CreateCardRequestOneOf0.maybeFromJson('),
+        );
+        expect(
+          body,
+          contains('CreateCardRequestOneOf1.maybeFromJson('),
+        );
+        // Parent maybeFromJson(null) check still appears once.
+        expect(body, contains('CreateCardRequest.maybeFromJson(null)'));
+      },
+    );
+
+    test(
       'api.dart barrel re-exports third-party packages used by models',
       () async {
         // A model with a `format: uri-template` field uses `UriTemplate`


### PR DESCRIPTION
## Summary

The smoosh series (#168/#169/#170) inlined ~25 oneOf variant data classes into their sealed parent's `.dart` file. Their round-trip tests went away with their files: the variant classes still exist (inlined) and their `fromJson`/`toJson` are unchanged, but no test exercised them anymore. This PR recovers that coverage.

For each `RenderOneOf` with smooshed inline-object variants, the renderer now emits a parent-level `test/.../<parent>_test.dart` with one `test()` per variant — built via the variant's own constructor, round-tripped through the variant's own `maybeFromJson` / `toJson`. The standard per-schema test path stays unchanged for everything else.

## Approach notes

- **Test in the parent's file, one test per variant.** Matches the smoosh design ("variant lives in the parent's library"). No new file per variant.
- **Round-trip via the variant, not the parent's dispatcher.** Some variants' example values are built only from required properties; predicate dispatch on the parent keys off `containsKey('foo')` for properties that may be absent from the example value, which routes the JSON to a sibling variant. Going through the variant's own factory exercises the variant's conversion (the unit under test) and avoids that brittleness.
- **Variants with `additionalProperties` are skipped.** Their example carries `entries: <String, ...>{}` and Dart's `Map ==` is reference equality, so the round-trip's equality assertion would fail spuriously. Same equality bug already affects the standard per-schema test for top-level objects with `additionalProperties` — this skip just keeps the smoosh path from regressing the github regen pass count for the same underlying issue. (Affects `ChecksCreateRequestOneOf{0,1}`, `ChecksUpdateRequestAnyOf{0,1}`.)
- **No runtime behavior change**, no smoosh-predicate change. Purely additive on the test side.

## github regen impact

- 16 new test files, 21 new variant round-trip tests.
- `dart analyze` clean on the github regen, before and after.
- Generated test pass count: 41 failing baseline -> 41 failing after (same set; zero new failures).

## Test plan

- [x] dart analyze clean on github regen
- [x] 21 new variant round-trip tests added across 16 parent test files
- [x] Generated tests pass on github regen output (no new failures vs baseline)
- [x] New unit test `oneOf with smooshed inline-object variants gets a parent test file with one round-trip per variant` in `test/render/file_renderer_test.dart`
- [x] `dart test` passes