### PR TITLE
fix: synthesize valid example values; validate newtypes in their own constructor

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -52,3 +52,4 @@ words:
   - bitfield
   - ints
   - fixnum
+  - codeowners

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -2885,7 +2885,7 @@ class RenderString extends RenderSchema {
   String validStringExample() {
     final fromSpec = _firstStringExample(common);
     if (fromSpec != null) return fromSpec;
-    return _synthesizeStringSatisfying(
+    return synthesizeStringSatisfying(
       pattern: pattern,
       minLength: minLength,
       maxLength: maxLength,
@@ -2924,7 +2924,8 @@ String? _firstStringExample(CommonProperties common) {
 /// padded `'example'` when no candidate matches — callers should still
 /// surface this to the user (it's better than silently emitting a
 /// constructor call that throws at synthesized-test time).
-String _synthesizeStringSatisfying({
+@visibleForTesting
+String synthesizeStringSatisfying({
   String? pattern,
   int? minLength,
   int? maxLength,
@@ -2934,7 +2935,7 @@ String _synthesizeStringSatisfying({
     final maxL = maxLength;
     var out = s;
     if (out.length < minL) {
-      final padChar = out.isEmpty ? 'x' : out[out.length - 1];
+      final padChar = out[out.length - 1];
       out = out + padChar * (minL - out.length);
     }
     if (maxL != null && out.length > maxL) {

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -130,6 +130,24 @@ Iterable<String> wrapDocComment(String value, {int indent = 0}) {
   ).map((line) => '$prefix$line');
 }
 
+/// Format a list of `validateXxx(...)` extension-method calls as the
+/// body of a newtype constructor. Single call: `<receiver>.<call>;`.
+/// Multiple calls: a `<receiver>` cascade chain so the
+/// `cascade_invocations` lint doesn't fire on the duplicated receiver.
+@visibleForTesting
+String validationBody(List<String> calls, {required String receiver}) {
+  if (calls.isEmpty) return '';
+  if (calls.length == 1) {
+    return '$receiver.${calls.first};';
+  }
+  final buffer = StringBuffer(receiver);
+  for (final call in calls) {
+    buffer.write('\n      ..$call');
+  }
+  buffer.write(';');
+  return buffer.toString();
+}
+
 /// Renders a two-part class-member doc comment that fits 80 cols
 /// even when long flattened type names would otherwise push the
 /// single-line form past the lint. Emits `/// $single` when the
@@ -1009,6 +1027,15 @@ class Endpoint implements ToTemplateContext {
   List<String> validationStatements(Quirks quirks) {
     final statements = <String>[];
     for (final parameter in parameters) {
+      // Newtype-typed parameters (e.g. github's `WaitTimer extends
+      // int`, Discord's `SnowflakeType extends String`) validate
+      // their wrapped value once in the newtype's own constructor —
+      // emitting per-call validation here would call `validateXxx`
+      // on the extension type, where the extension method doesn't
+      // resolve. Non-newtype params stay validated at the API
+      // boundary because their underlying String / num is the param
+      // type itself.
+      if (parameter.type.createsNewType) continue;
       final dartName = parameter.dartParameterName(quirks);
       final isNullable = !parameter.isRequired;
       final nameCall = isNullable ? '$dartName?.' : '$dartName.';
@@ -2757,11 +2784,16 @@ class RenderString extends RenderSchema {
   }
 
   @override
-  Map<String, dynamic> toTemplateContext(SchemaRenderer context) => {
-    'doc_comment': createDocComment(common: common),
-    'typeName': typeName,
-    'nullableTypeName': nullableTypeName(context),
-  };
+  Map<String, dynamic> toTemplateContext(SchemaRenderer context) {
+    final calls = validationCalls.toList();
+    return {
+      'doc_comment': createDocComment(common: common),
+      'typeName': typeName,
+      'nullableTypeName': nullableTypeName(context),
+      'hasValidations': calls.isNotEmpty,
+      'validationBody': validationBody(calls, receiver: 'value'),
+    };
+  }
 
   @override
   String? get wrapperTag => createsNewType ? null : 'String';
@@ -2840,9 +2872,98 @@ class RenderString extends RenderSchema {
       minLength == other.minLength &&
       super.equalsIgnoringName(other);
 
+  /// A literal `String` value that satisfies this schema's
+  /// validations (`pattern`, `minLength`, `maxLength`). Returns `null`
+  /// when synthesis can't produce a value the spec author would
+  /// recognize as legal — callers fall through to a generic
+  /// placeholder. The synthesizer prefers the spec's own `example` or
+  /// first `examples` entry (assumed valid by the author); failing
+  /// that, it tries simple character-class candidates against the
+  /// declared pattern; failing that, returns `'example'` padded /
+  /// truncated to fit the length range.
+  @visibleForTesting
+  String validStringExample() {
+    final fromSpec = _firstStringExample(common);
+    if (fromSpec != null) return fromSpec;
+    return _synthesizeStringSatisfying(
+      pattern: pattern,
+      minLength: minLength,
+      maxLength: maxLength,
+    );
+  }
+
   @override
-  String? exampleValue(SchemaRenderer context) =>
-      createsNewType ? "$typeName('example')" : "'example'";
+  String? exampleValue(SchemaRenderer context) {
+    final value = validStringExample();
+    return createsNewType
+        ? '$typeName(${quoteString(value)})'
+        : quoteString(value);
+  }
+}
+
+/// Pick the first `String`-typed entry from `common.example` or
+/// `common.examples`. OpenAPI lets the spec author declare both; we
+/// trust either as a valid representation for the schema's
+/// validations.
+String? _firstStringExample(CommonProperties common) {
+  final ex = common.example;
+  if (ex is String) return ex;
+  final examples = common.examples;
+  if (examples != null) {
+    for (final e in examples) {
+      if (e is String) return e;
+    }
+  }
+  return null;
+}
+
+/// Best-effort string synthesis from validation rules. Uses Dart's
+/// `RegExp` at codegen time to test candidate values; the candidates
+/// cover the patterns we've actually seen in real specs (github's
+/// `^[0-9a-fA-F]+$`, Discord's `^(0|[1-9][0-9]*)$`, etc.). Returns a
+/// padded `'example'` when no candidate matches — callers should still
+/// surface this to the user (it's better than silently emitting a
+/// constructor call that throws at synthesized-test time).
+String _synthesizeStringSatisfying({
+  String? pattern,
+  int? minLength,
+  int? maxLength,
+}) {
+  String resize(String s) {
+    final minL = minLength ?? 0;
+    final maxL = maxLength;
+    var out = s;
+    if (out.length < minL) {
+      final padChar = out.isEmpty ? 'x' : out[out.length - 1];
+      out = out + padChar * (minL - out.length);
+    }
+    if (maxL != null && out.length > maxL) {
+      out = out.substring(0, maxL);
+    }
+    return out;
+  }
+
+  if (pattern == null) return resize('example');
+  final RegExp regex;
+  try {
+    regex = RegExp(pattern);
+  } on FormatException {
+    // Spec-author-provided regex didn't parse. Fall through.
+    return resize('example');
+  }
+  // Try a small set of common candidates.
+  final targetLen = (minLength ?? 1).clamp(1, 256);
+  final candidates = <String>[
+    'a' * targetLen, // covers `[0-9a-fA-F]+`, `[a-z]+`, etc.
+    '0' * targetLen, // covers `[0-9]+`, `^(0|...)$`.
+    '1' * targetLen, // covers `^[1-9][0-9]*$`-leading patterns.
+    'example', // simple case for unconstrained patterns.
+    resize('example'),
+  ];
+  for (final c in candidates) {
+    if (regex.hasMatch(c)) return resize(c);
+  }
+  return resize('example');
 }
 
 abstract class RenderNumeric<T extends num> extends RenderSchema {
@@ -2924,6 +3045,7 @@ abstract class RenderNumeric<T extends num> extends RenderSchema {
         '$runtimeType.toTemplateContext called for non-new type: $this',
       );
     }
+    final calls = validationCalls.toList();
     return {
       'doc_comment': createDocComment(common: common),
       'typeName': typeName,
@@ -2931,6 +3053,8 @@ abstract class RenderNumeric<T extends num> extends RenderSchema {
       'jsonType': jsonStorageType(isNullable: false),
       'nullableTypeName': nullableTypeName(context),
       'jsonToDartCall': jsonToDartCall(jsonIsNullable: false),
+      'hasValidations': calls.isNotEmpty,
+      'validationBody': validationBody(calls, receiver: 'value'),
     };
   }
 
@@ -3046,8 +3170,10 @@ class RenderNumber extends RenderNumeric<double> {
       jsonIsNullable ? '?.toDouble()' : '.toDouble()';
 
   @override
-  String? exampleValue(SchemaRenderer context) =>
-      createsNewType ? '$typeName(0.0)' : '0.0';
+  String? exampleValue(SchemaRenderer context) {
+    final value = _validNumberExample(common, this).toString();
+    return createsNewType ? '$typeName($value)' : value;
+  }
 }
 
 class RenderInteger extends RenderNumeric<int> {
@@ -3086,8 +3212,53 @@ class RenderInteger extends RenderNumeric<int> {
   String jsonToDartCall({required bool jsonIsNullable}) => '';
 
   @override
-  String? exampleValue(SchemaRenderer context) =>
-      createsNewType ? '$typeName(0)' : '0';
+  String? exampleValue(SchemaRenderer context) {
+    final value = _validNumberExample(common, this).toInt().toString();
+    return createsNewType ? '$typeName($value)' : value;
+  }
+}
+
+/// Pick a numeric value satisfying [schema]'s declared bounds. Prefers
+/// the spec's own `example` / `examples` (assumed valid by the
+/// author); otherwise picks `minimum`, then `0` if `0` is in range,
+/// falling back to a value derived from `maximum`. `multipleOf` is
+/// honored as a final adjustment. Used by both
+/// [RenderNumber.exampleValue] and [RenderInteger.exampleValue]
+/// because the rules are uniform across the two — only the literal's
+/// rendered form differs.
+num _validNumberExample(CommonProperties common, RenderNumeric<num> schema) {
+  num? candidateFromSpec() {
+    final ex = common.example;
+    if (ex is num) return ex;
+    final examples = common.examples;
+    if (examples != null) {
+      for (final e in examples) {
+        if (e is num) return e;
+      }
+    }
+    return null;
+  }
+
+  num pick() {
+    final fromSpec = candidateFromSpec();
+    if (fromSpec != null) return fromSpec;
+    // Inclusive bound takes precedence over exclusive when both
+    // appear (rare in practice — they overlap conceptually).
+    final lo = schema.minimum ?? schema.exclusiveMinimum;
+    final hi = schema.maximum ?? schema.exclusiveMaximum;
+    if (lo != null) return lo;
+    if (hi != null && hi < 0) return hi;
+    return 0;
+  }
+
+  var v = pick();
+  final multiple = schema.multipleOf;
+  if (multiple != null && multiple != 0) {
+    // Round to nearest multiple at or above the candidate.
+    final n = (v / multiple).ceil();
+    v = n * multiple;
+  }
+  return v;
 }
 
 class RenderObject extends RenderNewType {

--- a/lib/src/render/schema_renderer.dart
+++ b/lib/src/render/schema_renderer.dart
@@ -13,6 +13,7 @@ import 'package:space_gen/src/render/templates.dart';
 class SchemaUsage {
   const SchemaUsage({
     this.usesMetaAnnotations = false,
+    this.usesValidationExtensions = false,
     this.modelHelpers = const {},
   });
 
@@ -20,6 +21,7 @@ class SchemaUsage {
   factory SchemaUsage.fromBody(String body) {
     return SchemaUsage(
       usesMetaAnnotations: body.contains('@immutable'),
+      usesValidationExtensions: _validationCallPattern.hasMatch(body),
       modelHelpers: {
         for (final h in ModelHelpers.all)
           if (body.contains(h)) h,
@@ -27,7 +29,21 @@ class SchemaUsage {
     );
   }
 
+  /// Matches any `validateXxx` extension-method call. The
+  /// `api_exception.dart` file declares them as extensions on
+  /// `String` / `num` / `List<T>`; a body that calls one needs to
+  /// import that file.
+  static final _validationCallPattern = RegExp(
+    r'\.validate(Maximum|Minimum|MaximumLength|MinimumLength|Pattern|'
+    'ExclusiveMaximum|ExclusiveMinimum|MultipleOf|MaximumItems|'
+    'MinimumItems|UniqueItems)' r'\b',
+  );
+
   final bool usesMetaAnnotations;
+
+  /// True when the body calls any `validateXxx` extension method.
+  /// Drives the `api_exception.dart` import.
+  final bool usesValidationExtensions;
 
   /// The set of `model_helpers.dart` identifiers referenced by the
   /// rendered body. A subset of [ModelHelpers.all].
@@ -41,6 +57,9 @@ class SchemaUsage {
     if (usesMetaAnnotations) yield const Import('package:meta/meta.dart');
     if (usesModelHelpers) {
       yield Import('package:$packageName/model_helpers.dart');
+    }
+    if (usesValidationExtensions) {
+      yield Import('package:$packageName/api_exception.dart');
     }
   }
 }

--- a/lib/src/render/schema_renderer.dart
+++ b/lib/src/render/schema_renderer.dart
@@ -36,7 +36,8 @@ class SchemaUsage {
   static final _validationCallPattern = RegExp(
     r'\.validate(Maximum|Minimum|MaximumLength|MinimumLength|Pattern|'
     'ExclusiveMaximum|ExclusiveMinimum|MultipleOf|MaximumItems|'
-    'MinimumItems|UniqueItems)' r'\b',
+    'MinimumItems|UniqueItems)'
+    r'\b',
   );
 
   final bool usesMetaAnnotations;

--- a/lib/src/string.dart
+++ b/lib/src/string.dart
@@ -155,7 +155,21 @@ bool isReservedWord(String word) {
 }
 
 String quoteString(String string) {
-  return "'${string.replaceAll("'", r"\'")}'";
+  // Escape `\` first so we don't double-escape the backslashes added
+  // by the `'`, `$`, `\n`, `\r` escapes below. `$` needs escaping
+  // because Dart single-quoted strings interpolate on `$` (regex
+  // patterns like `^(0|[1-9][0-9]*)$` would otherwise be a syntax
+  // error). Newlines need escaping because Dart single-quoted strings
+  // can't span multiple lines (some spec examples contain literal
+  // `\n`s — github's `codeowners-errors.errors[].message` is a
+  // formatted multi-line string).
+  final escaped = string
+      .replaceAll(r'\', r'\\')
+      .replaceAll("'", r"\'")
+      .replaceAll(r'$', r'\$')
+      .replaceAll('\n', r'\n')
+      .replaceAll('\r', r'\r');
+  return "'$escaped'";
 }
 
 extension CapitalizeString on String {

--- a/lib/templates/schema_number_newtype.mustache
+++ b/lib/templates/schema_number_newtype.mustache
@@ -1,5 +1,12 @@
 {{{ doc_comment }}}extension type const {{{ typeName }}}._({{dartType}} value) {
+{{#hasValidations}}
+    {{ typeName }}(this.value) {
+        {{{ validationBody }}}
+    }
+{{/hasValidations}}
+{{^hasValidations}}
     const {{ typeName }}(this.value);
+{{/hasValidations}}
 
     factory {{ typeName }}.fromJson({{jsonType}} json) => {{ typeName }}(json{{jsonToDartCall}});
 

--- a/lib/templates/schema_string_newtype.mustache
+++ b/lib/templates/schema_string_newtype.mustache
@@ -1,5 +1,12 @@
 {{{ doc_comment }}}extension type const {{{ typeName }}}._(String value) {
+{{#hasValidations}}
+    {{ typeName }}(this.value) {
+        {{{ validationBody }}}
+    }
+{{/hasValidations}}
+{{^hasValidations}}
     const {{ typeName }}(this.value);
+{{/hasValidations}}
 
     factory {{ typeName }}.fromJson(String json) => {{ typeName }}(json);
 

--- a/test/render/file_renderer_test.dart
+++ b/test/render/file_renderer_test.dart
@@ -2700,6 +2700,32 @@ void main() {
       });
     });
 
+    test('SchemaUsage.fromBody detects validateXxx calls and adds the '
+        'api_exception.dart import', () {
+      // Newtype constructors call `value.validateMaximumLength(40)` etc.
+      // SchemaUsage scans the body string and adds the api_exception
+      // import when any `validateXxx` shows up — the extensions live
+      // there, so the file needs the import.
+      final usage = SchemaUsage.fromBody(
+        r"Foo(this.value) { value.validatePattern('^...$'); }",
+      );
+      expect(usage.usesValidationExtensions, isTrue);
+      expect(
+        usage.importsFor('spacetraders'),
+        contains(const Import('package:spacetraders/api_exception.dart')),
+      );
+    });
+
+    test('SchemaUsage.fromBody does not add api_exception when no '
+        'validateXxx calls are present', () {
+      final usage = SchemaUsage.fromBody('class Foo { final int x; }');
+      expect(usage.usesValidationExtensions, isFalse);
+      expect(
+        usage.importsFor('spacetraders'),
+        isNot(contains(const Import('package:spacetraders/api_exception.dart'))),
+      );
+    });
+
     test('imports for api', () {
       final templates = TemplateProvider.defaultLocation();
       final schemaRenderer = SchemaRenderer(templates: templates);

--- a/test/render/file_renderer_test.dart
+++ b/test/render/file_renderer_test.dart
@@ -2722,7 +2722,9 @@ void main() {
       expect(usage.usesValidationExtensions, isFalse);
       expect(
         usage.importsFor('spacetraders'),
-        isNot(contains(const Import('package:spacetraders/api_exception.dart'))),
+        isNot(
+          contains(const Import('package:spacetraders/api_exception.dart')),
+        ),
       );
     });
 

--- a/test/render/render_operation_test.dart
+++ b/test/render/render_operation_test.dart
@@ -1136,7 +1136,7 @@ void main() {
         '    ) async {\n'
         '        foo?.validateMaximumLength(10);\n'
         '        foo?.validateMinimumLength(1);\n'
-        "        foo?.validatePattern('^[a-z]+\$');\n"
+        "        foo?.validatePattern('^[a-z]+\\\$');\n"
         '        bar?.validateMaximum(10);\n'
         '        bar?.validateMinimum(1);\n'
         '        bar?.validateExclusiveMaximum(10);\n'

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -3925,11 +3925,20 @@ void main() {
           'exclusiveMinimum': 9,
           'exclusiveMaximum': 0,
         };
-        // named schemas get their own class and thus include validations.
+        // Named schemas get their own newtype and validate each rule
+        // in the constructor body via a `value` cascade. `dart format`
+        // re-indents this cleanly in the user-visible regen.
         expect(
           renderTestSchema(json, asComponent: true),
           'extension type const Test._(int value) {\n'
-          '    const Test(this.value);\n'
+          '    Test(this.value) {\n'
+          '        value\n'
+          '      ..validateMaximum(10)\n'
+          '      ..validateMinimum(1)\n'
+          '      ..validateExclusiveMaximum(0)\n'
+          '      ..validateExclusiveMinimum(9)\n'
+          '      ..validateMultipleOf(2);\n'
+          '    }\n'
           '\n'
           '    factory Test.fromJson(int json) => Test(json);\n'
           '\n'
@@ -3972,7 +3981,12 @@ void main() {
         expect(
           renderTestSchema(json, asComponent: true),
           'extension type const Test._(double value) {\n'
-          '    const Test(this.value);\n'
+          '    Test(this.value) {\n'
+          '        value\n'
+          '      ..validateMaximum(10.2)\n'
+          '      ..validateMinimum(1.2)\n'
+          '      ..validateMultipleOf(2.2);\n'
+          '    }\n'
           '\n'
           '    factory Test.fromJson(num json) => Test(json.toDouble());\n'
           '\n'
@@ -3995,7 +4009,9 @@ void main() {
         expect(
           renderTestSchema(json, asComponent: true),
           'extension type const Test._(double value) {\n'
-          '    const Test(this.value);\n'
+          '    Test(this.value) {\n'
+          '        value.validateMaximum(10.2);\n'
+          '    }\n'
           '\n'
           '    factory Test.fromJson(num json) => Test(json.toDouble());\n'
           '\n'
@@ -4075,7 +4091,9 @@ void main() {
         expect(
           renderTestSchema(json, asComponent: true),
           'extension type const Test._(int value) {\n'
-          '    const Test(this.value);\n'
+          '    Test(this.value) {\n'
+          '        value.validateMinimum(0);\n'
+          '    }\n'
           '\n'
           '    factory Test.fromJson(int json) => Test(json);\n'
           '\n'
@@ -4652,17 +4670,25 @@ void main() {
   });
 
   group('string validations', () {
-    test('maxLength and minLength can be const in named string', () {
+    test('maxLength and minLength validate in named string constructor', () {
       final json = {
         'type': 'string',
         'default': 'foo',
         'maxLength': 10,
         'minLength': 1,
       };
+      // Length validations move into the constructor body so the
+      // newtype enforces them once at construction. Multiple calls
+      // emit as a `value` cascade chain to satisfy the
+      // `cascade_invocations` lint.
       expect(
         renderTestSchema(json, asComponent: true),
         'extension type const Test._(String value) {\n'
-        '    const Test(this.value);\n'
+        '    Test(this.value) {\n'
+        '        value\n'
+        '      ..validateMaximumLength(10)\n'
+        '      ..validateMinimumLength(1);\n'
+        '    }\n'
         '\n'
         '    factory Test.fromJson(String json) => Test(json);\n'
         '\n'

--- a/test/render/render_tree_test.dart
+++ b/test/render/render_tree_test.dart
@@ -1496,7 +1496,7 @@ void main() {
     });
 
     test('null pattern pads "example" to minLength using last char', () {
-      expect(synthesizeStringSatisfying(minLength: 10), 'exampleeee');
+      expect(synthesizeStringSatisfying(minLength: 10), "example${'e' * 3}");
     });
 
     test('null pattern truncates "example" to maxLength', () {
@@ -1506,7 +1506,7 @@ void main() {
     test('invalid regex falls back to padded "example"', () {
       expect(
         synthesizeStringSatisfying(pattern: '(', minLength: 10),
-        'exampleeee',
+        "example${'e' * 3}",
       );
     });
 
@@ -1559,7 +1559,7 @@ void main() {
       // arm which returns `resize('example')`.
       expect(
         synthesizeStringSatisfying(pattern: r'^Z+$', minLength: 10),
-        'exampleeee',
+        "example${'e' * 3}",
       );
     });
   });

--- a/test/render/render_tree_test.dart
+++ b/test/render/render_tree_test.dart
@@ -1278,6 +1278,216 @@ void main() {
       // Key example is the enum's first value; value is the string example.
       expect(map.exampleValue(context), "{Foo.values.first: 'example'}");
     });
+
+    test('string with spec example uses it verbatim', () {
+      const schema = RenderString(
+        common: CommonProperties.test(
+          snakeName: 'foo',
+          pointer: JsonPointer.empty(),
+          example: 'refs/heads/main',
+        ),
+        defaultValue: null,
+        maxLength: null,
+        minLength: null,
+        pattern: r'^refs/(heads|tags|pull)/.*$',
+        createsNewType: false,
+      );
+      expect(schema.exampleValue(context), "'refs/heads/main'");
+    });
+
+    test('string falls back to first String entry from examples list', () {
+      const schema = RenderString(
+        common: CommonProperties.test(
+          snakeName: 'foo',
+          pointer: JsonPointer.empty(),
+          examples: [42, 'second'],
+        ),
+        defaultValue: null,
+        maxLength: null,
+        minLength: null,
+        pattern: null,
+        createsNewType: false,
+      );
+      expect(schema.exampleValue(context), "'second'");
+    });
+
+    test('string synthesizes a value matching simple character-class '
+        'pattern, padded to minLength', () {
+      // github's `code-scanning-analysis-commit-sha`: no spec example,
+      // pattern is `^[0-9a-fA-F]+\$`, minLength = 40. Synthesizer
+      // tries `'a' * 40` against the regex — `a` is in `[0-9a-fA-F]`,
+      // length matches → pass.
+      const schema = RenderString(
+        common: CommonProperties.test(
+          snakeName: 'foo',
+          pointer: JsonPointer.empty(),
+        ),
+        defaultValue: null,
+        maxLength: 40,
+        minLength: 40,
+        pattern: r'^[0-9a-fA-F]+$',
+        createsNewType: false,
+      );
+      expect(schema.exampleValue(context), "'${'a' * 40}'");
+    });
+
+    test('string synthesizes for an alternation pattern by trying '
+        'numeric candidates', () {
+      // Discord's snowflake pattern.
+      const schema = RenderString(
+        common: CommonProperties.test(
+          snakeName: 'foo',
+          pointer: JsonPointer.empty(),
+        ),
+        defaultValue: null,
+        maxLength: null,
+        minLength: null,
+        pattern: r'^(0|[1-9][0-9]*)$',
+        createsNewType: false,
+      );
+      // `'a'` doesn't match; `'0'` does (the 0 alternative).
+      expect(schema.exampleValue(context), "'0'");
+    });
+
+    test('string truncates a too-long fallback to maxLength', () {
+      const schema = RenderString(
+        common: CommonProperties.test(
+          snakeName: 'foo',
+          pointer: JsonPointer.empty(),
+        ),
+        defaultValue: null,
+        maxLength: 4,
+        minLength: null,
+        pattern: null,
+        createsNewType: false,
+      );
+      expect(schema.exampleValue(context), "'exam'");
+    });
+
+    test('string falls back when no candidate matches the pattern', () {
+      // Pattern requires content the synthesizer's candidate set can't
+      // produce — `^Z+\$` won't match `'a'`, `'0'`, `'1'`, or
+      // `'example'`. Synthesizer surfaces a placeholder rather than
+      // throwing.
+      const schema = RenderString(
+        common: CommonProperties.test(
+          snakeName: 'foo',
+          pointer: JsonPointer.empty(),
+        ),
+        defaultValue: null,
+        maxLength: null,
+        minLength: null,
+        pattern: r'^Z+$',
+        createsNewType: false,
+      );
+      expect(schema.exampleValue(context), "'example'");
+    });
+
+    test('string falls back when the spec pattern is invalid regex', () {
+      // Spec author's pattern doesn't parse as a Dart RegExp. Synthesizer
+      // doesn't crash — returns a padded fallback.
+      const schema = RenderString(
+        common: CommonProperties.test(
+          snakeName: 'foo',
+          pointer: JsonPointer.empty(),
+        ),
+        defaultValue: null,
+        maxLength: null,
+        minLength: null,
+        pattern: '(',
+        createsNewType: false,
+      );
+      expect(schema.exampleValue(context), "'example'");
+    });
+
+    test('integer with spec example uses it', () {
+      const schema = RenderInteger(
+        common: CommonProperties.test(
+          snakeName: 'foo',
+          pointer: JsonPointer.empty(),
+          example: 42,
+        ),
+        defaultValue: null,
+        maximum: 100,
+        minimum: 1,
+        exclusiveMaximum: null,
+        exclusiveMinimum: null,
+        multipleOf: null,
+        createsNewType: false,
+      );
+      expect(schema.exampleValue(context), '42');
+    });
+
+    test('integer with no spec example picks minimum', () {
+      const schema = RenderInteger(
+        common: CommonProperties.test(
+          snakeName: 'foo',
+          pointer: JsonPointer.empty(),
+        ),
+        defaultValue: null,
+        maximum: 100,
+        minimum: 5,
+        exclusiveMaximum: null,
+        exclusiveMinimum: null,
+        multipleOf: null,
+        createsNewType: false,
+      );
+      expect(schema.exampleValue(context), '5');
+    });
+
+    test('integer falls back to first num in examples list when example '
+        'absent', () {
+      const schema = RenderInteger(
+        common: CommonProperties.test(
+          snakeName: 'foo',
+          pointer: JsonPointer.empty(),
+          examples: ['not-a-number', 7, 9],
+        ),
+        defaultValue: null,
+        maximum: null,
+        minimum: null,
+        exclusiveMaximum: null,
+        exclusiveMinimum: null,
+        multipleOf: null,
+        createsNewType: false,
+      );
+      expect(schema.exampleValue(context), '7');
+    });
+
+    test('integer with negative max picks the upper bound when zero is '
+        'out of range', () {
+      const schema = RenderInteger(
+        common: CommonProperties.test(
+          snakeName: 'foo',
+          pointer: JsonPointer.empty(),
+        ),
+        defaultValue: null,
+        maximum: -5,
+        minimum: null,
+        exclusiveMaximum: null,
+        exclusiveMinimum: null,
+        multipleOf: null,
+        createsNewType: false,
+      );
+      expect(schema.exampleValue(context), '-5');
+    });
+
+    test('integer rounds candidate up to the next multipleOf', () {
+      const schema = RenderInteger(
+        common: CommonProperties.test(
+          snakeName: 'foo',
+          pointer: JsonPointer.empty(),
+        ),
+        defaultValue: null,
+        maximum: null,
+        minimum: 7,
+        exclusiveMaximum: null,
+        exclusiveMinimum: null,
+        multipleOf: 5,
+        createsNewType: false,
+      );
+      expect(schema.exampleValue(context), '10');
+    });
   });
 
   group('RenderPod newtype', () {

--- a/test/render/render_tree_test.dart
+++ b/test/render/render_tree_test.dart
@@ -1490,6 +1490,80 @@ void main() {
     });
   });
 
+  group('synthesizeStringSatisfying', () {
+    test('null pattern returns "example" verbatim with no length bounds', () {
+      expect(synthesizeStringSatisfying(), 'example');
+    });
+
+    test('null pattern pads "example" to minLength using last char', () {
+      expect(synthesizeStringSatisfying(minLength: 10), 'exampleeee');
+    });
+
+    test('null pattern truncates "example" to maxLength', () {
+      expect(synthesizeStringSatisfying(maxLength: 4), 'exam');
+    });
+
+    test('invalid regex falls back to padded "example"', () {
+      expect(
+        synthesizeStringSatisfying(pattern: '(', minLength: 10),
+        'exampleeee',
+      );
+    });
+
+    test("'a' candidate matches first for [0-9a-fA-F]+", () {
+      expect(
+        synthesizeStringSatisfying(
+          pattern: r'^[0-9a-fA-F]+$',
+          minLength: 6,
+          maxLength: 6,
+        ),
+        'aaaaaa',
+      );
+    });
+
+    test("'0' candidate matches alternation when 'a' does not", () {
+      // `^(0|[1-9][0-9]*)$`: 'a' fails, '0' matches.
+      expect(
+        synthesizeStringSatisfying(pattern: r'^(0|[1-9][0-9]*)$'),
+        '0',
+      );
+    });
+
+    test("'1' candidate matches when 'a' and '0' do not", () {
+      // `^[1-9][0-9]*$`: 'a' fails, '0' fails (leading zero forbidden),
+      // '1' matches with the rest filled in by repeating the digit.
+      expect(
+        synthesizeStringSatisfying(pattern: r'^[1-9][0-9]*$', minLength: 3),
+        '111',
+      );
+    });
+
+    test("'example' candidate matches when single-char repeats do not", () {
+      // `^example$` only matches the literal — none of `'a'`, `'0'`, `'1'`
+      // (length 1) match; `'example'` does.
+      expect(synthesizeStringSatisfying(pattern: r'^example$'), 'example');
+    });
+
+    test('matched candidate is post-resized to fit length bounds', () {
+      // Pattern matches `'a'*N` for any N >= 1; with minLength 5,
+      // targetLen is 5, so `'a' * 5` is tried, matches, returned as-is.
+      expect(
+        synthesizeStringSatisfying(pattern: r'^a+$', minLength: 5),
+        'aaaaa',
+      );
+    });
+
+    test('no candidate matches falls back to padded "example"', () {
+      // `^Z+$`: none of `'a'`, `'0'`, `'1'`, `'example'`, or
+      // `resize('example')` match. Falls through to the literal-fallback
+      // arm which returns `resize('example')`.
+      expect(
+        synthesizeStringSatisfying(pattern: r'^Z+$', minLength: 10),
+        'exampleeee',
+      );
+    });
+  });
+
   group('RenderPod newtype', () {
     final context = SchemaRenderer(
       templates: TemplateProvider.defaultLocation(),


### PR DESCRIPTION
## The bug

OpenAPI parameters typed as a newtype with validations (e.g. Discord's `SnowflakeType extends String` with `pattern: '^(0|[1-9][0-9]*)$'`) generated uncompilable Dart at the API call site:

```dart
applicationId.validatePattern('^...$');  // ✗ method on String, not the extension type
```

**327 such call sites in Discord's `default_api.dart` alone.**

## The principled fix

Validation belongs in the newtype's own constructor — the newtype is always valid by construction. The blocker for that was the synthesized round-trip test:

```dart
const instance = CodeScanningAnalysisCommitSha('example');
//                                              ^^^^^^^^^
//   doesn't match `^[0-9a-fA-F]+$` + length 7 ≠ minLength 40 → throws
```

So this PR **makes example values satisfy their own schema's rules**, which unlocks moving validation into the newtype constructor cleanly.

### exampleValue is now schema-aware

**For `RenderString` newtypes:**
1. Use the spec's `example:` or first `examples:` entry (assumed valid by the author). github's `code-scanning-ref-full` provides `examples: ["refs/heads/main"]` which matches its pattern.
2. Synthesize a candidate that satisfies the regex by testing common character-class candidates (`'a' * N`, `'0' * N`, `'1' * N`, `'example'`) against the pattern via Dart's `RegExp` at codegen time. Resizes to fit `minLength` / `maxLength`. github's `code-scanning-analysis-commit-sha` (no spec example, `pattern: ^[0-9a-fA-F]+$, minLength: 40`) gets 40 `a`s.
3. Falls through to `'example'` resized to length range.

**For `RenderInteger` / `RenderNumber` newtypes:**
1. Use spec's `example:` or first `examples:` entry.
2. Pick `minimum` (or `exclusiveMinimum`); else `0` if zero is in range; else a value derived from `maximum`. Honors `multipleOf`.

### Newtype constructors validate

`schema_string_newtype.mustache` / `schema_number_newtype.mustache` now emit a constructor body when validations exist:

```dart
extension type const SnowflakeType._(String value) {
  SnowflakeType(this.value) {
    value.validatePattern(r'^(0|[1-9][0-9]*)$');
  }
  // ...
}
```

Multi-rule case uses a `value` cascade to satisfy `cascade_invocations`. `const` public constructor is preserved when no validations apply (no behavior change for github's many newtypes without constraints).

### Operation drops per-call validation for newtype params

`Operation.validationStatements` skips parameters whose type is a newtype — the constructor handled it. Non-newtype params still validate at the API boundary as before.

### `quoteString` escapes `$`, `\n`, `\r`

Discord's snowflake pattern `^(0|[1-9][0-9]*)$` was being emitted as `'^(0|[1-9][0-9]*)$'` — invalid Dart (parser tries to interpolate). github's `codeowners-errors.errors[].message` example contains a literal `\n`. The pre-fix `quoteString` only escaped `'`. `dart fix` post-processes to `r'^...$'` for patterns without `'`, so user-visible regen reads cleanly.

### `SchemaUsage.usesValidationExtensions`

Newtype files that emit `validateXxx` calls now import `api_exception.dart`. Detected from the rendered body via regex.

## Test plan

- [x] 488 passing tests; updated 6 snapshot tests for the new constructor body.
- [x] `dart analyze` clean on github regen, all 6100 generated round-trip tests still pass.
- [x] Example values for the two validation-bearing github newtypes now satisfy their rules: `CodeScanningAnalysisCommitSha('aaaa…')` (40 a's, matches `^[0-9a-fA-F]+$`), `CodeScanningRefFull('refs/heads/main')` (from spec).
- [x] Discord regen progresses past 327 `validatePattern` errors. Remaining 4 errors are unrelated (Guild/ThreadSearchResponse export ambiguity, separate gaps).