### PR TITLE
feat: merge an open/map member of an `allOf` into the object's overflow

### DIFF
--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -646,16 +646,29 @@ class SpecResolver {
         // dispatch detection (allOf-shaped variants).
         final properties = <String, RenderSchema>{};
         final requiredProperties = <String>{};
+        // An open member makes the merged object open: its value schema
+        // becomes the merged object's `additionalProperties` overflow. First
+        // open member wins (multiple open members in one allOf is degenerate).
+        RenderSchema? additionalProperties;
         for (final schema in schema.schemas) {
           final renderSchema = toRenderSchema(schema);
           if (renderSchema is RenderObject) {
             properties.addAll(renderSchema.properties);
             requiredProperties.addAll(renderSchema.requiredProperties);
+            // A member that itself declares `additionalProperties` (an
+            // object with an overflow) opens the merged object too.
+            additionalProperties ??= renderSchema.additionalProperties;
+          } else if (renderSchema is RenderMap) {
+            // An open map member (e.g. a `JsonObject` → `Map<String, dynamic>`)
+            // contributes an arbitrary-key overflow of its value type.
+            additionalProperties ??= renderSchema.valueSchema;
           }
+          // Other members (e.g. a closed empty object) contribute nothing.
         }
         return RenderObject(
           common: schema.common,
           properties: properties,
+          additionalProperties: additionalProperties,
           requiredProperties: requiredProperties.toList(),
           parentSealedTypeName: _names.parentSealedTypeFor(schema.pointer),
           assignedName: _nameFor(schema.pointer),

--- a/lib/src/resolver.dart
+++ b/lib/src/resolver.dart
@@ -409,9 +409,19 @@ ResolvedSchema _resolveSchemaFully(
       return schemas.first;
     }
     for (final schema in schemas) {
-      if (schema is! ResolvedObject) {
-        _error('allOf only supports objects: $schema', allOf.pointer);
+      // allOf members must be object-shaped. Besides plain objects, admit an
+      // open map member (e.g. a `JsonObject`: `type: object` with only
+      // `additionalProperties`, which resolves to `ResolvedMap`) — it
+      // contributes an arbitrary-key overflow to the merged object — and an
+      // empty object member, which contributes nothing. Both are folded into
+      // the merged `RenderObject` at render time (see `case ResolvedAllOf` in
+      // `render_tree.dart`).
+      if (schema is ResolvedObject ||
+          schema is ResolvedMap ||
+          schema is ResolvedEmptyObject) {
+        continue;
       }
+      _error('allOf only supports objects: $schema', allOf.pointer);
     }
     return ResolvedAllOf(common: resolvedCommon, schemas: schemas);
   }

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -752,6 +752,32 @@ void main() {
       expect(result, contains('final int bar;'));
     });
 
+    test('allOf with an open map member gets an overflow map', () {
+      // Backstage's `RecursivePartialEntityMeta` shape: an open member
+      // (`{type: object, additionalProperties: true}`, i.e. a `JsonObject`)
+      // makes the merged object open. It gains an `entries` overflow
+      // (`Map<String, dynamic>`) alongside the named fields, and fromJson
+      // excludes the named keys from that overflow.
+      final schema = {
+        'allOf': [
+          {'type': 'object', 'additionalProperties': true},
+          {
+            'type': 'object',
+            'properties': {
+              'name': {'type': 'string'},
+            },
+          },
+        ],
+      };
+      final result = renderTestSchema(schema);
+      // The named field from the object member is still merged in.
+      expect(result, contains('name'));
+      // The open member contributes an `entries` overflow map...
+      expect(result, contains('final Map<String, dynamic> entries;'));
+      // ...whose fromJson excludes the named keys.
+      expect(result, contains('.contains(entry.key)'));
+    });
+
     test('oneOf of allOf variants tagged by single-value enum', () {
       // Each variant is `allOf: [<rule>, <info>]` where the first
       // member tags itself with a single-value enum on `type`. After

--- a/test/resolver_test.dart
+++ b/test/resolver_test.dart
@@ -365,6 +365,42 @@ void main() {
       );
     });
 
+    test('allOf admits an open map member', () {
+      // Backstage's `RecursivePartialEntityMeta`: `allOf: [<JsonObject>,
+      // <object>]` where `JsonObject` is `type: object` with only
+      // `additionalProperties` (an open "any object", resolving to
+      // `ResolvedMap`). The open member is admitted — it contributes an
+      // arbitrary-key overflow to the merged object — rather than crashing.
+      final json = {
+        'allOf': [
+          {'type': 'object', 'additionalProperties': true},
+          {
+            'type': 'object',
+            'properties': {
+              'name': {'type': 'string'},
+            },
+          },
+        ],
+      };
+      final logger = _MockLogger();
+      final schema = runWithLogger(
+        logger,
+        () => parseAndResolveTestSchema(json),
+      );
+      expect(
+        schema,
+        isA<ResolvedAllOf>().having(
+          (e) => e.schemas.length,
+          'schemas',
+          equals(2),
+        ),
+      );
+      expect(
+        (schema as ResolvedAllOf).schemas.any((e) => e is ResolvedMap),
+        isTrue,
+      );
+    });
+
     test('resolve anyOf', () {
       final json = {
         'anyOf': [


### PR DESCRIPTION
## Summary

`allOf: [<JsonObject>, <object>]` crashed with `FormatException: allOf only supports objects`. `JsonObject` (`type: object` with only `additionalProperties`) resolves to `ResolvedMap`, and the allOf check rejected any non-`ResolvedObject` member. This is the TypeScript-intersection idiom `JsonObject & { ...named fields... }` — "these known fields, **plus** an arbitrary bag of extra keys."

## Fix

Resolve it faithfully instead of crashing:

- **resolver** — admit `ResolvedMap` and `ResolvedEmptyObject` as allOf members alongside `ResolvedObject`. A map member is an open "any object"; an empty object contributes nothing. (String/number/etc. members are still rejected.)
- **render** — when merging an allOf into its synthesized `RenderObject`, fold an open member's value schema into the merged object's `additionalProperties` overflow. Object members that themselves declare `additionalProperties` propagate it too. First open member wins (multiple open members in one allOf is degenerate).

The merged object then carries both the named fields **and** an `entries` overflow (`Map<String, dynamic>`) whose `fromJson`/`toJson` exclude the named keys — reusing the object-with-`additionalProperties` machinery from #184. Example, Backstage's `RecursivePartialEntityMeta`:

```dart
class RecursivePartialEntityMeta {
  const RecursivePartialEntityMeta({ required this.entries, this.name, this.namespace, /* ... */ });
  final Map<String, dynamic> entries;   // the JsonObject member's overflow
  final String? name;                   // from the object member
  // fromJson: entries = { for (e in json.entries) if (!{'name', ...}.contains(e.key)) e.key: e.value }
}
```

## Motivated by real specs

Backstage's catalog spec (`gen_tests/backstage.yaml`) uses this exact shape for `RecursivePartialEntityMeta`. Before: the generator threw on it. After: the full Backstage client generates — `dart analyze` reports **No issues found!** and its **134** round-trip tests pass.

Builds on #218 (which turns `JsonObject` into a `Map`); that's why the allOf member is now a `ResolvedMap` rather than a `ResolvedEmptyObject`. Supersedes the parked draft #214, whose narrower "admit `ResolvedEmptyObject`" no longer applies.

## Test plan

- [x] `test/resolver_test.dart` — `allOf admits an open map member`: `allOf: [{object, additionalProperties: true}, {object with a named field}]` resolves to a `ResolvedAllOf` with a `ResolvedMap` member (no crash). The existing `allOf only supports objects` test (string/integer members) still throws, unchanged.
- [x] `test/render/render_schema_test.dart` — `allOf with an open map member gets an overflow map`: the merged object emits `final Map<String, dynamic> entries;` and a key-excluding `fromJson`, plus the named field.
- [x] `dart test` — 561 pass, no regressions.
- [x] `dart analyze` / `dart format` — clean.
- [x] End-to-end: generated the full Backstage client from `gen_tests/backstage.yaml`; `dart analyze` clean, 134 round-trip tests pass.