### PR TITLE
feat: smoosh inline allOf variants into the sealed parent

### DIFF
--- a/lib/src/naming.dart
+++ b/lib/src/naming.dart
@@ -310,11 +310,16 @@ class _NameAssigner {
       _isStructurallySmooshable(variant) && _dispatchEmitsSmooshed(decision);
 
   /// Whether [variant] *could* be a direct subclass of a sealed
-  /// parent in idiomatic Dart. Two paths:
+  /// parent in idiomatic Dart. Three paths:
   ///
   /// - Inline `ResolvedObject` variant — the variant lives at
   ///   `<parent>/oneOf/<i>` (or `/anyOf/<i>`), so it's exclusive to
   ///   one parent by construction.
+  /// - Inline `ResolvedAllOf` variant at the same slot. AllOf
+  ///   collapses to a synthesized `RenderObject` at render, so it
+  ///   can extend the sealed parent the same way an inline object
+  ///   can. github's `RepositoryRuleDetailed` (21 inline `allOf`
+  ///   variants) is the motivating case.
   /// - Top-level `ResolvedObject` referenced by exactly one
   ///   oneOf/anyOf variant slot, with no other typed-reference uses
   ///   — "exclusive-by-use." `ResolvedAllOf` member uses don't
@@ -323,12 +328,22 @@ class _NameAssigner {
   ///   when their detailed twin re-uses the same components inside
   ///   an allOf.
   ///
+  /// Top-level `ResolvedAllOf` exclusive-use is a separate gap
+  /// (the presence-counting walk would need to distinguish allOf-
+  /// member uses from typed-reference uses for allOf itself); not
+  /// enabled here.
+  ///
   /// Independent of any dispatch — purely a structural / reachability
   /// property of the variant.
   bool _isStructurallySmooshable(ResolvedSchema variant) {
-    if (variant is! ResolvedObject) return false;
-    if (_isInlineCollectionVariant(variant)) return true;
-    return _isExclusiveUseTopLevel(variant);
+    if (variant is ResolvedObject) {
+      if (_isInlineCollectionVariant(variant)) return true;
+      return _isExclusiveUseTopLevel(variant);
+    }
+    if (variant is ResolvedAllOf) {
+      return _isInlineCollectionVariant(variant);
+    }
+    return false;
   }
 
   /// True when [variant] is a top-level component schema referenced

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -614,6 +614,7 @@ class SpecResolver {
           common: schema.common,
           properties: properties,
           requiredProperties: requiredProperties.toList(),
+          parentSealedTypeName: _names.parentSealedTypeFor(schema.pointer),
           assignedName: _nameFor(schema.pointer),
           assignedSnakeName: _snakeFor(schema.pointer),
         );

--- a/test/naming_test.dart
+++ b/test/naming_test.dart
@@ -610,6 +610,28 @@ void main() {
         ),
         'Pet',
       );
+      // The inline `allOf` variants of `PetDetailed` *also* smoosh:
+      // the synthesized merged class extends `PetDetailed` directly,
+      // no wrapper subclass is claimed for either slot.
+      final petDetailed = JsonPointer.parse(
+        '#/components/schemas/PetDetailed',
+      );
+      expect(
+        names.parentSealedTypeFor(petDetailed.add('oneOf').add('0')),
+        'PetDetailed',
+      );
+      expect(
+        names.parentSealedTypeFor(petDetailed.add('oneOf').add('1')),
+        'PetDetailed',
+      );
+      expect(
+        names.maybeGet(AssignedNames.wrapperPointer(petDetailed, 0)),
+        isNull,
+      );
+      expect(
+        names.maybeGet(AssignedNames.wrapperPointer(petDetailed, 1)),
+        isNull,
+      );
     });
 
     test('array-element dispatch wraps per-variant items with '

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -1821,58 +1821,32 @@ void main() {
       // this and falls back to a position-based wrapper name
       // (`TestVariant1`).
       //
-      // Every dispatch kind now smooshes inline `ResolvedObject`
-      // variants, so the doubling-fallback never fires for plain
-      // inline objects anymore. To exercise the fallback we need an
-      // inline variant that *isn't* `ResolvedObject` — an inline
-      // multi-member `allOf` qualifies. The structural smoosh
-      // predicate excludes `ResolvedAllOf`, so the wrapper still
-      // gets emitted and trips the doubling check.
-      //
-      // Two members are deliberate: the resolver collapses a
-      // single-member `allOf` to its inner schema (eliding the
-      // allOf), which would defeat the test setup. Two members
-      // forces the `allOf` to survive resolution as `ResolvedAllOf`.
-      final results = renderTestSchemas(
-        {
-          'Test': {
-            'oneOf': [
-              {'type': 'string'},
-              {
-                'allOf': [
-                  {r'$ref': '#/components/schemas/A'},
-                  {r'$ref': '#/components/schemas/B'},
-                ],
-              },
-            ],
+      // Every dispatch kind now smooshes inline `ResolvedObject` and
+      // `ResolvedAllOf` variants, so the doubling-fallback never
+      // fires for those anymore. To exercise the fallback we need an
+      // inline variant that's neither — an inline `ResolvedEnum`
+      // qualifies. The structural smoosh predicate excludes enums,
+      // so the wrapper still gets emitted and trips the doubling
+      // check. (This mirrors github's `gists_create_request_public`,
+      // which has `oneOf: [boolean, string-enum]`.)
+      final result = renderTestSchema({
+        'oneOf': [
+          {'type': 'boolean'},
+          {
+            'type': 'string',
+            'enum': ['true', 'false'],
           },
-          'A': {
-            'type': 'object',
-            'required': ['a'],
-            'properties': {
-              'a': {'type': 'string'},
-            },
-          },
-          'B': {
-            'type': 'object',
-            'required': ['b'],
-            'properties': {
-              'b': {'type': 'string'},
-            },
-          },
-        },
-        specUrl: Uri.parse('file:///spec.yaml'),
-      );
-      final test = results['Test']!;
-      // The string variant gets the structural `TestString` wrapper.
-      expect(test, contains('final class TestString extends Test'));
-      // The inline allOf variant's parser-synthesized name starts
+        ],
+      });
+      // The boolean variant gets the structural `TestBool` wrapper.
+      expect(result, contains('final class TestBool extends Test'));
+      // The inline enum variant's parser-synthesized name starts
       // with the parent (`TestOneOf1`), so naive composition would
       // give `TestTestOneOf1`; the fallback collapses to
       // `TestVariant1`.
-      expect(test, contains('final class TestVariant1 extends Test'));
-      expect(test, contains('final TestOneOf1 value;'));
-      expect(test, isNot(contains('TestTestOneOf')));
+      expect(result, contains('final class TestVariant1 extends Test'));
+      expect(result, contains('final TestOneOf1 value;'));
+      expect(result, isNot(contains('TestTestOneOf')));
     });
 
     test('predicate-required dispatch smooshes inline-object variants: '
@@ -2840,6 +2814,81 @@ void main() {
       expect(result, isNot(contains('class TestVariant0')));
       expect(result, isNot(contains('TestOneOf0 value')));
       expect(result, isNot(contains('TestOneOf1 value')));
+    });
+
+    test('discriminator dispatch smooshes inline-allOf variants: the '
+        'merged class extends the sealed parent directly', () {
+      // github's `repository-rule-detailed` shape: each oneOf variant
+      // is `allOf: [<rule-X>, <ruleset-info>]`, where the rule-X
+      // member carries the discriminator (`type` is a single-value
+      // enum). The synthesized merged class smooshes — extends the
+      // sealed parent, no separate wrapper, dispatch case arms call
+      // it directly.
+      final results = renderTestSchemas(
+        {
+          'Rule': {
+            'oneOf': [
+              {
+                'allOf': [
+                  {r'$ref': '#/components/schemas/Creation'},
+                  {r'$ref': '#/components/schemas/Meta'},
+                ],
+              },
+              {
+                'allOf': [
+                  {r'$ref': '#/components/schemas/Deletion'},
+                  {r'$ref': '#/components/schemas/Meta'},
+                ],
+              },
+            ],
+          },
+          'Creation': {
+            'type': 'object',
+            'required': ['type'],
+            'properties': {
+              'type': {
+                'type': 'string',
+                'enum': ['creation'],
+              },
+            },
+          },
+          'Deletion': {
+            'type': 'object',
+            'required': ['type'],
+            'properties': {
+              'type': {
+                'type': 'string',
+                'enum': ['deletion'],
+              },
+            },
+          },
+          'Meta': {
+            'type': 'object',
+            'required': ['ruleset_id'],
+            'properties': {
+              'ruleset_id': {'type': 'integer'},
+            },
+          },
+        },
+        specUrl: Uri.parse('file:///spec.yaml'),
+      );
+      final rule = results['Rule']!;
+      // Discriminator dispatch on `type` calls the merged class
+      // directly — no `<Wrapper>(<Merged>.fromJson(...))` outer call.
+      expect(rule, contains("final discriminator = json['type']"));
+      expect(rule, contains("'creation' => RuleOneOf0.fromJson(json)"));
+      expect(rule, contains("'deletion' => RuleOneOf1.fromJson(json)"));
+      // Each merged class is inlined into the parent's file as a
+      // direct sealed subclass.
+      expect(rule, contains('final class RuleOneOf0 extends Rule'));
+      expect(rule, contains('final class RuleOneOf1 extends Rule'));
+      // Merged properties from both allOf members are present in the
+      // smooshed class.
+      expect(rule, contains('this.rulesetId'));
+      // No wrapper subclasses survive in the parent file.
+      expect(rule, isNot(contains('class RuleVariant0')));
+      expect(rule, isNot(contains('RuleOneOf0 value')));
+      expect(rule, isNot(contains('RuleOneOf1 value')));
     });
 
     test('implicit-discriminator dispatch falls back when the single-enum '


### PR DESCRIPTION
## Summary

Extends the smoosh predicate to inline `ResolvedAllOf` variants of oneOf/anyOf collections, matching the existing inline-object behavior. Today's only blocker was the structural gate `if (variant is! ResolvedObject) return false;` in `_isStructurallySmooshable` — every other layer (dispatch's `_flattenedProperties`, render's allOf-to-RenderObject collapse, the wrapper-naming `_wrapperTagOf`, `file_renderer`'s `rendersToSeparateFile`) already handled allOf the same as object.

The motivating case is github's `RepositoryRuleDetailed` — 21 oneOf variants, each `allOf: [<rule-X>, <ruleset-info>]`, that previously emitted 21 standalone data classes plus 21 doubling-fallback `Variant<i>` wrappers. After the fix the 21 merged classes extend the sealed parent directly and live inline in `repository_rule_detailed.dart`.

Top-level allOf exclusive-use is a separate gap (the presence-counting walk would need to distinguish allOf-member uses from typed-reference uses for allOf itself); not enabled here.

## Github regen impact

- 21 `repository_rule_detailed_one_of_*.dart` files removed (now inlined into `repository_rule_detailed.dart`).
- `<Parent>Variant<i>` doubling-fallback wrappers: 22 → 1 (only `GistsCreateRequestPublicVariant1` survives — that's an inline enum, which still needs a wrapper).
- Standalone `<Parent>OneOf<i>` data classes: 30 → 0.
- Stub count unchanged at 3 (Group C — parked).
- `dart analyze` clean; all 6100 generated round-trip tests pass (smooshed allOf variants pick up per-variant tests via #181).

## Test plan

- [x] `dart test` — 475 passing, no regressions
- [x] `dart analyze` clean on the worktree
- [x] github regen (`/tmp/github_out`) `dart analyze` clean
- [x] github regen `dart test` passes (6100/6100)
- [x] New unit tests cover the inline-allOf smoosh path (naming + render)
- [x] Doubling-fallback test rewritten using inline string-enum (still trips the path; mirrors `gists_create_request_public`)