### PR TITLE
feat: collapse oneOf-of-consts to a single typed enum

### DIFF
--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -440,6 +440,18 @@ Schema? _handleCollectionTypes(
     if (_isConstraintOnlyCollection(json, 'oneOf')) {
       return null;
     }
+    // OpenAPI 3.1 / JSON Schema 2020-12 spec authors sometimes spell
+    // an enum as a oneOf of single-value `const:` variants — Discord
+    // does this for 84 typed enums (e.g. `MessageComponentTypes` with
+    // 20 `{title: ACTION_ROW, const: 1}` variants). Without collapse,
+    // each parent renders as a sealed class with an
+    // `UnimplementedError` `fromJson` (no discriminator to pick a
+    // variant). Collapse to `SchemaIntEnum` / `SchemaStringEnum` so
+    // they generate clean enum types instead.
+    final collapsed = _maybeCollapseOneOfOfConsts(json, common: common);
+    if (collapsed != null) {
+      return collapsed;
+    }
     final mergedVariants = _maybeMergeParentIntoVariants(json, 'oneOf');
     final discriminator = _parseDiscriminator(json);
     if (mergedVariants != null) {
@@ -538,6 +550,75 @@ bool _isConstraintOnlyCollection(MapContext json, String collectionKey) {
     if (variant.length != 1 || !variant.containsKey('required')) return false;
   }
   return true;
+}
+
+/// Detects the "oneOf-of-consts" enum pattern: a oneOf where every
+/// variant is `{const: X}` (optionally with `title:` and
+/// `description:`). Discord uses this for typed enums like
+/// `MessageComponentTypes`: `{type: integer, oneOf: [{title: 'ACTION_ROW',
+/// const: 1}, {title: 'BUTTON', const: 2}, ...]}`.
+///
+/// Returns the collapsed `SchemaIntEnum` / `SchemaStringEnum` when
+/// the pattern matches, or null to fall through to the regular
+/// oneOf-parse path. Parent `type:` is read for type-shape validation
+/// but isn't required (the const literal types determine the result).
+Schema? _maybeCollapseOneOfOfConsts(
+  MapContext json, {
+  required CommonProperties common,
+}) {
+  final list = json['oneOf'];
+  if (list is! List || list.isEmpty) return null;
+  // Every variant must be a const-only map (with optional title and
+  // description metadata). Anything else means a real polymorphic
+  // branch — fall through.
+  const allowedKeys = {'const', 'title', 'description'};
+  for (final variant in list) {
+    if (variant is! Map) return null;
+    if (!variant.containsKey('const')) return null;
+    if (variant.keys.any((k) => !allowedKeys.contains(k))) return null;
+  }
+  // Walk the variants once to collect values + descriptions. Titles
+  // aren't preserved yet — `RenderEnum.variableNamesFor` derives Dart
+  // names from the values — but the underlying enum type is correct
+  // and dispatches cleanly.
+  final values = <dynamic>[];
+  final descriptions = <String?>[];
+  for (final variant in list.cast<Map<dynamic, dynamic>>()) {
+    values.add(variant['const']);
+    descriptions.add(variant['description'] as String?);
+  }
+  // Mixed-type consts — fall through to the regular oneOf path
+  // before consuming any keys, so downstream parsing sees the
+  // original shape.
+  final isAllInt = values.every((v) => v is int);
+  final isAllString = values.every((v) => v is String);
+  if (!isAllInt && !isAllString) return null;
+  // Mark `oneOf` consumed so it doesn't show as unused. Same for
+  // `type:` (informational on the parent) and `format:` (Discord
+  // puts `format: int32` on integer-enum parents).
+  json
+    ..markUsed('oneOf')
+    ..markUsed('type')
+    ..markUsed('format');
+  // If any variant declared a description, plumb the parallel list
+  // through `enumDescriptions`. If none did, leave it null.
+  final descriptionsToPlumb = descriptions.any((d) => d != null)
+      ? descriptions.map((d) => d ?? '').toList()
+      : null;
+  if (isAllInt) {
+    return SchemaIntEnum(
+      common: common,
+      defaultValue: null,
+      enumValues: values.cast<int>(),
+      enumDescriptions: descriptionsToPlumb,
+    );
+  }
+  return SchemaStringEnum(
+    common: common,
+    defaultValue: null,
+    enumValues: values.cast<String>(),
+    enumDescriptions: descriptionsToPlumb,
+  );
 }
 
 /// Returns merged variant schemas when [json] declares a base object

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -435,6 +435,7 @@ SchemaDiscriminator? _parseDiscriminator(MapContext json) {
 Schema? _handleCollectionTypes(
   MapContext json, {
   required CommonProperties common,
+  required TypeAndFormat typeAndFormat,
 }) {
   if (json.containsKey('oneOf')) {
     if (_isConstraintOnlyCollection(json, 'oneOf')) {
@@ -448,7 +449,11 @@ Schema? _handleCollectionTypes(
     // `UnimplementedError` `fromJson` (no discriminator to pick a
     // variant). Collapse to `SchemaIntEnum` / `SchemaStringEnum` so
     // they generate clean enum types instead.
-    final collapsed = _maybeCollapseOneOfOfConsts(json, common: common);
+    final collapsed = _maybeCollapseOneOfOfConsts(
+      json,
+      common: common,
+      typeAndFormat: typeAndFormat,
+    );
     if (collapsed != null) {
       return collapsed;
     }
@@ -558,14 +563,27 @@ bool _isConstraintOnlyCollection(MapContext json, String collectionKey) {
 /// `MessageComponentTypes`: `{type: integer, oneOf: [{title: 'ACTION_ROW',
 /// const: 1}, {title: 'BUTTON', const: 2}, ...]}`.
 ///
-/// Returns the collapsed `SchemaIntEnum` / `SchemaStringEnum` when
-/// the pattern matches, or null to fall through to the regular
-/// oneOf-parse path. Parent `type:` is read for type-shape validation
-/// but isn't required (the const literal types determine the result).
+/// Trusts the parent's `type:` / `format:` the same way `_handleEnum`
+/// does. Bails (returns null) when the parent has a `format:` that
+/// would produce a `SchemaPod` (date, date-time, uri, email, uuid,
+/// boolean), since collapsing to `SchemaStringEnum` / `SchemaIntEnum`
+/// would silently drop the pod typing — the spec author asked for a
+/// `DateTime` (or similar) and we'd give them a `String` enum. Also
+/// bails on cross-type mismatches (declared `type: integer` but
+/// string-shaped consts, etc.).
+///
+/// Returns the collapsed enum schema when it cleanly fits, or null to
+/// fall through to the regular oneOf-parse path.
 Schema? _maybeCollapseOneOfOfConsts(
   MapContext json, {
   required CommonProperties common,
+  required TypeAndFormat typeAndFormat,
 }) {
+  // Pod formats (date-time, uri, email, uuid, etc.) name a typed Dart
+  // representation that a `String`/`int` enum couldn't carry. Don't
+  // collapse — let the regular oneOf path handle it (and surface any
+  // gaps as warnings).
+  if (typeAndFormat.podType != null) return null;
   final list = json['oneOf'];
   if (list is! List || list.isEmpty) return null;
   // Every variant must be a const-only map (with optional title and
@@ -587,25 +605,40 @@ Schema? _maybeCollapseOneOfOfConsts(
     values.add(variant['const']);
     descriptions.add(variant['description'] as String?);
   }
-  // Mixed-type consts — fall through to the regular oneOf path
-  // before consuming any keys, so downstream parsing sees the
-  // original shape.
-  final isAllInt = values.every((v) => v is int);
-  final isAllString = values.every((v) => v is String);
-  if (!isAllInt && !isAllString) return null;
-  // Mark `oneOf` consumed so it doesn't show as unused. Same for
-  // `type:` (informational on the parent) and `format:` (Discord
-  // puts `format: int32` on integer-enum parents).
-  json
-    ..markUsed('oneOf')
-    ..markUsed('type')
-    ..markUsed('format');
+  // Pick string vs int from the parent's declared `type:`, falling
+  // back to value-shape inference when `type:` is absent (matches the
+  // pattern in `_handleEnum`). When the declared type and the values
+  // disagree, bail — the spec is internally inconsistent and the
+  // regular oneOf path's warnings are more honest than a silent
+  // type-coercion.
+  final declaredType = typeAndFormat.type;
+  final bool isInt;
+  if (declaredType == 'integer') {
+    if (!values.every((v) => v is int)) return null;
+    isInt = true;
+  } else if (declaredType == 'string') {
+    if (!values.every((v) => v is String)) return null;
+    isInt = false;
+  } else if (declaredType == null) {
+    final allInt = values.every((v) => v is int);
+    final allString = values.every((v) => v is String);
+    if (!allInt && !allString) return null;
+    isInt = allInt;
+  } else {
+    // Other types (boolean, array, object) don't have a clean enum
+    // collapse — fall through.
+    return null;
+  }
+  // `type:` and `format:` on the parent were already consumed by
+  // `parseTypeAndFormat` upstream; `oneOf` was consumed by the
+  // `json['oneOf']` read above. No extra `markUsed` needed.
+  //
   // If any variant declared a description, plumb the parallel list
   // through `enumDescriptions`. If none did, leave it null.
   final descriptionsToPlumb = descriptions.any((d) => d != null)
       ? descriptions.map((d) => d ?? '').toList()
       : null;
-  if (isAllInt) {
+  if (isInt) {
     return SchemaIntEnum(
       common: common,
       defaultValue: null,
@@ -1115,7 +1148,11 @@ Schema _createCorrectSchemaSubtype(MapContext json) {
   // `oneOf`/`anyOf` do. The fallback below still routes it through
   // `_handleCollectionTypes`.
   if (json.containsKey('oneOf') || json.containsKey('anyOf')) {
-    final union = _handleCollectionTypes(json, common: common);
+    final union = _handleCollectionTypes(
+      json,
+      common: common,
+      typeAndFormat: typeAndFormat,
+    );
     if (union != null) {
       return union;
     }
@@ -1151,7 +1188,11 @@ Schema _createCorrectSchemaSubtype(MapContext json) {
   // a parallel `type:` array); this catches allOf, plus the
   // constraint-only oneOf/anyOf shapes that return null and fall
   // through to plain object parsing.
-  final collectionType = _handleCollectionTypes(json, common: common);
+  final collectionType = _handleCollectionTypes(
+    json,
+    common: common,
+    typeAndFormat: typeAndFormat,
+  );
   if (collectionType != null) {
     return collectionType;
   }

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -2140,6 +2140,39 @@ void main() {
         final schema = parseTestSchema(json);
         expect(schema, isA<SchemaOneOf>());
       });
+      test('oneOf-of-consts with a pod format does NOT collapse', () {
+        // Parent declares `format: date-time`, which would render as
+        // a `DateTime` newtype. Collapsing to `SchemaStringEnum` here
+        // would silently downgrade the typed pod to a String enum —
+        // bail and let the regular oneOf path handle the spec.
+        final json = {
+          'type': 'string',
+          'format': 'date-time',
+          'oneOf': [
+            {'const': '2024-01-01T00:00:00Z'},
+            {'const': '2024-12-31T23:59:59Z'},
+          ],
+        };
+        final logger = _MockLogger();
+        final schema = runWithLogger(logger, () => parseTestSchema(json));
+        expect(schema, isA<SchemaOneOf>());
+      });
+      test('oneOf-of-consts type/value mismatch does NOT collapse', () {
+        // Parent says `type: integer` but the consts are strings —
+        // an internally-inconsistent spec. Bail rather than silently
+        // pick a coercion direction; the regular oneOf path's warnings
+        // are more honest.
+        final json = {
+          'type': 'integer',
+          'oneOf': [
+            {'const': 'one'},
+            {'const': 'two'},
+          ],
+        };
+        final logger = _MockLogger();
+        final schema = runWithLogger(logger, () => parseTestSchema(json));
+        expect(schema, isA<SchemaOneOf>());
+      });
       test('oneOf-of-consts with mixed value types does NOT collapse', () {
         // If consts mix int and string types (unusual but spec-legal),
         // we can't pick one Dart enum value type — fall through to

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -2086,6 +2086,74 @@ void main() {
           ),
         );
       });
+      test('oneOf-of-consts (integer) collapses to SchemaIntEnum', () {
+        // Discord's `MessageComponentTypes` and 60+ similar typed
+        // enums spell themselves as `oneOf: [{const: N, title: ...}]`.
+        // Without collapse, each renders as a sealed class with an
+        // `UnimplementedError` `fromJson` (no discriminator).
+        final json = {
+          'type': 'integer',
+          'oneOf': [
+            {'title': 'JOIN', 'const': 1, 'description': 'Join activity'},
+            {'title': 'SPECTATE', 'const': 2},
+            {'title': 'LISTEN', 'const': 3},
+          ],
+        };
+        final logger = _MockLogger();
+        final schema = runWithLogger(logger, () => parseTestSchema(json));
+        if (schema is! SchemaIntEnum) {
+          fail('Expected SchemaIntEnum, got ${schema.runtimeType}');
+        }
+        expect(schema.enumValues, equals([1, 2, 3]));
+        // Descriptions are plumbed when ANY variant declares one;
+        // missing descriptions become empty strings (parallel to
+        // values).
+        expect(schema.enumDescriptions, equals(['Join activity', '', '']));
+      });
+      test('oneOf-of-consts (string) collapses to SchemaStringEnum', () {
+        final json = {
+          'type': 'string',
+          'oneOf': [
+            {'title': 'EVERYONE', 'const': 'everyone'},
+            {'title': 'ROLES', 'const': 'roles'},
+          ],
+        };
+        final logger = _MockLogger();
+        final schema = runWithLogger(logger, () => parseTestSchema(json));
+        if (schema is! SchemaStringEnum) {
+          fail('Expected SchemaStringEnum, got ${schema.runtimeType}');
+        }
+        expect(schema.enumValues, equals(['everyone', 'roles']));
+        // No variant declared a description: the whole list stays
+        // null rather than a list of empty strings.
+        expect(schema.enumDescriptions, isNull);
+      });
+      test('oneOf with non-const variants does NOT collapse', () {
+        // Real polymorphic oneOf: each variant has its own object
+        // shape. Falls through to `SchemaOneOf`.
+        final json = {
+          'oneOf': [
+            {'type': 'string'},
+            {'type': 'integer'},
+          ],
+        };
+        final schema = parseTestSchema(json);
+        expect(schema, isA<SchemaOneOf>());
+      });
+      test('oneOf-of-consts with mixed value types does NOT collapse', () {
+        // If consts mix int and string types (unusual but spec-legal),
+        // we can't pick one Dart enum value type — fall through to
+        // SchemaOneOf.
+        final json = {
+          'oneOf': [
+            {'const': 1},
+            {'const': 'two'},
+          ],
+        };
+        final logger = _MockLogger();
+        final schema = runWithLogger(logger, () => parseTestSchema(json));
+        expect(schema, isA<SchemaOneOf>());
+      });
       test('ignore boolean enums', () {
         final json = {
           'openapi': '3.1.0',


### PR DESCRIPTION
## Summary

OpenAPI 3.1 / JSON Schema 2020-12 spec authors sometimes spell an enum as a oneOf of single-value `const:` variants:

```yaml
MessageComponentTypes:
  type: integer
  oneOf:
    - {title: ACTION_ROW, const: 1}
    - {title: BUTTON,     const: 2}
    ...
```

Discord uses this for **84 typed enums**. Without collapse, each renders as a sealed class with an `UnimplementedError` `fromJson` (no discriminator to pick a variant — they're all single-value).

`_handleCollectionTypes` now detects "every variant is `{const: X}` plus optional `title`/`description` metadata" and returns a `SchemaIntEnum` / `SchemaStringEnum` directly. Mixed-type or non-const variants fall through to the regular `SchemaOneOf` path.

## Impact

- **Discord stub count: 414 → 334** (80 stubs eliminated).
- Round-trip tests now generate for 104 additional schemas (156 → 260 generated test files), expanding coverage.
- 2 of those new tests fail due to the multi-status name collision in `ThreadSearchResponse` — that's a downstream effect of the existing collision (fixed by **#196**), not a regression introduced here. Once #196 lands those tests pass too.
- Github regen byte-identical (github doesn't use this pattern).

## Test plan
- [x] 4 new parser tests covering integer collapse, string collapse, non-const-variants pass-through, and mixed-type-consts pass-through.
- [x] 516 total tests pass.
- [x] Discord regen drops 80 stubs.
- [x] Github regen byte-identical (same package path, no diff).

## Follow-up

Title preservation — turning `{title: ACTION_ROW, const: 1}` into a Dart case `actionRow` rather than the value-derived `value1` — needs `enumNames` plumbed through `Schema` / `Resolved` / `Render` in parallel with the existing `enumDescriptions` plumbing, plus generic `x-enum-varnames` support. Out of scope here; the collapse-without-titles is already strictly better than the current stub.