### PR TITLE
fix: validate newtype-typed parameters via .value at the call site

### DIFF
--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -1011,7 +1011,17 @@ class Endpoint implements ToTemplateContext {
     for (final parameter in parameters) {
       final dartName = parameter.dartParameterName(quirks);
       final isNullable = !parameter.isRequired;
-      final nameCall = isNullable ? '$dartName?.' : '$dartName.';
+      // Newtype-typed parameters (e.g. github's `WaitTimer extends
+      // int`, Discord's `SnowflakeType extends String`) are extension
+      // types — they don't expose the underlying type's `validateXxx`
+      // helpers, so the call has to navigate through `.value` to
+      // reach the wrapped String/num. Non-newtype params receive
+      // `validateXxx` directly via Dart's extension-on-String /
+      // extension-on-num imports.
+      final accessor = parameter.type.createsNewType ? 'value.' : '';
+      final nameCall = isNullable
+          ? '$dartName?.$accessor'
+          : '$dartName.$accessor';
       for (final call in parameter.validationCalls) {
         statements.add('$nameCall$call;');
       }

--- a/lib/src/string.dart
+++ b/lib/src/string.dart
@@ -155,7 +155,18 @@ bool isReservedWord(String word) {
 }
 
 String quoteString(String string) {
-  return "'${string.replaceAll("'", r"\'")}'";
+  // Escape `\` first so we don't double-escape the backslashes added by
+  // the `'` and `$` escapes below. `$` needs escaping because Dart
+  // single-quoted strings interpolate on `$` (regex patterns like
+  // `^(0|[1-9][0-9]*)$` would otherwise be a syntax error). `dart fix`
+  // converts the resulting `'\\$'`-form to a raw string `r'$'` for
+  // patterns that don't contain `'`, so the user-visible output reads
+  // cleanly even though the raw template emits the escape form.
+  final escaped = string
+      .replaceAll(r'\', r'\\')
+      .replaceAll("'", r"\'")
+      .replaceAll(r'$', r'\$');
+  return "'$escaped'";
 }
 
 extension CapitalizeString on String {

--- a/test/render/render_operation_test.dart
+++ b/test/render/render_operation_test.dart
@@ -1136,7 +1136,7 @@ void main() {
         '    ) async {\n'
         '        foo?.validateMaximumLength(10);\n'
         '        foo?.validateMinimumLength(1);\n'
-        "        foo?.validatePattern('^[a-z]+\$');\n"
+        "        foo?.validatePattern('^[a-z]+\\\$');\n"
         '        bar?.validateMaximum(10);\n'
         '        bar?.validateMinimum(1);\n'
         '        bar?.validateExclusiveMaximum(10);\n'
@@ -1163,6 +1163,69 @@ void main() {
         '        }\n'
         '    }\n'
         '}\n',
+      );
+    });
+
+    test('validation calls on newtype params splice .value', () {
+      // Discord's snowflake IDs are top-level `type: string` schemas
+      // with a regex pattern; they parse as newtypes (extension types
+      // around `String`). The generated `validatePattern` extension
+      // method is on `String`, not the extension type, so the call
+      // has to navigate `.value` to reach the wrapped String. Pre-fix
+      // the generator emitted `applicationId.validatePattern(...)`
+      // which doesn't compile.
+      final spec = {
+        'openapi': '3.0.0',
+        'info': {'title': 'Test', 'version': '1.0.0'},
+        'servers': [
+          {'url': 'https://api.spacetraders.io/v2'},
+        ],
+        'paths': {
+          '/users': {
+            'get': {
+              'summary': 'Get by id',
+              'parameters': [
+                {
+                  'name': 'snowflake',
+                  'in': 'query',
+                  'required': true,
+                  'schema': {r'$ref': '#/components/schemas/Snowflake'},
+                },
+                {
+                  'name': 'maybeSnowflake',
+                  'in': 'query',
+                  'schema': {r'$ref': '#/components/schemas/Snowflake'},
+                },
+              ],
+              'responses': {
+                '200': {'description': 'OK'},
+              },
+            },
+          },
+        },
+        'components': {
+          'schemas': {
+            'Snowflake': {
+              'type': 'string',
+              'pattern': r'^[0-9]+$',
+            },
+          },
+        },
+      };
+      final result = renderTestApiFromSpec(
+        specJson: spec,
+        serverUrl: Uri.parse('https://api.spacetraders.io/v2'),
+        specUrl: Uri.parse('file:///spec.yaml'),
+      );
+      // Required newtype param: `snowflake.value.validatePattern(...)`.
+      expect(
+        result,
+        contains("snowflake.value.validatePattern('^[0-9]+\\\$');"),
+      );
+      // Nullable newtype param: `maybeSnowflake?.value.validatePattern(...)`.
+      expect(
+        result,
+        contains("maybeSnowflake?.value.validatePattern('^[0-9]+\\\$');"),
       );
     });
 


### PR DESCRIPTION
## Summary

When an OpenAPI parameter is typed as a newtype (e.g. github's `WaitTimer extends int`, Discord's `SnowflakeType extends String`), the generated Dart was uncompilable:

```dart
// applicationId: SnowflakeType (extension type around String)
applicationId.validatePattern('^...$');  // ✗ method doesn't exist on extension type
```

The `validatePattern` extension method is on `String`, not on the extension type, so the call doesn't resolve. **327 such call sites** in Discord's `default_api.dart` alone. github doesn't trip this in the regen today — none of its newtypes get used as parameters with validation rules. Discord finds it for the first time.

Fix splices `.value.` between the param name and the validation call:

```dart
// After:
applicationId.value.validatePattern('^...$');  // ✓
```

Non-newtype params are unchanged.

## Quote escape

Discord's snowflake pattern `^(0|[1-9][0-9]*)$` was being emitted with single-quoted Dart string `'^(0|[1-9][0-9]*)$'` — invalid because Dart's parser sees `$` and tries to interpolate. Fix escapes `$` (and `\\` for correctness with literal backslashes) in `quoteString`. `dart fix . --apply` auto-converts the resulting `'\\$'`-form to a raw string `r'^(0|[1-9][0-9]*)$'`, so the user-visible regen reads cleanly.

## Why this approach

I first tried moving validation into the newtype's constructor (`SnowflakeType(value) { value.validatePattern(...); }`), so the newtype is "always valid." That's more idiomatic but broke synthesized round-trip tests because the example value `'example'` doesn't satisfy a 40-char hex regex. Backing out to the simpler call-site fix matches existing behavior for non-newtype params and keeps the diff small. We may revisit constructor-validation later by making example values respect their schema's rules — separate PR.

## Test plan

- [x] `dart test` — 489 passing (1 new test pinning `.value.` splice for required + nullable newtype params)
- [x] `dart analyze` clean on the github regen, all 6100 generated round-trip tests still pass — github doesn't have any newtype-with-validation parameters in its API surface, so the regen is functionally byte-identical (modulo the `\\$`-escape on the one validatePattern test fixture).
- [x] Discord regen progresses past the 327 `validatePattern` errors. Remaining Discord blockers (`ambiguous_export` for Guild/ThreadSearchResponse, scattered `cascade_invocations`) are separate gaps.