### PR TITLE
docs: document in-file lint suppression design decision

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,27 @@ a consensus towards a better Dart generator, so releasing this one.
   off to FileRenderer which uses SchemaRenderer to render api (operation) and
   model (schema) files and imports.
 
+### Lint suppression lives in the generated `.dart` files
+
+space_gen supports consumers who don't use the `analysis_options.yaml` it
+emits. A consumer can subclass `FileRenderer` and override the scaffold hooks
+(`renderAnalysisOptions`, the barrel, the HTTP client) to no-op, then
+hand-maintain those files themselves — `shorebird_code_push_protocol` does
+exactly this, down to its own workspace `analysis_options.yaml` formatter
+settings, which space_gen reads and respects at write time.
+
+Because of that, lint noise from spec-derived prose (angle brackets in
+descriptions, unresolvable `[bracket]` references, long lines, etc.) is
+suppressed **in-file**, via emit-time `// ignore_for_file:` directives added by
+the `maybeAdd*Ignore` helpers in `render/formatting.dart`. A per-file directive
+travels with the `.dart` file and works regardless of whose `analysis_options`
+wins; a blanket disable in the emitted `analysis_options.yaml` only reaches
+consumers who keep it, so it silently fails for the hand-maintained case.
+
+New per-spec lint suppression should follow this pattern rather than adding a
+blanket disable. (The blanket disables still present in the
+`analysis_options.mustache` template predate this decision.)
+
 ## Tested specs
 
 space_gen is iterated against a rotation of real-world OpenAPI specs.


### PR DESCRIPTION
## Summary

Records — under the README's Design section — why per-spec lint noise is
suppressed with emit-time `// ignore_for_file:` directives in the generated
`.dart` files rather than a blanket disable in the emitted
`analysis_options.yaml`.

The reason: space_gen supports consumers who don't keep the
`analysis_options.yaml` it emits. A consumer can override the scaffold hooks
(`renderAnalysisOptions`, barrel, HTTP client) to no-op and hand-maintain those
files — `shorebird_code_push_protocol` does exactly this, down to its own
workspace formatter config, which space_gen reads and respects. A per-file
directive travels with the `.dart` file and works regardless of whose
`analysis_options` wins; a blanket disable only reaches consumers who keep the
emitted config.

This decision landed in #209/#210 but was only recorded in commit messages and
scattered doc comments. New per-spec suppressions (e.g. #215) should follow the
per-file pattern; the note also flags the pre-existing blanket disables in
`analysis_options.mustache` as predating the decision.

Docs-only change.