### PR TITLE
fix: route explicit `properties: {}` + `additionalProperties` to the map path

### DIFF
--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -823,6 +823,30 @@ SchemaRef? _handleAdditionalProperties(MapContext parent) {
   _error(parent, 'additionalProperties must be a boolean or a map');
 }
 
+/// Builds a [SchemaMap] for an object with no named properties and an
+/// `additionalProperties` [valueSchema] (arbitrary string keys). Shared by
+/// the omitted-`properties` and explicit-`properties: {}` paths so the two
+/// spellings resolve identically.
+SchemaMap _mapSchema(
+  MapContext json, {
+  required CommonProperties common,
+  required SchemaRef valueSchema,
+}) {
+  // Optional: JSON Schema 2020-12 / OpenAPI 3.1 `propertyNames` constrains the
+  // keys of this map-shaped object to values that conform to the given schema.
+  // When that schema is (or resolves to) a string enum, we use it as the Dart
+  // map key type.
+  final propertyNamesJson = _optionalMap(json, 'propertyNames');
+  final keySchema = propertyNamesJson == null
+      ? null
+      : parseSchemaOrRef(propertyNamesJson);
+  return SchemaMap(
+    common: common,
+    valueSchema: valueSchema,
+    keySchema: keySchema,
+  );
+}
+
 SchemaEnum<Object>? _handleEnum({
   required MapContext json,
   required TypeAndFormat typeAndFormat,
@@ -1334,18 +1358,10 @@ Schema _createCorrectSchemaSubtype(MapContext json) {
     if (additionalPropertiesSchema == null) {
       return SchemaUnknown(common: common);
     }
-    // Optional: JSON Schema 2020-12 / OpenAPI 3.1 `propertyNames`
-    // constrains the keys of this map-shaped object to values that
-    // conform to the given schema. When that schema is (or resolves
-    // to) a string enum, we use it as the Dart map key type.
-    final propertyNamesJson = _optionalMap(json, 'propertyNames');
-    final keySchema = propertyNamesJson == null
-        ? null
-        : parseSchemaOrRef(propertyNamesJson);
-    return SchemaMap(
+    return _mapSchema(
+      json,
       common: common,
       valueSchema: additionalPropertiesSchema,
-      keySchema: keySchema,
     );
   }
   // The difference between an empty object and an unknown object is subtle
@@ -1354,6 +1370,20 @@ Schema _createCorrectSchemaSubtype(MapContext json) {
   // empty response.  Those aren't "dynamic" types, but unclear if they need
   // a separate class either.
   if (propertiesJson.keys.isEmpty) {
+    // An explicit `properties: {}` alongside an `additionalProperties` schema
+    // is a map — arbitrary string keys, no named fields — exactly like the
+    // omitted-`properties` case above. Route it the same way so the two
+    // spellings agree; an untyped `additionalProperties` (`true` / `{}`)
+    // gives a `SchemaUnknown` value schema, i.e. `Map<String, dynamic>`.
+    // Without an `additionalProperties` schema it stays an empty object
+    // (GitHub's nullable / empty-response marker; see above).
+    if (additionalPropertiesSchema != null) {
+      return _mapSchema(
+        json,
+        common: common,
+        valueSchema: additionalPropertiesSchema,
+      );
+    }
     return SchemaEmptyObject(common: common);
   }
 

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -1933,6 +1933,81 @@ void main() {
           ),
         );
       });
+      test(
+        'explicit `properties: {}` with `additionalProperties: true` is a map',
+        () {
+          // GitHub uses `{type: object, properties: {}, additionalProperties:
+          // true}` inline as an "arbitrary JSON object". Previously this hit
+          // the empty-properties branch and dropped to `SchemaEmptyObject` (a
+          // lossy empty stub that discards every entry); it should resolve to
+          // a map, exactly like the omitted-`properties` spelling.
+          final schema = parseTestSchema({
+            'type': 'object',
+            'properties': <String, dynamic>{},
+            'additionalProperties': true,
+          });
+          expect(schema, isA<SchemaMap>());
+          expect(
+            (schema as SchemaMap).valueSchema.object,
+            isA<SchemaUnknown>(),
+          );
+        },
+      );
+      test(
+        'explicit `properties: {}` with `additionalProperties: {}` is a map',
+        () {
+          // Backstage's `JsonObject`: an open "any object". Also a map with an
+          // unknown value schema (`Map<String, dynamic>`).
+          final schema = parseTestSchema({
+            'type': 'object',
+            'properties': <String, dynamic>{},
+            'additionalProperties': <String, dynamic>{},
+          });
+          expect(schema, isA<SchemaMap>());
+          expect(
+            (schema as SchemaMap).valueSchema.object,
+            isA<SchemaUnknown>(),
+          );
+        },
+      );
+      test(
+        'explicit `properties: {}` with typed `additionalProperties` is a map',
+        () {
+          // Backstage's `MapStringString`. The value schema is preserved.
+          final schema = parseTestSchema({
+            'type': 'object',
+            'properties': <String, dynamic>{},
+            'additionalProperties': {'type': 'string'},
+          });
+          expect(schema, isA<SchemaMap>());
+          expect((schema as SchemaMap).valueSchema.object, isA<SchemaString>());
+        },
+      );
+      test(
+        'explicit `properties: {}` with no `additionalProperties` '
+        'stays an empty object',
+        () {
+          // Preserve the existing marker: an explicitly empty object with no
+          // `additionalProperties` is GitHub's nullable / empty-response shape.
+          final schema = parseTestSchema({
+            'type': 'object',
+            'properties': <String, dynamic>{},
+          });
+          expect(schema, isA<SchemaEmptyObject>());
+        },
+      );
+      test(
+        'explicit `properties: {}` with `additionalProperties: false` '
+        'stays an empty object',
+        () {
+          final schema = parseTestSchema({
+            'type': 'object',
+            'properties': <String, dynamic>{},
+            'additionalProperties': false,
+          });
+          expect(schema, isA<SchemaEmptyObject>());
+        },
+      );
     });
 
     group('operationId', () {


### PR DESCRIPTION
## Summary

An object schema with an explicit empty `properties: {}` **plus** an `additionalProperties` schema is a map — arbitrary string keys, no named fields — identical in meaning to the same schema with `properties` omitted. The omitted-`properties` form already parsed to `SchemaMap`, but the explicit-empty form fell through to the empty-properties branch and became a `SchemaEmptyObject`: a lossy stub whose `fromJson` discards the input and whose `toJson` always emits `{}`. Every entry silently round-tripped away.

## Fix

In `_createCorrectSchemaSubtype` (`lib/src/parser.dart`), route the explicit `properties: {}` case through the map path when an `additionalProperties` schema is present, so the two spellings agree:

- untyped `additionalProperties` (`true` / `{}`) → `SchemaUnknown` value schema → `Map<String, dynamic>`
- typed `additionalProperties` (`{type: string}`) → value schema preserved → `Map<String, V>`
- **no** `additionalProperties` → still `SchemaEmptyObject` (GitHub's nullable / empty-response marker), unchanged
- `additionalProperties: false` → still `SchemaEmptyObject` (closed object), unchanged

Extracts the shared `propertyNames`/`SchemaMap` construction into a `_mapSchema` helper so the omitted- and explicit-empty paths resolve through one place.

## Motivated by real specs

GitHub's spec has **10 inline** `{type: object, properties: {}, additionalProperties: true}` nodes — e.g. the attestation `bundle`'s `verificationMaterial` / `dsseEnvelope` fields — that were generating lossy empty-stub classes. After this fix they render as round-tripping `Map<String, dynamic>?`:

```dart
final Map<String, dynamic>? verificationMaterial;
final Map<String, dynamic>? dsseEnvelope;
// fromJson: (json['verificationMaterial'] as Map<String, dynamic>?)?.map(...)
```

Backstage's `JsonObject` (`additionalProperties: {}`) and `MapStringString` (`additionalProperties: {type: string}`) use the same shape.

Note: this is the untyped-inclusive fix the prior draft PR #216 only did for the *typed* case — every real GitHub node here is untyped, so the typed-only version fixed none of them.

## Test plan

- [x] Added 5 tests to `test/parser_test.dart`'s `additionalProperties` group: explicit `{}` + `additionalProperties: true` / `{}` / typed → `SchemaMap` (with correct value schema); explicit `{}` with no `additionalProperties` and with `additionalProperties: false` → `SchemaEmptyObject` (preserved).
- [x] `dart test` — 559 pass, no regressions.
- [x] `dart analyze` / `dart format` — clean.
- [x] End-to-end: regenerated the full GitHub client. `dart analyze` reports **No issues found!**; the empty-object stub count drops 18 → 8 (the 10 open-object nodes fixed, remaining 8 are genuine empty objects); the attestation `bundle` fields confirmed round-tripping as `Map<String, dynamic>?`.