### PR TITLE
feat: parse OpenAPI 3.1 const as a single-value enum

### DIFF
--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -874,7 +874,8 @@ SchemaEnum<Object>? _handleEnum({
     return null;
   } else if (type == null) {
     final nonNullForInference = enumValues.where((e) => e != null);
-    isInt = nonNullForInference.isNotEmpty &&
+    isInt =
+        nonNullForInference.isNotEmpty &&
         nonNullForInference.every((e) => e is int);
   } else {
     _unimplemented(json, 'enumValues for type=$type');

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -829,26 +829,53 @@ SchemaEnum<Object>? _handleEnum({
   required dynamic defaultValue,
   required CommonProperties common,
 }) {
-  final enumValues = _optional<List<dynamic>>(json, 'enum');
+  // OpenAPI 3.1 / JSON Schema 2020-12: `const: X` is the single-value
+  // form of `enum: [X]`. Discord uses 128+ such sites — most are
+  // single-value tags (`const: 1`) on oneOf variants for implicit
+  // discrimination, the same role github fills with single-value
+  // strings. Treat the two spellings identically before validating.
+  final explicitEnum = _optional<List<dynamic>>(json, 'enum');
+  final constValue = _optional<dynamic>(json, 'const');
+  final List<dynamic>? enumValues;
+  if (explicitEnum != null) {
+    if (constValue != null) {
+      _error(
+        json,
+        "'enum' and 'const' cannot both be set: enum=$explicitEnum, "
+        'const=$constValue',
+      );
+    }
+    enumValues = explicitEnum;
+  } else if (constValue != null) {
+    enumValues = <dynamic>[constValue];
+  } else {
+    enumValues = null;
+  }
   final type = typeAndFormat.type;
   final podType = typeAndFormat.podType;
 
   if (enumValues == null) {
     return null;
   }
-  // String is the default when `type` is omitted (matches the most
-  // common OpenAPI 3.0/3.1 pattern). Integer enums show up in specs
-  // that use them as single-value discriminator tags (Discord's
-  // component types). Boolean enums (e.g. github's `fork: true`)
-  // parse as a non-enum boolean — there's nothing to dispatch on.
+  // Pick string vs int from the declared `type:`, falling back to
+  // value-shape inference when `type:` is absent (Discord's typed-
+  // enum pattern: `type: integer` on the parent + `const: N` on each
+  // oneOf variant, where the variant carries no `type` of its own).
+  // Boolean enums (e.g. github's `fork: true`) have nothing to
+  // dispatch on; bail and let the schema fall through to non-enum
+  // boolean.
   final bool isInt;
-  if (type == null || type == 'string') {
-    isInt = false;
-  } else if (type == 'integer') {
+  if (type == 'integer') {
     isInt = true;
+  } else if (type == 'string') {
+    isInt = false;
   } else if (podType == PodType.boolean) {
     _ignored<String>(json, 'type');
     return null;
+  } else if (type == null) {
+    final nonNullForInference = enumValues.where((e) => e != null);
+    isInt = nonNullForInference.isNotEmpty &&
+        nonNullForInference.every((e) => e is int);
   } else {
     _unimplemented(json, 'enumValues for type=$type');
   }

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -2132,6 +2132,107 @@ void main() {
           ),
         );
       });
+      test('oneOf-of-consts (integer) collapses to SchemaIntEnum', () {
+        // Discord's `MessageComponentTypes` and 60+ similar typed
+        // enums spell themselves as `oneOf: [{const: N, title: ...}]`.
+        // Without collapse, each renders as a sealed class with an
+        // `UnimplementedError` `fromJson` (no discriminator).
+        final json = {
+          'type': 'integer',
+          'oneOf': [
+            {'title': 'JOIN', 'const': 1, 'description': 'Join activity'},
+            {'title': 'SPECTATE', 'const': 2},
+            {'title': 'LISTEN', 'const': 3},
+          ],
+        };
+        final logger = _MockLogger();
+        final schema = runWithLogger(logger, () => parseTestSchema(json));
+        if (schema is! SchemaIntEnum) {
+          fail('Expected SchemaIntEnum, got ${schema.runtimeType}');
+        }
+        expect(schema.enumValues, equals([1, 2, 3]));
+        // Descriptions are plumbed when ANY variant declares one;
+        // missing descriptions become empty strings (parallel to
+        // values).
+        expect(schema.enumDescriptions, equals(['Join activity', '', '']));
+      });
+      test('oneOf-of-consts (string) collapses to SchemaStringEnum', () {
+        final json = {
+          'type': 'string',
+          'oneOf': [
+            {'title': 'EVERYONE', 'const': 'everyone'},
+            {'title': 'ROLES', 'const': 'roles'},
+          ],
+        };
+        final logger = _MockLogger();
+        final schema = runWithLogger(logger, () => parseTestSchema(json));
+        if (schema is! SchemaStringEnum) {
+          fail('Expected SchemaStringEnum, got ${schema.runtimeType}');
+        }
+        expect(schema.enumValues, equals(['everyone', 'roles']));
+        // No variant declared a description: the whole list stays
+        // null rather than a list of empty strings.
+        expect(schema.enumDescriptions, isNull);
+      });
+      test('oneOf with non-const variants does NOT collapse', () {
+        // Real polymorphic oneOf: each variant has its own object
+        // shape. Falls through to `SchemaOneOf`.
+        final json = {
+          'oneOf': [
+            {'type': 'string'},
+            {'type': 'integer'},
+          ],
+        };
+        final schema = parseTestSchema(json);
+        expect(schema, isA<SchemaOneOf>());
+      });
+      test('oneOf-of-consts with a pod format does NOT collapse', () {
+        // Parent declares `format: date-time`, which would render as
+        // a `DateTime` newtype. Collapsing to `SchemaStringEnum` here
+        // would silently downgrade the typed pod to a String enum —
+        // bail and let the regular oneOf path handle the spec.
+        final json = {
+          'type': 'string',
+          'format': 'date-time',
+          'oneOf': [
+            {'const': '2024-01-01T00:00:00Z'},
+            {'const': '2024-12-31T23:59:59Z'},
+          ],
+        };
+        final logger = _MockLogger();
+        final schema = runWithLogger(logger, () => parseTestSchema(json));
+        expect(schema, isA<SchemaOneOf>());
+      });
+      test('oneOf-of-consts type/value mismatch does NOT collapse', () {
+        // Parent says `type: integer` but the consts are strings —
+        // an internally-inconsistent spec. Bail rather than silently
+        // pick a coercion direction; the regular oneOf path's warnings
+        // are more honest.
+        final json = {
+          'type': 'integer',
+          'oneOf': [
+            {'const': 'one'},
+            {'const': 'two'},
+          ],
+        };
+        final logger = _MockLogger();
+        final schema = runWithLogger(logger, () => parseTestSchema(json));
+        expect(schema, isA<SchemaOneOf>());
+      });
+      test('oneOf-of-consts with mixed value types does NOT collapse', () {
+        // If consts mix int and string types (unusual but spec-legal),
+        // we can't pick one Dart enum value type — fall through to
+        // SchemaOneOf.
+        final json = {
+          'oneOf': [
+            {'const': 1},
+            {'const': 'two'},
+          ],
+        };
+        final logger = _MockLogger();
+        final schema = runWithLogger(logger, () => parseTestSchema(json));
+        expect(schema, isA<SchemaOneOf>());
+      });
       test('ignore boolean enums', () {
         final json = {
           'openapi': '3.1.0',

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -2086,106 +2086,51 @@ void main() {
           ),
         );
       });
-      test('oneOf-of-consts (integer) collapses to SchemaIntEnum', () {
-        // Discord's `MessageComponentTypes` and 60+ similar typed
-        // enums spell themselves as `oneOf: [{const: N, title: ...}]`.
-        // Without collapse, each renders as a sealed class with an
-        // `UnimplementedError` `fromJson` (no discriminator).
-        final json = {
-          'type': 'integer',
-          'oneOf': [
-            {'title': 'JOIN', 'const': 1, 'description': 'Join activity'},
-            {'title': 'SPECTATE', 'const': 2},
-            {'title': 'LISTEN', 'const': 3},
-          ],
-        };
-        final logger = _MockLogger();
-        final schema = runWithLogger(logger, () => parseTestSchema(json));
+      test('integer const parses as a single-value SchemaIntEnum', () {
+        // OpenAPI 3.1 / JSON Schema 2020-12: `const: N` is the single-
+        // value form of `enum: [N]`. Discord uses 128+ such sites as
+        // single-value tags on oneOf variants — same role as
+        // `enum: [N]` in #192.
+        final json = {'type': 'integer', 'const': 7};
+        final schema = parseTestSchema(json);
         if (schema is! SchemaIntEnum) {
           fail('Expected SchemaIntEnum, got ${schema.runtimeType}');
         }
-        expect(schema.enumValues, equals([1, 2, 3]));
-        // Descriptions are plumbed when ANY variant declares one;
-        // missing descriptions become empty strings (parallel to
-        // values).
-        expect(schema.enumDescriptions, equals(['Join activity', '', '']));
+        expect(schema.enumValues, equals([7]));
       });
-      test('oneOf-of-consts (string) collapses to SchemaStringEnum', () {
-        final json = {
-          'type': 'string',
-          'oneOf': [
-            {'title': 'EVERYONE', 'const': 'everyone'},
-            {'title': 'ROLES', 'const': 'roles'},
-          ],
-        };
-        final logger = _MockLogger();
-        final schema = runWithLogger(logger, () => parseTestSchema(json));
+      test('string const parses as a single-value SchemaStringEnum', () {
+        // Discord's `match_all` discriminator value uses `const`.
+        final json = {'type': 'string', 'const': 'match_all'};
+        final schema = parseTestSchema(json);
         if (schema is! SchemaStringEnum) {
           fail('Expected SchemaStringEnum, got ${schema.runtimeType}');
         }
-        expect(schema.enumValues, equals(['everyone', 'roles']));
-        // No variant declared a description: the whole list stays
-        // null rather than a list of empty strings.
-        expect(schema.enumDescriptions, isNull);
+        expect(schema.enumValues, equals(['match_all']));
       });
-      test('oneOf with non-const variants does NOT collapse', () {
-        // Real polymorphic oneOf: each variant has its own object
-        // shape. Falls through to `SchemaOneOf`.
-        final json = {
-          'oneOf': [
-            {'type': 'string'},
-            {'type': 'integer'},
-          ],
-        };
+      test('const without explicit type infers from the literal', () {
+        // No `type:` declared. The existing inference path (which
+        // already handles `enum: [...]` without explicit type) must
+        // recognize `const` the same way.
+        final json = {'const': 'foo'};
         final schema = parseTestSchema(json);
-        expect(schema, isA<SchemaOneOf>());
+        expect(schema, isA<SchemaStringEnum>());
       });
-      test('oneOf-of-consts with a pod format does NOT collapse', () {
-        // Parent declares `format: date-time`, which would render as
-        // a `DateTime` newtype. Collapsing to `SchemaStringEnum` here
-        // would silently downgrade the typed pod to a String enum —
-        // bail and let the regular oneOf path handle the spec.
-        final json = {
-          'type': 'string',
-          'format': 'date-time',
-          'oneOf': [
-            {'const': '2024-01-01T00:00:00Z'},
-            {'const': '2024-12-31T23:59:59Z'},
-          ],
-        };
-        final logger = _MockLogger();
-        final schema = runWithLogger(logger, () => parseTestSchema(json));
-        expect(schema, isA<SchemaOneOf>());
-      });
-      test('oneOf-of-consts type/value mismatch does NOT collapse', () {
-        // Parent says `type: integer` but the consts are strings —
-        // an internally-inconsistent spec. Bail rather than silently
-        // pick a coercion direction; the regular oneOf path's warnings
-        // are more honest.
+      test('declaring both enum and const is a spec error', () {
         final json = {
           'type': 'integer',
-          'oneOf': [
-            {'const': 'one'},
-            {'const': 'two'},
-          ],
+          'enum': [1, 2],
+          'const': 1,
         };
-        final logger = _MockLogger();
-        final schema = runWithLogger(logger, () => parseTestSchema(json));
-        expect(schema, isA<SchemaOneOf>());
-      });
-      test('oneOf-of-consts with mixed value types does NOT collapse', () {
-        // If consts mix int and string types (unusual but spec-legal),
-        // we can't pick one Dart enum value type — fall through to
-        // SchemaOneOf.
-        final json = {
-          'oneOf': [
-            {'const': 1},
-            {'const': 'two'},
-          ],
-        };
-        final logger = _MockLogger();
-        final schema = runWithLogger(logger, () => parseTestSchema(json));
-        expect(schema, isA<SchemaOneOf>());
+        expect(
+          () => parseTestSchema(json),
+          throwsA(
+            isA<FormatException>().having(
+              (e) => e.message,
+              'message',
+              contains("'enum' and 'const' cannot both be set"),
+            ),
+          ),
+        );
       });
       test('ignore boolean enums', () {
         final json = {


### PR DESCRIPTION
## Summary

OpenAPI 3.1 / JSON Schema 2020-12 lets a schema spell its single-allowed-value as `const: X` instead of `enum: [X]`. Discord uses 128+ such sites — most are single-value tags (`const: 1`) on oneOf variants for implicit discrimination, the same role github fills with `enum: [\"foo\"]`-style strings.

Closes the parser-level "Unused: const" warnings (128 → 0 in Discord's verbose log) and unblocks downstream dispatch on these enums.

## What changed

- `_handleEnum` reads both `enum:` and `const:`, rejects the combination as a spec error, and treats the const value as a one-element enum list. The downstream int/string typing branches already handle single-value lists (`SchemaIntEnum` / `SchemaStringEnum` from #192).

- For Discord's typed-enum pattern where the parent has `type: integer, oneOf: [{const: 1}, {const: 2}, ...]`, the variant carries no `type` of its own. Added value-shape inference for the `type == null` branch: pick `integer` when every value is an int, `string` otherwise. This composes with the existing untyped-string-enum inference path the test suite already covered.

## Test plan
- [x] 4 new parser tests covering: int const → SchemaIntEnum, string const → SchemaStringEnum, untyped const inferring from value, and the `enum + const` combination raising a spec error.
- [x] 516 total tests pass (`dart test`).
- [x] Discord regen: 128 `Unused: const` log entries → 0; whole-spec regen now succeeds (was throwing on `ActivityActionTypes/oneOf/0` before the inference branch).
- [x] Github regen byte-identical (same path, no diff). Github doesn't use `const:` anywhere.