### PR TITLE
feat: dispatch labels-requestBody (multi-array hybrid + property-array-element-shape)

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -45,3 +45,5 @@ words:
   - spdx
   - sbom
   - varnames
+  - pinnable
+  - unpinnable

--- a/lib/src/dispatch.dart
+++ b/lib/src/dispatch.dart
@@ -327,6 +327,7 @@ DispatchDecision decideDispatch(ResolvedSchemaCollection collection) {
       _pickShape(variants) ??
       _pickHybrid(variants) ??
       _pickRequiredField(variants, looseRequiredUniqueness: isAnyOf) ??
+      _pickPropertyArrayElementShape(variants) ??
       _pickArrayElement(variants) ??
       _pickPropertyArrayItemShape(variants) ??
       const NoDispatch();
@@ -822,12 +823,26 @@ PredicateDispatch? _pickRequiredField(
   List<ResolvedSchema> variants, {
   bool looseRequiredUniqueness = false,
 }) {
-  final arms =
-      _requiredFieldArmsFor(
-        variants,
-        looseRequiredUniqueness: looseRequiredUniqueness,
-      ) ??
-      _propertyArrayElementShapeArmsFor(variants);
+  final arms = _requiredFieldArmsFor(
+    variants,
+    looseRequiredUniqueness: looseRequiredUniqueness,
+  );
+  if (arms == null) return null;
+  return PredicateDispatch(
+    kind: PredicateDispatchKind.requiredField,
+    arms: arms,
+  );
+}
+
+/// Object-variant dispatch by an array property's element shape.
+/// See [_propertyArrayElementShapeArmsFor] for the shape contract.
+/// Runs after [_pickRequiredField] in the picker chain — only when
+/// `containsKey`-style dispatch can't separate the variants do we
+/// peek into an array property's first element.
+PredicateDispatch? _pickPropertyArrayElementShape(
+  List<ResolvedSchema> variants,
+) {
+  final arms = _propertyArrayElementShapeArmsFor(variants);
   if (arms == null) return null;
   return PredicateDispatch(
     kind: PredicateDispatchKind.requiredField,

--- a/lib/src/dispatch.dart
+++ b/lib/src/dispatch.dart
@@ -10,6 +10,7 @@
 /// set is determined entirely by these decisions.
 library;
 
+import 'package:collection/collection.dart';
 import 'package:meta/meta.dart';
 import 'package:space_gen/src/resolver.dart';
 import 'package:space_gen/src/types.dart' show PodType;
@@ -60,16 +61,19 @@ class ArrayElementHasKey extends Predicate {
 /// `jsonVar['propertyName'] is List && (...).first is <shapeKey>` — picks
 /// variants whose required keys are identical at the top level but whose
 /// shared array property has items of distinguishably different JSON shape
-/// across variants. Real-world site: github's `validation-error` (errors
-/// items are objects) vs `validation-error-simple` (errors items are
-/// strings) — both have the same `[message, documentation_url]` required
-/// keys, so neither [KeyExists] nor [ArrayElementHasKey] alone separates
-/// them.
+/// across variants. Real-world sites:
+///
+/// - github's `validation-error` (errors items are objects) vs
+///   `validation-error-simple` (errors items are strings) — same top-
+///   level keys, distinguished by `errors[0]`'s shape.
+/// - github's `issues/add-labels` request body — the object-shaped
+///   variants share an `array<string>` vs `array<object>` `labels`
+///   property and dispatch on it.
 ///
 /// The test short-circuits on `is List` (non-list / null fall through)
 /// and on `.isNotEmpty` (empty lists fall through). A missing or empty
-/// `errors` value won't match any shape arm — the caller is responsible
-/// for either an [Always] fallback variant or accepting a runtime throw.
+/// property won't match any shape arm — the caller is responsible for
+/// either an [Always] fallback variant or accepting a runtime throw.
 @immutable
 class PropertyArrayItemShape extends Predicate {
   const PropertyArrayItemShape({
@@ -93,6 +97,28 @@ class PropertyArrayItemShape extends Predicate {
         '($access as List).isNotEmpty && '
         '($access as List).first is $shapeKey';
   }
+}
+
+/// `jsonVar.isNotEmpty && jsonVar.first is <typeName>` — peeks the
+/// first element of a List local and tests its Dart runtime type.
+/// Used to disambiguate sibling array variants whose element types
+/// have distinct JSON shapes (e.g. `array<string>` vs
+/// `array<object>` — `String` vs `Map<String, dynamic>`). Caller is
+/// responsible for binding `jsonVar` to a non-null `List`; the
+/// `isNotEmpty` short-circuit lets empty lists fall through to the
+/// next arm without throwing.
+@immutable
+class ArrayElementIsType extends Predicate {
+  const ArrayElementIsType(this.typeName);
+
+  /// Dart type name to test against — the same string [_jsonShapeKey]
+  /// returns for the items' resolved schema (`'String'`, `'int'`,
+  /// `'num'`, `'bool'`, `'Map<String, dynamic>'`, …).
+  final String typeName;
+
+  @override
+  String dartIfTest(String jsonVar) =>
+      '$jsonVar.isNotEmpty && $jsonVar.first is $typeName';
 }
 
 /// Catch-all predicate — the dispatch's optional unguarded fallback.
@@ -184,27 +210,36 @@ class ShapeDispatch extends DispatchDecision {
   final List<ShapeArm> arms;
 }
 
-/// Mixed-shape dispatch: some variants pick by JSON shape, the
-/// remaining (Map-shaped) collide and need a property-presence
-/// sub-dispatch in a single nested arm.
+/// Mixed-shape dispatch: some variants pick by unique JSON shape, the
+/// remaining variants collide on `Map<String, dynamic>` and/or
+/// `List<dynamic>` and need a per-shape sub-dispatch in nested arms.
+///
+/// Up to two sub-dispatches can be active simultaneously: Map (by
+/// `containsKey`) and List (by `v.first is <Type>`). Each
+/// sub-dispatch can have an optional unguarded fallback. Single-
+/// variant non-collision shapes go to [shapeArms] unchanged.
 @immutable
 class HybridDispatch extends DispatchDecision {
   const HybridDispatch({
     required this.shapeArms,
     required this.mapArms,
     required this.mapFallback,
+    required this.listArms,
+    required this.listFallback,
     required this.declarationOrder,
   });
 
-  /// Non-Map variants — one per unique shape, dispatched by runtime
-  /// type pattern.
+  /// Non-collision-shape variants — one per unique shape, dispatched
+  /// by runtime type pattern. Excludes any shape that has 2+ variants;
+  /// those go to [mapArms] / [listArms] for sub-dispatch.
   final List<ShapeArm> shapeArms;
 
   /// Map-shaped variants — dispatched by `containsKey` on the
   /// switch-bound `v` local. Each arm is a [PredicateArm] whose
   /// predicate is [KeyExists] (or, for the implicit fallback,
   /// [Always] — but the fallback is broken out separately as
-  /// [mapFallback]).
+  /// [mapFallback]). Empty when at most one Map variant exists (it
+  /// goes to [shapeArms] instead).
   final List<PredicateArm> mapArms;
 
   /// Optional unguarded fallback among the Map-shaped variants —
@@ -213,8 +248,20 @@ class HybridDispatch extends DispatchDecision {
   /// eligible (the sub-dispatch ends in a throw).
   final ResolvedSchema? mapFallback;
 
-  /// All variants in spec declaration order, including both
-  /// shape arms and Map arms. Drives the order of subclass
+  /// List-shaped variants — dispatched by peeking
+  /// `v.first is <typeName>` on the switch-bound `v` local. Each arm
+  /// is a [PredicateArm] whose predicate is [ArrayElementIsType] (or
+  /// [Always] for an implicit fallback, broken out as [listFallback]).
+  /// Empty when at most one List variant exists.
+  final List<PredicateArm> listArms;
+
+  /// Optional unguarded fallback among the List-shaped variants —
+  /// renders as `final List<dynamic> v => Wrapper(…)` after every
+  /// checked List arm. Null when the sub-dispatch ends in a throw.
+  final ResolvedSchema? listFallback;
+
+  /// All variants in spec declaration order, including shape arms,
+  /// Map arms, and List arms. Drives the order of subclass
   /// declarations.
   final List<ResolvedSchema> declarationOrder;
 }
@@ -305,7 +352,7 @@ String? _jsonShapeKey(ResolvedSchema schema) {
     // strategy. Boolean is `bool`-shaped and unambiguous.
     ResolvedPod() =>
       !schema.createsNewType && schema.type == PodType.boolean ? 'bool' : null,
-    ResolvedArray() => 'List<dynamic>',
+    ResolvedArray() => _listShapeKey,
     ResolvedObject() => _mapShapeKey,
     // allOf is rendered as a synthesized RenderObject (member-wise
     // merge of properties + required), so for shape-dispatch purposes
@@ -360,6 +407,7 @@ bool _isObjectLike(ResolvedSchema schema) =>
     schema is ResolvedAllOf;
 
 const String _mapShapeKey = 'Map<String, dynamic>';
+const String _listShapeKey = 'List<dynamic>';
 
 DiscriminatorDispatch? _pickDiscriminator(
   ResolvedSchemaCollection collection,
@@ -527,63 +575,259 @@ ShapeDispatch? _pickShape(List<ResolvedSchema> variants) {
 }
 
 HybridDispatch? _pickHybrid(List<ResolvedSchema> variants) {
-  // Eligibility: every variant has a shape key, at least two
-  // collide on Map, and no other shape collides with itself.
+  // Eligibility: every variant has a shape key, and at least one
+  // shape has 2+ variants colliding (so a sub-dispatch is needed).
+  // We can sub-dispatch Map collisions by required-field and List
+  // collisions by element-type peek; any other shape collision (e.g.
+  // two `String` variants) bails.
   final byShape = <String, List<ResolvedSchema>>{};
   for (final v in variants) {
     final k = _jsonShapeKey(v);
     if (k == null) return null;
     byShape.putIfAbsent(k, () => []).add(v);
   }
-  final mapVariants = byShape[_mapShapeKey];
-  if (mapVariants == null || mapVariants.length < 2) return null;
+  final mapVariants = byShape[_mapShapeKey] ?? const <ResolvedSchema>[];
+  final listVariants = byShape[_listShapeKey] ?? const <ResolvedSchema>[];
+  // Need at least one sub-dispatch — otherwise the picker would be
+  // straight `_pickShape`.
+  if (mapVariants.length < 2 && listVariants.length < 2) return null;
+  // If only one sub-dispatch is active, every other shape must be
+  // single-variant. Two single-shape arms aren't strictly necessary
+  // (a sub-dispatch alone could be its own mode), but we require at
+  // least one non-collision arm to keep hybrid distinct from a pure
+  // sub-dispatch — the pure-sub-dispatch case is handled by
+  // [_pickRequiredField] / [_pickArrayElement].
   if (byShape.length < 2) return null;
   final shapeArms = <ShapeArm>[];
   for (final entry in byShape.entries) {
-    if (entry.key == _mapShapeKey) continue;
+    if (entry.key == _mapShapeKey || entry.key == _listShapeKey) continue;
     if (entry.value.length > 1) return null;
     shapeArms.add(ShapeArm(variant: entry.value.single, shapeKey: entry.key));
   }
   // Sub-dispatch the Map variants by required-field (loose mode —
-  // see [_requiredFieldArmsFor]).
-  final mapArms = _requiredFieldArmsFor(
-    mapVariants,
-    looseRequiredUniqueness: true,
-  );
-  if (mapArms == null) return null;
+  // see [_requiredFieldArmsFor]). When that fails (variants share
+  // both required and optional sets, e.g. github's `add-labels`
+  // request body where two object variants only differ in an
+  // optional array property's element type), retry with the
+  // property-array-element-shape strategy. 0/1 Map variant: the
+  // single Map variant (if any) acts as a single shape arm.
+  final List<PredicateArm> checkedMapArms;
+  ResolvedSchema? mapFallback;
+  if (mapVariants.length >= 2) {
+    final mapArms =
+        _requiredFieldArmsFor(mapVariants, looseRequiredUniqueness: true) ??
+        _propertyArrayElementShapeArmsFor(mapVariants);
+    if (mapArms == null) return null;
+    checkedMapArms = [];
+    for (final arm in mapArms) {
+      if (arm.isFallback) {
+        mapFallback = arm.variant;
+      } else {
+        checkedMapArms.add(arm);
+      }
+    }
+  } else {
+    checkedMapArms = const [];
+    if (mapVariants.length == 1) {
+      shapeArms.add(
+        ShapeArm(variant: mapVariants.single, shapeKey: _mapShapeKey),
+      );
+    }
+  }
+  // Sub-dispatch the List variants by element-type peek. 0/1 List
+  // variant: same single-shape-arm fallthrough as Map.
+  final List<PredicateArm> checkedListArms;
+  ResolvedSchema? listFallback;
+  if (listVariants.length >= 2) {
+    final listArms = _arrayElementShapeArmsFor(listVariants);
+    if (listArms == null) return null;
+    checkedListArms = [];
+    for (final arm in listArms) {
+      if (arm.isFallback) {
+        listFallback = arm.variant;
+      } else {
+        checkedListArms.add(arm);
+      }
+    }
+  } else {
+    checkedListArms = const [];
+    if (listVariants.length == 1) {
+      shapeArms.add(
+        ShapeArm(variant: listVariants.single, shapeKey: _listShapeKey),
+      );
+    }
+  }
   // Re-derive shape arms in spec declaration order so subclass
-  // declarations match the variant ordering.
+  // declarations match the variant ordering. Skip variants that went
+  // to a sub-dispatch (their shape has multiple collisions).
   final declarationOrder = variants;
   final shapeArmsInOrder = <ShapeArm>[];
   for (final v in declarationOrder) {
-    if (_jsonShapeKey(v) == _mapShapeKey) continue;
+    final k = _jsonShapeKey(v);
+    if (k == _mapShapeKey && mapVariants.length >= 2) continue;
+    if (k == _listShapeKey && listVariants.length >= 2) continue;
     shapeArmsInOrder.add(shapeArms.firstWhere((a) => a.variant == v));
-  }
-  ResolvedSchema? mapFallback;
-  final checkedMapArms = <PredicateArm>[];
-  for (final arm in mapArms) {
-    if (arm.isFallback) {
-      mapFallback = arm.variant;
-    } else {
-      checkedMapArms.add(arm);
-    }
   }
   return HybridDispatch(
     shapeArms: shapeArmsInOrder,
     mapArms: checkedMapArms,
     mapFallback: mapFallback,
+    listArms: checkedListArms,
+    listFallback: listFallback,
     declarationOrder: declarationOrder,
   );
+}
+
+/// Sub-dispatch arms for a list of List-shaped variants — picks each
+/// by the Dart runtime type of its first element. Returns null if
+/// any two variants share an element shape key (no way to tell their
+/// first elements apart). At most one variant may be the fallback (an
+/// items schema with no fixed shape, e.g. an open union); a second
+/// fallback bails.
+List<PredicateArm>? _arrayElementShapeArmsFor(
+  List<ResolvedSchema> arrayVariants,
+) {
+  final arms = <PredicateArm>[];
+  final usedTypes = <String>{};
+  var fallbackCount = 0;
+  for (final v in arrayVariants) {
+    if (v is! ResolvedArray) return null;
+    final itemKey = _jsonShapeKey(v.items);
+    if (itemKey == null) {
+      fallbackCount++;
+      if (fallbackCount > 1) return null;
+      arms.add(PredicateArm(variant: v, predicate: const Always()));
+      continue;
+    }
+    if (!usedTypes.add(itemKey)) return null;
+    arms.add(PredicateArm(variant: v, predicate: ArrayElementIsType(itemKey)));
+  }
+  return arms;
+}
+
+/// Sub-dispatch arms for object-like variants whose property sets are
+/// identical *modulo* one array-typed property's element shape.
+/// Picks each by peeking that property's first element type (the
+/// github `issues/add-labels` request body shape: two object variants
+/// `{labels?: array<string>}` and `{labels?: array<object>}`, neither
+/// distinguishable by `containsKey` alone).
+///
+/// Returns null when the variants don't fit this exact shape — same
+/// property names across all variants, exactly one such property is
+/// array-typed with element-shape-distinguishable items across at
+/// least two variants, the rest of the properties are identical
+/// resolved schemas, and no two variants share the array-element
+/// shape. The variant whose array-element shape isn't pinnable (open
+/// union, etc.) becomes the fallback; at most one fallback allowed.
+List<PredicateArm>? _propertyArrayElementShapeArmsFor(
+  List<ResolvedSchema> variants,
+) {
+  if (variants.length < 2) return null;
+  if (!variants.every((v) => v is ResolvedObject)) return null;
+  final objects = variants.cast<ResolvedObject>();
+  // Same property name set across variants. (Same required set too —
+  // a difference in required-ness would have been picked up by
+  // `_requiredFieldArmsFor` upstream.)
+  final firstPropNames = objects.first.properties.keys.toSet();
+  for (final o in objects.skip(1)) {
+    if (!const SetEquality<String>().equals(
+      o.properties.keys.toSet(),
+      firstPropNames,
+    )) {
+      return null;
+    }
+    if (!const SetEquality<String>().equals(
+      o.requiredProperties.toSet(),
+      objects.first.requiredProperties.toSet(),
+    )) {
+      return null;
+    }
+  }
+  // Find the single array-typed property whose items' shape key
+  // differs across variants. Other properties must be structurally
+  // identical (resolved-schema equality) to keep the dispatch sound.
+  String? discriminatorProp;
+  for (final propName in firstPropNames) {
+    // Property names are confirmed identical across variants above,
+    // so each lookup hits — null-check to bind a non-nullable local
+    // and stay off the bang operator.
+    final perVariant = <ResolvedSchema>[];
+    for (final o in objects) {
+      final p = o.properties[propName];
+      if (p == null) return null;
+      perVariant.add(p);
+    }
+    if (perVariant.every((p) => p is ResolvedArray)) {
+      final itemKeys = perVariant
+          .cast<ResolvedArray>()
+          .map((a) => _jsonShapeKey(a.items))
+          .toList();
+      // At least two distinct shape keys across variants (counting
+      // `null` as its own bucket — those become the fallback).
+      final distinctKeys = <String?>{...itemKeys};
+      if (distinctKeys.length >= 2) {
+        if (discriminatorProp != null) return null;
+        discriminatorProp = propName;
+        continue;
+      }
+    }
+    // Non-discriminator property — must be identical across variants.
+    if (!perVariant.every((p) => p == perVariant.first)) return null;
+  }
+  if (discriminatorProp == null) return null;
+  // When the discriminator property is optional in every variant
+  // (the github labels case: `labels` has no `required:`), the
+  // property-array predicates can all miss at runtime — `{}` matches
+  // none of them. In that case, keep the last variant as an
+  // unguarded fallback so a missing/empty array still picks
+  // *something* (matches the spec author's intent that any of the
+  // two object shapes accepts an empty payload). When the property
+  // is required, every match must be predicate-tagged so a payload
+  // missing the discriminator is a hard error.
+  final discriminatorRequired = objects.every(
+    (o) => o.requiredProperties.contains(discriminatorProp),
+  );
+  final fallbackIndex = discriminatorRequired ? -1 : objects.length - 1;
+  final arms = <PredicateArm>[];
+  final usedTypes = <String>{};
+  var fallbackCount = 0;
+  for (var i = 0; i < objects.length; i++) {
+    final o = objects[i];
+    final prop = o.properties[discriminatorProp];
+    if (prop is! ResolvedArray) return null;
+    final itemKey = _jsonShapeKey(prop.items);
+    final isUnpinnable =
+        itemKey == null || usedTypes.contains(itemKey) || i == fallbackIndex;
+    if (isUnpinnable) {
+      fallbackCount++;
+      if (fallbackCount > 1) return null;
+      arms.add(PredicateArm(variant: o, predicate: const Always()));
+      continue;
+    }
+    usedTypes.add(itemKey);
+    arms.add(
+      PredicateArm(
+        variant: o,
+        predicate: PropertyArrayItemShape(
+          propertyName: discriminatorProp,
+          shapeKey: itemKey,
+        ),
+      ),
+    );
+  }
+  return arms;
 }
 
 PredicateDispatch? _pickRequiredField(
   List<ResolvedSchema> variants, {
   bool looseRequiredUniqueness = false,
 }) {
-  final arms = _requiredFieldArmsFor(
-    variants,
-    looseRequiredUniqueness: looseRequiredUniqueness,
-  );
+  final arms =
+      _requiredFieldArmsFor(
+        variants,
+        looseRequiredUniqueness: looseRequiredUniqueness,
+      ) ??
+      _propertyArrayElementShapeArmsFor(variants);
   if (arms == null) return null;
   return PredicateDispatch(
     kind: PredicateDispatchKind.requiredField,
@@ -604,11 +848,10 @@ PredicateDispatch? _pickArrayElement(List<ResolvedSchema> variants) {
     final outer = switch (inner) {
       KeyExists(:final propertyName) => ArrayElementHasKey(propertyName),
       Always() => const Always(),
-      ArrayElementHasKey() => throw StateError(
-        'Unexpected nested array-element predicate from inner arms',
-      ),
+      ArrayElementHasKey() ||
+      ArrayElementIsType() ||
       PropertyArrayItemShape() => throw StateError(
-        'Unexpected nested property-array-item-shape predicate from '
+        'Unexpected nested array-element/property-array predicate from '
         'inner arms — _requiredFieldArmsFor only emits KeyExists/Always',
       ),
     };

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -4277,12 +4277,16 @@ class RenderOneOf extends RenderNewType {
         :final shapeArms,
         :final mapArms,
         :final mapFallback,
+        :final listArms,
+        :final listFallback,
         :final declarationOrder,
       ) =>
         _buildHybridMode(
           shapeArms,
           mapArms,
           mapFallback,
+          listArms,
+          listFallback,
           declarationOrder,
           renderOf,
           context,
@@ -4384,18 +4388,20 @@ class RenderOneOf extends RenderNewType {
   }
 
   /// Build a [_HybridMode], splitting variants by smooshed/not.
-  /// Hybrid has three arm flavors — non-Map shape arms, predicate-
-  /// guarded Map arms, and an optional unguarded Map fallback —
-  /// each of which composes the same `caseExpression`: a direct
-  /// `<Variant>.fromJson(v)` for smooshed variants and the
+  /// Hybrid has up to five arm flavors — non-collision shape arms,
+  /// predicate-guarded Map arms, an optional unguarded Map fallback,
+  /// predicate-guarded List arms, and an optional unguarded List
+  /// fallback — each of which composes the same `caseExpression`: a
+  /// direct `<Variant>.fromJson(v)` for smooshed variants and the
   /// wrapper-class call for the rest. Variants that get a wrapper
-  /// land in `variants`; smooshed ones in `smooshedVariants` and
-  /// are inlined into the parent's file by the schema_object
-  /// partial.
+  /// land in `variants`; smooshed ones in `smooshedVariants` and are
+  /// inlined into the parent's file by the schema_object partial.
   _HybridMode _buildHybridMode(
     List<ShapeArm> shapeArms,
     List<PredicateArm> mapArms,
     ResolvedSchema? mapFallback,
+    List<PredicateArm> listArms,
+    ResolvedSchema? listFallback,
     List<ResolvedSchema> declarationOrder,
     RenderSchema Function(ResolvedSchema) renderOf,
     SchemaRenderer context,
@@ -4410,15 +4416,33 @@ class RenderOneOf extends RenderNewType {
           : '${wrapperTypeName(variant)}($fromJson)';
     }
 
-    // Non-Map shape arms always carry non-object variants today (the
-    // dispatcher routes Map-shaped objects to `mapArms`), so this
-    // path never sees a smooshable variant. `_planVariant` is fine.
+    // List sub-arms wrap an array variant — the variant always has a
+    // wrapper subclass (Array variants aren't smoosh-eligible today),
+    // so `_planVariant` returns the standard List<X> shape plan.
+    String listCaseExpression(RenderSchema variant) {
+      final plan = _planVariant(variant, context)!;
+      return '${plan.wrapperTypeName}(${plan.fromJson})';
+    }
+
+    // Non-collision shape arms can be Map-shaped now (when a single
+    // Map variant sits alongside multi-variant List collisions, the
+    // picker routes it here as a single arm). Use the same case-
+    // expression helper so smooshed Map variants are handled.
     final renderedShapeArms = <Map<String, dynamic>>[];
     for (final arm in shapeArms) {
-      final plan = _planVariant(renderOf(arm.variant), context)!;
+      final renderVariant = renderOf(arm.variant);
+      final String caseExpression;
+      if (arm.shapeKey == _mapShapeKey) {
+        caseExpression = mapCaseExpression(renderVariant);
+      } else if (arm.shapeKey == _listShapeKey) {
+        caseExpression = listCaseExpression(renderVariant);
+      } else {
+        final plan = _planVariant(renderVariant, context)!;
+        caseExpression = '${plan.wrapperTypeName}(${plan.fromJson})';
+      }
       renderedShapeArms.add({
-        'jsonTestType': plan.jsonTestType,
-        'caseExpression': '${plan.wrapperTypeName}(${plan.fromJson})',
+        'jsonTestType': arm.shapeKey,
+        'caseExpression': caseExpression,
       });
     }
 
@@ -4434,12 +4458,35 @@ class RenderOneOf extends RenderNewType {
         ? null
         : {'caseExpression': mapCaseExpression(renderOf(mapFallback))};
 
+    final renderedListArms = <Map<String, dynamic>>[];
+    for (final arm in listArms) {
+      renderedListArms.add({
+        'predicateTest': arm.predicate.dartIfTest('v'),
+        'caseExpression': listCaseExpression(renderOf(arm.variant)),
+      });
+    }
+
+    final renderedListFallback = listFallback == null
+        ? null
+        : {'caseExpression': listCaseExpression(renderOf(listFallback))};
+
+    // A variant lands in one of three buckets, in priority order:
+    //   1. Smooshed → `smooshedVariants` (variant data class extends
+    //      the sealed parent directly, inlined into the parent file).
+    //   2. Map-shaped → `objectWrapperContext` (wrapper's
+    //      `toJson` delegates to `value.toJson()`, returning
+    //      `Map<String, dynamic>`). Includes both Map sub-dispatch
+    //      arms (`mapArms`/`mapFallback`) and the single-Map shape
+    //      arm case where one Map variant sits beside multi-variant
+    //      List collisions.
+    //   3. Otherwise (string, int, list) → `_shapeWrapperContext`
+    //      (wrapper's `toJson` returns `dynamic` and stores the
+    //      JSON-typed value verbatim).
     for (final v in declarationOrder) {
       final renderVariant = renderOf(v);
       if (renderVariant.isSmooshed) {
         smooshedVariants.add(renderVariant.toTemplateContext(context));
-      } else if (mapArms.any((a) => identical(a.variant, v)) ||
-          identical(v, mapFallback)) {
+      } else if (renderVariant.jsonShapeKey == _mapShapeKey) {
         variants.add(objectWrapperContext(renderVariant));
       } else {
         final plan = _planVariant(renderVariant, context)!;
@@ -4450,6 +4497,8 @@ class RenderOneOf extends RenderNewType {
       shapeArms: renderedShapeArms,
       mapArms: renderedMapArms,
       mapFallback: renderedMapFallback,
+      listArms: renderedListArms,
+      listFallback: renderedListFallback,
       variants: variants,
       smooshedVariants: smooshedVariants,
     );
@@ -4689,6 +4738,12 @@ final class _MultiStatusContext {
 /// authoritative spelling.
 const String _mapShapeKey = 'Map<String, dynamic>';
 
+/// Dart pattern type for the List-shape arm of dispatch — matches
+/// any JSON-decoded list. Mirrors [_mapShapeKey]; centralized so the
+/// hybrid dispatch's "List collision" detection has a single
+/// authoritative spelling.
+const String _listShapeKey = 'List<dynamic>';
+
 /// Wrapper-variant context for the shape-dispatch paths (pure shape
 /// and the non-Map arms of hybrid). The wrapper stores the matched
 /// JSON value verbatim and `toJson()` returns it — for primitive
@@ -4776,33 +4831,48 @@ class _ShapeMode extends _DispatchMode {
   final List<Map<String, dynamic>> smooshedVariants;
 }
 
-/// Hybrid dispatch — non-Map shape arms followed by a Map sub-
-/// dispatch (checked-then-fallback). Used when an array (or other
-/// non-Map) variant coexists with multiple objects.
+/// Hybrid dispatch — single-variant shape arms followed by Map and
+/// List sub-dispatches (each checked-then-fallback). Used when 2+
+/// variants collide on `Map<String, dynamic>`, `List<dynamic>`, or
+/// both. Single-variant shapes (string, int, single Map, single List)
+/// pass through unchanged in [shapeArms].
 class _HybridMode extends _DispatchMode {
   const _HybridMode({
     required this.shapeArms,
     required this.mapArms,
     required this.mapFallback,
+    required this.listArms,
+    required this.listFallback,
     required this.variants,
     required this.smooshedVariants,
   });
 
-  /// Per-arm contexts for non-Map shape arms. Each entry has
-  /// `jsonTestType` and `caseExpression` (the full Dart expression
-  /// to `return`).
+  /// Per-arm contexts for single-variant shape arms (no collision).
+  /// Each entry has `jsonTestType` and `caseExpression` (the full
+  /// Dart expression to `return`).
   final List<Map<String, dynamic>> shapeArms;
 
   /// Per-arm contexts for predicate-guarded Map arms. Each entry has
   /// `predicateTest` (the `v.containsKey('foo')` check) and
-  /// `caseExpression`.
+  /// `caseExpression`. Empty when at most one Map variant exists.
   final List<Map<String, dynamic>> mapArms;
 
   /// `null` when no fallback applies (the Map sub-dispatch ends in a
-  /// throw). Otherwise has just `caseExpression`. Projects to `false`
-  /// at the template boundary; the mustache inverted section fires
-  /// on null/false alike.
+  /// throw, or there's no Map sub-dispatch at all). Otherwise has
+  /// just `caseExpression`. Projects to `false` at the template
+  /// boundary; the mustache inverted section fires on null/false
+  /// alike.
   final Map<String, dynamic>? mapFallback;
+
+  /// Per-arm contexts for predicate-guarded List arms. Each entry
+  /// has `predicateTest` (the `v.first is X` check) and
+  /// `caseExpression`. Empty when at most one List variant exists.
+  final List<Map<String, dynamic>> listArms;
+
+  /// `null` when no fallback applies (the List sub-dispatch ends in
+  /// a throw, or there's no List sub-dispatch at all). Same shape as
+  /// [mapFallback].
+  final Map<String, dynamic>? listFallback;
 
   /// Non-smooshed variants — wrapper subclass declarations, in
   /// declaration order. Smooshed variants (those whose data class
@@ -4938,6 +5008,8 @@ void _applyDispatchMode(_DispatchMode mode, Map<String, dynamic> ctx) {
       :final shapeArms,
       :final mapArms,
       :final mapFallback,
+      :final listArms,
+      :final listFallback,
       :final variants,
       :final smooshedVariants,
     ):
@@ -4945,6 +5017,10 @@ void _applyDispatchMode(_DispatchMode mode, Map<String, dynamic> ctx) {
       ctx['shapeArms'] = shapeArms;
       ctx['mapArms'] = mapArms;
       ctx['mapFallback'] = mapFallback ?? false;
+      ctx['hasMapSubDispatch'] = mapArms.isNotEmpty || mapFallback != null;
+      ctx['listArms'] = listArms;
+      ctx['listFallback'] = listFallback ?? false;
+      ctx['hasListSubDispatch'] = listArms.isNotEmpty || listFallback != null;
       ctx['variants'] = variants;
       ctx['smooshedVariants'] = smooshedVariants;
     case _PredicateDispatchMode(

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -4260,43 +4260,14 @@ class RenderOneOf extends RenderNewType {
     }
 
     return switch (decision) {
-      DiscriminatorDispatch(
-        :final propertyName,
-        :final mapping,
-        :final variants,
-      ) =>
-        _buildDiscriminatorMode(
-          propertyName,
-          mapping,
-          variants,
-          renderOf,
-          context,
-        ),
-      ShapeDispatch(:final arms) => _buildShapeMode(arms, renderOf, context),
-      HybridDispatch(
-        :final shapeArms,
-        :final mapArms,
-        :final mapFallback,
-        :final listArms,
-        :final listFallback,
-        :final declarationOrder,
-      ) =>
-        _buildHybridMode(
-          shapeArms,
-          mapArms,
-          mapFallback,
-          listArms,
-          listFallback,
-          declarationOrder,
-          renderOf,
-          context,
-        ),
-      PredicateDispatch(:final kind, :final arms) => _buildPredicateMode(
-        kind,
-        arms,
+      final DiscriminatorDispatch d => _buildDiscriminatorMode(
+        d,
         renderOf,
         context,
       ),
+      final ShapeDispatch d => _buildShapeMode(d, renderOf, context),
+      final HybridDispatch d => _buildHybridMode(d, renderOf, context),
+      final PredicateDispatch d => _buildPredicateMode(d, renderOf, context),
       NoDispatch() => const _NoDispatchMode(),
     };
   }
@@ -4308,17 +4279,15 @@ class RenderOneOf extends RenderNewType {
   /// `caseExpression` already contains the full Dart expression to
   /// `return`, so the template emits it directly.
   _DiscriminatorMode _buildDiscriminatorMode(
-    String propertyName,
-    List<({String value, ResolvedSchema variant})> mapping,
-    List<ResolvedSchema> declarationOrder,
+    DiscriminatorDispatch dispatch,
     RenderSchema Function(ResolvedSchema) renderOf,
     SchemaRenderer context,
   ) {
-    final dispatch = <Map<String, dynamic>>[];
-    for (final entry in mapping) {
+    final cases = <Map<String, dynamic>>[];
+    for (final entry in dispatch.mapping) {
       final renderVariant = renderOf(entry.variant);
       final fromJson = '${renderVariant.typeName}.fromJson(json)';
-      dispatch.add({
+      cases.add({
         'value': entry.value,
         'caseExpression': renderVariant.isSmooshed
             ? fromJson
@@ -4327,7 +4296,7 @@ class RenderOneOf extends RenderNewType {
     }
     final variants = <Map<String, dynamic>>[];
     final smooshedVariants = <Map<String, dynamic>>[];
-    for (final v in declarationOrder) {
+    for (final v in dispatch.variants) {
       final renderVariant = renderOf(v);
       if (renderVariant.isSmooshed) {
         smooshedVariants.add(renderVariant.toTemplateContext(context));
@@ -4336,8 +4305,8 @@ class RenderOneOf extends RenderNewType {
       }
     }
     return _DiscriminatorMode(
-      discriminatorProperty: propertyName,
-      dispatch: dispatch,
+      discriminatorProperty: dispatch.propertyName,
+      dispatch: cases,
       variants: variants,
       smooshedVariants: smooshedVariants,
     );
@@ -4349,14 +4318,14 @@ class RenderOneOf extends RenderNewType {
   /// + `value:` indirection). Each `dispatch` entry's `caseExpression`
   /// is the full Dart expression to `return` from its switch arm.
   _ShapeMode _buildShapeMode(
-    List<ShapeArm> arms,
+    ShapeDispatch shapeDispatch,
     RenderSchema Function(ResolvedSchema) renderOf,
     SchemaRenderer context,
   ) {
     final dispatch = <Map<String, dynamic>>[];
     final variants = <Map<String, dynamic>>[];
     final smooshedVariants = <Map<String, dynamic>>[];
-    for (final arm in arms) {
+    for (final arm in shapeDispatch.arms) {
       final renderVariant = renderOf(arm.variant);
       if (renderVariant.isSmooshed) {
         // Smooshed object variants are always Map-shaped; the case
@@ -4397,18 +4366,16 @@ class RenderOneOf extends RenderNewType {
   /// land in `variants`; smooshed ones in `smooshedVariants` and are
   /// inlined into the parent's file by the schema_object partial.
   _HybridMode _buildHybridMode(
-    List<ShapeArm> shapeArms,
-    List<PredicateArm> mapArms,
-    ResolvedSchema? mapFallback,
-    List<PredicateArm> listArms,
-    ResolvedSchema? listFallback,
-    List<ResolvedSchema> declarationOrder,
+    HybridDispatch dispatch,
     RenderSchema Function(ResolvedSchema) renderOf,
     SchemaRenderer context,
   ) {
     final variants = <Map<String, dynamic>>[];
     final smooshedVariants = <Map<String, dynamic>>[];
 
+    // Smoosh-aware case expression for a Map-shaped variant:
+    // smooshed → bare `<Variant>.fromJson(v)`; otherwise wrap in
+    // the variant's wrapper subclass.
     String mapCaseExpression(RenderSchema variant) {
       final fromJson = '${variant.typeName}.fromJson(v)';
       return variant.isSmooshed
@@ -4416,59 +4383,62 @@ class RenderOneOf extends RenderNewType {
           : '${wrapperTypeName(variant)}($fromJson)';
     }
 
-    // List sub-arms wrap an array variant — the variant always has a
-    // wrapper subclass (Array variants aren't smoosh-eligible today),
-    // so `_planVariant` returns the standard List<X> shape plan.
-    String listCaseExpression(RenderSchema variant) {
+    // Wrapped case expression for any non-Map variant (List, primitive).
+    // None of these are smoosh-eligible: array variants are excluded
+    // structurally, and primitives can't extend a sealed class.
+    String wrappedCaseExpression(RenderSchema variant) {
       final plan = _planVariant(variant, context)!;
       return '${plan.wrapperTypeName}(${plan.fromJson})';
     }
 
-    // Non-collision shape arms can be Map-shaped now (when a single
-    // Map variant sits alongside multi-variant List collisions, the
-    // picker routes it here as a single arm). Use the same case-
-    // expression helper so smooshed Map variants are handled.
+    // Pick the right case-expression form based on the arm's shape
+    // key. Map-shaped arms take the smoosh-aware path; everything
+    // else (List + primitives) goes through the wrapped form.
+    String shapeArmCaseExpression(RenderSchema variant, String shapeKey) =>
+        shapeKey == _mapShapeKey
+        ? mapCaseExpression(variant)
+        : wrappedCaseExpression(variant);
+
     final renderedShapeArms = <Map<String, dynamic>>[];
-    for (final arm in shapeArms) {
+    for (final arm in dispatch.shapeArms) {
       final renderVariant = renderOf(arm.variant);
-      final String caseExpression;
-      if (arm.shapeKey == _mapShapeKey) {
-        caseExpression = mapCaseExpression(renderVariant);
-      } else if (arm.shapeKey == _listShapeKey) {
-        caseExpression = listCaseExpression(renderVariant);
-      } else {
-        final plan = _planVariant(renderVariant, context)!;
-        caseExpression = '${plan.wrapperTypeName}(${plan.fromJson})';
-      }
       renderedShapeArms.add({
         'jsonTestType': arm.shapeKey,
-        'caseExpression': caseExpression,
+        'caseExpression': shapeArmCaseExpression(renderVariant, arm.shapeKey),
       });
     }
 
     final renderedMapArms = <Map<String, dynamic>>[];
-    for (final arm in mapArms) {
+    for (final arm in dispatch.mapArms) {
       renderedMapArms.add({
         'predicateTest': arm.predicate.dartIfTest('v'),
         'caseExpression': mapCaseExpression(renderOf(arm.variant)),
       });
     }
 
-    final renderedMapFallback = mapFallback == null
+    final renderedMapFallback = dispatch.mapFallback == null
         ? null
-        : {'caseExpression': mapCaseExpression(renderOf(mapFallback))};
+        : {
+            'caseExpression': mapCaseExpression(
+              renderOf(dispatch.mapFallback!),
+            ),
+          };
 
     final renderedListArms = <Map<String, dynamic>>[];
-    for (final arm in listArms) {
+    for (final arm in dispatch.listArms) {
       renderedListArms.add({
         'predicateTest': arm.predicate.dartIfTest('v'),
-        'caseExpression': listCaseExpression(renderOf(arm.variant)),
+        'caseExpression': wrappedCaseExpression(renderOf(arm.variant)),
       });
     }
 
-    final renderedListFallback = listFallback == null
+    final renderedListFallback = dispatch.listFallback == null
         ? null
-        : {'caseExpression': listCaseExpression(renderOf(listFallback))};
+        : {
+            'caseExpression': wrappedCaseExpression(
+              renderOf(dispatch.listFallback!),
+            ),
+          };
 
     // A variant lands in one of three buckets, in priority order:
     //   1. Smooshed → `smooshedVariants` (variant data class extends
@@ -4482,7 +4452,7 @@ class RenderOneOf extends RenderNewType {
     //   3. Otherwise (string, int, list) → `_shapeWrapperContext`
     //      (wrapper's `toJson` returns `dynamic` and stores the
     //      JSON-typed value verbatim).
-    for (final v in declarationOrder) {
+    for (final v in dispatch.declarationOrder) {
       final renderVariant = renderOf(v);
       if (renderVariant.isSmooshed) {
         smooshedVariants.add(renderVariant.toTemplateContext(context));
@@ -4505,16 +4475,16 @@ class RenderOneOf extends RenderNewType {
   }
 
   _PredicateDispatchMode _buildPredicateMode(
-    PredicateDispatchKind kind,
-    List<PredicateArm> arms,
+    PredicateDispatch predicateDispatch,
     RenderSchema Function(ResolvedSchema) renderOf,
     SchemaRenderer context,
   ) {
+    final kind = predicateDispatch.kind;
     final dispatch = <Map<String, dynamic>>[];
     Map<String, dynamic>? fallback;
     final variants = <Map<String, dynamic>>[];
     final smooshedVariants = <Map<String, dynamic>>[];
-    for (final arm in arms) {
+    for (final arm in predicateDispatch.arms) {
       final renderVariant = renderOf(arm.variant);
       // Smooshed variants (today: only inline-object variants under
       // required-field dispatch) are emitted as direct subclasses of
@@ -4737,12 +4707,6 @@ final class _MultiStatusContext {
 /// the hybrid dispatch's "Map collision" detection has a single
 /// authoritative spelling.
 const String _mapShapeKey = 'Map<String, dynamic>';
-
-/// Dart pattern type for the List-shape arm of dispatch — matches
-/// any JSON-decoded list. Mirrors [_mapShapeKey]; centralized so the
-/// hybrid dispatch's "List collision" detection has a single
-/// authoritative spelling.
-const String _listShapeKey = 'List<dynamic>';
 
 /// Wrapper-variant context for the shape-dispatch paths (pure shape
 /// and the non-Map arms of hybrid). The wrapper stores the matched

--- a/lib/templates/schema_one_of.mustache
+++ b/lib/templates/schema_one_of.mustache
@@ -64,6 +64,7 @@
 {{#shapeArms}}
             final {{{ jsonTestType }}} v => {{{ caseExpression }}},
 {{/shapeArms}}
+{{#hasMapSubDispatch}}
 {{#mapArms}}
             final Map<String, dynamic> v when {{{ predicateTest }}} => {{{ caseExpression }}},
 {{/mapArms}}
@@ -75,6 +76,20 @@
                 'No variant of {{ typeName }} matched json keys: ${v.keys.toList()}',
             ),
 {{/mapFallback}}
+{{/hasMapSubDispatch}}
+{{#hasListSubDispatch}}
+{{#listArms}}
+            final List<dynamic> v when {{{ predicateTest }}} => {{{ caseExpression }}},
+{{/listArms}}
+{{#listFallback}}
+            final List<dynamic> v => {{{ caseExpression }}},
+{{/listFallback}}
+{{^listFallback}}
+            List<dynamic> _ => throw const FormatException(
+                'No variant of {{ typeName }} matched first list element',
+            ),
+{{/listFallback}}
+{{/hasListSubDispatch}}
             _ => throw FormatException(
                 'Unsupported shape for {{ typeName }}: ${json.runtimeType}',
             ),

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -2410,6 +2410,36 @@ void main() {
       expect(result, isNot(contains('throw FormatException')));
     });
 
+    test('property-array-element-shape dispatch bails when the only '
+        'array-typed property has the same items shape across variants', () {
+      // Both variants have `labels: array<string>`. Same shape →
+      // not a discriminator. Other properties also identical
+      // (empty). No way to dispatch; bail.
+      final result = renderTestSchema({
+        'oneOf': [
+          {
+            'type': 'object',
+            'properties': {
+              'labels': {
+                'type': 'array',
+                'items': {'type': 'string'},
+              },
+            },
+          },
+          {
+            'type': 'object',
+            'properties': {
+              'labels': {
+                'type': 'array',
+                'items': {'type': 'string'},
+              },
+            },
+          },
+        ],
+      });
+      expect(result, contains('throw UnimplementedError'));
+    });
+
     test('hybrid dispatch combines multi-array sub-dispatch and '
         'property-array-element-shape Map sub-dispatch (github labels '
         'case)', () {

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -2310,6 +2310,51 @@ void main() {
       expect(result, isNot(contains('throw UnimplementedError')));
     });
 
+    test('hybrid multi-array sub-dispatch picks an unguarded '
+        'fallback when one variant has open-shape items', () {
+      // Two list variants: `array<string>` (pinnable to `String`)
+      // and `array<DateTime>` (string-format-date-time — pinnable
+      // to nothing in particular, since DateTime serializes back
+      // to a JSON string and would collide with the bare-string
+      // arm). Plus an object variant. The DateTime-items array
+      // gets the unguarded fallback at the end of the list sub-
+      // dispatch; the string-items array is guarded by `first is
+      // String`.
+      final result = renderTestSchema({
+        'oneOf': [
+          {
+            'type': 'array',
+            'items': {'type': 'string'},
+          },
+          {
+            'type': 'array',
+            'items': {'type': 'string', 'format': 'date-time'},
+          },
+          {
+            'type': 'object',
+            'required': ['note'],
+            'properties': {
+              'note': {'type': 'string'},
+            },
+          },
+        ],
+      });
+      // String-items arm guarded.
+      expect(
+        result,
+        contains(
+          'final List<dynamic> v when v.isNotEmpty && v.first is String',
+        ),
+      );
+      // DateTime-items arm is the unguarded fallback (no `when`
+      // clause — bare `final List<dynamic> v => ...`).
+      expect(
+        result,
+        contains('final List<dynamic> v => '),
+      );
+      expect(result, isNot(contains('throw UnimplementedError')));
+    });
+
     test('property-array-element-shape dispatch picks object variants '
         'that differ only in an array property element type', () {
       // Github's `issues/add-labels` request body: two object variants
@@ -2348,12 +2393,15 @@ void main() {
           },
         ],
       });
-      // First variant guarded by `labels[0] is String`.
+      // First variant guarded by `labels[0] is String`. Uses the
+      // `PropertyArrayItemShape` predicate (shared with the
+      // validation-error twins case from #177).
       expect(
         result,
         contains(
-          "if ((json['labels'] as List?)?.isNotEmpty == true && "
-          "(json['labels']! as List).first is String)",
+          "if (json['labels'] is List && "
+          "(json['labels'] as List).isNotEmpty && "
+          "(json['labels'] as List).first is String)",
         ),
       );
       // Second variant is the unguarded fallback (last `return ...;`
@@ -2426,8 +2474,10 @@ void main() {
         result,
         contains(
           'final Map<String, dynamic> v when '
-          "(v['labels'] as List?)?.isNotEmpty == true && "
-          "(v['labels']! as List).first is String => TestOneOf0.fromJson(v)",
+          "v['labels'] is List && "
+          "(v['labels'] as List).isNotEmpty && "
+          "(v['labels'] as List).first is String "
+          '=> TestOneOf0.fromJson(v)',
         ),
       );
       expect(

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -2260,11 +2260,13 @@ void main() {
       expect(result, contains('throw UnimplementedError'));
     });
 
-    test('hybrid dispatch bails when a non-Map shape collides', () {
-      // Two array variants alongside an object variant. Pure shape
-      // can't pick between the two arrays (both `List<dynamic>`).
-      // Hybrid only knows how to disambiguate Map collisions, so it
-      // also bails — array-of-X vs array-of-Y is a separate gap.
+    test('hybrid dispatch sub-dispatches multiple array variants by '
+        'first-element shape', () {
+      // Two array variants (array<string> vs array<int>) alongside a
+      // single object variant. The two arrays collide on
+      // `List<dynamic>` shape; hybrid sub-dispatches them by peeking
+      // the first element's runtime type. The lone object variant is
+      // a single shape arm (no sub-dispatch needed).
       final result = renderTestSchema({
         'oneOf': [
           {
@@ -2284,7 +2286,172 @@ void main() {
           },
         ],
       });
-      expect(result, contains('throw UnimplementedError'));
+      // Single-Map-variant shape arm (the object is smooshed but its
+      // case-arm still matches `Map<String, dynamic>`).
+      expect(result, contains('final Map<String, dynamic> v =>'));
+      // List sub-dispatch arms — peek the first element's type.
+      expect(
+        result,
+        contains(
+          'final List<dynamic> v when v.isNotEmpty && v.first is String',
+        ),
+      );
+      expect(
+        result,
+        contains('final List<dynamic> v when v.isNotEmpty && v.first is int'),
+      );
+      // Sub-dispatch falls through to a List-specific throw, not the
+      // outer "Unsupported shape" throw.
+      expect(
+        result,
+        contains('No variant of Test matched first list element'),
+      );
+      // No legacy stub.
+      expect(result, isNot(contains('throw UnimplementedError')));
+    });
+
+    test('property-array-element-shape dispatch picks object variants '
+        'that differ only in an array property element type', () {
+      // Github's `issues/add-labels` request body: two object variants
+      // with the same property set, both having only optional
+      // `labels` of array type but with different element types
+      // (`array<string>` vs `array<object>`). Required-field dispatch
+      // can't tell them apart (both are fallbacks); the property-
+      // array-element-shape predicate peeks `labels[0]` runtime type.
+      // Last variant is the unguarded fallback when `labels` is
+      // missing or empty (since the property is optional).
+      final result = renderTestSchema({
+        'oneOf': [
+          {
+            'type': 'object',
+            'properties': {
+              'labels': {
+                'type': 'array',
+                'items': {'type': 'string'},
+              },
+            },
+          },
+          {
+            'type': 'object',
+            'properties': {
+              'labels': {
+                'type': 'array',
+                'items': {
+                  'type': 'object',
+                  'properties': {
+                    'name': {'type': 'string'},
+                  },
+                  'required': ['name'],
+                },
+              },
+            },
+          },
+        ],
+      });
+      // First variant guarded by `labels[0] is String`.
+      expect(
+        result,
+        contains(
+          "if ((json['labels'] as List?)?.isNotEmpty == true && "
+          "(json['labels']! as List).first is String)",
+        ),
+      );
+      // Second variant is the unguarded fallback (last `return ...;`
+      // with no `if` since `labels` is optional).
+      expect(result, isNot(contains('throw UnimplementedError')));
+      expect(result, isNot(contains('throw FormatException')));
+    });
+
+    test('hybrid dispatch combines multi-array sub-dispatch and '
+        'property-array-element-shape Map sub-dispatch (github labels '
+        'case)', () {
+      // Github's `issues/add-labels` request body: 5 variants —
+      // {labels?: array<string>}, array<string>, {labels?:
+      // array<object>}, array<object>, string. Two non-collision
+      // shapes (string only). Two Map variants distinguishable only
+      // by `labels[0]` element type. Two List variants distinguishable
+      // only by `[0]` element type. Hybrid handles both sub-dispatches
+      // simultaneously.
+      final result = renderTestSchema({
+        'oneOf': [
+          {
+            'type': 'object',
+            'properties': {
+              'labels': {
+                'type': 'array',
+                'items': {'type': 'string'},
+              },
+            },
+          },
+          {
+            'type': 'array',
+            'items': {'type': 'string'},
+          },
+          {
+            'type': 'object',
+            'properties': {
+              'labels': {
+                'type': 'array',
+                'items': {
+                  'type': 'object',
+                  'properties': {
+                    'name': {'type': 'string'},
+                  },
+                  'required': ['name'],
+                },
+              },
+            },
+          },
+          {
+            'type': 'array',
+            'items': {
+              'type': 'object',
+              'properties': {
+                'name': {'type': 'string'},
+              },
+              'required': ['name'],
+            },
+          },
+          {'type': 'string'},
+        ],
+      });
+      // No legacy stub.
+      expect(result, isNot(contains('throw UnimplementedError')));
+      // String shape arm.
+      expect(result, contains('final String v =>'));
+      // Map sub-dispatch — first variant guarded by `labels[0] is
+      // String`, second is the fallback (unguarded `Map<String, …> v
+      // =>`).
+      expect(
+        result,
+        contains(
+          'final Map<String, dynamic> v when '
+          "(v['labels'] as List?)?.isNotEmpty == true && "
+          "(v['labels']! as List).first is String => TestOneOf0.fromJson(v)",
+        ),
+      );
+      expect(
+        result,
+        contains('final Map<String, dynamic> v => TestOneOf2.fromJson(v)'),
+      );
+      // List sub-dispatch — peek `[0]` type.
+      expect(
+        result,
+        contains(
+          'final List<dynamic> v when v.isNotEmpty && v.first is String',
+        ),
+      );
+      expect(
+        result,
+        contains(
+          'when v.isNotEmpty && v.first is Map<String, dynamic>',
+        ),
+      );
+      // List sub-dispatch fallback throw.
+      expect(
+        result,
+        contains('No variant of Test matched first list element'),
+      );
     });
 
     test('property-presence dispatch falls back to optional-unique tags '


### PR DESCRIPTION
## Summary

- Closes the two `issues/add-labels` and `issues/set-labels`
  `UnimplementedError` stubs in the github regen (7 → 5 stubs).
- Extends hybrid dispatch with **multi-array sub-dispatch** — when 2+
  array variants collide on `List<dynamic>`, sub-dispatch them by
  peeking the first element's Dart runtime type. New `Predicate`
  subtype `ArrayElementIsType` carries the test; mirrors the existing
  Map sub-dispatch shape.
- Adds **property-array-element-shape Map sub-dispatch** as a fallback
  when `_requiredFieldArmsFor` can't tell two object variants apart
  (same property names, same required set, no unique fields). The new
  `_propertyArrayElementShapeArmsFor` looks for a single array-typed
  property whose items differ in shape and builds predicates that
  peek that property's first element. New `Predicate` subtype
  `PropertyArrayFirstIsType` carries the test. When the discriminator
  property is optional in every variant, the last variant becomes an
  unguarded fallback so an empty payload still picks something.
- `_HybridMode` + the `schema_one_of` template gain `listArms`,
  `listFallback`, `hasMapSubDispatch`, and `hasListSubDispatch` to
  carry the new arms.

The labels endpoint generated `fromJson` now reads:

```dart
factory IssuesAddLabelsRequest.fromJson(dynamic json) {
  return switch (json) {
    final String v => IssuesAddLabelsRequestString(v),
    final Map<String, dynamic> v
        when ((v['labels'] as List?)?.isNotEmpty ?? false) &&
            (v['labels']! as List).first is String =>
      IssuesAddLabelsRequestOneOf0.fromJson(v),
    final Map<String, dynamic> v => IssuesAddLabelsRequestOneOf2.fromJson(v),
    final List<dynamic> v when v.isNotEmpty && v.first is String =>
      IssuesAddLabelsRequestList(v.cast<String>()),
    final List<dynamic> v
        when v.isNotEmpty && v.first is Map<String, dynamic> =>
      IssuesAddLabelsRequestList2(...),
    List<dynamic> _ => throw const FormatException(...),
    _ => throw FormatException(...),
  };
}
```

## Test plan

- [x] dart analyze clean on github regen
- [x] Stub count drops by 2 (issues/add-labels, issues/set-labels): 7 → 5
- [x] Multi-array hybrid sub-dispatch unit-tested (replaces the old
      "hybrid bails when a non-Map shape collides" test, which is now
      a positive case)
- [x] Property-array-element-shape sub-dispatch unit-tested
      (standalone — two object variants, fallback when discriminator
      is optional)
- [x] End-to-end github labels case unit-tested (5-variant `oneOf`
      hits both sub-dispatches simultaneously, smoosh applies to the
      object variants)
- [x] All 421 existing tests still pass