### PR TITLE
feat: contentEncoding=base64 renders as Uint8List with auto base64 codec

### DIFF
--- a/lib/src/naming.dart
+++ b/lib/src/naming.dart
@@ -574,6 +574,7 @@ class _NameAssigner {
       case ResolvedRecursiveRef():
       case ResolvedVoid():
       case ResolvedBinary():
+      case ResolvedBase64Bytes():
       case ResolvedNull():
       case ResolvedUnknown():
         // Leaf — no inline children to visit.

--- a/lib/src/parse/spec.dart
+++ b/lib/src/parse/spec.dart
@@ -237,6 +237,16 @@ class SchemaBinary extends Schema {
   const SchemaBinary({required super.common});
 }
 
+/// A base64-encoded binary string. JSON Schema 2020-12 / OpenAPI 3.1
+/// spell this as `{type: string, contentEncoding: base64}`. The wire
+/// format is a JSON string; the Dart-side type is `Uint8List` with
+/// `base64.encode`/`base64.decode` automatically applied at the JSON
+/// boundary. Discord uses this for fields like `avatar` and `image`
+/// in upload request bodies.
+class SchemaBase64Bytes extends Schema {
+  const SchemaBase64Bytes({required super.common});
+}
+
 /// An enum schema. OpenAPI most commonly uses string enums, but
 /// `type: integer` enums also occur — Discord uses single-value int
 /// enums (`enum: [1]`) as oneOf discriminator markers, the same role

--- a/lib/src/parse/visitor.dart
+++ b/lib/src/parse/visitor.dart
@@ -147,6 +147,7 @@ class SpecWalker {
       case SchemaString():
       case SchemaNull():
       case SchemaBinary():
+      case SchemaBase64Bytes():
       case SchemaEmptyObject():
         break;
       case SchemaCombiner():

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -1205,6 +1205,37 @@ Schema _createCorrectSchemaSubtype(MapContext json) {
     if (typeAndFormat.format == 'binary') {
       return SchemaBinary(common: common);
     }
+    // JSON Schema 2020-12 / OpenAPI 3.1 successors to `format: byte`
+    // and `format: binary`. The wire is still a JSON string, but the
+    // string value is encoded binary — base64 (most common) or raw
+    // octets (`binary`, only meaningful when the surrounding content
+    // type is non-JSON like multipart). Discord uses
+    // `contentEncoding: base64` on `avatar`/`image` upload fields.
+    final contentEncoding = _optional<String>(json, 'contentEncoding');
+    // `contentMediaType` (e.g. `image/png`) is metadata about the
+    // bytes' MIME type. Not actionable on the Dart side beyond
+    // documentation; consume to suppress the unused-key warning.
+    _ignored<String>(json, 'contentMediaType');
+    if (contentEncoding == 'base64') {
+      return SchemaBase64Bytes(common: common);
+    }
+    // `contentEncoding: binary` is the OpenAPI 3.1 successor to
+    // `format: binary`, but on a non-multipart response body (e.g.
+    // an `image/png` content type) it implies the response method
+    // should return `Uint8List` from `response.bodyBytes`, not
+    // `String` from `response.body`. That's a separate render-path
+    // change; until then, acknowledge the keyword and keep the
+    // wire-shape `String` so the existing non-JSON response handler
+    // continues to compile. `contentEncoding: binary` on a JSON
+    // property is also nonsensical (JSON strings are UTF-8 text);
+    // same fallback covers it.
+    if (contentEncoding != null && contentEncoding != 'base64') {
+      // Mark used; detail-log the value at -v.
+      logger.detail(
+        'Ignoring: contentEncoding=$contentEncoding (String) in '
+        '${json.pointer}',
+      );
+    }
   }
 
   final defaultValue = _optional<dynamic>(json, 'default');

--- a/lib/src/render/file_renderer.dart
+++ b/lib/src/render/file_renderer.dart
@@ -666,7 +666,7 @@ class FileRenderer {
     // from the barrel, narrowed to `show <exact types>` so we only
     // surface the specific names used by public field signatures —
     // not every symbol the third-party package happens to define.
-    final thirdPartyExports = collectThirdPartyExports(schemas);
+    final externalExports = collectExternalBarrelExports(schemas);
     final exportContexts = [
       for (final path in (paths.toList()..sort()))
         {
@@ -674,7 +674,7 @@ class FileRenderer {
           'hasShow': false,
           'shownTypes': '',
         },
-      for (final e in thirdPartyExports)
+      for (final e in externalExports)
         {
           'path': e.path,
           'hasShow': e.shown.isNotEmpty,
@@ -688,15 +688,19 @@ class FileRenderer {
     );
   }
 
-  /// Imports (third-party, non-prefixed) that the public API surface
-  /// references, grouped by package path. Each returned `Import` has a
+  /// Non-local imports (not from the generated package itself) that
+  /// the public API surface references and need re-exporting from
+  /// `lib/api.dart`, grouped by URI. Each returned `Import` has a
   /// non-empty `shown` list (the union of shown types across all
-  /// schema-level usages of that package).
+  /// schema-level usages of that import).
   ///
-  /// Includes `package:` imports (e.g. `package:uri/uri.dart` for
-  /// `UriTemplate`) and `dart:` SDK imports that expose a public type
-  /// in field signatures (`dart:typed_data` for `Uint8List` from
-  /// `contentEncoding: base64` fields).
+  /// Includes both `package:` imports (e.g. `package:uri/uri.dart`
+  /// for `UriTemplate`) and `dart:` SDK imports that expose a public
+  /// type in field signatures (`dart:typed_data` for `Uint8List`
+  /// from `contentEncoding: base64` fields). Dart's `export`
+  /// directive doesn't chain through `import`, so consumers of the
+  /// barrel — including the generated round-trip tests — need these
+  /// names re-exposed explicitly.
   ///
   /// Only imports with an explicit `shown:` list are candidates — an
   /// unconstrained `Import('package:x/x.dart')` means "the schema
@@ -704,7 +708,7 @@ class FileRenderer {
   /// for `@immutable` or `dart:convert` for the `base64` codec), not
   /// "expose every symbol in it to consumers of the barrel."
   @visibleForTesting
-  List<Import> collectThirdPartyExports(Iterable<RenderSchema> schemas) {
+  List<Import> collectExternalBarrelExports(Iterable<RenderSchema> schemas) {
     final collector = _ImportCollector();
     for (final schema in schemas) {
       RenderTreeWalker(visitor: collector).walkSchema(schema);

--- a/lib/src/render/file_renderer.dart
+++ b/lib/src/render/file_renderer.dart
@@ -639,6 +639,10 @@ class FileRenderer {
         'needsUriPackageImport': usedModelHelpers.contains(
           ModelHelpers.maybeParseUriTemplate,
         ),
+        'needsBase64Imports': const {
+          ModelHelpers.maybeBase64Encode,
+          ModelHelpers.maybeBase64Decode,
+        }.any(usedModelHelpers.contains),
       },
     );
   }
@@ -689,11 +693,16 @@ class FileRenderer {
   /// non-empty `shown` list (the union of shown types across all
   /// schema-level usages of that package).
   ///
+  /// Includes `package:` imports (e.g. `package:uri/uri.dart` for
+  /// `UriTemplate`) and `dart:` SDK imports that expose a public type
+  /// in field signatures (`dart:typed_data` for `Uint8List` from
+  /// `contentEncoding: base64` fields).
+  ///
   /// Only imports with an explicit `shown:` list are candidates — an
   /// unconstrained `Import('package:x/x.dart')` means "the schema
   /// needs the package internally" (e.g. `package:meta/meta.dart`
-  /// for `@immutable`), not "expose every symbol in it to consumers
-  /// of the barrel."
+  /// for `@immutable` or `dart:convert` for the `base64` codec), not
+  /// "expose every symbol in it to consumers of the barrel."
   @visibleForTesting
   List<Import> collectThirdPartyExports(Iterable<RenderSchema> schemas) {
     final collector = _ImportCollector();
@@ -702,7 +711,9 @@ class FileRenderer {
     }
     final byPath = <String, Set<String>>{};
     for (final i in collector.imports) {
-      if (!i.path.startsWith('package:')) continue;
+      final isPkg = i.path.startsWith('package:');
+      final isDart = i.path.startsWith('dart:');
+      if (!isPkg && !isDart) continue;
       if (i.path.startsWith('package:$packageName/')) continue;
       if (i.asName != null) continue;
       if (i.shown.isEmpty) continue;

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -403,6 +403,8 @@ abstract final class ModelHelpers {
   static const mapHash = 'mapHash';
   static const parseFromJson = 'parseFromJson';
   static const checkedKey = 'checkedKey';
+  static const maybeBase64Encode = 'maybeBase64Encode';
+  static const maybeBase64Decode = 'maybeBase64Decode';
 
   static const List<String> all = [
     maybeParseDateTime,
@@ -415,6 +417,8 @@ abstract final class ModelHelpers {
     mapHash,
     parseFromJson,
     checkedKey,
+    maybeBase64Encode,
+    maybeBase64Decode,
   ];
 }
 
@@ -584,6 +588,8 @@ class SpecResolver {
         return RenderUnknown(common: schema.common);
       case ResolvedBinary():
         return RenderBinary(common: schema.common);
+      case ResolvedBase64Bytes():
+        return RenderBase64Bytes(common: schema.common);
       case ResolvedOneOf():
         final renderSchemas = schema.schemas.map(toRenderSchema).toList();
         final disc = schema.discriminator;
@@ -5634,6 +5640,88 @@ class RenderBinary extends RenderNoJson {
 
   @override
   bool get defaultCanConstConstruct => false;
+}
+
+/// Base64-encoded binary string. Wire format is a JSON `String`; Dart-
+/// side type is `Uint8List`. `fromJson` runs `base64.decode`, `toJson`
+/// runs `base64.encode`. Inline only — top-level newtype mode is a
+/// follow-up if a real spec needs it.
+class RenderBase64Bytes extends RenderSchema {
+  const RenderBase64Bytes({required super.common})
+    : super(createsNewType: false);
+
+  @override
+  dynamic get defaultValue => null;
+
+  @override
+  bool get defaultCanConstConstruct => false;
+
+  @override
+  Iterable<Import> get additionalImports => [
+    ...super.additionalImports,
+    // `shown: ['Uint8List']` flags this for re-export from the api.dart
+    // barrel; `dart:convert` stays unshown since `base64` is only used
+    // internally by the encoded fromJson/toJson and never appears in a
+    // public field signature.
+    const Import('dart:typed_data', shown: ['Uint8List']),
+    const Import('dart:convert'),
+  ];
+
+  @override
+  String get typeName => 'Uint8List';
+
+  @override
+  bool get shouldCallToJson => false;
+
+  @override
+  String jsonStorageType({required bool isNullable}) =>
+      isNullable ? 'String?' : 'String';
+
+  @override
+  String equalsExpression(String name, SchemaRenderer context) =>
+      '${ModelHelpers.listsEqual}(this.$name, other.$name)';
+
+  @override
+  String hashCodeExpression(String name) => '${ModelHelpers.listHash}($name)';
+
+  @override
+  String fromJsonExpression(
+    String jsonValue,
+    SchemaRenderer context, {
+    required bool jsonIsNullable,
+    required bool dartIsNullable,
+  }) {
+    final jsonType = jsonStorageType(isNullable: jsonIsNullable);
+    if (jsonIsNullable) {
+      // Use the model_helpers wrapper so `Uint8List?` parses cleanly
+      // without forcing the call site to write its own null check (a
+      // ternary on a public-property `Uint8List?` doesn't promote).
+      return '${ModelHelpers.maybeBase64Decode}($jsonValue as $jsonType)';
+    }
+    return 'base64.decode($jsonValue as $jsonType)';
+  }
+
+  @override
+  String toJsonExpression(
+    String dartName,
+    SchemaRenderer context, {
+    required bool dartIsNullable,
+  }) {
+    if (dartIsNullable) {
+      // Same reasoning as `fromJsonExpression`: nullable `Uint8List`
+      // doesn't promote in a ternary at a property access site.
+      return '${ModelHelpers.maybeBase64Encode}($dartName)';
+    }
+    return 'base64.encode($dartName)';
+  }
+
+  @override
+  String? exampleValue(SchemaRenderer context) =>
+      'Uint8List.fromList(<int>[0])';
+
+  @override
+  Map<String, dynamic> toTemplateContext(SchemaRenderer context) =>
+      throw UnimplementedError('RenderBase64Bytes.toTemplateContext');
 }
 
 class RenderEmptyObject extends RenderNewType {

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -5659,10 +5659,10 @@ class RenderBase64Bytes extends RenderSchema {
   @override
   Iterable<Import> get additionalImports => [
     ...super.additionalImports,
-    // `shown: ['Uint8List']` flags this for re-export from the api.dart
-    // barrel; `dart:convert` stays unshown since `base64` is only used
-    // internally by the encoded fromJson/toJson and never appears in a
-    // public field signature.
+    // `shown: ['Uint8List']` flags this for re-export from the
+    // api.dart barrel. `dart:convert` is imported without a `shown:`
+    // list since `base64` is only used internally by the encoded
+    // fromJson/toJson and never appears in a public field signature.
     const Import('dart:typed_data', shown: ['Uint8List']),
     const Import('dart:convert'),
   ];

--- a/lib/src/resolver.dart
+++ b/lib/src/resolver.dart
@@ -315,6 +315,12 @@ ResolvedSchema _resolveSchemaFully(
       createsNewType: createsNewType,
     );
   }
+  if (schema is SchemaBase64Bytes) {
+    return ResolvedBase64Bytes(
+      common: resolvedCommon,
+      createsNewType: createsNewType,
+    );
+  }
   if (schema is SchemaPod) {
     return ResolvedPod(
       common: resolvedCommon,
@@ -881,6 +887,7 @@ bool shouldCreateNewType(Schema schema) {
     case SchemaUnknown():
     case SchemaPod():
     case SchemaBinary():
+    case SchemaBase64Bytes():
     case SchemaNumeric():
       // OpenApi creates a new file for each top level component, even
       // if it's a simple type.  Matching this behavior for now.
@@ -1708,6 +1715,23 @@ class ResolvedBinary extends ResolvedSchema {
   @override
   ResolvedBinary copyWith({CommonProperties? common}) {
     return ResolvedBinary(
+      common: common ?? this.common,
+      createsNewType: createsNewType,
+    );
+  }
+}
+
+/// Resolved counterpart to [SchemaBase64Bytes]. Renders as `Uint8List`
+/// with `base64.encode`/`base64.decode` at the JSON boundary.
+class ResolvedBase64Bytes extends ResolvedSchema {
+  const ResolvedBase64Bytes({
+    required super.common,
+    required super.createsNewType,
+  });
+
+  @override
+  ResolvedBase64Bytes copyWith({CommonProperties? common}) {
+    return ResolvedBase64Bytes(
       common: common ?? this.common,
       createsNewType: createsNewType,
     );

--- a/lib/templates/model_helpers.mustache
+++ b/lib/templates/model_helpers.mustache
@@ -1,3 +1,7 @@
+{{#needsBase64Imports}}
+import 'dart:convert';
+import 'dart:typed_data';
+{{/needsBase64Imports}}
 {{#needsCollectionImport}}
 import 'package:collection/collection.dart';
 {{/needsCollectionImport}}
@@ -45,6 +49,26 @@ UriTemplate? maybeParseUriTemplate(String? value) {
   return UriTemplate(value);
 }
 {{/maybeParseUriTemplate}}
+
+{{#maybeBase64Encode}}
+/// Encodes nullable bytes as a nullable base64 string. Used by
+/// generated `toJson` for `contentEncoding: base64` fields. Takes
+/// `List<int>?` rather than `Uint8List?` so it accepts both the
+/// generator's `Uint8List` type and any subtype the user passes in.
+String? maybeBase64Encode(List<int>? bytes) {
+  if (bytes == null) return null;
+  return base64.encode(bytes);
+}
+{{/maybeBase64Encode}}
+
+{{#maybeBase64Decode}}
+/// Decodes a nullable base64 string into bytes. Used by generated
+/// `fromJson` for `contentEncoding: base64` fields.
+Uint8List? maybeBase64Decode(String? value) {
+  if (value == null) return null;
+  return base64.decode(value);
+}
+{{/maybeBase64Decode}}
 
 {{#parseFromJson}}
 /// Runs [build] to construct a `fromJson`-parsed value of type [T],

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -2352,6 +2352,46 @@ void main() {
         expect(schema, isA<SchemaString>());
         expect(schema.common.nullable, isTrue);
       });
+      test('contentEncoding=base64 parses as SchemaBase64Bytes', () {
+        // Discord's `avatar` / `image` properties: base64-encoded
+        // binary on the wire, `Uint8List` Dart-side.
+        final json = {'type': 'string', 'contentEncoding': 'base64'};
+        final logger = _MockLogger();
+        final schema = runWithLogger(logger, () => parseTestSchema(json));
+        expect(schema, isA<SchemaBase64Bytes>());
+      });
+      test('contentEncoding=binary stays a SchemaString (deferred)', () {
+        // Routing `contentEncoding: binary` to `SchemaBinary` (a no-
+        // JSON type) breaks generated response handlers for non-JSON
+        // content types (`image/png` returning `Uint8List` from a
+        // String-shaped path). Until the response-bytes pipeline
+        // lands, acknowledge the keyword via the verbose log and
+        // keep the wire-shape `String`.
+        final json = {'type': 'string', 'contentEncoding': 'binary'};
+        final logger = _MockLogger();
+        final schema = runWithLogger(logger, () => parseTestSchema(json));
+        expect(schema, isA<SchemaString>());
+        verify(
+          () => logger.detail(
+            any(that: contains('Ignoring: contentEncoding=binary')),
+          ),
+        ).called(1);
+      });
+      test('contentMediaType is consumed alongside contentEncoding', () {
+        final json = {
+          'type': 'string',
+          'contentEncoding': 'base64',
+          'contentMediaType': 'image/png',
+        };
+        final logger = _MockLogger();
+        final schema = runWithLogger(logger, () => parseTestSchema(json));
+        expect(schema, isA<SchemaBase64Bytes>());
+        verify(
+          () => logger.detail(
+            any(that: contains('Ignoring: contentMediaType=image/png')),
+          ),
+        ).called(1);
+      });
     });
 
     group('multiple types', () {

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -192,6 +192,43 @@ void main() {
       );
     });
 
+    test(
+      'contentEncoding=base64 property renders as Uint8List with '
+      'base64 codec',
+      () {
+        // Discord's `avatar`/`image` upload fields. The wire is a JSON
+        // string; the Dart-side type is `Uint8List` with auto-encode in
+        // `toJson` and auto-decode in `fromJson`. The required path
+        // calls `base64.decode` / `base64.encode` directly; the nullable
+        // path goes through `maybeBase64Decode` / `maybeBase64Encode`
+        // helpers (so a public-property `Uint8List?` doesn't need to
+        // promote inside a ternary).
+        final schema = {
+          'type': 'object',
+          'required': ['image'],
+          'properties': {
+            'image': {'type': 'string', 'contentEncoding': 'base64'},
+            'avatar': {'type': 'string', 'contentEncoding': 'base64'},
+          },
+        };
+        final result = renderTestSchema(schema);
+        expect(result, contains('final Uint8List image;'));
+        expect(result, contains('final Uint8List? avatar;'));
+        // Required: direct calls.
+        expect(
+          result,
+          contains("image: base64.decode(json['image'] as String)"),
+        );
+        expect(result, contains("'image': base64.encode(image)"));
+        // Nullable: via the model_helpers wrappers.
+        expect(
+          result,
+          contains("avatar: maybeBase64Decode(json['avatar'] as String?)"),
+        );
+        expect(result, contains("'avatar': maybeBase64Encode(avatar)"));
+      },
+    );
+
     test('x-enum-descriptions emits dartdoc per enum case', () {
       final schema = {
         'type': 'string',


### PR DESCRIPTION
## Summary

Replaces #199 (which only suppressed the unused-key warning) with the actual semantic handling: `{type: string, contentEncoding: base64}` properties now render as `Uint8List` with `base64.encode`/`base64.decode` automatically applied at the JSON boundary. Discord's `avatar`, `image`, and `sound` upload fields — 26 properties total — flip from `String?` to `Uint8List?`. The user passes raw bytes; the wire stays base64.

## What changed

- **Parse** — new `SchemaBase64Bytes` (alongside `SchemaBinary`). `_createCorrectSchemaSubtype` reads `contentEncoding`/`contentMediaType` in the `type: string` path; `base64` routes to the new schema, anything else (binary, etc.) stays a `SchemaString` with the keyword detail-logged at `-v`. Routing `contentEncoding: binary` to `SchemaBinary` is *deferred* — that path needs the response-bytes pipeline (Discord's `image/png` endpoint returns a non-JSON body that the existing handler expects as `String`).
- **Resolve** — `ResolvedBase64Bytes`, mirrors the `ResolvedBinary` shape.
- **Render** — `RenderBase64Bytes` extends `RenderSchema` (not `RenderNoJson` like `RenderBinary`) since we round-trip through JSON. `typeName: 'Uint8List'`; equality/hash via `ModelHelpers.listsEqual`/`listHash`.
- **Imports** — `dart:typed_data show Uint8List` flagged for re-export from `lib/api.dart` so generated round-trip tests can construct `Uint8List` values. `dart:convert` imported privately by each model file that needs `base64`. The barrel-collector now walks `dart:` SDK imports with explicit `shown:` lists, not just `package:` imports.
- **model_helpers** — new `maybeBase64Encode(List<int>?)` and `maybeBase64Decode(String?)` helpers handle the nullable path. Required fields call `base64.encode/decode` directly; nullable fields go through the helpers because a public-property `Uint8List?` doesn't promote inside a ternary, and `name == null ? null : base64.encode(name)` fails as `Uint8List? can't be assigned to List<int>`. Helper imports gated by a new `needsBase64Imports` template flag.

## Generated example

```dart
// before:
final String? avatar;
'avatar': avatar,                                      // base64 string passed through
avatar: json['avatar'] as String?,

// after:
final Uint8List? avatar;
'avatar': maybeBase64Encode(avatar),                   // bytes → base64 at the boundary
avatar: maybeBase64Decode(json['avatar'] as String?),  // base64 → bytes at the boundary
```

For required fields:

```dart
final Uint8List image;
'image': base64.encode(image),
image: base64.decode(json['image'] as String),
```

## Test plan
- [x] 3 new parser tests covering `contentEncoding=base64`, the `binary`-stays-String fallback, and `contentMediaType` consumption.
- [x] 1 new render test covering the full required+nullable round-trip pattern.
- [x] 516 total tests pass.
- [x] Discord regen drops from 34 errors (a regression spike during PR development) to 4 — all 4 are the pre-existing multi-status name collision fixed by #196.
- [x] Github regen byte-identical (no `contentEncoding` usage in github's spec).

## Closes #199 in favor of this

#199 only suppressed the warning. This is the actual fix — supersedes it.