### PR TITLE
fix: multi-status sealed wrapper name collides with same-named top-level schema

### DIFF
--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -446,6 +446,14 @@ class SpecResolver {
   /// it (e.g. non-newtype schemas like inline arrays/maps).
   String? _nameFor(JsonPointer pointer) => _names.maybeGet(pointer);
 
+  /// Looks up the assigned name for [pointer], asserting the naming
+  /// pass enumerated it. Use at sites where the entity is known to be
+  /// named (e.g. operations always claim `<op>_response`); a `null`
+  /// here means the naming pass missed an entity it should have
+  /// covered. Delegates to [AssignedNames.operator []], which throws
+  /// a `StateError` with the offending pointer.
+  String _requireNameFor(JsonPointer pointer) => _names[pointer];
+
   /// Looks up the assigned snake name for a resolved schema's pointer
   /// — used as a file basename. Paired with [_nameFor]: when one
   /// returns non-null, so does the other.
@@ -791,21 +799,12 @@ class SpecResolver {
       // Without this lookup the wrapper would emit the bare
       // `<op>Response`, shadowing the imported schema in the api file
       // (and re-exporting it ambiguously from `api.dart`).
-      final wrapperTypeName = _nameFor(operation.pointer);
-      if (wrapperTypeName == null) {
-        throw StateError(
-          'Naming pass did not assign a name to operation '
-          '${operation.snakeName} (pointer: ${operation.pointer}). '
-          'Multi-status dispatch needs the synthesized `<op>_response` '
-          'name claimed by `_NameAssigner.visitOperation`.',
-        );
-      }
       return MultiStatusReturn(
         responses: {
           for (final response in explicit2xx)
             response.statusCode: toRenderResponse(response),
         },
-        wrapperTypeName: wrapperTypeName,
+        wrapperTypeName: _requireNameFor(operation.pointer),
       );
     }
     return SingleSchemaReturn(

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -785,11 +785,27 @@ class SpecResolver {
     // `Foo201`), and a range can't be enumerated. Range-mixed cases
     // fall through to the legacy oneOf path for now.
     if (successfulRange.isEmpty) {
+      // Naming pass claims `<op>_response` on the operation's pointer
+      // in phase 1 (see `_NameAssigner.visitOperation`); the allocator
+      // suffixes if a same-named top-level schema also claimed it.
+      // Without this lookup the wrapper would emit the bare
+      // `<op>Response`, shadowing the imported schema in the api file
+      // (and re-exporting it ambiguously from `api.dart`).
+      final wrapperTypeName = _nameFor(operation.pointer);
+      if (wrapperTypeName == null) {
+        throw StateError(
+          'Naming pass did not assign a name to operation '
+          '${operation.snakeName} (pointer: ${operation.pointer}). '
+          'Multi-status dispatch needs the synthesized `<op>_response` '
+          'name claimed by `_NameAssigner.visitOperation`.',
+        );
+      }
       return MultiStatusReturn(
         responses: {
           for (final response in explicit2xx)
             response.statusCode: toRenderResponse(response),
         },
+        wrapperTypeName: wrapperTypeName,
       );
     }
     return SingleSchemaReturn(
@@ -1426,22 +1442,18 @@ class Endpoint implements ToTemplateContext {
   }
 
   /// Build the per-status sealed-class context for a multi-status
-  /// operation. The synthesized class name follows the same
-  /// `<snake>_response` convention (where `<snake>` is the operation's
-  /// snake name) that the legacy oneOf path used, so existing
-  /// regenerated output only shows the dispatch change, not a rename.
+  /// operation. The synthesized class name comes from the naming pass
+  /// (see `MultiStatusReturn.wrapperTypeName`), so a top-level schema
+  /// that already claimed `<op>Response` keeps the bare name and the
+  /// wrapper picks up a `_2`-style suffix.
   ///
   /// Sorting on the status code guarantees `200` ahead of `204` in
   /// the emitted switch regardless of spec ordering.
-  ///
-  /// Synthesized typeName can collide with a schema in the spec named
-  /// `<op>_response`. Not handled here — that's the job of a future
-  /// resolve-stage collision pass that accounts for generated names.
   _MultiStatusContext _buildMultiStatusContext(
     MultiStatusReturn multiStatus,
     SchemaRenderer context,
   ) {
-    final typeName = camelFromSnake('${operation.snakeName}_response');
+    final typeName = multiStatus.wrapperTypeName;
     final sortedEntries = multiStatus.responses.entries.toList()
       ..sort((a, b) => a.key.compareTo(b.key));
     final statuses = [
@@ -1795,13 +1807,24 @@ final class SingleSchemaReturn extends OperationReturn {
 /// right subclass.
 @immutable
 final class MultiStatusReturn extends OperationReturn {
-  const MultiStatusReturn({required this.responses});
+  const MultiStatusReturn({
+    required this.responses,
+    required this.wrapperTypeName,
+  });
 
   /// Status code → response. Carries content-type per status so each
   /// switch arm can pick the right decode (`jsonDecode` vs raw
   /// `response.body`); a `RenderVoid` content signals no body and
   /// produces a value-less wrapper subclass.
   final Map<int, RenderResponse> responses;
+
+  /// Camel-case Dart name for the synthesized sealed class. Pre-resolved
+  /// via the naming pass on the operation's pointer so a top-level
+  /// component schema sharing the un-suffixed `<op>Response` name
+  /// (which Dart-imports into the api file) doesn't shadow itself.
+  /// Per-status subclasses are this name with the status-code suffix
+  /// (`<wrapper>200`, `<wrapper>201`, …).
+  final String wrapperTypeName;
 }
 
 /// Sealed so the endpoint arg-builder can pattern-match exhaustively on

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -4954,5 +4954,89 @@ void main() {
         '}\n',
       );
     });
+
+    test(
+      'multi-status sealed wrapper does not collide with a same-named '
+      'top-level schema',
+      () {
+        // Discord regression: a top-level component schema named e.g.
+        // `ThreadSearchResponse` is the body of an operation's 200
+        // response, and the operation also has a 202 with a different
+        // body — multi-status dispatch synthesizes a sealed wrapper
+        // class. If that wrapper is also named `ThreadSearchResponse`,
+        // the wrapper shadows the imported top-level schema in the
+        // api file (so `ThreadSearchResponse.fromJson(...)` fails to
+        // resolve) and `lib/api.dart` re-exports the same name from
+        // two libraries (`ambiguous_export`).
+        //
+        // The naming pass must claim the synthesized wrapper's name
+        // distinctly from any colliding top-level schema, and the
+        // renderer must read the assigned name back from it (rather
+        // than recompute `<op>Response`).
+        final spec = {
+          'openapi': '3.0.0',
+          'info': {'title': 'Test', 'version': '1.0.0'},
+          'servers': [
+            {'url': 'https://api.example.com'},
+          ],
+          'paths': {
+            '/things/search': {
+              'get': {
+                'operationId': 'thingSearch',
+                'responses': {
+                  '200': {
+                    'description': 'OK',
+                    'content': {
+                      'application/json': {
+                        'schema': {
+                          r'$ref': '#/components/schemas/ThingSearchResponse',
+                        },
+                      },
+                    },
+                  },
+                  '202': {
+                    'description': 'Pending',
+                    'content': {
+                      'application/json': {
+                        'schema': {'type': 'string'},
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          'components': {
+            'schemas': {
+              'ThingSearchResponse': {
+                'type': 'object',
+                'properties': {
+                  'total': {'type': 'integer'},
+                },
+              },
+            },
+          },
+        };
+        final result = renderTestApiFromSpec(
+          specJson: spec,
+          serverUrl: Uri.parse('https://api.example.com'),
+          specUrl: Uri.parse('file:///spec.yaml'),
+        );
+        // The synthesized sealed wrapper must not reuse the top-level
+        // schema's name. It picks up a `_2` suffix from the allocator.
+        expect(result, contains('sealed class ThingSearchResponse2'));
+        expect(result, contains('class ThingSearchResponse2200'));
+        expect(result, contains('class ThingSearchResponse2202'));
+        // The 200 wrapper's `value` is the top-level schema (the
+        // un-suffixed `ThingSearchResponse`), not the local sealed
+        // class. If the names collided, the local class would shadow
+        // the imported one and the field would loop back into itself.
+        expect(result, contains('final ThingSearchResponse value;'));
+        // The synchronous return type and switch-arm fromJson call
+        // also point at the assigned wrapper name.
+        expect(result, contains('Future<ThingSearchResponse2>'));
+        expect(result, contains('ThingSearchResponse.fromJson('));
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary

Closes 4 of Discord's 6 analyze errors. When a top-level component schema is named the same as a multi-status operation's synthesized response wrapper (Discord's `ThreadSearchResponse` schema + `threadSearch` 200/202 operation), the renderer was hard-computing the wrapper class name as `camelFromSnake('${operation.snakeName}_response')` — bypassing the naming pass that already claimed and disambiguated the same string on the operation's pointer.

Symptoms:
- `ambiguous_export` from `lib/api.dart` (same name re-exported from the schema's file and the api file).
- `undefined_method`: inside the api file, the local `sealed class ThreadSearchResponse` shadowed the imported schema, and `ThreadSearchResponse.fromJson(...)` resolved to the sealed class which has no `fromJson`.
- The 200 wrapper subclass had `final ThreadSearchResponse value;` looping back into the local sealed class instead of pointing at the schema body.

## The fix

`MultiStatusReturn` now carries `wrapperTypeName: String`, populated in `_determineReturnShape` from `_nameFor(operation.pointer)` — the same naming-pass lookup every other render path uses. `_buildMultiStatusContext` reads the field instead of recomputing.

The naming pass already claims `<op>_response` on every operation's pointer in phase 1; the allocator's collision handling suffixes one of the colliding claimants (`ThreadSearchResponse2`). Wiring the renderer to consult the allocator activates that path. The previous comment promising "a future resolve-stage collision pass" is now done.

## Test plan
- [x] New unit test in `renderTestApiFromSpec` covering the collision: a `ThingSearchResponse` schema + a `thingSearch` 200/202 operation produces `sealed class ThingSearchResponse2` and the 200 subclass's `value` field is the un-suffixed schema.
- [x] 513 existing tests pass.
- [x] github regen byte-identical — github's `<tag><op>Response` names (`ActionsCreateOrUpdateOrgSecretResponse` etc.) don't collide with any schema, so the allocator returns the same name and behavior is unchanged. All 6100+ generated round-trip tests still pass.
- [x] Discord regen drops from 6 analyze errors to 2 (the remaining 2 are unrelated `cascade_invocations` infos on parameter validation, separate gap).