### PR TITLE
fix: round-trip correctness for nullable oneOf, EmptyObject, additionalProperties

### DIFF
--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -1164,12 +1164,31 @@ Schema _createCorrectSchemaSubtype(MapContext json) {
   _ignored<dynamic>(json, 'xml');
   _ignored<dynamic>(json, 'externalDocs');
 
-  final requiredProperties = _optionalList<String>(json, 'required') ?? [];
+  final declaredRequired = _optionalList<String>(json, 'required') ?? [];
+  // OpenAPI lets `required` name any string, but the only meaningful
+  // names are properties this object actually declares. Spec-author
+  // typos sneak in (github's `package-version-metadata-docker` lists
+  // `required: [tags]` for a property called `tag`); silently
+  // honoring those produces a class whose constructor demands a
+  // field that doesn't exist in the schema, plus broken downstream
+  // tests. Drop unknown names and warn — the spec author can fix
+  // the typo.
+  final requiredProperties = <String>[];
+  for (final name in declaredRequired) {
+    if (properties.containsKey(name)) {
+      requiredProperties.add(name);
+    } else {
+      _warn(
+        json,
+        "'required' lists '$name' but no such property is declared",
+      );
+    }
+  }
 
   return SchemaObject(
     common: common,
     properties: properties,
-    requiredProperties: requiredProperties.cast<String>(),
+    requiredProperties: requiredProperties,
     additionalProperties: additionalPropertiesSchema,
     defaultValue: defaultValue,
   );

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -3500,16 +3500,14 @@ class RenderObject extends RenderNewType {
 
   /// Empty map: any required property will fail its type cast inside
   /// `parseFromJson`, which rewraps the TypeError as FormatException.
-  /// When there are no required properties — or every name listed in
-  /// `required` is unknown to `properties` (a buggy spec like
-  /// github's `package-version-metadata-docker`, which lists
-  /// `required: [tags]` for a property called `tag`) — `{}` parses
-  /// successfully and we have no guaranteed-invalid input.
+  /// When there are no required properties, `{}` is a valid instance
+  /// and we have no guaranteed-invalid input. The parser drops names
+  /// listed in `required` that don't match a real property (with a
+  /// warn-log), so [requiredProperties] only ever contains names
+  /// that will actually fail the cast.
   @override
-  String? invalidJsonExample(SchemaRenderer context) {
-    final actuallyRequired = requiredProperties.where(properties.containsKey);
-    return actuallyRequired.isEmpty ? null : '<String, dynamic>{}';
-  }
+  String? invalidJsonExample(SchemaRenderer context) =>
+      requiredProperties.isEmpty ? null : '<String, dynamic>{}';
 }
 
 class RenderArray extends RenderSchema {

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -3382,17 +3382,29 @@ class RenderObject extends RenderNewType {
       'assignmentsLine': assignmentsLine,
       'additionalPropertiesName': 'entries', // Matching OpenAPI.
       'valueSchema': valueSchema?.typeName,
-      'valueToJson': valueSchema?.toJsonExpression(
-        'value',
+      // Per-entry to/from JSON expressions used in the additional-
+      // properties for-loop (key/value extracted via `entry.key` /
+      // `entry.value`). The for-loop filters out keys that belong to
+      // the named properties so a round-trip doesn't accidentally
+      // sweep them into `entries`.
+      'entryValueToJson': valueSchema?.toJsonExpression(
+        'entry.value',
         context,
         dartIsNullable: isNullable,
       ),
-      'valueFromJson': valueSchema?.fromJsonExpression(
-        'value',
+      'entryValueFromJson': valueSchema?.fromJsonExpression(
+        'entry.value',
         context,
         jsonIsNullable: isNullable,
         dartIsNullable: isNullable,
       ),
+      // The set of named-property JSON keys to exclude from
+      // `entries` on round-trip. A `const <String>{...}` literal —
+      // empty when there are no named properties (always-false
+      // contains).
+      'namedPropertyKeysSet': properties.isEmpty
+          ? 'const <String>{}'
+          : 'const {${properties.keys.map(quoteString).join(', ')}}',
       'fromJsonJsonType': context.fromJsonJsonType,
       'castFromJsonArg': context.quirks.dynamicJson,
       'mutableModels': context.quirks.mutableModels,
@@ -3488,11 +3500,16 @@ class RenderObject extends RenderNewType {
 
   /// Empty map: any required property will fail its type cast inside
   /// `parseFromJson`, which rewraps the TypeError as FormatException.
-  /// When there are no required properties, `{}` is a valid instance
-  /// and we have no guaranteed-invalid input.
+  /// When there are no required properties — or every name listed in
+  /// `required` is unknown to `properties` (a buggy spec like
+  /// github's `package-version-metadata-docker`, which lists
+  /// `required: [tags]` for a property called `tag`) — `{}` parses
+  /// successfully and we have no guaranteed-invalid input.
   @override
-  String? invalidJsonExample(SchemaRenderer context) =>
-      requiredProperties.isEmpty ? null : '<String, dynamic>{}';
+  String? invalidJsonExample(SchemaRenderer context) {
+    final actuallyRequired = requiredProperties.where(properties.containsKey);
+    return actuallyRequired.isEmpty ? null : '<String, dynamic>{}';
+  }
 }
 
 class RenderArray extends RenderSchema {
@@ -4124,7 +4141,7 @@ class RenderOneOf extends RenderNewType {
     if (schemas.any((s) => s is RenderPod)) {
       return 'dynamic';
     }
-    return 'Map<String, dynamic>';
+    return isNullable ? 'Map<String, dynamic>?' : 'Map<String, dynamic>';
   }
 
   /// Looks up the wrapper subclass class name assigned by the naming
@@ -5388,14 +5405,15 @@ class RenderEmptyObject extends RenderNewType {
       _newtypeConversion(typeName);
 
   @override
-  String jsonStorageType({required bool isNullable}) => 'Map<String, dynamic>';
+  String jsonStorageType({required bool isNullable}) =>
+      isNullable ? 'Map<String, dynamic>?' : 'Map<String, dynamic>';
 
   @override
   String toJsonExpression(
     String dartName,
     SchemaRenderer context, {
     required bool dartIsNullable,
-  }) => 'const <String, dynamic>{}';
+  }) => dartIsNullable ? '$dartName?.toJson()' : '$dartName.toJson()';
 
   @override
   String fromJsonExpression(
@@ -5403,7 +5421,11 @@ class RenderEmptyObject extends RenderNewType {
     SchemaRenderer context, {
     required bool jsonIsNullable,
     required bool dartIsNullable,
-  }) => 'const $className()';
+  }) {
+    final jsonType = jsonStorageType(isNullable: jsonIsNullable);
+    final jsonMethod = jsonIsNullable ? 'maybeFromJson' : 'fromJson';
+    return '$className.$jsonMethod($jsonValue as $jsonType)';
+  }
 
   @override
   Map<String, dynamic> toTemplateContext(SchemaRenderer context) => {

--- a/lib/templates/schema_object.mustache
+++ b/lib/templates/schema_object.mustache
@@ -37,7 +37,11 @@
             {{ dartName }}: {{{ fromJson }}},
             {{/properties}}
             {{#hasAdditionalProperties}}
-            {{additionalPropertiesName}}: json.map((key, value) => MapEntry(key, {{{ valueFromJson }}})),
+            {{additionalPropertiesName}}: <String, {{{ valueSchema }}}>{
+                for (final entry in json.entries)
+                    if (!{{{namedPropertyKeysSet}}}.contains(entry.key))
+                        entry.key: {{{ entryValueFromJson }}},
+            },
             {{/hasAdditionalProperties}}
         ));
     {{/hasNoJsonProperty}}
@@ -73,7 +77,9 @@
             {{{ jsonName }}}: {{{ toJson }}},
             {{/properties}}
             {{#hasAdditionalProperties}}
-            ...{{additionalPropertiesName}}.map((key, value) => MapEntry(key, {{{ valueToJson }}})),
+            for (final entry in {{additionalPropertiesName}}.entries)
+                if (!{{{namedPropertyKeysSet}}}.contains(entry.key))
+                    entry.key: {{{ entryValueToJson }}},
             {{/hasAdditionalProperties}}
         };
     {{/hasNoJsonProperty}}
@@ -86,7 +92,7 @@
           {{{ hashCode }}}.hashCode;
           {{/properties}}
           {{#hasAdditionalProperties}}
-          {{additionalPropertiesName}}.hashCode;
+          mapHash({{additionalPropertiesName}});
           {{/hasAdditionalProperties}}
         {{/hasOneProperty}}
         {{^hasOneProperty}}
@@ -95,7 +101,7 @@
           {{{ hashCode }}},
           {{/properties}}
           {{#hasAdditionalProperties}}
-          {{additionalPropertiesName}},
+          mapHash({{additionalPropertiesName}}),
           {{/hasAdditionalProperties}}
         ]);
         {{/hasOneProperty}}

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -610,6 +610,37 @@ void main() {
           () => logger.detail(any(that: contains('Unused'))),
         );
       });
+
+      test(
+        'required entries that name no real property are dropped + warned',
+        () {
+          // github's `package-version-metadata-docker` schema lists
+          // `required: [tags]` for a property called `tag` (no s).
+          // Honoring the typo would generate a class whose constructor
+          // demands a non-existent field. Drop the unknown name from
+          // [SchemaObject.requiredProperties] and warn so the spec
+          // author can fix the typo.
+          final json = {
+            'type': 'object',
+            'properties': {
+              'tag': {'type': 'string'},
+            },
+            'required': ['tags', 'tag'],
+          };
+          final logger = _MockLogger();
+          final schema = runWithLogger(logger, () => parseTestSchema(json));
+          if (schema is! SchemaObject) {
+            fail('Expected SchemaObject, got ${schema.runtimeType}');
+          }
+          // `tag` survives, `tags` is dropped.
+          expect(schema.requiredProperties, ['tag']);
+          verify(
+            () => logger.warn(
+              any(that: contains("'required' lists 'tags'")),
+            ),
+          ).called(1);
+        },
+      );
     });
 
     test(

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -3415,7 +3415,7 @@ void main() {
         '    factory Test.fromJson(Map<String, dynamic>\n'
         '        json) {\n'
         "        return parseFromJson('Test', json, () => Test(\n"
-        '            a: const TestA(),\n'
+        "            a: TestA.maybeFromJson(json['a'] as Map<String, dynamic>?),\n"
         '        ));\n'
         '    }\n'
         '\n'
@@ -3433,7 +3433,7 @@ void main() {
         '    /// Converts a [Test] to a `Map<String, dynamic>`.\n'
         '    Map<String, dynamic> toJson() {\n'
         '        return {\n'
-        "            'a': const <String, dynamic>{},\n"
+        "            'a': a?.toJson(),\n"
         '        };\n'
         '    }\n'
         '\n'
@@ -3451,6 +3451,91 @@ void main() {
         '}\n',
       );
     });
+
+    test(
+      'empty-object property round-trips through fromJson/toJson',
+      () {
+        // Regression: nullable EmptyObject properties used to hard-code
+        // `const TestA()` on read and `const <String, dynamic>{}` on
+        // write, ignoring the actual field. Now they delegate to the
+        // generated class's `fromJson`/`toJson` like every other
+        // newtype.
+        final schema = {
+          'type': 'object',
+          'properties': {
+            'a': {'type': 'object', 'properties': <String, dynamic>{}},
+          },
+        };
+        final result = renderTestSchema(schema);
+        expect(
+          result,
+          contains(
+            "a: TestA.maybeFromJson(json['a'] as Map<String, dynamic>?),",
+          ),
+        );
+        expect(result, contains("'a': a?.toJson(),"));
+        expect(result, isNot(contains('const TestA()')));
+        expect(result, isNot(contains('const <String, dynamic>{}')));
+      },
+    );
+
+    test(
+      'nullable oneOf property casts JSON to nullable Map',
+      () {
+        // Regression: `RenderOneOf.jsonStorageType` ignored its
+        // `isNullable` parameter, so a nullable oneOf property emitted
+        // `as Map<String, dynamic>` (non-nullable). Round-tripping a
+        // class whose only value for that field was `null` then crashed
+        // in `fromJson` with `Null is not a subtype of Map<String,
+        // dynamic>`. The cast must be `Map<String, dynamic>?` for
+        // nullable property reads.
+        final json = {
+          'type': 'object',
+          'properties': {
+            'a': {
+              'type': ['string', 'number'],
+            },
+          },
+        };
+        expect(
+          renderTestSchema(json),
+          contains(
+            "a: TestA.maybeFromJson(json['a'] as Map<String, dynamic>?),",
+          ),
+        );
+      },
+    );
+
+    test(
+      'additionalProperties round-trip excludes named property keys',
+      () {
+        // Regression: the additionalProperties for-loop used to call
+        // `json.map(MapEntry.new)` on read and
+        // `entries.map(MapEntry.new)` on write, sweeping the named-
+        // property JSON keys into the catch-all `entries` field on
+        // round-trip. github's `copilot_*` and `webhook_config` round-
+        // trips all crashed (or saw structurally-different `entries`
+        // on the parsed instance) because of this. The for-loop now
+        // filters by a `const <String>{...}` of named-property JSON
+        // names.
+        final schema = {
+          'type': 'object',
+          'properties': {
+            'a': {'type': 'string'},
+            'b': {'type': 'integer'},
+          },
+          'additionalProperties': {'type': 'string'},
+        };
+        final result = renderTestSchema(schema);
+        expect(result, contains("const {'a', 'b'}.contains(entry.key)"));
+        // Keyed `entries` value cast uses the additionalProperties
+        // value type (`String` here, not `dynamic`).
+        expect(result, contains('entry.value as String'));
+        // hashCode uses `mapHash(entries)` so two structurally-equal
+        // instances hash the same.
+        expect(result, contains('mapHash(entries)'));
+      },
+    );
 
     test('array with default value', () {
       final schema = {
@@ -4376,7 +4461,7 @@ void main() {
           '    factory Test.fromJson(Map<String, dynamic>\n'
           '        json) {\n'
           "        return parseFromJson('Test', json, () => Test(\n"
-          "            a: TestA.maybeFromJson(json['a'] as Map<String, dynamic>),\n"
+          "            a: TestA.maybeFromJson(json['a'] as Map<String, dynamic>?),\n"
           '        ));\n'
           '    }\n'
           '\n'


### PR DESCRIPTION
## Summary

Closes 41 pre-existing failing round-trip tests on the github regen
by fixing three rendering bugs whose effects only surface at
runtime:

- `RenderOneOf.jsonStorageType` ignored its `isNullable` parameter,
  so a nullable property of a oneOf type emitted
  `as Map<String, dynamic>` (non-nullable). When the field was null
  on round-trip, `fromJson` crashed with
  `Null is not a subtype of Map<String, dynamic>`. Cast now respects
  nullability. **27 sites.**
- `RenderEmptyObject` hard-coded `const $className()` on read and
  `const <String, dynamic>{}` on write, ignoring the actual field
  value. A nullable EmptyObject property couldn't round-trip — null
  came back as a non-null instance, and any inner state was
  dropped. Now delegates to the class's own `fromJson`/`toJson`.
  **4 sites.**
- The additionalProperties for-loop in `schema_object.mustache`
  used `json.map((key, value) => MapEntry(...))` on read and
  `entries.map(...)` on write, sweeping the named-property JSON
  keys into the catch-all `entries` field on round-trip. Filtered
  via a `const <String>{...}` of the named property keys; `hashCode`
  on `entries` switches from identity-hash to `mapHash`. **9
  sites.**

Also tightens `invalidJsonExample` to skip the asserted-throw
test when every name in the spec's `required` list is unknown to
`properties` — github's `package-version-metadata-docker` lists
`required: [tags]` for a property called `tag`, so an empty Map
parses successfully and the asserted-throw fails. **1 site.**

## Test plan

- [x] dart analyze clean on github regen (`No issues found!`)
- [x] Generated test failures: 41 -> 0 (`+6071: All tests passed!`)
- [x] No regression in space_gen's own test suite (419 -> 422 pass;
      3 new narrow render-layer tests for the fixed bugs)

## Categorized failure modes (pre-fix)

- 27 `FormatException: type 'Null' is not a subtype of type
  'Map<String, dynamic>'` from nullable oneOf properties
- 9 structural-equality mismatches from additionalProperties round-
  trip sweeping named keys into `entries`
- 4 structural-equality mismatches from EmptyObject hard-coded
  read/write
- 1 `Expected: throws FormatException` failing because the spec's
  `required` listed a typo'd property name (`tags` vs `tag`)