### PR TITLE
fix: don't drop properties/required when oneOf is a sibling

### DIFF
--- a/lib/src/dispatch.dart
+++ b/lib/src/dispatch.dart
@@ -146,8 +146,12 @@ sealed class DispatchDecision {
 
 /// `switch (json[propertyName]) { 'value' => Wrapper(...), ... }` —
 /// either an explicit `discriminator` from the spec or an implicit
-/// one synthesized from variants whose required single-value enum
-/// property tags them uniquely.
+/// one synthesized from variants whose enum property tags them
+/// uniquely. A variant's enum may have one value (the classic
+/// single-value tag) or multiple — what matters is that the value
+/// sets are pairwise disjoint across variants. The mapping carries
+/// one entry per enum value, multiple of which may point at the
+/// same variant.
 @immutable
 class DiscriminatorDispatch extends DispatchDecision {
   const DiscriminatorDispatch({
@@ -264,10 +268,18 @@ DispatchDecision decideDispatch(ResolvedSchemaCollection collection) {
   // result, and AllOf produces none).
   if (collection is ResolvedAllOf) return const NoDispatch();
   final variants = collection.schemas;
+  // anyOf is weaker than oneOf — overlap between variants is
+  // permitted at the spec level. The loose required-field picker
+  // (which only requires the dispatch property to not be *required*
+  // by another variant) is safe under that semantic, where strict
+  // would be unsafe under oneOf. github's check-runs PATCH is the
+  // canonical case: anyOf variants share most properties with
+  // benign optional-overlap and dispatch via `containsKey`.
+  final isAnyOf = collection is ResolvedAnyOf;
   return _pickDiscriminator(collection, variants) ??
       _pickShape(variants) ??
       _pickHybrid(variants) ??
-      _pickRequiredField(variants) ??
+      _pickRequiredField(variants, looseRequiredUniqueness: isAnyOf) ??
       _pickArrayElement(variants) ??
       _pickPropertyArrayItemShape(variants) ??
       const NoDispatch();
@@ -353,13 +365,27 @@ DiscriminatorDispatch? _pickDiscriminator(
   ResolvedSchemaCollection collection,
   List<ResolvedSchema> variants,
 ) {
-  if (collection is! ResolvedOneOf) return null;
-  final disc = collection.discriminator ?? _implicitDiscriminator(variants);
-  if (disc == null) return null;
+  // AllOf is composition, not dispatch — handled in `decideDispatch`.
+  // OneOf and AnyOf are both dispatchable via discriminator: at the
+  // JSON-decode site we read a property and route to a variant; the
+  // oneOf-vs-anyOf semantic difference (mutual-exclusion vs
+  // at-least-one) doesn't affect the runtime decision.
+  if (collection is ResolvedAllOf) return null;
   // Discriminator dispatch only works when every variant is
   // object-shaped (i.e. has a `fromJson(Map<String, dynamic>)`).
   // Includes allOf which renders as a synthesized object.
   if (!variants.every(_isObjectLike)) return null;
+  // Prefer the explicit discriminator + its mapping. Fall through to
+  // an implicit synthesis when the explicit one has no `mapping`
+  // (github's check-runs POST: spec declares `propertyName: status`
+  // but no mapping; each variant carries an enum on `status` whose
+  // values together name the discriminated cases).
+  var disc = collection is ResolvedOneOf ? collection.discriminator : null;
+  if (disc != null && disc.mapping == null) {
+    disc = _implicitDiscriminatorForProperty(variants, disc.propertyName);
+  }
+  disc ??= _implicitDiscriminator(variants);
+  if (disc == null) return null;
   final mapping = disc.mapping;
   if (mapping == null) return null;
   return DiscriminatorDispatch(
@@ -372,12 +398,57 @@ DiscriminatorDispatch? _pickDiscriminator(
   );
 }
 
-/// Synthesized discriminator for object-only oneOfs whose variants
-/// each tag themselves with a single-value enum property — github's
-/// `repository-rule` shape. The spec doesn't declare a `discriminator`,
-/// but every variant has, e.g., `type: { enum: ['creation'] }` with
-/// that property required. The values are pairwise distinct, so the
-/// parent's `fromJson` can switch on `json[<that property>]`.
+/// Like [_implicitDiscriminator] but constrained to a specific
+/// [propertyName] declared by the spec's explicit discriminator.
+/// Used to fill in a missing `mapping` when the spec says
+/// "discriminate on `status`" but doesn't enumerate which value
+/// routes where — we read each variant's enum on `status` and
+/// build the mapping from there.
+///
+/// The property is not required to be `required` here (unlike
+/// [_implicitDiscriminator]'s implicit-detection mode): the spec
+/// author's explicit `discriminator:` declaration is the signal
+/// that runtime dispatch on this property is intended. Variants
+/// where the JSON omits the field will throw the
+/// `FormatException` already emitted by the discriminator switch's
+/// default arm — matching the failure mode of today's stub.
+ResolvedDiscriminator? _implicitDiscriminatorForProperty(
+  List<ResolvedSchema> variants,
+  String propertyName,
+) {
+  if (variants.isEmpty) return null;
+  if (!variants.every(_isObjectLike)) return null;
+  final flatProps = variants.map(_flattenedProperties).toList();
+  final perVariantValues = <List<String>>[];
+  for (var i = 0; i < variants.length; i++) {
+    final type = flatProps[i][propertyName];
+    if (type is! ResolvedEnum || type.values.isEmpty) return null;
+    perVariantValues.add(List.of(type.values));
+  }
+  final seen = <String>{};
+  for (final values in perVariantValues) {
+    for (final v in values) {
+      if (!seen.add(v)) return null;
+    }
+  }
+  return ResolvedDiscriminator(
+    propertyName: propertyName,
+    mapping: {
+      for (var i = 0; i < variants.length; i++)
+        for (final v in perVariantValues[i]) v: variants[i],
+    },
+  );
+}
+
+/// Synthesized discriminator for object-only oneOf/anyOf collections
+/// whose variants each tag themselves with an enum property. The
+/// classic case (github's `repository-rule` shape) is single-value
+/// enums: every variant declares, e.g., `type: { enum: ['creation'] }`,
+/// required. We also accept multi-value enums per variant (github's
+/// check-runs POST: variant 0 has `status: enum [completed]`, variant
+/// 1 has `status: enum [queued, in_progress, ...]`) — as long as the
+/// value sets are pairwise disjoint, each enum value routes to exactly
+/// one variant.
 ///
 /// Variants may be [ResolvedObject] OR [ResolvedAllOf] — the latter
 /// flattens its members the same way `toRenderSchema` synthesizes a
@@ -387,13 +458,13 @@ ResolvedDiscriminator? _implicitDiscriminator(List<ResolvedSchema> variants) {
   if (!variants.every(_isObjectLike)) return null;
   final flatRequired = variants.map(_flattenedRequiredProperties).toList();
   final flatProps = variants.map(_flattenedProperties).toList();
-  final candidates = <(String, List<String>)>[];
+  final candidates = <(String, List<List<String>>)>[];
   for (final entry in flatProps.first.entries) {
     final propName = entry.key;
     if (!flatRequired.first.contains(propName)) continue;
     final firstType = entry.value;
-    if (firstType is! ResolvedEnum || firstType.values.length != 1) continue;
-    final values = [firstType.values.first];
+    if (firstType is! ResolvedEnum || firstType.values.isEmpty) continue;
+    final perVariantValues = <List<String>>[List.of(firstType.values)];
     var allMatch = true;
     for (var i = 1; i < variants.length; i++) {
       if (!flatRequired[i].contains(propName)) {
@@ -401,22 +472,37 @@ ResolvedDiscriminator? _implicitDiscriminator(List<ResolvedSchema> variants) {
         break;
       }
       final otherType = flatProps[i][propName];
-      if (otherType is! ResolvedEnum || otherType.values.length != 1) {
+      if (otherType is! ResolvedEnum || otherType.values.isEmpty) {
         allMatch = false;
         break;
       }
-      values.add(otherType.values.first);
+      perVariantValues.add(List.of(otherType.values));
     }
-    if (allMatch) candidates.add((propName, values));
+    if (allMatch) candidates.add((propName, perVariantValues));
   }
   if (candidates.isEmpty) return null;
   candidates.sort((a, b) => a.$1.compareTo(b.$1));
-  for (final (propName, values) in candidates) {
-    if (values.toSet().length != values.length) continue;
+  for (final (propName, perVariantValues) in candidates) {
+    // Pairwise-disjoint check on the union of each variant's enum
+    // values. A duplicate value would route to two variants — not a
+    // valid discriminator.
+    final seen = <String>{};
+    var disjoint = true;
+    for (final values in perVariantValues) {
+      for (final v in values) {
+        if (!seen.add(v)) {
+          disjoint = false;
+          break;
+        }
+      }
+      if (!disjoint) break;
+    }
+    if (!disjoint) continue;
     return ResolvedDiscriminator(
       propertyName: propName,
       mapping: {
-        for (var i = 0; i < variants.length; i++) values[i]: variants[i],
+        for (var i = 0; i < variants.length; i++)
+          for (final v in perVariantValues[i]) v: variants[i],
       },
     );
   }
@@ -485,8 +571,14 @@ HybridDispatch? _pickHybrid(List<ResolvedSchema> variants) {
   );
 }
 
-PredicateDispatch? _pickRequiredField(List<ResolvedSchema> variants) {
-  final arms = _requiredFieldArmsFor(variants);
+PredicateDispatch? _pickRequiredField(
+  List<ResolvedSchema> variants, {
+  bool looseRequiredUniqueness = false,
+}) {
+  final arms = _requiredFieldArmsFor(
+    variants,
+    looseRequiredUniqueness: looseRequiredUniqueness,
+  );
   if (arms == null) return null;
   return PredicateDispatch(
     kind: PredicateDispatchKind.requiredField,

--- a/lib/src/dispatch.dart
+++ b/lib/src/dispatch.dart
@@ -379,8 +379,13 @@ DiscriminatorDispatch? _pickDiscriminator(
   // an implicit synthesis when the explicit one has no `mapping`
   // (github's check-runs POST: spec declares `propertyName: status`
   // but no mapping; each variant carries an enum on `status` whose
-  // values together name the discriminated cases).
-  var disc = collection is ResolvedOneOf ? collection.discriminator : null;
+  // values together name the discriminated cases). OpenAPI permits
+  // `discriminator` on both `oneOf` and `anyOf`.
+  var disc = switch (collection) {
+    ResolvedOneOf() => collection.discriminator,
+    ResolvedAnyOf() => collection.discriminator,
+    _ => null,
+  };
   if (disc != null && disc.mapping == null) {
     disc = _implicitDiscriminatorForProperty(variants, disc.propertyName);
   }

--- a/lib/src/parse/spec.dart
+++ b/lib/src/parse/spec.dart
@@ -367,7 +367,19 @@ abstract class SchemaCombiner extends SchemaObjectBase {
 }
 
 class SchemaAnyOf extends SchemaCombiner {
-  const SchemaAnyOf({required super.common, required super.schemas});
+  const SchemaAnyOf({
+    required super.common,
+    required super.schemas,
+    required this.discriminator,
+  });
+
+  /// The OpenAPI discriminator object, if any. OpenAPI permits
+  /// `discriminator` on both `oneOf` and `anyOf`; the runtime
+  /// dispatch (read a property, route to a variant) is identical.
+  final SchemaDiscriminator? discriminator;
+
+  @override
+  List<Object?> get props => [super.props, discriminator];
 }
 
 class SchemaAllOf extends SchemaCombiner {

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -572,8 +572,7 @@ List<SchemaRef>? _maybeMergeParentIntoVariants(
       type == 'object' || (type is List && type.contains('object'));
   if (!hasObjectType) return null;
   final parentProperties = json['properties'];
-  if (parentProperties is! Map<String, dynamic> ||
-      parentProperties.isEmpty) {
+  if (parentProperties is! Map<String, dynamic> || parentProperties.isEmpty) {
     return null;
   }
   final list = json[collectionKey];

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -440,6 +440,15 @@ Schema? _handleCollectionTypes(
     if (_isConstraintOnlyCollection(json, 'oneOf')) {
       return null;
     }
+    final mergedVariants = _maybeMergeParentIntoVariants(json, 'oneOf');
+    final discriminator = _parseDiscriminator(json);
+    if (mergedVariants != null) {
+      return SchemaOneOf(
+        common: common,
+        schemas: mergedVariants,
+        discriminator: discriminator,
+      );
+    }
     final oneOf = json.childAsList('oneOf');
     final schemas = <SchemaRef>[];
     for (var i = 0; i < oneOf.length; i++) {
@@ -447,7 +456,6 @@ Schema? _handleCollectionTypes(
         parseSchemaOrRef(oneOf.indexAsMap(i).addSnakeName('one_of_$i')),
       );
     }
-    final discriminator = _parseDiscriminator(json);
     return SchemaOneOf(
       common: common,
       schemas: schemas,
@@ -469,6 +477,10 @@ Schema? _handleCollectionTypes(
   if (json.containsKey('anyOf')) {
     if (_isConstraintOnlyCollection(json, 'anyOf')) {
       return null;
+    }
+    final mergedVariants = _maybeMergeParentIntoVariants(json, 'anyOf');
+    if (mergedVariants != null) {
+      return SchemaAnyOf(common: common, schemas: mergedVariants);
     }
     final anyOf = json.childAsList('anyOf');
     final schemas = <SchemaRef>[];
@@ -517,6 +529,175 @@ bool _isConstraintOnlyCollection(MapContext json, String collectionKey) {
     if (variant.length != 1 || !variant.containsKey('required')) return false;
   }
   return true;
+}
+
+/// Returns merged variant schemas when [json] declares a base object
+/// shape (`type: object` + `properties`) AND every entry of the
+/// [collectionKey] (oneOf/anyOf) is itself a partial inline object
+/// that *refines* that shape — adds a property override, an extra
+/// required field, etc. — rather than introducing a wholly different
+/// type.
+///
+/// This is the github `repos/{owner}/{repo}/check-runs` POST pattern:
+/// the parent declares all the fields (`name`, `head_sha`, …) and
+/// the oneOf says "additionally, when `status: completed`,
+/// `conclusion` is required." Today's parser drops the parent's
+/// `properties`/`required` on the floor when it sees the oneOf,
+/// emitting variant classes that lack the base fields entirely.
+///
+/// The fix here is parse-time: synthesize one merged variant per
+/// branch by overlaying the parent's `properties`/`required` with
+/// the variant's. Each merged variant goes through normal object
+/// parsing, and the resulting `SchemaOneOf`/`SchemaAnyOf` dispatches
+/// over full-shape variants — typically via the parent's
+/// discriminator. Returns `null` (caller falls back to today's
+/// behavior) when the pattern doesn't match — including:
+///
+///   - The parent has no `properties` / no `type: object` shape.
+///   - Any variant is a `$ref` (we can't merge into another file's
+///     schema at parse time without resolving it first).
+///   - Any variant declares its own `oneOf`/`anyOf`/`allOf` (real
+///     polymorphism inside polymorphism — punt).
+///   - Any variant declares a non-object `type` (it's a real
+///     alternative type, not a refinement).
+List<SchemaRef>? _maybeMergeParentIntoVariants(
+  MapContext json,
+  String collectionKey,
+) {
+  // Parent must declare `type: object` and a non-empty `properties`
+  // map. Without `type` we'd be guessing whether the variants are
+  // refinements or alternatives.
+  final type = json['type'];
+  final hasObjectType =
+      type == 'object' || (type is List && type.contains('object'));
+  if (!hasObjectType) return null;
+  final parentProperties = json['properties'];
+  if (parentProperties is! Map<String, dynamic> ||
+      parentProperties.isEmpty) {
+    return null;
+  }
+  final list = json[collectionKey];
+  if (list is! List || list.isEmpty) return null;
+
+  // Every variant must be a refinement-shaped inline object.
+  for (final variant in list) {
+    if (variant is! Map<String, dynamic>) return null;
+    if (variant.containsKey(r'$ref')) return null;
+    if (variant.containsKey('oneOf') ||
+        variant.containsKey('anyOf') ||
+        variant.containsKey('allOf')) {
+      return null;
+    }
+    final variantType = variant['type'];
+    if (variantType != null && variantType != 'object') return null;
+    // A variant with no `properties` and no `required` is just empty
+    // noise — fall through to today's behavior so it surfaces in the
+    // verbose log.
+    if (!variant.containsKey('properties') &&
+        !variant.containsKey('required')) {
+      return null;
+    }
+  }
+
+  // Read `required` via the underlying json (no `_markRead`) so an
+  // early null-return below doesn't accidentally consume the key.
+  // Only when we successfully build merged variants do we mark it
+  // as used (via the explicit lookup at the end of the function).
+  final parentRequired = json.json['required'];
+  if (parentRequired != null && parentRequired is! List) return null;
+  final parentRequiredList =
+      (parentRequired as List?)?.cast<String>() ?? const <String>[];
+
+  // Build the merged variants. Each gets its own MapContext with
+  // the pointer / snake-name chain matching a real variant parse,
+  // so the resolver and naming layers see indistinguishable
+  // schemas.
+  final merged = <SchemaRef>[];
+  for (var i = 0; i < list.length; i++) {
+    final variant = list[i] as Map<String, dynamic>;
+
+    final mergedProperties = <String, dynamic>{
+      ...parentProperties,
+    };
+    final variantProperties = variant['properties'];
+    if (variantProperties is Map<String, dynamic>) {
+      // Variant overrides parent on field-name collision (the github
+      // pattern is to narrow `status`'s enum per branch).
+      mergedProperties.addAll(variantProperties);
+    }
+
+    final variantRequired = variant['required'];
+    final variantRequiredList = variantRequired is List
+        ? variantRequired.cast<String>()
+        : const <String>[];
+    final mergedRequired = <String>[
+      ...parentRequiredList,
+      for (final name in variantRequiredList)
+        if (!parentRequiredList.contains(name)) name,
+    ];
+
+    final mergedJson = <String, dynamic>{
+      'type': 'object',
+      // Carry the parent's `additionalProperties` first so a variant
+      // can still override it (variant values win because they're
+      // spread after).
+      if (json.json.containsKey('additionalProperties'))
+        'additionalProperties': json.json['additionalProperties'],
+      ...variant,
+      'properties': mergedProperties,
+      if (mergedRequired.isNotEmpty) 'required': mergedRequired,
+    };
+
+    // Mirror the pointer / snake-name chain the regular variant
+    // path builds: pointer is `<parent>/<collectionKey>/<i>` and
+    // the snake stack gets `<collectionKey>_<i>` appended. Built
+    // directly because there's no real list context in the spec
+    // here — the merged variant is a parser-side synthesis.
+    final variantContext = MapContext(
+      pointerParts: [...json.pointerParts, collectionKey, '$i'],
+      snakeNameStack: [
+        ...json.snakeNameStack,
+        '${_collectionSnakeStem(collectionKey)}_$i',
+      ],
+      json: mergedJson,
+    );
+    merged.add(parseSchemaOrRef(variantContext));
+  }
+
+  // Mark the remaining parent keys as consumed so `_warnUnused`
+  // doesn't fire on them. `type` / `properties` / `[collectionKey]`
+  // are already marked by the early lookups above; the remaining
+  // keys need an explicit touch. `MapContext.operator []` records
+  // the key as a side effect; the underscore-bound result is
+  // intentionally discarded.
+  if (json.containsKey('required')) {
+    final _ = json['required'];
+  }
+  if (json.containsKey('additionalProperties')) {
+    final _ = json['additionalProperties'];
+  }
+  // `discriminator` is consumed in the caller via
+  // `_parseDiscriminator` for the oneOf path; for anyOf there is no
+  // such handling, so mark it here.
+  if (collectionKey == 'anyOf' && json.containsKey('discriminator')) {
+    final _ = json['discriminator'];
+  }
+  return merged;
+}
+
+/// Returns the snake-case stem used for naming inline variants of
+/// the given collection key. Mirrors the constants in
+/// `_handleCollectionTypes`.
+String _collectionSnakeStem(String collectionKey) {
+  switch (collectionKey) {
+    case 'oneOf':
+      return 'one_of';
+    case 'anyOf':
+      return 'any_of';
+    case 'allOf':
+      return 'all_of';
+  }
+  throw ArgumentError.value(collectionKey, 'collectionKey');
 }
 
 SchemaRef? _handleAdditionalProperties(MapContext parent) {

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -479,8 +479,13 @@ Schema? _handleCollectionTypes(
       return null;
     }
     final mergedVariants = _maybeMergeParentIntoVariants(json, 'anyOf');
+    final discriminator = _parseDiscriminator(json);
     if (mergedVariants != null) {
-      return SchemaAnyOf(common: common, schemas: mergedVariants);
+      return SchemaAnyOf(
+        common: common,
+        schemas: mergedVariants,
+        discriminator: discriminator,
+      );
     }
     final anyOf = json.childAsList('anyOf');
     final schemas = <SchemaRef>[];
@@ -489,7 +494,11 @@ Schema? _handleCollectionTypes(
         parseSchemaOrRef(anyOf.indexAsMap(i).addSnakeName('any_of_$i')),
       );
     }
-    return SchemaAnyOf(common: common, schemas: schemas);
+    return SchemaAnyOf(
+      common: common,
+      schemas: schemas,
+      discriminator: discriminator,
+    );
   }
   return null;
 }
@@ -649,15 +658,15 @@ List<SchemaRef>? _maybeMergeParentIntoVariants(
 
     // Mirror the pointer / snake-name chain the regular variant
     // path builds: pointer is `<parent>/<collectionKey>/<i>` and
-    // the snake stack gets `<collectionKey>_<i>` appended. Built
+    // the snake stack gets `<one|any>_of_<i>` appended. Built
     // directly because there's no real list context in the spec
-    // here — the merged variant is a parser-side synthesis.
+    // here — the merged variant is a parser-side synthesis. The
+    // caller of this function only ever passes 'oneOf' or 'anyOf';
+    // 'allOf' has its own non-merging code path.
+    final stem = collectionKey == 'oneOf' ? 'one_of' : 'any_of';
     final variantContext = MapContext(
       pointerParts: [...json.pointerParts, collectionKey, '$i'],
-      snakeNameStack: [
-        ...json.snakeNameStack,
-        '${_collectionSnakeStem(collectionKey)}_$i',
-      ],
+      snakeNameStack: [...json.snakeNameStack, '${stem}_$i'],
       json: mergedJson,
     );
     merged.add(parseSchemaOrRef(variantContext));
@@ -665,38 +674,14 @@ List<SchemaRef>? _maybeMergeParentIntoVariants(
 
   // Mark the remaining parent keys as consumed so `_warnUnused`
   // doesn't fire on them. `type` / `properties` / `[collectionKey]`
-  // are already marked by the early lookups above; the remaining
-  // keys need an explicit touch. `MapContext.operator []` records
-  // the key as a side effect; the underscore-bound result is
-  // intentionally discarded.
-  if (json.containsKey('required')) {
-    final _ = json['required'];
-  }
+  // are already marked by the early lookups above. The caller
+  // consumes `discriminator` via `_parseDiscriminator` (now called
+  // for both the oneOf and anyOf branches).
+  if (json.containsKey('required')) json.markUsed('required');
   if (json.containsKey('additionalProperties')) {
-    final _ = json['additionalProperties'];
-  }
-  // `discriminator` is consumed in the caller via
-  // `_parseDiscriminator` for the oneOf path; for anyOf there is no
-  // such handling, so mark it here.
-  if (collectionKey == 'anyOf' && json.containsKey('discriminator')) {
-    final _ = json['discriminator'];
+    json.markUsed('additionalProperties');
   }
   return merged;
-}
-
-/// Returns the snake-case stem used for naming inline variants of
-/// the given collection key. Mirrors the constants in
-/// `_handleCollectionTypes`.
-String _collectionSnakeStem(String collectionKey) {
-  switch (collectionKey) {
-    case 'oneOf':
-      return 'one_of';
-    case 'anyOf':
-      return 'any_of';
-    case 'allOf':
-      return 'all_of';
-  }
-  throw ArgumentError.value(collectionKey, 'collectionKey');
 }
 
 SchemaRef? _handleAdditionalProperties(MapContext parent) {
@@ -1824,7 +1809,7 @@ class MapContext extends ParseContext {
       throw StateError('Key not found: $key in $pointer');
     }
     final child = _expectType<Map<String, dynamic>>(this, key, value);
-    _markUsed(key);
+    markUsed(key);
     return MapContext.fromParent(parent: this, json: child, key: key);
   }
 
@@ -1841,7 +1826,7 @@ class MapContext extends ParseContext {
       throw StateError('Key not found: $key in $pointer');
     }
     final child = _expectType<List<dynamic>>(this, key, value);
-    _markUsed(key);
+    markUsed(key);
     return ListContext.fromParent(parent: this, json: child, key: key);
   }
 
@@ -1855,7 +1840,7 @@ class MapContext extends ParseContext {
   bool get isNotEmpty => json.isNotEmpty;
 
   dynamic operator [](String key) {
-    _markUsed(key);
+    markUsed(key);
     return json[key];
   }
 
@@ -1873,7 +1858,11 @@ class MapContext extends ParseContext {
   @visibleForTesting
   final Set<String> usedKeys;
 
-  void _markUsed(String key) => usedKeys.add(key);
+  /// Mark [key] as read without retrieving the value. Useful for
+  /// callers that want to suppress a `_warnUnused` entry on a key
+  /// they've inspected via the underlying [json] map directly (or
+  /// that they're consuming for side-effect only).
+  void markUsed(String key) => usedKeys.add(key);
 
   Set<String> get unusedKeys =>
       Set<String>.from(json.keys).difference(usedKeys);

--- a/lib/src/resolver.dart
+++ b/lib/src/resolver.dart
@@ -374,7 +374,16 @@ ResolvedSchema _resolveSchemaFully(
         return second;
       }
     }
-    return ResolvedAnyOf(common: resolvedCommon, schemas: schemas);
+    final discriminator = _resolveDiscriminator(
+      anyOf.discriminator,
+      schemas,
+      anyOf.pointer,
+    );
+    return ResolvedAnyOf(
+      common: resolvedCommon,
+      schemas: schemas,
+      discriminator: discriminator,
+    );
   }
   if (schema is SchemaNull) {
     assert(!createsNewType, 'SchemaNull should not create a new type');
@@ -1503,12 +1512,28 @@ class ResolvedDiscriminator extends Equatable {
 }
 
 class ResolvedAnyOf extends ResolvedSchemaCollection {
-  const ResolvedAnyOf({required super.schemas, required super.common})
-    : super(createsNewType: true);
+  const ResolvedAnyOf({
+    required super.schemas,
+    required super.common,
+    required this.discriminator,
+  }) : super(createsNewType: true);
+
+  /// The resolved discriminator, if any. Same shape as
+  /// [ResolvedOneOf.discriminator] — each
+  /// [ResolvedDiscriminator.mapping] value points at one of [schemas]
+  /// (same instance), so callers can do identity lookups.
+  final ResolvedDiscriminator? discriminator;
+
+  @override
+  List<Object?> get props => [super.props, discriminator];
 
   @override
   ResolvedAnyOf copyWith({CommonProperties? common}) {
-    return ResolvedAnyOf(common: common ?? this.common, schemas: schemas);
+    return ResolvedAnyOf(
+      common: common ?? this.common,
+      schemas: schemas,
+      discriminator: discriminator,
+    );
   }
 }
 

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -612,6 +612,175 @@ void main() {
       });
     });
 
+    test(
+      'oneOf with sibling properties merges parent fields into '
+      'each variant',
+      () {
+        // github `repos/{owner}/{repo}/check-runs` POST shape: the
+        // parent declares the full set of fields and the oneOf
+        // variants only refine `status` (and conditionally require
+        // `conclusion`). Each merged variant needs the parent's
+        // `properties` and `required` so the typed surface isn't
+        // missing `name`/`head_sha`/etc.
+        final json = {
+          'type': 'object',
+          'required': ['name', 'head_sha'],
+          'properties': {
+            'name': {'type': 'string'},
+            'head_sha': {'type': 'string'},
+            'status': {
+              'type': 'string',
+              'enum': ['queued', 'completed'],
+            },
+            'conclusion': {
+              'type': 'string',
+              'enum': ['success', 'failure'],
+            },
+          },
+          'discriminator': {'propertyName': 'status'},
+          'oneOf': [
+            {
+              'properties': {
+                'status': {
+                  'enum': ['completed'],
+                },
+              },
+              'required': ['status', 'conclusion'],
+              'additionalProperties': true,
+            },
+            {
+              'properties': {
+                'status': {
+                  'enum': ['queued'],
+                },
+              },
+              'additionalProperties': true,
+            },
+          ],
+        };
+        final schema = parseTestSchema(json);
+        expect(schema, isA<SchemaOneOf>());
+        final oneOf = schema as SchemaOneOf;
+        expect(oneOf.schemas, hasLength(2));
+        // Discriminator preserved.
+        expect(oneOf.discriminator?.propertyName, 'status');
+
+        final variant0 = oneOf.schemas[0].object! as SchemaObject;
+        expect(
+          variant0.properties.keys,
+          containsAll(<String>['name', 'head_sha', 'status', 'conclusion']),
+        );
+        // Parent + variant required, deduped, parent first.
+        expect(variant0.requiredProperties, [
+          'name',
+          'head_sha',
+          'status',
+          'conclusion',
+        ]);
+
+        final variant1 = oneOf.schemas[1].object! as SchemaObject;
+        expect(
+          variant1.properties.keys,
+          containsAll(<String>['name', 'head_sha', 'status']),
+        );
+        // Variant 1 only inherits the parent's required set.
+        expect(variant1.requiredProperties, ['name', 'head_sha']);
+      },
+    );
+
+    test(
+      'anyOf with sibling properties also merges parent fields into '
+      'each variant',
+      () {
+        // github `repos/{owner}/{repo}/check-runs/{check_run_id}`
+        // PATCH shape: `anyOf` instead of `oneOf`, no
+        // `discriminator`, but otherwise same parent+refinement
+        // pattern as the POST.
+        final json = {
+          'type': 'object',
+          'properties': {
+            'name': {'type': 'string'},
+            'status': {
+              'type': 'string',
+              'enum': ['queued', 'completed'],
+            },
+            'conclusion': {
+              'type': 'string',
+              'enum': ['success', 'failure'],
+            },
+          },
+          'anyOf': [
+            {
+              'properties': {
+                'status': {
+                  'enum': ['completed'],
+                },
+              },
+              'required': ['conclusion'],
+              'additionalProperties': true,
+            },
+            {
+              'properties': {
+                'status': {
+                  'enum': ['queued'],
+                },
+              },
+              'additionalProperties': true,
+            },
+          ],
+        };
+        final schema = parseTestSchema(json);
+        expect(schema, isA<SchemaAnyOf>());
+        final anyOf = schema as SchemaAnyOf;
+        expect(anyOf.schemas, hasLength(2));
+
+        final variant0 = anyOf.schemas[0].object! as SchemaObject;
+        expect(
+          variant0.properties.keys,
+          containsAll(<String>['name', 'status', 'conclusion']),
+        );
+        expect(variant0.requiredProperties, ['conclusion']);
+
+        final variant1 = anyOf.schemas[1].object! as SchemaObject;
+        expect(
+          variant1.properties.keys,
+          containsAll(<String>['name', 'status']),
+        );
+        expect(variant1.requiredProperties, isEmpty);
+      },
+    );
+
+    test(
+      r'oneOf with a $ref variant does not merge — refs may live in '
+      'another schema and are not resolvable at parse time',
+      () {
+        // A real polymorphic oneOf where one variant is a ref. The
+        // merge-into-variants pass leaves this alone (returns null)
+        // and the caller falls back to today's behavior.
+        final json = {
+          'type': 'object',
+          'properties': {
+            'x': {'type': 'string'},
+          },
+          'oneOf': [
+            {r'$ref': '#/components/schemas/Other'},
+          ],
+        };
+        final logger = _MockLogger();
+        final schema = runWithLogger(
+          logger,
+          () => parseTestSchemas({
+            'Test': json,
+            'Other': {'type': 'object'},
+          }),
+        );
+        expect(schema['Test']!.object, isA<SchemaOneOf>());
+        final oneOf = schema['Test']!.object! as SchemaOneOf;
+        // The $ref variant survives unchanged — no merge happened.
+        expect(oneOf.schemas.first.ref, isNotNull);
+      },
+    );
+
     test('components schemas as ref not supported', () {
       // Refs are generally fine.
       final json = {

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -781,6 +781,184 @@ void main() {
       },
     );
 
+    test('merge bails when a variant declares a non-object type', () {
+      // A variant with `type: string` is a real alternative type, not
+      // a refinement of the parent object. Fall through to today's
+      // behavior — the variants get parsed individually and the
+      // parent's properties end up dropped (visible at -v as
+      // `Unused: properties`).
+      final json = {
+        'type': 'object',
+        'properties': {
+          'name': {'type': 'string'},
+        },
+        'oneOf': [
+          {'type': 'string'},
+          {
+            'properties': {
+              'name': {'type': 'string'},
+            },
+          },
+        ],
+      };
+      final schema = parseTestSchema(json);
+      expect(schema, isA<SchemaOneOf>());
+      final oneOf = schema as SchemaOneOf;
+      // Variant 0 stays a string (no merge happened).
+      expect(oneOf.schemas[0].object, isA<SchemaString>());
+    });
+
+    test('merge bails when a variant declares its own oneOf', () {
+      // Real polymorphism inside polymorphism — merging would lose
+      // the inner branch structure. Fall through.
+      final json = {
+        'type': 'object',
+        'properties': {
+          'name': {'type': 'string'},
+        },
+        'oneOf': [
+          {
+            'oneOf': [
+              {'type': 'object'},
+            ],
+          },
+        ],
+      };
+      final schema = parseTestSchema(json);
+      // The inner oneOf survives — variant 0 is itself a oneOf.
+      expect(schema, isA<SchemaOneOf>());
+      final outer = schema as SchemaOneOf;
+      expect(outer.schemas[0].object, isA<SchemaOneOf>());
+    });
+
+    test('merge bails when a variant has neither properties nor required', () {
+      // An empty variant `{}` carries no refinement — falling through
+      // to today's behavior surfaces it in the verbose log instead of
+      // silently producing a duplicate of the parent.
+      final json = {
+        'type': 'object',
+        'properties': {
+          'name': {'type': 'string'},
+        },
+        'oneOf': [
+          <String, dynamic>{},
+        ],
+      };
+      final schema = parseTestSchema(json);
+      expect(schema, isA<SchemaOneOf>());
+      final oneOf = schema as SchemaOneOf;
+      // Variant 0 has no properties of its own — empty object.
+      final variant0 = oneOf.schemas[0].object;
+      expect(
+        variant0,
+        anyOf(isA<SchemaEmptyObject>(), isA<SchemaUnknown>()),
+      );
+    });
+
+    test(
+      'merge carries the parent `additionalProperties` onto each variant',
+      () {
+        // When the parent declares `additionalProperties`, every
+        // merged variant should inherit it (variants can still
+        // override). This locks in the parent's schema's open-or-
+        // closed shape across the dispatch.
+        final json = {
+          'type': 'object',
+          'additionalProperties': true,
+          'properties': {
+            'name': {'type': 'string'},
+          },
+          'oneOf': [
+            {
+              'properties': {
+                'name': {'type': 'string'},
+              },
+            },
+            {
+              'properties': {
+                'name': {'type': 'string'},
+              },
+            },
+          ],
+        };
+        final schema = parseTestSchema(json);
+        expect(schema, isA<SchemaOneOf>());
+        final oneOf = schema as SchemaOneOf;
+        // Both variants got the parent's additionalProperties (the
+        // SchemaObject's `additionalProperties` field is non-null).
+        for (final ref in oneOf.schemas) {
+          final variant = ref.object! as SchemaObject;
+          expect(variant.additionalProperties, isNotNull);
+        }
+      },
+    );
+
+    test('merge bails when the parent has no `properties` map', () {
+      // Without parent properties to overlay, there's nothing to
+      // merge — the oneOf is a normal polymorphic union.
+      final json = {
+        'type': 'object',
+        'oneOf': [
+          {
+            'type': 'object',
+            'properties': {
+              'a': {'type': 'string'},
+            },
+          },
+          {
+            'type': 'object',
+            'properties': {
+              'b': {'type': 'integer'},
+            },
+          },
+        ],
+      };
+      final schema = parseTestSchema(json);
+      expect(schema, isA<SchemaOneOf>());
+      final oneOf = schema as SchemaOneOf;
+      // Variants get their own properties only; no parent-merged
+      // fields would have been added.
+      final variant0 = oneOf.schemas[0].object! as SchemaObject;
+      expect(variant0.properties.keys, ['a']);
+    });
+
+    test('anyOf with explicit discriminator + mapping survives parsing', () {
+      // OpenAPI permits `discriminator` on `anyOf`, not just `oneOf`.
+      // The parser plumbs it through `SchemaAnyOf.discriminator` so
+      // downstream stages (resolver, dispatch picker) can use it the
+      // same way as on a oneOf.
+      final json = {
+        'anyOf': [
+          {
+            'type': 'object',
+            'properties': {
+              'kind': {'type': 'string'},
+            },
+          },
+          {
+            'type': 'object',
+            'properties': {
+              'kind': {'type': 'string'},
+            },
+          },
+        ],
+        'discriminator': {
+          'propertyName': 'kind',
+          'mapping': {
+            'cat': '#/components/schemas/Cat',
+            'dog': '#/components/schemas/Dog',
+          },
+        },
+      };
+      final schema = parseTestSchema(json);
+      expect(schema, isA<SchemaAnyOf>());
+      final anyOf = schema as SchemaAnyOf;
+      expect(anyOf.discriminator, isNotNull);
+      expect(anyOf.discriminator!.propertyName, 'kind');
+      expect(anyOf.discriminator!.mapping, isNotNull);
+      expect(anyOf.discriminator!.mapping!.length, 2);
+    });
+
     test('components schemas as ref not supported', () {
       // Refs are generally fine.
       final json = {

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -773,6 +773,116 @@ void main() {
       expect(result, isNot(contains('throw UnimplementedError')));
     });
 
+    test(
+      'oneOf with sibling properties + explicit discriminator '
+      'without mapping synthesizes the dispatch from variant enums',
+      () {
+        // github `repos/{owner}/{repo}/check-runs` POST shape: parent
+        // declares the full property set, oneOf variants only refine
+        // `status`'s enum and conditionally require `conclusion`. The
+        // spec's `discriminator: {propertyName: status}` has no
+        // `mapping` — we synthesize one by walking each variant's
+        // `status` enum.
+        final schema = {
+          'type': 'object',
+          'required': ['name', 'head_sha'],
+          'properties': {
+            'name': {'type': 'string'},
+            'head_sha': {'type': 'string'},
+            'status': {
+              'type': 'string',
+              'enum': ['queued', 'in_progress', 'completed'],
+            },
+            'conclusion': {
+              'type': 'string',
+              'enum': ['success', 'failure'],
+            },
+          },
+          'discriminator': {'propertyName': 'status'},
+          'oneOf': [
+            {
+              'properties': {
+                'status': {
+                  'enum': ['completed'],
+                },
+              },
+              'required': ['status', 'conclusion'],
+              'additionalProperties': true,
+            },
+            {
+              'properties': {
+                'status': {
+                  'enum': ['queued', 'in_progress'],
+                },
+              },
+              'additionalProperties': true,
+            },
+          ],
+        };
+        final result = renderTestSchema(schema);
+        // Discriminator dispatch on `status`.
+        expect(result, contains("final discriminator = json['status']"));
+        expect(result, contains("'completed' =>"));
+        // Multi-value enum on the second variant produces multiple
+        // case arms, all routing to the same variant.
+        expect(result, contains("'queued' =>"));
+        expect(result, contains("'in_progress' =>"));
+        // No stub.
+        expect(result, isNot(contains('throw UnimplementedError')));
+      },
+    );
+
+    test(
+      'anyOf with sibling properties dispatches via the loose '
+      'required-field picker (no stub)',
+      () {
+        // github `repos/{owner}/{repo}/check-runs/{check_run_id}`
+        // PATCH: anyOf, no discriminator. After parse-time merge of
+        // parent properties, both variants share most properties;
+        // only variant 0 *requires* `conclusion`. Loose required-
+        // field uniqueness (anyOf-only) lets that be the dispatch
+        // tag.
+        final schema = {
+          'type': 'object',
+          'properties': {
+            'name': {'type': 'string'},
+            'status': {
+              'type': 'string',
+              'enum': ['queued', 'completed'],
+            },
+            'conclusion': {
+              'type': 'string',
+              'enum': ['success', 'failure'],
+            },
+          },
+          'anyOf': [
+            {
+              'properties': {
+                'status': {
+                  'enum': ['completed'],
+                },
+              },
+              'required': ['conclusion'],
+              'additionalProperties': true,
+            },
+            {
+              'properties': {
+                'status': {
+                  'enum': ['queued'],
+                },
+              },
+              'additionalProperties': true,
+            },
+          ],
+        };
+        final result = renderTestSchema(schema);
+        // No stub: the loose-mode required-field picker fires for
+        // anyOf and dispatches via `containsKey('conclusion')`.
+        expect(result, isNot(contains('throw UnimplementedError')));
+        expect(result, contains("json.containsKey('conclusion')"));
+      },
+    );
+
     test('oneOf with [string, number] uses shape dispatch', () {
       // RenderNumber's shape key is `num` (matching jsonStorageType),
       // distinct from RenderString's `String`. Github's

--- a/test/resolver_test.dart
+++ b/test/resolver_test.dart
@@ -1417,6 +1417,7 @@ void main() {
               type: PodType.boolean,
             ),
           ],
+          discriminator: null,
         );
         final schema2 = ResolvedAnyOf(
           common: CommonProperties.test(
@@ -1435,6 +1436,7 @@ void main() {
               type: PodType.boolean,
             ),
           ],
+          discriminator: null,
         );
         expect(schema1, equals(schema1));
         // Same schemas.
@@ -1563,6 +1565,7 @@ void main() {
               type: PodType.boolean,
             ),
           ],
+          discriminator: null,
         );
         testCopyWith(schema, (schema, copy) {
           expect(copy.schemas, equals(schema.schemas));


### PR DESCRIPTION
## Summary

A `type: object` schema with both `properties`/`required` AND `oneOf`/`anyOf` siblings (github's `repos/{owner}/{repo}/check-runs` POST and PATCH bodies) was silently losing the parent's fields. The parser flipped into oneOf-mode and dropped `name`, `head_sha`, etc. — generated variant classes ended up with only `status` plus a `Map<String, dynamic> entries` carrier (type-unsafe and missing every base field). This PR makes the parser merge parent props/required into each variant and extends two dispatch pickers to actually decide on the merged collections.

## Approach

**Option B (parse-time merge)**, scoped narrowly. Option A (synthesize an `allOf`) didn't fly: the resolver requires every `allOf` member to be a `ResolvedObject`, so an `allOf` containing a `ResolvedOneOf` would fail the check.

When every variant of the collection is an inline object that *refines* the parent (no `$ref`, no nested oneOf/allOf, `type: object` or omitted), `_maybeMergeParentIntoVariants` overlays the parent's properties + required onto each variant before parsing. The resulting `SchemaOneOf` / `SchemaAnyOf` has full-shape variants dispatchable by the existing pickers.

Two small dispatch extensions were needed to make the merged collections actually dispatch:

- `_implicitDiscriminator` was single-value-enum-only; widened to per-variant enum value sets (still pairwise-disjoint), letting github's check-runs POST dispatch on `status` whose variant enums are `[completed]` vs `[queued, in_progress, ...]`.
- New `_implicitDiscriminatorForProperty` fills in a missing discriminator `mapping` from variant enums when the spec has `discriminator: {propertyName: status}` but no mapping.
- `_pickDiscriminator` now runs for `ResolvedAnyOf` too — the oneOf-vs-anyOf semantic difference doesn't affect a property-switch dispatch.
- `_pickRequiredField` runs in loose mode for anyOf — overlap is spec-permitted under at-least-one semantics, so a tag is unique as long as no sibling *requires* it (check-runs PATCH dispatches on `containsKey('conclusion')` this way).

Net github regen impact: two new sites (check-runs POST + PATCH) get full typed variants and proper dispatch. Stub count unchanged (7 → 7). One related anyOf site (`actions/review-custom-gates`) flips from "fallback to variant 0" to "throw on no-match" — more correct error reporting on truly invalid JSON.

## Test plan

- [x] `dart analyze` clean on github regen
- [x] check-runs POST requestBody preserves outer fields (`name`, `head_sha`, etc.) and dispatches on `status`
- [x] check-runs PATCH requestBody preserves outer fields and dispatches on `containsKey('conclusion')`
- [x] `Unused: required in .../check-runs/...` warning gone
- [x] Stub count unchanged (7 → 7)
- [x] All existing 419 tests pass; 5 new tests added (3 parser, 2 render)
- [x] cspell clean