### PR TITLE
fix: prune model helpers by whole-identifier match, not substring

### DIFF
--- a/lib/src/render/schema_renderer.dart
+++ b/lib/src/render/schema_renderer.dart
@@ -2,14 +2,42 @@ import 'package:space_gen/src/quirks.dart';
 import 'package:space_gen/src/render/render_tree.dart';
 import 'package:space_gen/src/render/templates.dart';
 
+/// A maximal Dart identifier: `[a-zA-Z_$]` head, `[\w$]*` tail.
+final _identifierPattern = RegExp(r'[a-zA-Z_$][\w$]*');
+
+/// [ModelHelpers.all] as a set, for O(1) membership while scanning.
+final Set<String> _helperNames = ModelHelpers.all.toSet();
+
+/// The subset of [ModelHelpers.all] that [body] references as whole
+/// identifiers.
+///
+/// We tokenize [body] into identifiers in a single pass and match each
+/// token against [_helperNames] by exact equality. A plain
+/// `body.contains(name)` would over-match helper names that are
+/// prefixes of others — `maybeParseDateTime` contains `maybeParseDate`,
+/// `maybeParseUriTemplate` contains `maybeParseUri` — so a body that
+/// calls only the longer helper would drag the shorter, never-called
+/// one into `model_helpers.dart` as a dead function: uncovered lines
+/// that fail the consuming package's coverage gate. Comparing whole
+/// tokens makes that impossible by construction.
+Set<String> _referencedModelHelpers(String body) {
+  final found = <String>{};
+  for (final match in _identifierPattern.allMatches(body)) {
+    final token = match[0]!;
+    if (_helperNames.contains(token)) found.add(token);
+  }
+  return found;
+}
+
 /// Which imports a rendered schema body needs beyond the schemas it
 /// references, plus which `model_helpers.dart` helpers the body calls
 /// (used to prune unused helpers from the shared file).
 ///
-/// Today we derive this from the rendered body via substring checks. The
-/// long-term plan is for the rendering pipeline in render_tree.dart to
-/// populate this directly as it emits helper calls — the [importsFor]
-/// interface will not change.
+/// Today we derive this from the rendered body by scanning its
+/// identifier tokens (see [_referencedModelHelpers]). The long-term
+/// plan is for the rendering pipeline in render_tree.dart to populate
+/// this directly as it emits helper calls — the [importsFor] interface
+/// will not change.
 class SchemaUsage {
   const SchemaUsage({
     this.usesMetaAnnotations = false,
@@ -22,10 +50,7 @@ class SchemaUsage {
     return SchemaUsage(
       usesMetaAnnotations: body.contains('@immutable'),
       usesValidationExtensions: _validationCallPattern.hasMatch(body),
-      modelHelpers: {
-        for (final h in ModelHelpers.all)
-          if (body.contains(h)) h,
-      },
+      modelHelpers: _referencedModelHelpers(body),
     );
   }
 
@@ -75,10 +100,7 @@ class ApiUsage {
 
   factory ApiUsage.fromBody(String body) => ApiUsage(
     usesMetaAnnotations: body.contains('@immutable'),
-    modelHelpers: {
-      for (final h in ModelHelpers.all)
-        if (body.contains(h)) h,
-    },
+    modelHelpers: _referencedModelHelpers(body),
   );
 
   /// True when the body emits `@immutable` (multi-status response

--- a/test/render/file_renderer_test.dart
+++ b/test/render/file_renderer_test.dart
@@ -1011,6 +1011,61 @@ void main() {
       expect(helpers, isNot(contains("import 'package:uri/uri.dart")));
     });
 
+    test(
+      'model_helpers.dart prunes a prefix helper that is never called',
+      () async {
+        // A nullable date-time field emits `maybeParseDateTime(...)`. The
+        // shorter `maybeParseDate` is a prefix of it but is never called,
+        // so it must not land in model_helpers.dart as dead, uncovered
+        // code.
+        final fs = MemoryFileSystem.test();
+        final spec = {
+          'openapi': '3.1.0',
+          'info': {'title': 'Test API', 'version': '1.0.0'},
+          'servers': [
+            {'url': 'https://example.com'},
+          ],
+          'paths': {
+            '/thing': {
+              'get': {
+                'operationId': 'get-thing',
+                'responses': {
+                  '200': {
+                    'description': 'OK',
+                    'content': {
+                      'application/json': {
+                        'schema': {r'$ref': '#/components/schemas/Thing'},
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          'components': {
+            'schemas': {
+              'Thing': {
+                'type': 'object',
+                'properties': {
+                  // Optional → nullable json → `maybeParseDateTime(...)`.
+                  'updatedAt': {'type': 'string', 'format': 'date-time'},
+                },
+              },
+            },
+          },
+        };
+        final out = fs.directory('out');
+        await renderToDirectory(spec: spec, outDir: out);
+        final helpers = out
+            .childFile('lib/model_helpers.dart')
+            .readAsStringSync();
+        expect(helpers, contains('DateTime? maybeParseDateTime(String'));
+        // Full signature, not the bare name: avoids matching the
+        // `maybeParseDate` substring inside `maybeParseDateTime`.
+        expect(helpers, isNot(contains('DateTime? maybeParseDate(String')));
+      },
+    );
+
     test('model_helpers.dart includes collection helpers for list/map '
         'properties', () async {
       final fs = MemoryFileSystem.test();
@@ -2527,6 +2582,34 @@ void main() {
           contains(const Import('package:spacetraders/api_exception.dart')),
         ),
       );
+    });
+
+    test('SchemaUsage.fromBody matches helper names as whole identifiers', () {
+      // `maybeParseDate`/`maybeParseUri` are prefixes of
+      // `maybeParseDateTime`/`maybeParseUriTemplate`. A substring scan
+      // would pull the shorter, never-called helper into
+      // model_helpers.dart as dead, uncovered code. A call to the longer
+      // helper must match only the longer one; the shorter still matches
+      // when it is the one called.
+      Set<String> usedBy(String helper) => SchemaUsage.fromBody(
+        "x: $helper(json['x'] as String?),",
+      ).modelHelpers;
+
+      expect(usedBy('maybeParseDateTime'), {ModelHelpers.maybeParseDateTime});
+      expect(usedBy('maybeParseUriTemplate'), {
+        ModelHelpers.maybeParseUriTemplate,
+      });
+      expect(usedBy('maybeParseDate'), {ModelHelpers.maybeParseDate});
+      expect(usedBy('maybeParseUri'), {ModelHelpers.maybeParseUri});
+    });
+
+    test('ApiUsage.fromBody uses the same whole-identifier match', () {
+      // ApiUsage derives modelHelpers independently of SchemaUsage; pin
+      // that it doesn't regress to a substring scan on its own.
+      final usage = ApiUsage.fromBody(
+        "x: maybeParseDateTime(json['x'] as String?),",
+      );
+      expect(usage.modelHelpers, {ModelHelpers.maybeParseDateTime});
     });
 
     test('imports for api', () {


### PR DESCRIPTION
## Summary

Helper pruning used `body.contains(name)`, so a body calling `maybeParseDateTime` also matched `maybeParseDate` (same for `maybeParseUriTemplate` / `maybeParseUri`). The unused helper got written into `model_helpers.dart` with no caller, which reads as uncovered lines on the generated package.

The `maybeParse*` helpers only show up for nullable fields, so any spec with a nullable date-time or uri-template field trips it. Hit it regenerating shorebird's `code_push_server`.

## Fix

Match helper names as whole identifiers: `_referencedModelHelpers` tokenizes the body once and intersects with `ModelHelpers.all`, so the longer name no longer drags in the shorter. Both `SchemaUsage.fromBody` and `ApiUsage.fromBody` use it.

No `gen_tests` fixture has a nullable date-time field, which is why this slipped through. Added unit and e2e coverage.

## Verification

547 tests pass, analyze and format clean. On the shorebird spec, `maybeParseDate` was emitted with zero call sites before and is gone after.
