### PR TITLE
chore: acknowledge contentEncoding/contentMediaType on string schemas

### DIFF
--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -1083,6 +1083,16 @@ Schema _createCorrectSchemaSubtype(MapContext json) {
     if (typeAndFormat.format == 'binary') {
       return SchemaBinary(common: common);
     }
+    // JSON Schema 2020-12 / OpenAPI 3.1 successors to `format: byte`
+    // and `format: binary`. The wire value is still a JSON string —
+    // a base64 string for `contentEncoding: base64`, raw octets (when
+    // the surrounding `contentMediaType` is non-JSON) for `binary`.
+    // We acknowledge them so they aren't flagged as unused; auto-
+    // decoding to `Uint8List` would change the API surface and is a
+    // separate UX call. Discord uses `contentEncoding: base64` on
+    // 26 properties (`avatar`, `image`) and `binary` on 46 more.
+    _ignored<String>(json, 'contentEncoding');
+    _ignored<String>(json, 'contentMediaType');
   }
 
   final defaultValue = _optional<dynamic>(json, 'default');

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -2251,6 +2251,44 @@ void main() {
         expect(schema, isA<SchemaString>());
         expect(schema.common.nullable, isTrue);
       });
+      test('contentEncoding=base64 parses as a SchemaString', () {
+        // Discord's `avatar` / `image` properties: a base64-encoded
+        // binary in the JSON wire format. The string IS the wire
+        // value, so we keep `SchemaString`; the keyword is consumed
+        // (logged at -v as `Ignoring`) instead of flagged as unused.
+        final json = {'type': 'string', 'contentEncoding': 'base64'};
+        final logger = _MockLogger();
+        final schema = runWithLogger(logger, () => parseTestSchema(json));
+        expect(schema, isA<SchemaString>());
+        verify(
+          () => logger.detail(
+            any(that: contains('Ignoring: contentEncoding=base64')),
+          ),
+        ).called(1);
+      });
+      test('contentEncoding=binary parses as a SchemaString', () {
+        // OpenAPI 3.1 successor to `format: binary` on a JSON-shaped
+        // string property. Same handling as base64.
+        final json = {'type': 'string', 'contentEncoding': 'binary'};
+        final logger = _MockLogger();
+        final schema = runWithLogger(logger, () => parseTestSchema(json));
+        expect(schema, isA<SchemaString>());
+      });
+      test('contentMediaType is consumed alongside contentEncoding', () {
+        final json = {
+          'type': 'string',
+          'contentEncoding': 'base64',
+          'contentMediaType': 'image/png',
+        };
+        final logger = _MockLogger();
+        final schema = runWithLogger(logger, () => parseTestSchema(json));
+        expect(schema, isA<SchemaString>());
+        verify(
+          () => logger.detail(
+            any(that: contains('Ignoring: contentMediaType=image/png')),
+          ),
+        ).called(1);
+      });
     });
 
     group('multiple types', () {


### PR DESCRIPTION
## Summary

OpenAPI 3.1 / JSON Schema 2020-12 successors to `format: byte` / `format: binary` for marking a JSON-shaped string property as encoded binary. Discord uses `contentEncoding: base64` on 26 properties (`avatar`, `image`) and `contentEncoding: binary` on 46 more.

The wire value is still a JSON string — a base64 string for `base64`, raw octets (when `contentMediaType` is non-JSON) for `binary`. The Dart-side `SchemaString` faithfully represents that; auto-decoding to `Uint8List` would change the API surface and is a separate UX call.

This PR consumes the keywords with `_ignored` (detail-logged at `-v`) so they move from `Unused` to `Ignoring` in the verbose log, signaling "acknowledged but not auto-decoded" rather than "the parser missed this."

## Test plan
- [x] 3 new parser tests covering `contentEncoding=base64`, `contentEncoding=binary`, and `contentMediaType` alongside `contentEncoding`. Each verifies the schema parses as `SchemaString` and the keyword is detail-logged.
- [x] 515 total tests pass.
- [x] Discord regen: 72 unused-warning entries (46 binary + 26 base64) → 0.
- [x] Github regen byte-identical (github doesn't use these keywords).

## Future direction (not in this PR)

Auto-decoding `contentEncoding: base64` properties to `Uint8List` (with `base64.encode`/`base64.decode` round-trip in fromJson/toJson) would be more idiomatic Dart. That's a separate PR — it changes the API surface, motivates a `Quirks` flag, and needs a real validation target with such properties. Discord's `avatar` upload sites are the natural target.