### PR TITLE
feat: parse and render integer enums (type: integer, enum: [...])

### DIFF
--- a/lib/src/dispatch.dart
+++ b/lib/src/dispatch.dart
@@ -191,7 +191,11 @@ class DiscriminatorDispatch extends DispatchDecision {
 
   /// Each entry is a `(value, variant)` pair. Order is the order
   /// `mapping` keys appear; the renderer's `case` arms follow it.
-  final List<({String value, ResolvedSchema variant})> mapping;
+  /// Values are typically `String` but `int` for integer-typed
+  /// discriminators; the [propertyName] property's enum on each
+  /// variant pins this — the picker rejects collections whose
+  /// variants disagree on value type.
+  final List<({Object value, ResolvedSchema variant})> mapping;
 
   /// All variants in declaration order (matches the spec's `oneOf`
   /// ordering). Drives the order subclasses are declared.
@@ -361,10 +365,14 @@ String? _jsonShapeKey(ResolvedSchema schema) {
     ResolvedAllOf() => _mapShapeKey,
     ResolvedMap() => _mapShapeKey,
     ResolvedEmptyObject() => _mapShapeKey,
-    // Enums always serialize as `String`; the wrapper class is the
-    // enum type itself. Shape-dispatchable as long as no sibling
-    // variant collides on the `String` key.
-    ResolvedEnum() => 'String',
+    // Enums serialize as their value type — `String` or `int`.
+    // Shape-dispatchable as long as no sibling variant collides on
+    // the same key. Must agree with [RenderEnum.jsonShapeKey] (the
+    // render side splices the same string into the `case <type> v =>`
+    // arm), and with [RenderInteger.jsonShapeKey] / [RenderString]'s
+    // non-newtype keys for cross-shape collisions.
+    ResolvedStringEnum() => 'String',
+    ResolvedIntEnum() => 'int',
     // RecursiveRef points at a top-level (always object today). Treat
     // as Map for shape collision purposes; render handles the actual
     // construction via the target's name.
@@ -473,13 +481,13 @@ ResolvedDiscriminator? _implicitDiscriminatorForProperty(
   if (variants.isEmpty) return null;
   if (!variants.every(_isObjectLike)) return null;
   final flatProps = variants.map(_flattenedProperties).toList();
-  final perVariantValues = <List<String>>[];
+  final perVariantValues = <List<Object>>[];
   for (var i = 0; i < variants.length; i++) {
     final type = flatProps[i][propertyName];
     if (type is! ResolvedEnum || type.values.isEmpty) return null;
     perVariantValues.add(List.of(type.values));
   }
-  final seen = <String>{};
+  final seen = <Object>{};
   for (final values in perVariantValues) {
     for (final v in values) {
       if (!seen.add(v)) return null;
@@ -512,13 +520,13 @@ ResolvedDiscriminator? _implicitDiscriminator(List<ResolvedSchema> variants) {
   if (!variants.every(_isObjectLike)) return null;
   final flatRequired = variants.map(_flattenedRequiredProperties).toList();
   final flatProps = variants.map(_flattenedProperties).toList();
-  final candidates = <(String, List<List<String>>)>[];
+  final candidates = <(String, List<List<Object>>)>[];
   for (final entry in flatProps.first.entries) {
     final propName = entry.key;
     if (!flatRequired.first.contains(propName)) continue;
     final firstType = entry.value;
     if (firstType is! ResolvedEnum || firstType.values.isEmpty) continue;
-    final perVariantValues = <List<String>>[List.of(firstType.values)];
+    final perVariantValues = <List<Object>>[List.of(firstType.values)];
     var allMatch = true;
     for (var i = 1; i < variants.length; i++) {
       if (!flatRequired[i].contains(propName)) {
@@ -527,6 +535,13 @@ ResolvedDiscriminator? _implicitDiscriminator(List<ResolvedSchema> variants) {
       }
       final otherType = flatProps[i][propName];
       if (otherType is! ResolvedEnum || otherType.values.isEmpty) {
+        allMatch = false;
+        break;
+      }
+      // All variants' tag enums must agree on the value type — mixing
+      // string and integer tags within one discriminator would force
+      // a runtime check we don't want to emit.
+      if (otherType.runtimeType != firstType.runtimeType) {
         allMatch = false;
         break;
       }
@@ -540,7 +555,7 @@ ResolvedDiscriminator? _implicitDiscriminator(List<ResolvedSchema> variants) {
     // Pairwise-disjoint check on the union of each variant's enum
     // values. A duplicate value would route to two variants — not a
     // valid discriminator.
-    final seen = <String>{};
+    final seen = <Object>{};
     var disjoint = true;
     for (final values in perVariantValues) {
       for (final v in values) {

--- a/lib/src/parse/spec.dart
+++ b/lib/src/parse/spec.dart
@@ -237,7 +237,16 @@ class SchemaBinary extends Schema {
   const SchemaBinary({required super.common});
 }
 
-class SchemaEnum extends Schema {
+/// An enum schema. OpenAPI most commonly uses string enums, but
+/// `type: integer` enums also occur — Discord uses single-value int
+/// enums (`enum: [1]`) as oneOf discriminator markers, the same role
+/// github plays with single-value string enums. The two cases share
+/// the parser and resolver shape, but differ in element type for
+/// [enumValues] and [defaultValue] and in how render emits Dart
+/// (string literal vs int literal). Mirrors the [SchemaNumeric] /
+/// [SchemaInteger] / [SchemaNumber] pattern: parameterized abstract
+/// base with two concrete subclasses pinning [T].
+abstract class SchemaEnum<T extends Object> extends Schema {
   const SchemaEnum({
     required super.common,
     required this.defaultValue,
@@ -245,16 +254,34 @@ class SchemaEnum extends Schema {
     required this.enumDescriptions,
   });
 
-  /// The default value of the enum.
-  final String? defaultValue;
+  /// The default value of the enum, if any.
+  final T? defaultValue;
 
-  // Only string enums are supported for now.
-  final List<String> enumValues;
+  /// All enum values.
+  final List<T> enumValues;
 
   /// Optional per-value dartdoc descriptions, parallel to [enumValues].
   /// Populated from the OpenAPI vendor extension `x-enum-descriptions`
   /// when present.
   final List<String>? enumDescriptions;
+}
+
+class SchemaStringEnum extends SchemaEnum<String> {
+  const SchemaStringEnum({
+    required super.common,
+    required super.defaultValue,
+    required super.enumValues,
+    required super.enumDescriptions,
+  });
+}
+
+class SchemaIntEnum extends SchemaEnum<int> {
+  const SchemaIntEnum({
+    required super.common,
+    required super.defaultValue,
+    required super.enumValues,
+    required super.enumDescriptions,
+  });
 }
 
 class SchemaNull extends Schema {

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -709,7 +709,7 @@ SchemaRef? _handleAdditionalProperties(MapContext parent) {
   _error(parent, 'additionalProperties must be a boolean or a map');
 }
 
-SchemaEnum? _handleEnum({
+SchemaEnum<Object>? _handleEnum({
   required MapContext json,
   required TypeAndFormat typeAndFormat,
   required dynamic defaultValue,
@@ -722,18 +722,64 @@ SchemaEnum? _handleEnum({
   if (enumValues == null) {
     return null;
   }
-  // We will infer the type from the enum values if not provided.
-  if (type != null && type != 'string') {
-    // boolean enums are valid but not yet supported (or particularly
-    // consequential to ignore). GitHub uses one for fork=true.
-    if (podType == PodType.boolean) {
-      _ignored<String>(json, 'type');
-      return null;
-    }
+  // String is the default when `type` is omitted (matches the most
+  // common OpenAPI 3.0/3.1 pattern). Integer enums show up in specs
+  // that use them as single-value discriminator tags (Discord's
+  // component types). Boolean enums (e.g. github's `fork: true`)
+  // parse as a non-enum boolean — there's nothing to dispatch on.
+  final bool isInt;
+  if (type == null || type == 'string') {
+    isInt = false;
+  } else if (type == 'integer') {
+    isInt = true;
+  } else if (podType == PodType.boolean) {
+    _ignored<String>(json, 'type');
+    return null;
+  } else {
     _unimplemented(json, 'enumValues for type=$type');
   }
   // TODO(eseidel): null should only be valid when enum is nullable.
   final nonNullValues = enumValues.where((e) => e != null).toList();
+  final xEnumDescriptions = _optionalList<dynamic>(json, 'x-enum-descriptions');
+  List<String>? enumDescriptions;
+  if (xEnumDescriptions != null) {
+    if (xEnumDescriptions.length != nonNullValues.length) {
+      _error(
+        json,
+        'x-enum-descriptions length (${xEnumDescriptions.length}) must '
+        'match enum length (${nonNullValues.length})',
+      );
+    }
+    if (xEnumDescriptions.any((e) => e is! String)) {
+      _error(
+        json,
+        'x-enum-descriptions must be a list of strings: $xEnumDescriptions',
+      );
+    }
+    enumDescriptions = xEnumDescriptions.cast<String>();
+  }
+  if (isInt) {
+    if (nonNullValues.any((e) => e is! int)) {
+      _error(json, 'enumValues must be a list of integers: $enumValues');
+    }
+    final typedEnumValues = nonNullValues.cast<int>();
+    int? typedDefaultValue;
+    if (defaultValue != null) {
+      if (!nonNullValues.contains(defaultValue)) {
+        _error(
+          json,
+          'defaultValue must be one of the enum values: $defaultValue',
+        );
+      }
+      typedDefaultValue = defaultValue as int;
+    }
+    return SchemaIntEnum(
+      common: common,
+      defaultValue: typedDefaultValue,
+      enumValues: typedEnumValues,
+      enumDescriptions: enumDescriptions,
+    );
+  }
   if (nonNullValues.any((e) => e is! String)) {
     _error(json, 'enumValues must be a list of strings: $enumValues');
   }
@@ -756,25 +802,7 @@ SchemaEnum? _handleEnum({
       typedDefaultValue = defaultValue as String?;
     }
   }
-  final xEnumDescriptions = _optionalList<dynamic>(json, 'x-enum-descriptions');
-  List<String>? enumDescriptions;
-  if (xEnumDescriptions != null) {
-    if (xEnumDescriptions.length != typedEnumValues.length) {
-      _error(
-        json,
-        'x-enum-descriptions length (${xEnumDescriptions.length}) must '
-        'match enum length (${typedEnumValues.length})',
-      );
-    }
-    if (xEnumDescriptions.any((e) => e is! String)) {
-      _error(
-        json,
-        'x-enum-descriptions must be a list of strings: $xEnumDescriptions',
-      );
-    }
-    enumDescriptions = xEnumDescriptions.cast<String>();
-  }
-  return SchemaEnum(
+  return SchemaStringEnum(
     common: common,
     defaultValue: typedDefaultValue,
     enumValues: typedEnumValues,

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -459,12 +459,23 @@ class SpecResolver {
           assignedName: _nameFor(schema.targetPointer),
           assignedSnakeName: _snakeFor(schema.targetPointer),
         );
-      case ResolvedEnum():
-        return RenderEnum(
+      case ResolvedStringEnum():
+        return RenderStringEnum(
           common: schema.common,
           values: schema.values,
           names: RenderEnum.variableNamesFor(quirks, schema.values),
           descriptions: schema.descriptions,
+          defaultValue: schema.defaultValue,
+          assignedName: _nameFor(schema.pointer),
+          assignedSnakeName: _snakeFor(schema.pointer),
+        );
+      case ResolvedIntEnum():
+        return RenderIntEnum(
+          common: schema.common,
+          values: schema.values,
+          names: RenderEnum.variableNamesForInts(schema.values),
+          descriptions: schema.descriptions,
+          defaultValue: schema.defaultValue,
           assignedName: _nameFor(schema.pointer),
           assignedSnakeName: _snakeFor(schema.pointer),
         );
@@ -565,7 +576,7 @@ class SpecResolver {
             // For each ResolvedSchema in the resolver-side mapping, find
             // its index in schema.schemas (identity match, established by
             // the resolver) and use the corresponding rendered variant.
-            final renderMapping = <String, RenderSchema>{};
+            final renderMapping = <Object, RenderSchema>{};
             for (final entry in rawMapping.entries) {
               final i = schema.schemas.indexWhere(
                 (s) => identical(s, entry.value),
@@ -3898,7 +3909,12 @@ class RenderMap extends RenderSchema {
   }
 }
 
-class RenderEnum extends RenderNewType {
+/// Render-tree counterpart to [ResolvedEnum]. Same generic-with-typed-
+/// subclasses pattern: parameterized abstract base, [RenderStringEnum]
+/// and [RenderIntEnum] pin [T]. Branch points where Dart-emission
+/// differs (literal form, JSON storage type, invalid-JSON sentinel)
+/// become abstract methods on the parent.
+abstract class RenderEnum<T extends Object> extends RenderNewType {
   const RenderEnum({
     required super.common,
     required this.values,
@@ -3938,26 +3954,46 @@ class RenderEnum extends RenderNewType {
     return values.map(toShortVariableName).toList();
   }
 
+  /// Variable names for an int-valued enum. Defaults to `value<N>`
+  /// (e.g. `value1`, `value11`) — not great for multi-value enums in
+  /// principle, but in the common case (single-value discriminator
+  /// tags) this is unambiguous and the variant is rarely referenced
+  /// by name in user code anyway.
+  @visibleForTesting
+  static List<String> variableNamesForInts(List<int> values) {
+    return values.map((v) => v >= 0 ? 'value$v' : 'valueNeg${-v}').toList();
+  }
+
   @override
-  final dynamic defaultValue;
+  final T? defaultValue;
 
   @override
   bool get defaultCanConstConstruct => true;
 
-  /// The values of the resolved schema.
-  final List<String> values;
+  /// The enum values.
+  final List<T> values;
 
-  /// The names of the resolved schema.
+  /// The Dart variable names of [values], parallel.
   final List<String> names;
 
   /// Optional per-value dartdoc descriptions, parallel to [values].
   final List<String>? descriptions;
 
+  /// Dart literal for one enum value as it appears after `._(` in the
+  /// generated enum declaration. For string enums this quotes; for
+  /// int enums it's the int's bare numeric form.
+  String enumValueLiteral(T value);
+
+  /// The bare Dart type name of the enum's underlying value (e.g.
+  /// `String`, `int`). Drives the template's `final <type> value`
+  /// declaration and `<type> toJson()` return type.
+  String get valueDartType;
+
   @override
   String? get wrapperTag => typeName;
 
   @override
-  String? get jsonShapeKey => 'String';
+  String? get jsonShapeKey => valueDartType;
 
   @override
   _VariantConversion? _variantConversion(SchemaRenderer context) =>
@@ -3974,7 +4010,7 @@ class RenderEnum extends RenderNewType {
 
   @override
   String jsonStorageType({required bool isNullable}) {
-    return isNullable ? 'String?' : 'String';
+    return isNullable ? '$valueDartType?' : valueDartType;
   }
 
   /// Template context for an enum schema.
@@ -3985,7 +4021,7 @@ class RenderEnum extends RenderNewType {
       final description = descriptions?[index];
       return {
         'enumValueName': variableNameFor(value),
-        'enumValue': quoteString(value),
+        'enumValue': enumValueLiteral(value),
         'enum_value_doc_comment': createDocCommentFromParts(
           body: description,
           indent: 4,
@@ -3997,6 +4033,7 @@ class RenderEnum extends RenderNewType {
       'doc_comment': createDocComment(common: common),
       'typeName': typeName,
       'nullableTypeName': nullableTypeName(context),
+      'valueDartType': valueDartType,
       'enumValues': [
         for (var i = 0; i < values.length; i++) enumValueToTemplateContext(i),
       ],
@@ -4006,12 +4043,9 @@ class RenderEnum extends RenderNewType {
   /// The default value of this schema as a string.
   @override
   String? defaultValueString(SchemaRenderer context) {
-    // If the type of this schema is an object we need to convert the default
-    // value to that object type.
-    if (defaultValue is String) {
-      return '$className.${variableNameFor(defaultValue as String)}';
-    }
-    return defaultValue?.toString();
+    final value = defaultValue;
+    if (value == null) return null;
+    return '$className.${variableNameFor(value)}';
   }
 
   @override
@@ -4031,14 +4065,15 @@ class RenderEnum extends RenderNewType {
     return '$className.$jsonMethod($jsonValue as $jsonType)$orDefault';
   }
 
-  String variableNameFor(String value) => names[values.indexOf(value)];
+  String variableNameFor(T value) => names[values.indexOf(value)];
 
   @override
   bool equalsIgnoringName(RenderSchema other) {
     if (other is! RenderEnum) {
       return false;
     }
-    if (!const ListEquality<String>().equals(values, other.values)) {
+    if (other.runtimeType != runtimeType) return false;
+    if (!const ListEquality<Object>().equals(values, other.values)) {
       return false;
     }
     if (!const ListEquality<String>().equals(names, other.names)) {
@@ -4049,10 +4084,56 @@ class RenderEnum extends RenderNewType {
 
   @override
   String? exampleValue(SchemaRenderer context) => '$typeName.values.first';
+}
+
+class RenderStringEnum extends RenderEnum<String> {
+  const RenderStringEnum({
+    required super.common,
+    required super.values,
+    required super.names,
+    required super.descriptions,
+    super.defaultValue,
+    super.assignedName,
+    super.assignedSnakeName,
+  });
+
+  @override
+  String enumValueLiteral(String value) => quoteString(value);
+
+  @override
+  String get valueDartType => 'String';
 
   @override
   String? invalidJsonExample(SchemaRenderer context) =>
       "'__invalid_enum_value__'";
+}
+
+class RenderIntEnum extends RenderEnum<int> {
+  const RenderIntEnum({
+    required super.common,
+    required super.values,
+    required super.names,
+    required super.descriptions,
+    super.defaultValue,
+    super.assignedName,
+    super.assignedSnakeName,
+  });
+
+  @override
+  String enumValueLiteral(int value) => value.toString();
+
+  @override
+  String get valueDartType => 'int';
+
+  @override
+  String? invalidJsonExample(SchemaRenderer context) {
+    // Pick a value outside the spec'd range. -1 works for almost every
+    // real spec (most int enums use small non-negative values like
+    // bitfield flags or component-type tags). Falls back to a
+    // distinctly-large negative if -1 is somehow in the value set.
+    if (!values.contains(-1)) return '-1';
+    return '-999999';
+  }
 }
 
 class RenderOneOf extends RenderNewType {
@@ -4288,6 +4369,16 @@ class RenderOneOf extends RenderNewType {
     };
   }
 
+  /// Format a discriminator value as the Dart literal that goes into a
+  /// `switch (json[propertyName])` case key. String values are quoted
+  /// (`'creation'`); int values are emitted raw (`1`). Generated as a
+  /// pre-formatted string at render time so the template can splice
+  /// it without further quoting.
+  String _discriminatorCaseLiteral(Object value) {
+    if (value is String) return quoteString(value);
+    return value.toString();
+  }
+
   /// Build a [_DiscriminatorMode], splitting variants into smooshed
   /// (the variant data class extends the sealed parent directly,
   /// inlined in the parent's file) and non-smooshed (today's wrapper-
@@ -4304,7 +4395,7 @@ class RenderOneOf extends RenderNewType {
       final renderVariant = renderOf(entry.variant);
       final fromJson = '${renderVariant.typeName}.fromJson(json)';
       cases.add({
-        'value': entry.value,
+        'caseLiteral': _discriminatorCaseLiteral(entry.value),
         'caseExpression': renderVariant.isSmooshed
             ? fromJson
             : '${wrapperTypeName(renderVariant)}($fromJson)',
@@ -5141,7 +5232,7 @@ class RenderDiscriminator extends Equatable {
   });
 
   final String propertyName;
-  final Map<String, RenderSchema> mapping;
+  final Map<Object, RenderSchema> mapping;
 
   @override
   List<Object?> get props => [propertyName, mapping];

--- a/lib/src/resolver.dart
+++ b/lib/src/resolver.dart
@@ -291,9 +291,18 @@ ResolvedSchema _resolveSchemaFully(
       requiredProperties: schema.requiredProperties,
     );
   }
-  if (schema is SchemaEnum) {
+  if (schema is SchemaStringEnum) {
     assert(createsNewType, 'SchemaEnum should create a new type');
-    return ResolvedEnum(
+    return ResolvedStringEnum(
+      common: resolvedCommon,
+      defaultValue: schema.defaultValue,
+      values: schema.enumValues,
+      descriptions: schema.enumDescriptions,
+    );
+  }
+  if (schema is SchemaIntEnum) {
+    assert(createsNewType, 'SchemaEnum should create a new type');
+    return ResolvedIntEnum(
       common: resolvedCommon,
       defaultValue: schema.defaultValue,
       values: schema.enumValues,
@@ -1476,7 +1485,10 @@ class ResolvedArray extends ResolvedSchema {
   ];
 }
 
-class ResolvedEnum extends ResolvedSchema {
+/// Resolved counterpart to [SchemaEnum]. Same generic-with-typed-
+/// subclasses pattern: parameterized abstract base, concrete
+/// [ResolvedStringEnum] and [ResolvedIntEnum] pin [T].
+abstract class ResolvedEnum<T extends Object> extends ResolvedSchema {
   const ResolvedEnum({
     required super.common,
     required this.defaultValue,
@@ -1485,28 +1497,54 @@ class ResolvedEnum extends ResolvedSchema {
   }) : super(createsNewType: true);
 
   /// The values of the resolved schema.
-  // If we support non-string, non-integer enums, we will need to fix path
-  // parameter validation to only allow string and integer enum types.
-  final List<String> values;
+  final List<T> values;
 
   /// The default value of the enum type.
-  final dynamic defaultValue;
+  final T? defaultValue;
 
   /// Optional per-value dartdoc descriptions, parallel to [values].
   final List<String>? descriptions;
 
   @override
-  ResolvedEnum copyWith({CommonProperties? common}) {
-    return ResolvedEnum(
+  List<Object?> get props => [super.props, values, defaultValue, descriptions];
+}
+
+class ResolvedStringEnum extends ResolvedEnum<String> {
+  const ResolvedStringEnum({
+    required super.common,
+    required super.defaultValue,
+    required super.values,
+    required super.descriptions,
+  });
+
+  @override
+  ResolvedStringEnum copyWith({CommonProperties? common}) {
+    return ResolvedStringEnum(
       common: common ?? this.common,
       defaultValue: defaultValue,
       values: values,
       descriptions: descriptions,
     );
   }
+}
+
+class ResolvedIntEnum extends ResolvedEnum<int> {
+  const ResolvedIntEnum({
+    required super.common,
+    required super.defaultValue,
+    required super.values,
+    required super.descriptions,
+  });
 
   @override
-  List<Object?> get props => [super.props, values, defaultValue, descriptions];
+  ResolvedIntEnum copyWith({CommonProperties? common}) {
+    return ResolvedIntEnum(
+      common: common ?? this.common,
+      defaultValue: defaultValue,
+      values: values,
+      descriptions: descriptions,
+    );
+  }
 }
 
 class ResolvedObject extends ResolvedSchema {
@@ -1600,6 +1638,11 @@ class ResolvedOneOf extends ResolvedSchemaCollection {
 
 /// Resolved form of [SchemaDiscriminator]. Each [mapping] value is one
 /// of the [ResolvedOneOf.schemas] entries, identified by pointer match.
+/// The map key is the discriminator value as it appears on the wire —
+/// typically `String`, but `int` for integer-typed discriminator
+/// fields (Discord's component types). Keys within one mapping are
+/// always uniform in runtime type; the implicit-discriminator picker
+/// rejects variants whose tag enums disagree on value type.
 @immutable
 class ResolvedDiscriminator extends Equatable {
   const ResolvedDiscriminator({
@@ -1608,7 +1651,7 @@ class ResolvedDiscriminator extends Equatable {
   });
 
   final String propertyName;
-  final Map<String, ResolvedSchema>? mapping;
+  final Map<Object, ResolvedSchema>? mapping;
 
   @override
   List<Object?> get props => [propertyName, mapping];

--- a/lib/templates/schema_enum.mustache
+++ b/lib/templates/schema_enum.mustache
@@ -6,8 +6,8 @@
 
     const {{typeName}}._(this.value);
 
-    /// Creates a {{ typeName }} from a json string.
-    factory {{ typeName }}.fromJson(String json) {
+    /// Creates a {{ typeName }} from a json value.
+    factory {{ typeName }}.fromJson({{ valueDartType }} json) {
         return {{ typeName }}.values.firstWhere(
             (value) => value.value == json,
             orElse: () =>
@@ -15,23 +15,23 @@
         );
     }
 
-    /// Convenience to create a nullable type from a nullable json object.
+    /// Convenience to create a nullable type from a nullable json value.
     /// Useful when parsing optional fields.
-    static {{ nullableTypeName }} maybeFromJson(String? json) {
+    static {{ nullableTypeName }} maybeFromJson({{ valueDartType }}? json) {
         if (json == null) {
             return null;
         }
         return {{ typeName }}.fromJson(json);
     }
 
-    /// The value of the enum, as a string.  This is the exact value
+    /// The value of the enum.  This is the exact value
     /// from the OpenAPI spec and will be used for network transport.
-    final String value;
+    final {{ valueDartType }} value;
 
-    /// Converts the enum to a json string.
-    String toJson() => value;
+    /// Converts the enum to its json value.
+    {{ valueDartType }} toJson() => value;
 
-    /// Returns the string value of the enum.
+    /// Returns the string form of the enum.
     @override
-    String toString() => value;
+    String toString() => value.toString();
 }

--- a/lib/templates/schema_one_of.mustache
+++ b/lib/templates/schema_one_of.mustache
@@ -6,7 +6,7 @@
         final discriminator = json['{{ discriminatorProperty }}'];
         return switch (discriminator) {
 {{#dispatch}}
-            '{{ value }}' => {{{ caseExpression }}},
+            {{{ caseLiteral }}} => {{{ caseExpression }}},
 {{/dispatch}}
             _ => throw FormatException(
                 "Unknown {{ discriminatorProperty }} '$discriminator' for {{ typeName }}",

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -2026,7 +2026,65 @@ void main() {
           'enum': ['foo', 'bar', 'baz'],
         };
         final schema = parseTestSchema(json);
-        expect(schema, isA<SchemaEnum>());
+        expect(schema, isA<SchemaStringEnum>());
+      });
+      test('integer enum parses to SchemaIntEnum', () {
+        // Discord uses single-value `type: integer, enum: [N]` enums
+        // as oneOf discriminator markers (component types).
+        final json = {
+          'type': 'integer',
+          'enum': [1, 2, 11],
+        };
+        final schema = parseTestSchema(json);
+        if (schema is! SchemaIntEnum) {
+          fail('Expected SchemaIntEnum, got ${schema.runtimeType}');
+        }
+        expect(schema.enumValues, equals([1, 2, 11]));
+      });
+      test('integer enum with non-int values is a spec error', () {
+        final json = {
+          'type': 'integer',
+          'enum': [1, 'foo'],
+        };
+        expect(
+          () => parseTestSchema(json),
+          throwsA(
+            isA<FormatException>().having(
+              (e) => e.message,
+              'message',
+              contains('enumValues must be a list of integers'),
+            ),
+          ),
+        );
+      });
+      test('integer enum with valid default value parses', () {
+        final json = {
+          'type': 'integer',
+          'enum': [1, 2, 11],
+          'default': 11,
+        };
+        final schema = parseTestSchema(json);
+        if (schema is! SchemaIntEnum) {
+          fail('Expected SchemaIntEnum, got ${schema.runtimeType}');
+        }
+        expect(schema.defaultValue, equals(11));
+      });
+      test('integer enum default value not in enum is a spec error', () {
+        final json = {
+          'type': 'integer',
+          'enum': [1, 2, 11],
+          'default': 99,
+        };
+        expect(
+          () => parseTestSchema(json),
+          throwsA(
+            isA<FormatException>().having(
+              (e) => e.message,
+              'message',
+              contains('defaultValue must be one of the enum values: 99'),
+            ),
+          ),
+        );
       });
       test('ignore boolean enums', () {
         final json = {

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -2816,6 +2816,69 @@ void main() {
       expect(result, isNot(contains('TestOneOf1 value')));
     });
 
+    test('shape dispatch picks oneOf<int-enum, object> with int + Map '
+        'arms', () {
+      // Integer enums report `int` as their shape key (matches
+      // RenderInteger's non-newtype convention). A oneOf with an
+      // int-enum and an object variant shape-dispatches on those
+      // distinct keys.
+      final result = renderTestSchema({
+        'oneOf': [
+          {
+            'type': 'integer',
+            'enum': [1, 2, 3],
+          },
+          {
+            'type': 'object',
+            'properties': {
+              'name': {'type': 'string'},
+            },
+          },
+        ],
+      });
+      expect(result, contains('int v => '));
+      expect(result, contains('Map<String, dynamic> v =>'));
+      expect(result, isNot(contains('throw UnimplementedError')));
+    });
+
+    test('discriminator dispatch with integer-typed tags emits int '
+        'case arms, not string', () {
+      // Mirrors Discord's component-type pattern: each variant tags
+      // itself with `type: { type: integer, enum: [N] }` for distinct
+      // N. The generated switch must use raw int literals (`case 1:`)
+      // not strings (`case '1':`); the lookup is `json['type']`.
+      final result = renderTestSchema({
+        'oneOf': [
+          {
+            'type': 'object',
+            'properties': {
+              'type': {
+                'type': 'integer',
+                'enum': [1],
+              },
+            },
+            'required': ['type'],
+          },
+          {
+            'type': 'object',
+            'properties': {
+              'type': {
+                'type': 'integer',
+                'enum': [11],
+              },
+            },
+            'required': ['type'],
+          },
+        ],
+      });
+      expect(result, contains("final discriminator = json['type']"));
+      expect(result, contains('1 => TestOneOf0.fromJson(json)'));
+      expect(result, contains('11 => TestOneOf1.fromJson(json)'));
+      // No quoted-int case keys.
+      expect(result, isNot(contains("'1' =>")));
+      expect(result, isNot(contains("'11' =>")));
+    });
+
     test('discriminator dispatch smooshes inline-allOf variants: the '
         'merged class extends the sealed parent directly', () {
       // github's `repository-rule-detailed` shape: each oneOf variant
@@ -3664,7 +3727,7 @@ void main() {
         '\n'
         '    const Test._(this.value);\n'
         '\n'
-        '    /// Creates a Test from a json string.\n'
+        '    /// Creates a Test from a json value.\n'
         '    factory Test.fromJson(String json) {\n'
         '        return Test.values.firstWhere(\n'
         '            (value) => value.value == json,\n'
@@ -3673,7 +3736,7 @@ void main() {
         '        );\n'
         '    }\n'
         '\n'
-        '    /// Convenience to create a nullable type from a nullable json object.\n'
+        '    /// Convenience to create a nullable type from a nullable json value.\n'
         '    /// Useful when parsing optional fields.\n'
         '    static Test? maybeFromJson(String? json) {\n'
         '        if (json == null) {\n'
@@ -3682,18 +3745,57 @@ void main() {
         '        return Test.fromJson(json);\n'
         '    }\n'
         '\n'
-        '    /// The value of the enum, as a string.  This is the exact value\n'
+        '    /// The value of the enum.  This is the exact value\n'
         '    /// from the OpenAPI spec and will be used for network transport.\n'
         '    final String value;\n'
         '\n'
-        '    /// Converts the enum to a json string.\n'
+        '    /// Converts the enum to its json value.\n'
         '    String toJson() => value;\n'
         '\n'
-        '    /// Returns the string value of the enum.\n'
+        '    /// Returns the string form of the enum.\n'
         '    @override\n'
-        '    String toString() => value;\n'
+        '    String toString() => value.toString();\n'
         '}\n',
       );
+    });
+
+    test('integer enum renders as a Dart enum with int-typed value', () {
+      // Discord uses single-value `type: integer, enum: [N]` enums as
+      // oneOf discriminator markers (component types). Verify the
+      // generated Dart enum stores the value as `int`, the
+      // factory/maybeFromJson accept `int`/`int?`, and `toJson()`
+      // returns `int`.
+      final json = {
+        'type': 'integer',
+        'enum': [1, 2, 11],
+      };
+      final result = renderTestSchema(json);
+      // Variants get name `value<N>` since int values aren't valid
+      // Dart identifiers on their own.
+      expect(result, contains('value1._(1)'));
+      expect(result, contains('value2._(2)'));
+      expect(result, contains('value11._(11)'));
+      // JSON wire types are `int`, not `String`.
+      expect(result, contains('factory Test.fromJson(int json)'));
+      expect(result, contains('static Test? maybeFromJson(int? json)'));
+      expect(result, contains('final int value;'));
+      expect(result, contains('int toJson() => value;'));
+      // No String-typed survivors anywhere in the body.
+      expect(result, isNot(contains('final String value;')));
+      expect(result, isNot(contains('factory Test.fromJson(String')));
+    });
+
+    test('integer enum with negative values uses safe variable names', () {
+      final json = {
+        'type': 'integer',
+        'enum': [-1, 0, 1],
+      };
+      final result = renderTestSchema(json);
+      // Negative values would be invalid Dart identifiers (`value-1`);
+      // generator falls back to `valueNeg<abs>`.
+      expect(result, contains('valueNeg1._(-1)'));
+      expect(result, contains('value0._(0)'));
+      expect(result, contains('value1._(1)'));
     });
 
     test('properties with invalid names', () {

--- a/test/render/render_tree_test.dart
+++ b/test/render/render_tree_test.dart
@@ -662,7 +662,7 @@ void main() {
     });
 
     test('RenderEnum', () {
-      final a = RenderEnum(
+      final a = RenderStringEnum(
         common: const CommonProperties.test(
           snakeName: 'a',
           pointer: JsonPointer.empty(),
@@ -674,7 +674,7 @@ void main() {
       );
       expect(a.equalsIgnoringName(a), isTrue);
 
-      final b = RenderEnum(
+      final b = RenderStringEnum(
         common: const CommonProperties.test(
           snakeName: 'b',
           pointer: JsonPointer.empty(),
@@ -686,7 +686,7 @@ void main() {
       );
       expect(a.equalsIgnoringName(b), isTrue);
 
-      final c = RenderEnum(
+      final c = RenderStringEnum(
         common: const CommonProperties.test(
           snakeName: 'a',
           pointer: JsonPointer.empty(),
@@ -697,6 +697,57 @@ void main() {
         descriptions: null,
       );
       expect(a.equalsIgnoringName(c), isFalse);
+    });
+
+    test('RenderStringEnum and RenderIntEnum with same shape do not '
+        'compare equal (different concrete subtypes)', () {
+      // The runtime-type guard in RenderEnum.equalsIgnoringName keeps
+      // a String-valued enum from being treated as semantically equal
+      // to an Int-valued one even when the names happen to coincide.
+      const common = CommonProperties.test(
+        snakeName: 'foo',
+        pointer: JsonPointer.empty(),
+      );
+      final stringEnum = RenderStringEnum(
+        common: common,
+        names: const ['a'],
+        values: const ['a'],
+        descriptions: null,
+      );
+      final intEnum = RenderIntEnum(
+        common: common,
+        names: const ['a'],
+        values: const [1],
+        descriptions: null,
+      );
+      expect(stringEnum.equalsIgnoringName(intEnum), isFalse);
+    });
+
+    test('RenderIntEnum.invalidJsonExample picks an out-of-range int', () {
+      // The default fallback is `-1` since most spec int enums use
+      // small non-negative values (bitfield flags, component types).
+      // When -1 is somehow in the value set, we step further out.
+      const common = CommonProperties.test(
+        snakeName: 'foo',
+        pointer: JsonPointer.empty(),
+      );
+      final context = SchemaRenderer(
+        templates: TemplateProvider.defaultLocation(),
+      );
+      final ordinary = RenderIntEnum(
+        common: common,
+        names: const ['value1', 'value2'],
+        values: const [1, 2],
+        descriptions: null,
+      );
+      expect(ordinary.invalidJsonExample(context), '-1');
+      final includesNegOne = RenderIntEnum(
+        common: common,
+        names: const ['valueNeg1', 'value0', 'value1'],
+        values: const [-1, 0, 1],
+        descriptions: null,
+      );
+      expect(includesNegOne.invalidJsonExample(context), '-999999');
     });
 
     test('RenderOneOf', () {
@@ -786,7 +837,7 @@ void main() {
         type: PodType.boolean,
         createsNewType: false,
       );
-      final enumKey = RenderEnum(
+      final enumKey = RenderStringEnum(
         common: const CommonProperties.test(
           snakeName: 'platform',
           pointer: JsonPointer.empty(),
@@ -1212,7 +1263,7 @@ void main() {
         minLength: null,
         pattern: null,
       );
-      final keySchema = RenderEnum(
+      final keySchema = RenderStringEnum(
         common: common,
         values: const ['a', 'b'],
         names: const ['a', 'b'],

--- a/test/resolver_test.dart
+++ b/test/resolver_test.dart
@@ -1670,7 +1670,7 @@ void main() {
       });
 
       test('ResolvedEnum', () {
-        final schema1 = ResolvedEnum(
+        final schema1 = ResolvedStringEnum(
           common: CommonProperties.test(
             snakeName: 'Foo',
             pointer: JsonPointer.parse(
@@ -1682,7 +1682,7 @@ void main() {
           defaultValue: null,
           descriptions: null,
         );
-        final schema2 = ResolvedEnum(
+        final schema2 = ResolvedStringEnum(
           common: CommonProperties.test(
             snakeName: 'Foo',
             pointer: JsonPointer.parse(
@@ -1846,10 +1846,22 @@ void main() {
         });
       });
       test('ResolvedEnum', () {
-        final schema = ResolvedEnum(
+        final schema = ResolvedStringEnum(
           common: beforeCommon,
           values: const ['bar', 'baz'],
           defaultValue: null,
+          descriptions: null,
+        );
+        testCopyWith(schema, (schema, copy) {
+          expect(copy.values, equals(schema.values));
+          expect(copy.defaultValue, equals(schema.defaultValue));
+        });
+      });
+      test('ResolvedIntEnum', () {
+        final schema = ResolvedIntEnum(
+          common: beforeCommon,
+          values: const [1, 11, 100],
+          defaultValue: 1,
           descriptions: null,
         );
         testCopyWith(schema, (schema, copy) {


### PR DESCRIPTION
## Summary

OpenAPI specs occasionally declare enums on `type: integer` rather than the more common `type: string`. Discord's spec uses 132 such sites — most as single-value tags (`enum: [N]`) on oneOf variants, the same role github fills with single-value strings. Until now, `_handleEnum` in the parser hard-threw `UnimplementedError` on the first integer enum, which blocked the entire Discord regen.

This PR generalizes enum support across parse / resolve / render layers, mirroring the existing `SchemaNumeric<T>` / `SchemaInteger` / `SchemaNumber` pattern: a parameterized abstract base + two concrete subclasses pinning `T` to `String` or `int`.

## Type design

```dart
abstract class SchemaEnum<T extends Object> extends Schema { ... }
class SchemaStringEnum extends SchemaEnum<String> { ... }
class SchemaIntEnum    extends SchemaEnum<int> { ... }
```

Same shape at every layer:
- `ResolvedEnum<T>` / `ResolvedStringEnum` / `ResolvedIntEnum`
- `RenderEnum<T>` / `RenderStringEnum` / `RenderIntEnum`

Polymorphic walkers match on the abstract base; type-specific code switches on the concrete subclass.

`ResolvedDiscriminator.mapping` and `RenderDiscriminator.mapping` generalize from `Map<String, …>` to `Map<Object, …>` to carry int keys; the implicit-discriminator picker rejects collections whose variants disagree on tag value type, so within one mapping the keys are always uniform.

## Render output

Single-value int enum at `{type: integer, enum: [1]}` renders as:

```dart
enum CreateLobbyRequestFlagsOneOf1 {
  value1._(1);

  const CreateLobbyRequestFlagsOneOf1._(this.value);

  factory CreateLobbyRequestFlagsOneOf1.fromJson(int json) => ...;
  static CreateLobbyRequestFlagsOneOf1? maybeFromJson(int? json) => ...;

  final int value;
  int toJson() => value;

  @override
  String toString() => value.toString();
}
```

Variant names default to `value<N>` (`value1`, `value11`, `valueNeg1` for negatives) — int values aren't valid Dart identifiers on their own.

## Test plan

- [x] `dart test` — all 481 passing (4 new tests: int-enum parse, int-enum + non-int values is a spec error, int-enum render, int-enum negative-value variable names)
- [x] `dart analyze` clean
- [x] github regen still clean, 3 stubs unchanged, 6100 generated round-trip tests pass. Diff vs `main` is exclusively doc-comment wording changes from the template — functionally byte-identical
- [x] Discord parses past the integer-enum blocker for the first time. Still hits the `validatePattern` issue at the next layer (327 sites; separate next-PR gap)