### PR TITLE
fix: scope lines_longer_than_80_chars suppression to files we emit

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -56,3 +56,4 @@ words:
   - backticked
   - favorited
   - readback
+  - flaggable

--- a/lib/src/render/file_renderer.dart
+++ b/lib/src/render/file_renderer.dart
@@ -168,12 +168,11 @@ String maybeAddCommentReferencesIgnore(String content) {
   return '$commentReferencesIgnoreBlock\n$content';
 }
 
-/// Composes the per-file emit-time suppression helpers. Wired through
-/// `_renderTemplate(transform: ...)` at every space_gen-emitted file
-/// so each call site references one entry point — adding a new helper
-/// to the chain is a single-place change here, not a sweep across
-/// every spec-emit call site. Hand-written templates skip the
-/// `transform:` argument entirely (see #138's design rationale).
+/// Composes the per-file emit-time suppression helpers applied by
+/// `_renderSpecTemplate`. Adding a new gen-time suppression to the
+/// pipeline is a single edit here; call sites stay unchanged.
+/// Hand-written templates use `_renderTemplate` instead and bypass
+/// this entirely (see #138's design rationale).
 @visibleForTesting
 String maybeAddIgnoreDirectives(String content) =>
     maybeAddLongLineIgnore(maybeAddCommentReferencesIgnore(content));
@@ -529,19 +528,38 @@ class FileRenderer {
   String modelPackageImport(FileRenderer context, RenderSchema schema) =>
       'package:${context.packageName}/${context.modelPackagePath(schema)}';
 
-  /// Render a template. [transform] runs on the rendered content
-  /// before it lands on disk — used by the schema/operation paths to
-  /// add `// ignore_for_file: comment_references` when the spec's
-  /// description text would trip the lint.
+  /// Render a hand-written template — pubspec, analysis_options,
+  /// `auth.dart`, the `client.dart` facade, etc. The output is the
+  /// template verbatim with no spec-derived class names spliced in,
+  /// so the gen-time lint suppressions don't apply. See
+  /// [_renderSpecTemplate] for the path that emits spec-derived
+  /// content.
   void _renderTemplate({
     required String template,
     required String outPath,
     Map<String, dynamic> context = const {},
-    String Function(String content)? transform,
   }) {
     final output = templates.loadTemplate(template).renderString(context);
-    final finalContent = transform == null ? output : transform(output);
-    fileWriter.writeFile(path: outPath, content: finalContent);
+    fileWriter.writeFile(path: outPath, content: output);
+  }
+
+  /// Render a template that emits content shaped by the spec — model
+  /// files, api files, generated round-trip tests. The output is run
+  /// through [maybeAddIgnoreDirectives] before it lands on disk, which
+  /// adds the standard `// ignore_for_file:` block(s) for any lint
+  /// the gen-time content provably triggers. Adding a new gen-time
+  /// suppression is one edit inside [maybeAddIgnoreDirectives]; call
+  /// sites stay unchanged.
+  void _renderSpecTemplate({
+    required String template,
+    required String outPath,
+    Map<String, dynamic> context = const {},
+  }) {
+    final output = templates.loadTemplate(template).renderString(context);
+    fileWriter.writeFile(
+      path: outPath,
+      content: maybeAddIgnoreDirectives(output),
+    );
   }
 
   /// Set up the package directory (creates [fileWriter]'s outDir and
@@ -822,11 +840,10 @@ class FileRenderer {
           .map((i) => i.toTemplateContext())
           .toList();
       final outPath = apiFilePath(api);
-      _renderTemplate(
+      _renderSpecTemplate(
         template: 'add_imports',
         outPath: outPath,
         context: {'imports': importsContext, 'content': renderedApi.body},
-        transform: maybeAddIgnoreDirectives,
       );
       rendered.add(api);
     }
@@ -894,11 +911,10 @@ class FileRenderer {
           .toList();
 
       final outPath = modelFilePath(schema);
-      _renderTemplate(
+      _renderSpecTemplate(
         template: 'add_imports',
         outPath: outPath,
         context: {'imports': importsContext, 'content': rendered.body},
-        transform: maybeAddIgnoreDirectives,
       );
     }
   }
@@ -929,7 +945,7 @@ class FileRenderer {
       final example = schema.exampleValue(schemaContext);
       if (example == null) continue;
       final invalidJson = schema.invalidJsonExample(schemaContext);
-      _renderTemplate(
+      _renderSpecTemplate(
         template: 'schema_round_trip_test',
         outPath: outPath,
         context: {
@@ -940,7 +956,6 @@ class FileRenderer {
           'invalidJsonExample': invalidJson,
           'isEnum': schema is RenderEnum,
         },
-        transform: maybeAddIgnoreDirectives,
       );
     }
   }
@@ -987,7 +1002,7 @@ class FileRenderer {
       });
     }
     if (variants.isEmpty) return;
-    _renderTemplate(
+    _renderSpecTemplate(
       template: 'schema_oneof_round_trip_test',
       outPath: outPath,
       context: {
@@ -996,7 +1011,6 @@ class FileRenderer {
         'typeName': schema.typeName,
         'variants': variants,
       },
-      transform: maybeAddIgnoreDirectives,
     );
   }
 

--- a/lib/src/render/file_renderer.dart
+++ b/lib/src/render/file_renderer.dart
@@ -87,9 +87,9 @@ const longLineIgnoreBlock =
 
 /// Returns [content] with [longLineIgnoreBlock] prepended if any line
 /// outside the analyzer's existing carve-outs (URI imports/exports,
-/// `///` dartdoc) exceeds 80 cols. Used at file-emit time on the two
-/// render paths that produce structurally-unavoidable long lines
-/// (schemas, operations) — hand-written templates skip the call so a
+/// `///` dartdoc) exceeds 80 cols. Threaded through
+/// [maybeAddIgnoreDirectives] at file-emit time on every
+/// space_gen-emitted file — hand-written templates skip the call so a
 /// directive isn't smuggled into files space_gen doesn't own.
 ///
 /// Emit-time decision matches `maybeAddCommentReferencesIgnore`'s
@@ -139,11 +139,11 @@ const commentReferencesIgnoreBlock =
 
 /// Returns [content] with [commentReferencesIgnoreBlock] prepended if
 /// any `///` doc comment carries a bracketed token that wouldn't
-/// resolve in scope. Used at file-emit time on the two render paths
-/// that splice raw spec descriptions into dartdoc (schemas,
-/// operations) — hand-written templates skip the call so a spurious
-/// `[FormatException]` reference in their docs doesn't get silently
-/// suppressed when it should be fixed at the source.
+/// resolve in scope. Threaded through [maybeAddIgnoreDirectives] at
+/// file-emit time on every space_gen-emitted file — hand-written
+/// templates skip the call so a spurious `[FormatException]`
+/// reference in their docs doesn't get silently suppressed when it
+/// should be fixed at the source.
 ///
 /// "In scope" today means *declared as a top-level type in the same
 /// file* (class / enum / extension type / mixin). Imported names
@@ -167,6 +167,16 @@ String maybeAddCommentReferencesIgnore(String content) {
   if (tokens.every(resolvesLocally)) return content;
   return '$commentReferencesIgnoreBlock\n$content';
 }
+
+/// Composes the per-file emit-time suppression helpers. Wired through
+/// `_renderTemplate(transform: ...)` at every space_gen-emitted file
+/// so each call site references one entry point — adding a new helper
+/// to the chain is a single-place change here, not a sweep across
+/// every spec-emit call site. Hand-written templates skip the
+/// `transform:` argument entirely (see #138's design rationale).
+@visibleForTesting
+String maybeAddIgnoreDirectives(String content) =>
+    maybeAddLongLineIgnore(maybeAddCommentReferencesIgnore(content));
 
 /// Collects every `[token]` bracketed reference inside a `///` doc
 /// comment, ignoring `[Foo](url)` markdown links (the `(?!\()` guard).
@@ -816,8 +826,7 @@ class FileRenderer {
         template: 'add_imports',
         outPath: outPath,
         context: {'imports': importsContext, 'content': renderedApi.body},
-        transform: (s) =>
-            maybeAddLongLineIgnore(maybeAddCommentReferencesIgnore(s)),
+        transform: maybeAddIgnoreDirectives,
       );
       rendered.add(api);
     }
@@ -889,8 +898,7 @@ class FileRenderer {
         template: 'add_imports',
         outPath: outPath,
         context: {'imports': importsContext, 'content': rendered.body},
-        transform: (s) =>
-            maybeAddLongLineIgnore(maybeAddCommentReferencesIgnore(s)),
+        transform: maybeAddIgnoreDirectives,
       );
     }
   }
@@ -932,7 +940,7 @@ class FileRenderer {
           'invalidJsonExample': invalidJson,
           'isEnum': schema is RenderEnum,
         },
-        transform: maybeAddLongLineIgnore,
+        transform: maybeAddIgnoreDirectives,
       );
     }
   }
@@ -988,7 +996,7 @@ class FileRenderer {
         'typeName': schema.typeName,
         'variants': variants,
       },
-      transform: maybeAddLongLineIgnore,
+      transform: maybeAddIgnoreDirectives,
     );
   }
 

--- a/lib/src/render/file_renderer.dart
+++ b/lib/src/render/file_renderer.dart
@@ -85,32 +85,42 @@ const longLineIgnoreBlock =
     '// 80 cols as bare identifiers.\n'
     '// ignore_for_file: lines_longer_than_80_chars';
 
-/// Walks [dir] and prepends [longLineIgnoreBlock] to any `.dart` file
-/// that still has a line over 80 cols after `dart format`. Some specs
-/// flatten deeply-nested inline schemas into class names long enough
-/// that common call-site patterns (`.map<Name>(`,
-/// `Name.maybeFromJson(`) and import paths overflow as bare
-/// identifiers — cases `dart format` provably cannot fix by
-/// reflowing. Emitting the directive per-file keeps the lint live
-/// everywhere it could still catch a real generator bug, and it
-/// self-documents which files have structurally-unavoidable long
-/// lines.
+/// Returns [content] with [longLineIgnoreBlock] prepended if any line
+/// outside the analyzer's existing carve-outs (URI imports/exports,
+/// `///` dartdoc) exceeds 80 cols. Used at file-emit time on the two
+/// render paths that produce structurally-unavoidable long lines
+/// (schemas, operations) — hand-written templates skip the call so a
+/// directive isn't smuggled into files space_gen doesn't own.
+///
+/// Emit-time decision matches `maybeAddCommentReferencesIgnore`'s
+/// shape and avoids the previous post-walk pass that scanned every
+/// `.dart` in the output directory — including hand-written ones a
+/// subclass `FileRenderer` was deliberately preserving by overriding
+/// `renderClient` / `renderPublicApi` to no-ops. Skipping
+/// `import`/`export` lines mirrors the analyzer's own behavior:
+/// `lines_longer_than_80_chars` ignores URIs, so a long `import` was
+/// never going to fire the lint and shouldn't trigger the directive
+/// either (the unused directive in turn trips `unnecessary_ignore`).
+///
+/// `dart format` runs after this, so the check is on pre-format
+/// content. Format only reflows long lines shorter when wrapping
+/// points exist — it can't stretch a short line to >80 nor split a
+/// bare identifier — so pre-format detection is a safe overestimate
+/// for the files this generator emits.
 @visibleForTesting
-void suppressLongLineLintInGeneratedFiles(Directory dir) {
+String maybeAddLongLineIgnore(String content) {
   const marker = '// ignore_for_file: lines_longer_than_80_chars';
-  final dartFiles = dir
-      .listSync(recursive: true)
-      .whereType<File>()
-      .where((f) => f.path.endsWith('.dart'));
-  for (final file in dartFiles) {
-    final content = file.readAsStringSync();
-    // Idempotent — a previous run or handwritten override of the
-    // directive already covers this file.
-    if (content.contains(marker)) continue;
-    final hasLongLine = content.split('\n').any((line) => line.length > 80);
-    if (!hasLongLine) continue;
-    file.writeAsStringSync('$longLineIgnoreBlock\n$content');
-  }
+  if (content.contains(marker)) return content;
+  final hasFlaggableLongLine = content.split('\n').any((line) {
+    if (line.length <= 80) return false;
+    final trimmed = line.trimLeft();
+    if (trimmed.startsWith('import ')) return false;
+    if (trimmed.startsWith('export ')) return false;
+    if (trimmed.startsWith('///')) return false;
+    return true;
+  });
+  if (!hasFlaggableLongLine) return content;
+  return '$longLineIgnoreBlock\n$content';
 }
 
 /// Block prepended to generated `.dart` files whose dartdoc contains
@@ -806,7 +816,8 @@ class FileRenderer {
         template: 'add_imports',
         outPath: outPath,
         context: {'imports': importsContext, 'content': renderedApi.body},
-        transform: maybeAddCommentReferencesIgnore,
+        transform: (s) =>
+            maybeAddLongLineIgnore(maybeAddCommentReferencesIgnore(s)),
       );
       rendered.add(api);
     }
@@ -878,7 +889,8 @@ class FileRenderer {
         template: 'add_imports',
         outPath: outPath,
         context: {'imports': importsContext, 'content': rendered.body},
-        transform: maybeAddCommentReferencesIgnore,
+        transform: (s) =>
+            maybeAddLongLineIgnore(maybeAddCommentReferencesIgnore(s)),
       );
     }
   }
@@ -920,6 +932,7 @@ class FileRenderer {
           'invalidJsonExample': invalidJson,
           'isEnum': schema is RenderEnum,
         },
+        transform: maybeAddLongLineIgnore,
       );
     }
   }
@@ -975,6 +988,7 @@ class FileRenderer {
         'typeName': schema.typeName,
         'variants': variants,
       },
+      transform: maybeAddLongLineIgnore,
     );
   }
 
@@ -1038,7 +1052,6 @@ class FileRenderer {
     // Render the combined api.dart exporting all rendered schemas.
     renderPublicApi(spec.apis, schemas);
     formatter.formatAndFix(pkgDir: fileWriter.outDir.path);
-    suppressLongLineLintInGeneratedFiles(fileWriter.outDir);
 
     final misspellings = spellChecker.collectMisspellings(fileWriter.outDir);
     renderCspellConfig(misspellings);

--- a/test/render/file_renderer_test.dart
+++ b/test/render/file_renderer_test.dart
@@ -2416,7 +2416,8 @@ void main() {
 
   group('maybeAddLongLineIgnore', () {
     test('passes through short-only content', () {
-      final content = '${List.generate(5, (i) => 'var x$i = $i;').join('\n')}\n';
+      final content =
+          '${List.generate(5, (i) => 'var x$i = $i;').join('\n')}\n';
       expect(maybeAddLongLineIgnore(content), content);
     });
 

--- a/test/render/file_renderer_test.dart
+++ b/test/render/file_renderer_test.dart
@@ -2414,75 +2414,71 @@ void main() {
     });
   });
 
-  group('suppressLongLineLintInGeneratedFiles', () {
-    Directory setUpDir(Map<String, String> files) {
-      final fs = MemoryFileSystem.test();
-      final dir = fs.directory('/out')..createSync(recursive: true);
-      for (final entry in files.entries) {
-        dir.childFile(entry.key)
-          ..parent.createSync(recursive: true)
-          ..writeAsStringSync(entry.value);
-      }
-      return dir;
-    }
-
-    test('leaves short-only files untouched', () {
-      final shortContent = List.generate(5, (i) => 'var x$i = $i;').join('\n');
-      final dir = setUpDir({'lib/short.dart': shortContent});
-      suppressLongLineLintInGeneratedFiles(dir);
-      expect(
-        dir.childFile('lib/short.dart').readAsStringSync(),
-        shortContent,
-      );
+  group('maybeAddLongLineIgnore', () {
+    test('passes through short-only content', () {
+      final content = '${List.generate(5, (i) => 'var x$i = $i;').join('\n')}\n';
+      expect(maybeAddLongLineIgnore(content), content);
     });
 
-    test('prepends directive to files with any line > 80 cols', () {
-      final longLine = '// ${'a' * 100}';
-      const shortContent = 'var x = 1;\n';
-      final dir = setUpDir({
-        'lib/long.dart': '$shortContent$longLine\n',
-        'lib/also_short.dart': shortContent,
-      });
-      suppressLongLineLintInGeneratedFiles(dir);
+    test('prepends directive when a non-import line exceeds 80 cols', () {
+      final longLine = 'final x = ${'a' * 80};';
+      final content = 'var x = 1;\n$longLine\n';
       expect(
-        dir.childFile('lib/long.dart').readAsStringSync(),
+        maybeAddLongLineIgnore(content),
         startsWith('$longLineIgnoreBlock\n'),
-      );
-      expect(
-        dir.childFile('lib/also_short.dart').readAsStringSync(),
-        shortContent,
       );
     });
 
     test('is idempotent — does not stack the directive', () {
-      final longLine = '// ${'a' * 100}';
-      final dir = setUpDir({
-        'lib/long.dart': '$longLineIgnoreBlock\n$longLine\n',
-      });
-      suppressLongLineLintInGeneratedFiles(dir);
-      final content = dir.childFile('lib/long.dart').readAsStringSync();
-      // Directive appears exactly once.
+      final longLine = 'final x = ${'a' * 80};';
+      final content = '$longLineIgnoreBlock\n$longLine\n';
+      // Directive present exactly once before and after.
+      expect(longLineIgnoreBlock.allMatches(content).length, 1);
+      final result = maybeAddLongLineIgnore(content);
+      expect(longLineIgnoreBlock.allMatches(result).length, 1);
+    });
+
+    test('passes through when only long lines are imports', () {
+      // Mirrors the analyzer's `lines_longer_than_80_chars` carve-out
+      // for URI imports — flagging these would trip `unnecessary_ignore`
+      // because the underlying lint never fires.
+      final longImport =
+          "import 'package:${'a' * 60}/foo.dart' as ${'b' * 30};";
+      final content = '$longImport\nclass Foo {}\n';
+      expect(longImport.length, greaterThan(80));
+      expect(maybeAddLongLineIgnore(content), content);
+    });
+
+    test('passes through when only long lines are exports', () {
+      final longExport =
+          "export 'package:${'a' * 60}/foo.dart' show ${'b' * 30};";
+      final content = '$longExport\nclass Foo {}\n';
+      expect(longExport.length, greaterThan(80));
+      expect(maybeAddLongLineIgnore(content), content);
+    });
+
+    test('passes through when only long lines are `///` dartdoc', () {
+      final longDoc = '/// ${'a' * 90}';
+      final content = '$longDoc\nclass Foo {}\n';
+      expect(longDoc.length, greaterThan(80));
+      expect(maybeAddLongLineIgnore(content), content);
+    });
+
+    test('still fires when a real long line sits next to a long import', () {
+      final longImport =
+          "import 'package:${'a' * 60}/foo.dart' as ${'b' * 30};";
+      final longCode = 'final x = ${'a' * 80};';
+      final content = '$longImport\n$longCode\n';
       expect(
-        longLineIgnoreBlock.allMatches(content).length,
-        1,
+        maybeAddLongLineIgnore(content),
+        startsWith('$longLineIgnoreBlock\n'),
       );
     });
 
-    test('ignores non-dart files', () {
-      final longLine = 'x' * 100;
-      final dir = setUpDir({'README.md': longLine});
-      suppressLongLineLintInGeneratedFiles(dir);
-      expect(dir.childFile('README.md').readAsStringSync(), longLine);
-    });
-
-    test('ignores a line exactly 80 chars (at the limit, not over)', () {
+    test('treats exactly 80 chars as not over', () {
       final exactly80 = 'x' * 80;
-      final dir = setUpDir({'lib/borderline.dart': '$exactly80\n'});
-      suppressLongLineLintInGeneratedFiles(dir);
-      expect(
-        dir.childFile('lib/borderline.dart').readAsStringSync(),
-        '$exactly80\n',
-      );
+      final content = '$exactly80\n';
+      expect(maybeAddLongLineIgnore(content), content);
     });
   });
 


### PR DESCRIPTION
## Summary

Two related bugs in `suppressLongLineLintInGeneratedFiles`:

1. **Wrong scope.** The pass walked the entire output directory and rewrote any `.dart` file with a long line. A `FileRenderer` subclass that overrides `renderClient` / `renderPublicApi` / etc. to no-op (so the package can hand-maintain its barrel and HTTP client) still saw those hand-written files mutated by space_gen. Surfaced when regenerating `shorebird_code_push_protocol`: its `tool/gen.dart` hand-overrides the barrel, and the 1.2.1 regen prepended a directive to the hand-written `shorebird_code_push_protocol.dart`.

2. **Over-trigger.** The pass counted raw line length without the carve-outs the analyzer's `lines_longer_than_80_chars` lint applies — URI `import`/`export` and `///` dartdoc are excluded by the lint. A file whose only over-80 lines were imports got the directive anyway, then tripped `unnecessary_ignore` because the underlying lint never fires. 4 such files showed up in the same regen.

## Fix

Mirrors the pattern PR #138 settled on for `comment_references`: replace the post-walk pass with a per-file emit-time helper `maybeAddLongLineIgnore(content)`, threaded through the same `_renderTemplate` transform parameter. Only the four paths that emit content shaped by spec-derived class names call it: `renderApis`, `renderModels`, `renderModelTests`, `_renderOneOfTest`. Hand-written templates skip it.

When measuring, the helper skips any line whose trimmed start is `import `, `export `, or `///` — matching the analyzer's own carve-outs.

The post-walk function is gone; the call site in `render()` is gone.

## Verification

- All 530 unit tests pass.
- github regen `dart analyze` clean end-to-end.
- The `shorebird_code_push_protocol` regen that exposed both bugs: when re-pinned to a future release with this fix, the hand-written barrel stays untouched and the 4 false-positive directives don't appear.

## Test plan

- [x] Replaces the `suppressLongLineLintInGeneratedFiles` test group with a `maybeAddLongLineIgnore` group covering: short-only content, real long line, idempotency, import-only / export-only / dartdoc-only long-lines (no directive), mixed-content (long code next to long import still fires), borderline 80-col.
- [x] github regen — `dart analyze` clean (`/tmp/g_post_refactor2`).
- [x] Existing renderApis / renderModels paths still produce the directive on the same files where it's actually needed (long type names that survive format).