### PR TITLE
docs: document that great Dart output outranks OpenAPI-Generator similarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,23 +99,29 @@ New per-spec lint suppression should follow this pattern rather than adding a
 blanket disable. (The blanket disables still present in the
 `analysis_options.mustache` template predate this decision.)
 
-### Prefer output similar to the OpenAPI Generator (for now)
+### Great Dart first; OpenAPI-Generator-shaped when convenient
 
-When two output shapes are otherwise equal, space_gen leans toward the one that
-looks like the [OpenAPI Generator](https://openapi-generator.tech/)'s Dart
-client. The reason is migration: when this project started, the OpenAPI
-Generator was the most popular Dart client generator, so the main way people
-would adopt space_gen was by porting an existing generated client — which is
-only painless if the generated surface (field names, accessors, types) lines
+The overriding goal is Dart output that reads as if it were hand-written (see
+[Project Values](#project-values)). That always wins. Where — and only where —
+it leaves a genuine choice between shapes that are equally good Dart, space_gen
+prefers the one that resembles the [OpenAPI
+Generator](https://openapi-generator.tech/)'s Dart client. Resembling the
+OpenAPI Generator is a fallback we reach for when it's free; it is never a
+reason to generate worse Dart.
+
+The reason for the fallback is migration: when this project started, the
+OpenAPI Generator was the most popular Dart client generator, so the main way
+people would adopt space_gen was by porting an existing generated client, which
+is smoothest when the generated surface (field names, accessors, types) lines
 up. This is why, for example, an object with `additionalProperties` exposes its
 overflow through an `entries` map rather than a field name we might pick in
 isolation.
 
-This is a default, not a law — the opt-in [quirks](#openapi-quirks) already
-diverge on purpose — and it's a candidate for revisiting: as LLMs take over the
-mechanical parts of migration, byte-level familiarity with one reference
-generator matters less than it used to. Until we revisit it, when a design
-choice is a toss-up, match the OpenAPI Generator.
+Even this fallback is a revisitable default — the opt-in [quirks](#openapi-quirks)
+already diverge on purpose, and as LLMs take over the mechanical parts of
+migration, byte-level familiarity with one reference generator matters less
+than it used to. But being OpenAPI-Generator-shaped is always subordinate to
+being good Dart.
 
 ## Tested specs
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,24 @@ New per-spec lint suppression should follow this pattern rather than adding a
 blanket disable. (The blanket disables still present in the
 `analysis_options.mustache` template predate this decision.)
 
+### Prefer output similar to the OpenAPI Generator (for now)
+
+When two output shapes are otherwise equal, space_gen leans toward the one that
+looks like the [OpenAPI Generator](https://openapi-generator.tech/)'s Dart
+client. The reason is migration: when this project started, the OpenAPI
+Generator was the most popular Dart client generator, so the main way people
+would adopt space_gen was by porting an existing generated client — which is
+only painless if the generated surface (field names, accessors, types) lines
+up. This is why, for example, an object with `additionalProperties` exposes its
+overflow through an `entries` map rather than a field name we might pick in
+isolation.
+
+This is a default, not a law — the opt-in [quirks](#openapi-quirks) already
+diverge on purpose — and it's a candidate for revisiting: as LLMs take over the
+mechanical parts of migration, byte-level familiarity with one reference
+generator matters less than it used to. Until we revisit it, when a design
+choice is a toss-up, match the OpenAPI Generator.
+
 ## Tested specs
 
 space_gen is iterated against a rotation of real-world OpenAPI specs.

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ up. This is why, for example, an object with `additionalProperties` exposes its
 overflow through an `entries` map rather than a field name we might pick in
 isolation.
 
-Even this fallback is a revisitable default — the opt-in [quirks](#openapi-quirks)
+Even this fallback is a default we may revisit — the opt-in [quirks](#openapi-quirks)
 already diverge on purpose, and as LLMs take over the mechanical parts of
 migration, byte-level familiarity with one reference generator matters less
 than it used to. But being OpenAPI-Generator-shaped is always subordinate to


### PR DESCRIPTION
## Summary

Documents, under the README's Design section, the priority between two goals:

1. **Great Dart is the rule.** Output that reads as if hand-written always wins.
2. **OpenAPI-Generator-shaped is the fallback.** Where — and only where — a choice is otherwise a toss-up between equally good Dart, space_gen prefers the shape that resembles the [OpenAPI Generator](https://openapi-generator.tech/)'s Dart client, so that porting an existing generated client is smooth. This is never a reason to generate worse Dart.

The migration rationale (the OpenAPI Generator was the most popular Dart client generator when this project started) is captured, along with the note that it's a revisitable default — LLMs change the migration calculus.

This was implicit (the `OpenApi Quirks` section mentions openapi-generator compatibility as an opt-in) but never stated as a general, quality-subordinate design stance. Docs-only.