### PR TITLE
fix: admit empty-object allOf members instead of crashing

### DIFF
--- a/lib/src/resolver.dart
+++ b/lib/src/resolver.dart
@@ -409,9 +409,14 @@ ResolvedSchema _resolveSchemaFully(
       return schemas.first;
     }
     for (final schema in schemas) {
-      if (schema is! ResolvedObject) {
-        _error('allOf only supports objects: $schema', allOf.pointer);
-      }
+      // An open empty object (`type: object` with no properties and no closed
+      // `additionalProperties`) intersects trivially — every JSON object
+      // satisfies it — so it is a valid allOf member that contributes no
+      // properties to the merge. The render pass only merges `RenderObject`
+      // members, so `ResolvedEmptyObject` is already a no-op there; this just
+      // stops the resolver rejecting it on the way.
+      if (schema is ResolvedObject || schema is ResolvedEmptyObject) continue;
+      _error('allOf only supports objects: $schema', allOf.pointer);
     }
     return ResolvedAllOf(common: resolvedCommon, schemas: schemas);
   }

--- a/test/resolver_test.dart
+++ b/test/resolver_test.dart
@@ -365,6 +365,51 @@ void main() {
       );
     });
 
+    test(
+      'allOf admits empty-object members',
+      () {
+        // Mirrors the shape that surfaced this: `allOf: [{$ref: JsonObject},
+        // {type: object, properties: {...}}]` where `JsonObject` is `type:
+        // object, properties: {}, additionalProperties: {}` (an open empty
+        // object). The empty open object intersects trivially, so it should be
+        // admitted as an allOf member (contributing no properties to the
+        // merge) rather than crashing the resolver. Here we use
+        // `additionalProperties: true`, which is semantically identical to `{}`
+        // per JSON Schema 2020-12 and is how the YAML loader surfaces the
+        // shape after parsing such a spec.
+        final json = {
+          'allOf': [
+            {
+              'type': 'object',
+              'properties': <String, dynamic>{},
+              'additionalProperties': true,
+            },
+            {
+              'type': 'object',
+              'properties': {
+                'name': {'type': 'string'},
+              },
+            },
+          ],
+        };
+        final logger = _MockLogger();
+        final schema = runWithLogger(
+          logger,
+          () => parseAndResolveTestSchema(json),
+        );
+        // The allOf is preserved (not collapsed) so the parent schema keeps its
+        // name; the empty member contributes no properties at render time.
+        expect(
+          schema,
+          isA<ResolvedAllOf>().having(
+            (e) => e.schemas.length,
+            'schemas',
+            equals(2),
+          ),
+        );
+      },
+    );
+
     test('resolve anyOf', () {
       final json = {
         'anyOf': [


### PR DESCRIPTION
## Summary

`allOf: [{$ref: JsonObject}, {type: object, properties: {...}}]` crashes with `FormatException: allOf only supports objects` because `JsonObject` (an open empty object: `type: object, properties: {}, additionalProperties: {}`) resolves to `ResolvedEmptyObject`, not `ResolvedObject`, and the resolver rejected any non-`ResolvedObject` allOf member.

## Fix

Allow `ResolvedEmptyObject` as an allOf member (alongside `ResolvedObject`) in the type-check at `resolver.dart`. An empty open object intersects trivially — every JSON object satisfies it — so it is a valid allOf member that simply contributes no properties to the merged object the renderer builds.

The render pass already only merges `RenderObject` members (`case ResolvedAllOf` in `render_tree.dart`), so a `ResolvedEmptyObject` member is already a no-op there; this just makes the resolver stop crashing on the way there. The allOf is preserved (not collapsed), so the parent schema keeps its name — important for test emission and downstream naming.

This mirrors the spirit of PR #138's `comment_references` handling: spec prose / spec shapes that trip Dart's tooling should be sanitized at the generator boundary rather than crashing.

## Spec that surfaced this

Backstage's catalog OpenAPI spec uses this exact shape for `RecursivePartialEntityMeta`:

https://github.com/backstage/backstage/blob/master/plugins/catalog-backend/src/schema/openapi.yaml

Schema excerpt:

```yaml
JsonObject:
  type: object
  properties: {}
  additionalProperties: {}
  description: A type representing all allowed JSON object values.
RecursivePartialEntityMeta:
  allOf:
    - $ref: '#/components/schemas/JsonObject'
    - type: object
      properties: { ... }
      additionalProperties: false
```

With this fix, space_gen generates the full Backstage catalog client from the remote spec with no patches or vendoring required.

## Test plan

- [x] Added `allOf admits empty-object members` to `test/resolver_test.dart` — verifies an `allOf` containing an open empty object plus a real object resolves to a `ResolvedAllOf` with both members preserved (no crash, no collapse).
- [x] `dart test test/resolver_test.dart` — all resolver tests pass.
- [x] `dart test` (full suite) — 548 tests pass, no regressions.
- [x] End-to-end: ran this branch's `bin/space_gen.dart` against the remote Backstage catalog spec URL; full client generated successfully (`name: devhub_client`, all `lib/` emitted, `RecursivePartialEntityMeta` model present, 138 generated round-trip tests pass).