### PR TITLE
fix: suppress unintended_html_in_doc_comment for spec-prose angle brackets

### DIFF
--- a/lib/src/render/formatting.dart
+++ b/lib/src/render/formatting.dart
@@ -105,7 +105,7 @@ const commentReferencesIgnoreBlock =
 const unintendedHtmlInDocCommentIgnoreBlock =
     '// Spec descriptions copy prose verbatim into dartdoc, where `<x>`\n'
     '// is parsed as an HTML tag start even when it is not HTML (e.g.\n'
-    '// entity-ref examples like `location:default/generated-<sha1hex>`).\n'
+    '// placeholder tokens like `<sha1hex>`).\n'
     '// Suppress file-locally so the lint stays live elsewhere; spec\n'
     '// authors do not always escape angle brackets.\n'
     '// ignore_for_file: unintended_html_in_doc_comment';
@@ -141,7 +141,7 @@ String maybeAddUnintendedHtmlIgnore(String content) {
 /// `</foo>` tags both match via the leading `/` arm only when a
 /// letter follows (so `</` followed by whitespace won't match).
 bool _dartdocHasHtmlTag(String content) {
-  final tagRe = RegExp('<(?:[A-Za-z]|/[A-Za-z])');
+  final tagRe = RegExp('</?[A-Za-z]');
   for (final line in content.split('\n')) {
     final stripped = line.trimLeft();
     if (!stripped.startsWith('///')) continue;

--- a/lib/src/render/formatting.dart
+++ b/lib/src/render/formatting.dart
@@ -96,6 +96,60 @@ const commentReferencesIgnoreBlock =
     '// elsewhere; spec authors do not always escape brackets.\n'
     '// ignore_for_file: comment_references';
 
+/// Block prepended to generated `.dart` files whose dartdoc contains
+/// `<...>` patterns that dartdoc parses as (unclosed) HTML tags (e.g.
+/// Backstage's catalog spec describes an entity ref as
+/// `location:default/generated-<sha1hex>`, and `<sha1hex>` reads as a
+/// tag start to dartdoc). Exposed for tests.
+@visibleForTesting
+const unintendedHtmlInDocCommentIgnoreBlock =
+    '// Spec descriptions copy prose verbatim into dartdoc, where `<x>`\n'
+    '// is parsed as an HTML tag start even when it is not HTML (e.g.\n'
+    '// entity-ref examples like `location:default/generated-<sha1hex>`).\n'
+    '// Suppress file-locally so the lint stays live elsewhere; spec\n'
+    '// authors do not always escape angle brackets.\n'
+    '// ignore_for_file: unintended_html_in_doc_comment';
+
+/// Returns [content] with [unintendedHtmlInDocCommentIgnoreBlock]
+/// prepended if any `///` doc comment carries an angle-bracket token
+/// that dartdoc parses as an HTML tag start. Threaded through
+/// [maybeAddIgnoreDirectives] at file-emit time on every space_gen-
+/// emitted file — hand-written templates skip the call so a spurious
+/// `<...>` in their docs doesn't get silently suppressed when it
+/// should be fixed at the source.
+///
+/// Mirrors [maybeAddCommentReferencesIgnore]'s approach to `[x]`
+/// bracketed refs (PR #138): spec prose / spec shapes that trip
+/// dartdoc's parser should be sanitized at the generator boundary
+/// rather than forcing every consumer to hand-suppress.
+@visibleForTesting
+String maybeAddUnintendedHtmlIgnore(String content) {
+  const marker = '// ignore_for_file: unintended_html_in_doc_comment';
+  if (content.contains(marker)) return content;
+  if (!_dartdocHasHtmlTag(content)) return content;
+  return '$unintendedHtmlInDocCommentIgnoreBlock\n$content';
+}
+
+/// Whether any `///` doc comment line in [content] carries an
+/// angle-bracket token dartdoc would parse as an HTML tag start.
+///
+/// Matches `<` immediately followed by a letter or `/` — the shapes
+/// dartdoc's HTML parser treats as element starts (HTML names must
+/// start with an ASCII letter). Plain prose like `a < b` or `i < 0`
+/// does not match because the character after `<` is a space or
+/// digit, not a letter. Self-closing `<br/>`-style tags and closing
+/// `</foo>` tags both match via the leading `/` arm only when a
+/// letter follows (so `</` followed by whitespace won't match).
+bool _dartdocHasHtmlTag(String content) {
+  final tagRe = RegExp('<(?:[A-Za-z]|/[A-Za-z])');
+  for (final line in content.split('\n')) {
+    final stripped = line.trimLeft();
+    if (!stripped.startsWith('///')) continue;
+    if (tagRe.hasMatch(stripped)) return true;
+  }
+  return false;
+}
+
 /// Returns [content] with [commentReferencesIgnoreBlock] prepended if
 /// any `///` doc comment carries a bracketed token that wouldn't
 /// resolve in scope. Threaded through [maybeAddIgnoreDirectives] at
@@ -130,8 +184,9 @@ String maybeAddCommentReferencesIgnore(String content) {
 /// pipeline is a single edit here; call sites stay unchanged.
 /// Hand-written templates use `_renderTemplate` instead and bypass
 /// this entirely (see #138's design rationale).
-String maybeAddIgnoreDirectives(String content) =>
-    maybeAddLongLineIgnore(maybeAddCommentReferencesIgnore(content));
+String maybeAddIgnoreDirectives(String content) => maybeAddLongLineIgnore(
+  maybeAddCommentReferencesIgnore(maybeAddUnintendedHtmlIgnore(content)),
+);
 
 /// Collects every `[token]` bracketed reference inside a `///` doc
 /// comment, ignoring `[Foo](url)` markdown links (the `(?!\()` guard).

--- a/test/render/formatting_test.dart
+++ b/test/render/formatting_test.dart
@@ -238,6 +238,76 @@ void main() {
     });
   });
 
+  group('maybeAddUnintendedHtmlIgnore', () {
+    test('passes through content with no angle-bracket dartdoc', () {
+      const content = '/// A class with no angle brackets.\nclass Foo {}\n';
+      expect(maybeAddUnintendedHtmlIgnore(content), content);
+    });
+
+    test(
+      'prepends directive when dartdoc has an angle-bracket tag-like token',
+      () {
+        // Mirrors Backstage's catalog spec: an entity ref example like
+        // `location:default/generated-<sha1hex>`.
+        const content =
+            '/// The entity ref, e.g. location:default/generated-<sha1hex>.\n'
+            'final String entityRef;\n';
+        expect(
+          maybeAddUnintendedHtmlIgnore(content),
+          startsWith('$unintendedHtmlInDocCommentIgnoreBlock\n'),
+        );
+      },
+    );
+
+    test('does not match plain-comment angle brackets, only `///` doc', () {
+      // A `//` line comment with `<sha1hex>` should not trigger.
+      const content = '// note: see <sha1hex> for details\nclass Foo {}\n';
+      expect(maybeAddUnintendedHtmlIgnore(content), content);
+    });
+
+    test('does not fire on comparison prose like `a < b` or `i < 0`', () {
+      const content =
+          '/// Returns true if a < b for all i < 0.\n'
+          'bool compare() => true;\n';
+      expect(maybeAddUnintendedHtmlIgnore(content), content);
+    });
+
+    test('fires on closing-tag-shaped `</foo>` in dartdoc', () {
+      const content = '/// Closes with </body>.\nclass Foo {}\n';
+      expect(
+        maybeAddUnintendedHtmlIgnore(content),
+        startsWith('$unintendedHtmlInDocCommentIgnoreBlock\n'),
+      );
+    });
+
+    test('idempotent: does not double-prepend if marker already present', () {
+      const content =
+          '$unintendedHtmlInDocCommentIgnoreBlock\n'
+          '/// e.g. <sha1hex>\nclass Foo {}\n';
+      expect(
+        unintendedHtmlInDocCommentIgnoreBlock.allMatches(content).length,
+        1,
+      );
+      final result = maybeAddUnintendedHtmlIgnore(content);
+      expect(
+        unintendedHtmlInDocCommentIgnoreBlock.allMatches(result).length,
+        1,
+      );
+    });
+
+    test('indented `///` member docs still count', () {
+      const content =
+          'class Foo {\n'
+          '  /// e.g. <sha1hex>\n'
+          '  final String ref;\n'
+          '}\n';
+      expect(
+        maybeAddUnintendedHtmlIgnore(content),
+        startsWith('$unintendedHtmlInDocCommentIgnoreBlock\n'),
+      );
+    });
+  });
+
   group('DartFileFormatter', () {
     DartFileFormatter buildFormatter(Map<String, String> files) {
       final fs = MemoryFileSystem.test();


### PR DESCRIPTION
## Summary

Spec descriptions copy prose verbatim into dartdoc, where `<x>` is parsed as an HTML tag start even when it is not HTML. Backstage's catalog spec describes an entity ref as `location:default/generated-<sha1hex>`, and `<sha1hex>` reads as an (unclosed) tag start to dartdoc, tripping `very_good_analysis`'s `unintended_html_in_doc_comment` on every consumer package.

## Fix

Mirrors PR #138's `comment_references` handling: spec prose that trips dartdoc's parser should be sanitized at the generator boundary rather than forcing every consumer to hand-suppress. Adds a `maybeAddUnintendedHtmlIgnore` emit-time helper (analogous to `maybeAddCommentReferencesIgnore`) that prepends `// ignore_for_file: unintended_html_in_doc_comment` to any file whose `///` doc comments carry an angle-bracket token dartdoc would parse as an HTML tag start.

Wired into `maybeAddIgnoreDirectives` alongside the existing long-line and `comment_references` helpers, so it runs at file-emit time on every space_gen-emitted file. Hand-written templates bypass it (same design rationale as #138).

Detection matches `<` immediately followed by an ASCII letter or by `/`+letter — the shapes dartdoc's HTML parser treats as element starts. Plain comparison prose like `a < b` or `i < 0` does not match because the character after `<` is a space or digit, not a letter.

## Spec that surfaced this

Backstage's catalog OpenAPI spec:

https://github.com/backstage/backstage/blob/master/plugins/catalog-backend/src/schema/openapi.yaml

Schema excerpt (`Location.entityRef`):

```yaml
entityRef:
  type: string
  description: The entity ref of the corresponding Location kind entity, e.g. location:default/generated-<sha1hex>.
```

Generated dartdoc (`location.dart`):

```dart
/// The entity ref of the corresponding Location kind entity, e.g.
/// location:default/generated-<sha1hex>.
final String entityRef;
```

Before this fix: `dart analyze` on the generated package reports `info - lib/models/location.dart:45:34 - Angle brackets will be interpreted as HTML.` After this fix: `No issues found!`

## Test plan

- [x] Added a `maybeAddUnintendedHtmlIgnore` group to `test/render/formatting_test.dart` — 7 tests covering: pass-through with no angle brackets, prepend on tag-like `<sha1hex>`, no match on `//` plain comments, no fire on comparison prose (`a < b`, `i < 0`), fire on closing-tag `</foo>`, idempotency, indented member docs.
- [x] `dart test test/render/formatting_test.dart` — all formatting tests pass.
- [x] `dart test` (full suite) — 554 tests pass, no regressions.
- [x] End-to-end: ran this branch's `bin/space_gen.dart` against the Backstage catalog spec; `dart analyze` on the generated package reports `No issues found!` (previously 1 `unintended_html_in_doc_comment` info).

Made with [Cursor](https://cursor.com)