### PR TITLE
docs: replace stale TODO with tested-specs section

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,15 +83,12 @@ space_gen is iterated against a rotation of real-world OpenAPI specs.
 For each, the regenerated client is expected to `dart analyze` clean
 and its synthesized round-trip tests are expected to pass.
 
-- **GitHub REST API** (~1000 operations, OpenAPI 3.0) — `dart analyze`
-  clean; 6100+ generated round-trip tests pass. The bar we hold the
-  rest to.
-- **Discord API** (~511 schemas, ~141 paths, OpenAPI 3.1) — regenerates
-  end-to-end; remaining gaps surface as iteration topics, not blockers.
-- **SpaceTraders** — `dart analyze` clean.
-- **Train Travel API** (YAML, OpenAPI 3.1) — `dart analyze` clean.
-- **Petstore** (the OpenAPI canonical example) — `dart analyze` clean;
-  shipped under [`example/`](example/).
+- **GitHub REST API** (~1000 operations, OpenAPI 3.0) — Complete.
+- **Discord API** (~511 schemas, ~141 paths, OpenAPI 3.1) — In progress.
+- **SpaceTraders** — Complete.
+- **Train Travel API** (YAML, OpenAPI 3.1) — Complete.
+- **Petstore** (the OpenAPI canonical example) — Complete; shipped
+  under [`example/`](example/).
 
 If you try space_gen against a public spec and the output isn't
 clean, please [file an issue](https://github.com/eseidel/space_gen/issues).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![codecov](https://codecov.io/gh/eseidel/space_gen/graph/badge.svg?token=nOnPSYpPXi)](https://codecov.io/gh/eseidel/space_gen)
+[![Powered by Shorebird](https://img.shields.io/endpoint?url=https://tinyurl.com/shorebirddev)](https://shorebird.dev)
 
 # space_gen
 

--- a/README.md
+++ b/README.md
@@ -87,8 +87,7 @@ and its synthesized round-trip tests are expected to pass.
 - **Discord API** (~511 schemas, ~141 paths, OpenAPI 3.1) — In progress.
 - **SpaceTraders** — Complete.
 - **Train Travel API** (YAML, OpenAPI 3.1) — Complete.
-- **Petstore** (the OpenAPI canonical example) — Complete; shipped
-  under [`example/`](example/).
+- **Petstore** (the OpenAPI canonical example) — Complete.
 
 If you try space_gen against a public spec and the output isn't
 clean, please [file an issue](https://github.com/eseidel/space_gen/issues).

--- a/README.md
+++ b/README.md
@@ -77,34 +77,26 @@ a consensus towards a better Dart generator, so releasing this one.
   off to FileRenderer which uses SchemaRenderer to render api (operation) and
   model (schema) files and imports.
 
-## Todo
+## Tested specs
 
-- Wire up Authentication and sending of bearer header.
-- Generate tests. https://github.com/eseidel/space_gen/issues/1
-- Fix toString hack for queryParameters.
-- Support Parameter.explode.
-- Finish oneOf support.
-- Remove the 'prop' hack for GitHub spec.
-- Split render tree into some sort of "types" library and types -> code gen.
-- Support 'default' for objects.
-- Make RenderPod and RenderEnum typed.
-- Wrap description doc comments to 80c.
-- Recursively validations for properties of named schemas (currently only
-  do top-level const-ready validations).
-- Add (non-const) validation during construction of new-type objects, will
-  require making generator aware that some objects can't be const constructed
-  as well as adding a const-constructor for those objects for default values.
-- Handle 'example' and 'examples' fields.
-- explicitly handle format=int64
-- Handle format=double and format=float
-- Handle deprecated=true in more places (e.g. enums)
-- Map & Array newtype via explicitly named schema?
-- readOnly and writeOnly
-- GitHub: Don't generate workflow_usage_billable_prop_m_a_c_o_s_prop.dart
-- Support multi-level references.
-- Support detecting/stopping reference cycles.
+space_gen is iterated against a rotation of real-world OpenAPI specs.
+For each, the regenerated client is expected to `dart analyze` clean
+and its synthesized round-trip tests are expected to pass.
 
-### OpenApi Quirks
+- **GitHub REST API** (~1000 operations, OpenAPI 3.0) — `dart analyze`
+  clean; 6100+ generated round-trip tests pass. The bar we hold the
+  rest to.
+- **Discord API** (~511 schemas, ~141 paths, OpenAPI 3.1) — regenerates
+  end-to-end; remaining gaps surface as iteration topics, not blockers.
+- **SpaceTraders** — `dart analyze` clean.
+- **Train Travel API** (YAML, OpenAPI 3.1) — `dart analyze` clean.
+- **Petstore** (the OpenAPI canonical example) — `dart analyze` clean;
+  shipped under [`example/`](example/).
+
+If you try space_gen against a public spec and the output isn't
+clean, please [file an issue](https://github.com/eseidel/space_gen/issues).
+
+## OpenApi Quirks
 
 space_gen implements a few OpenAPI quirks to optionally make the generated
 output maximally openapi_generator compatible in case you're transitioning

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -53,3 +53,6 @@ words:
   - ints
   - fixnum
   - codeowners
+  - backticked
+  - favorited
+  - readback


### PR DESCRIPTION
## Summary

Replace the stale TODO list (23 bullets, most superseded by 1.2.0) with a **Tested specs** section that lists the real-world specs space_gen iterates against and their current status. Goal: the README answers "will it work for my spec?" with concrete evidence rather than a wishlist.

## TODO audit

Before deleting, audited each of the original 23 bullets:

| Status | Count | Items |
|---|---|---|
| Done in 1.x | 13 | auth bearer, generate tests, queryParam toString, Parameter.explode (defaults), finish oneOf (substantively), prop hack, default for objects (const path), validation in newtypes, examples, multi-level $refs, recursion cycles, plus more |
| Already tracked as issues | 6 | non-default explode (#100), readOnly/writeOnly (#101 + #186), object defaults (#102), more formats (#132), int64 strategy (#185) |
| Internal/skip | 4 | split render tree (superseded by dispatch.dart + naming.dart), RenderPod typing, doc-comment 80c (CLAUDE.md notes intentionally not strict), "finish oneOf" aspirational |
| Still real, untracked → filed | 4 | #204 #205 #206 #207 |

New issues filed:

- **#204** — Validate constraints on inline object properties at construction time (`Foo.fromJson({'name': '!!!'})` doesn't throw on a pattern violation today; only newtypes validate)
- **#205** — Honor `deprecated: true` on enum values (operations and schemas already emit `@deprecated`)
- **#206** — Map and Array newtypes via explicitly-named top-level schemas
- **#207** — Schema names with consecutive capitals (`MACOS`, `UBUNTU`) snake-split character-by-character into ugly filenames

## Other changes

- Promote `### OpenApi Quirks` → `## OpenApi Quirks` — it was wedged under Todo as an h3 but is a sibling section.

## Test plan

- [x] No code changes; markdown-only.
- [x] Renders correctly in GitHub markdown preview.