### PR TITLE
docs: link tested specs to their public sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,11 +84,15 @@ space_gen is iterated against a rotation of real-world OpenAPI specs.
 For each, the regenerated client is expected to `dart analyze` clean
 and its synthesized round-trip tests are expected to pass.
 
-- **GitHub REST API** (~1000 operations, OpenAPI 3.0) — Complete.
-- **Discord API** (~511 schemas, ~141 paths, OpenAPI 3.1) — In progress.
-- **SpaceTraders** — Complete.
-- **Train Travel API** (YAML, OpenAPI 3.1) — Complete.
-- **Petstore** (the OpenAPI canonical example) — Complete.
+- **[GitHub REST API](https://github.com/github/rest-api-description)**
+  (~1000 operations, OpenAPI 3.0) — Complete.
+- **[Discord API](https://github.com/discord/discord-api-spec)**
+  (~511 schemas, ~141 paths, OpenAPI 3.1) — In progress.
+- **[SpaceTraders](https://spacetraders.io)** — Complete.
+- **[Train Travel API](https://github.com/bump-sh-examples/train-travel-api)**
+  (YAML, OpenAPI 3.1) — Complete.
+- **[Petstore](https://github.com/swagger-api/swagger-petstore)** (the
+  OpenAPI canonical example) — Complete.
 
 If you try space_gen against a public spec and the output isn't
 clean, please [file an issue](https://github.com/eseidel/space_gen/issues).


### PR DESCRIPTION
## Summary

Links each entry in the README's Tested specs section to the public source repo (or, for SpaceTraders, the website):

- **GitHub** → [github/rest-api-description](https://github.com/github/rest-api-description)
- **Discord** → [discord/discord-api-spec](https://github.com/discord/discord-api-spec) (Discord's official OpenAPI repo)
- **SpaceTraders** → [spacetraders.io](https://spacetraders.io)
- **Train Travel** → [bump-sh-examples/train-travel-api](https://github.com/bump-sh-examples/train-travel-api)
- **Petstore** → [swagger-api/swagger-petstore](https://github.com/swagger-api/swagger-petstore)

Sources double-checked against the headers in the locally-tracked specs and `gen_tests/README.md`.

## Test plan

- [x] No code changes; markdown-only.
- [x] Renders correctly in GitHub markdown preview.