### PR TITLE
feat: introduce a DartType model (slice 1) — powers operator[]'s common-type logic

### DIFF
--- a/lib/src/render/dart_type.dart
+++ b/lib/src/render/dart_type.dart
@@ -54,9 +54,16 @@ class DartType extends Equatable {
   // TODO(eseidel): This unifies by structural equality only; it does not know
   // the type hierarchy. Distinct types that share a real supertype (two
   // subclasses of one base, or generated enums that all implement `Enum`) fall
-  // back to `Object?` even though a tighter common type exists. A true
-  // least-upper-bound needs each [DartType] to carry its supertype(s), which
-  // the render tree does not thread through yet.
+  // back to `Object?` even though a tighter common type exists.
+  //
+  // When we add a real least-upper-bound, the inheritance graph should live in
+  // a separate type environment this consults (e.g. `commonType(types, graph)`
+  // or `graph.leastUpperBound(a, b)`) — NOT as a `superType` field on
+  // [DartType]. Keeping [DartType] a pure value expression keeps `==` simple
+  // and avoids making every type reference a graph node (the same supertype
+  // chain repeated on every occurrence, and cycles on recursive schemas like
+  // `Node -> Node`). The graph isn't threaded through to the render context
+  // yet.
   static DartType commonType(Iterable<DartType> types) {
     final list = types.toList();
     if (list.isEmpty) return nullableObject;

--- a/lib/src/render/dart_type.dart
+++ b/lib/src/render/dart_type.dart
@@ -1,0 +1,81 @@
+import 'package:equatable/equatable.dart';
+import 'package:meta/meta.dart';
+
+/// A structured Dart type: a base [name], optional [typeArguments], and
+/// [isNullable]. The generator's own minimal type model so type logic
+/// (rendering, nullability, common-type) is real structure instead of string
+/// manipulation over type names.
+///
+/// This is deliberately small — just what the renderer needs today. It does
+/// not yet model the type hierarchy (see [commonType]) or import provenance.
+@immutable
+class DartType extends Equatable {
+  const DartType(
+    this.name, {
+    this.typeArguments = const [],
+    this.isNullable = false,
+  });
+
+  /// The base identifier: `String`, `List`, `Map`, `DateTime`, or a generated
+  /// class name. No type arguments, no trailing `?`.
+  final String name;
+
+  /// Type arguments for a generic type, e.g. `[DartType('String')]` for
+  /// `List<String>` or `[DartType('String'), DartType('int')]` for
+  /// `Map<String, int>`.
+  final List<DartType> typeArguments;
+
+  /// Whether the type is nullable (renders a trailing `?`).
+  final bool isNullable;
+
+  /// `dynamic` — the untyped escape hatch. Already nullable; never renders `?`.
+  static const dynamic_ = DartType('dynamic');
+
+  /// `Object?` — the nullable top type; the fallback when a set of types has
+  /// no tighter common supertype.
+  static const nullableObject = DartType('Object', isNullable: true);
+
+  /// This type made nullable.
+  DartType asNullable() => isNullable
+      ? this
+      : DartType(name, typeArguments: typeArguments, isNullable: true);
+
+  /// This type made non-nullable.
+  DartType asNonNullable() =>
+      isNullable ? DartType(name, typeArguments: typeArguments) : this;
+
+  /// The tightest [DartType] that soundly covers every type in [types].
+  ///
+  /// When they share one base type (ignoring nullability), that type — made
+  /// nullable if any input was nullable. Otherwise [nullableObject]. `dynamic`
+  /// and `Object` bases fall back to [nullableObject] rather than a redundant
+  /// `dynamic?`, and an empty set is [nullableObject].
+  ///
+  // TODO(eseidel): This unifies by structural equality only; it does not know
+  // the type hierarchy. Distinct types that share a real supertype (two
+  // subclasses of one base, or generated enums that all implement `Enum`) fall
+  // back to `Object?` even though a tighter common type exists. A true
+  // least-upper-bound needs each [DartType] to carry its supertype(s), which
+  // the render tree does not thread through yet.
+  static DartType commonType(Iterable<DartType> types) {
+    final list = types.toList();
+    if (list.isEmpty) return nullableObject;
+    final base = list.first.asNonNullable();
+    final allSame = list.every((type) => type.asNonNullable() == base);
+    if (allSame && base != dynamic_ && base.name != 'Object') {
+      return list.any((type) => type.isNullable) ? base.asNullable() : base;
+    }
+    return nullableObject;
+  }
+
+  @override
+  String toString() {
+    final args = typeArguments.isEmpty ? '' : '<${typeArguments.join(', ')}>';
+    // `dynamic` is already nullable; a trailing `?` on it is a lint.
+    final suffix = isNullable && name != 'dynamic' ? '?' : '';
+    return '$name$args$suffix';
+  }
+
+  @override
+  List<Object?> get props => [name, typeArguments, isNullable];
+}

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -7,6 +7,7 @@ import 'package:space_gen/src/dispatch.dart';
 import 'package:space_gen/src/naming.dart';
 import 'package:space_gen/src/parse/spec.dart' show StatusCodeRange;
 import 'package:space_gen/src/quirks.dart';
+import 'package:space_gen/src/render/dart_type.dart';
 // Any code that depends on SchemaRenderer probably should be moved out
 // of this file and into the schema_renderer.dart file.
 import 'package:space_gen/src/render/schema_renderer.dart';
@@ -19,41 +20,6 @@ String avoidReservedWord(String value) {
     return '${value}_';
   }
   return value;
-}
-
-/// The tightest Dart type that soundly covers every base type name in [types].
-///
-/// When they all share one base type, that type made nullable
-/// (`['String', 'String']` → `'String?'`); otherwise `Object?` — the only
-/// common supertype we can name without walking the full type hierarchy (and
-/// unrelated classes bottom out at `Object` anyway). `dynamic` and `Object`
-/// bases yield `Object?` rather than a redundant `dynamic?`, and an empty bag
-/// is `Object?`.
-///
-/// [types] are non-nullable base type names (e.g. `String`, `List<int>`); the
-/// result is always nullable because callers use it where a null (absent key,
-/// optional field) is possible.
-String tightestCommonType(Iterable<String> types) {
-  // TODO(eseidel): This is string manipulation over type *names*, not real type
-  // logic, so it is weaker than a true least-upper-bound in two ways:
-  //  - Ignores the type hierarchy: distinct types that share a supertype (two
-  //    subclasses of one base, or generated enums that all implement `Enum`)
-  //    fall back to `Object?` even though a tighter common type exists.
-  //  - Ignores nullability of the inputs and unconditionally makes the result
-  //    nullable, instead of deriving nullability from the bag. (Correct for
-  //    today's sole caller, `operator[]`, where an absent key yields null.)
-  // Both want a structured type model that carries nullability and inheritance
-  // — our own Zod-like type library, or an existing Dart one — so we can do
-  // actual logic over types instead of comparing name strings. The resolved
-  // type graph isn't threaded through to the render context here today.
-  final distinct = types.toSet();
-  if (distinct.length == 1) {
-    final only = distinct.first;
-    if (only != 'dynamic' && only != 'Object') {
-      return '$only?';
-    }
-  }
-  return 'Object?';
 }
 
 Never _unimplemented(String message, JsonPointer pointer) {
@@ -2425,6 +2391,14 @@ abstract class RenderSchema extends Equatable implements ToTemplateContext {
   /// e.g. 'String', 'Uri', or the class name of a new type.
   String get typeName;
 
+  /// The structured [DartType] for this schema.
+  ///
+  /// The base implementation wraps [typeName] as a flat, non-nullable type,
+  /// which is enough for structural comparison and rendering. Generic schemas
+  /// (list/map) will override this to decompose their type arguments as the
+  /// model takes over from the `typeName` strings.
+  DartType get dartType => DartType(typeName);
+
   /// This is the resolved Dart type name for the schema, with a ? if it is
   /// nullable.
   /// e.g. 'String?', 'Uri?', or the ClassName? of a new type.
@@ -2521,8 +2495,8 @@ abstract class RenderSchema extends Equatable implements ToTemplateContext {
 // string subsets (email, uuid).
 //
 // When [createsNewType] is true this is a top-level named schema and
-// renders to its own file as an extension type wrapping [dartType]. When
-// false the schema is inline and uses [dartType] directly at the use
+// renders to its own file as an extension type wrapping [dartTypeName]. When
+// false the schema is inline and uses [dartTypeName] directly at the use
 // site.
 class RenderPod extends RenderSchema {
   const RenderPod({
@@ -2558,7 +2532,7 @@ class RenderPod extends RenderSchema {
 
   @override
   bool get defaultCanConstConstruct {
-    // Newtype defaults wrap dartType in a constructor call; const-ness
+    // Newtype defaults wrap dartTypeName in a constructor call; const-ness
     // depends on whether the wrapped expression is const.
     return switch (type) {
       PodType.dateTime ||
@@ -2572,9 +2546,9 @@ class RenderPod extends RenderSchema {
   @override
   List<Object?> get props => [super.props, type, defaultValue];
 
-  /// The Dart type that represents this pod at the use site (when inline)
-  /// or that the newtype wraps (when a newtype).
-  String get dartType => switch (type) {
+  /// The name of the Dart type that represents this pod at the use site
+  /// (when inline) or that the newtype wraps (when a newtype).
+  String get dartTypeName => switch (type) {
     PodType.boolean => 'bool',
     PodType.dateTime => 'DateTime',
     PodType.uri => 'Uri',
@@ -2586,7 +2560,7 @@ class RenderPod extends RenderSchema {
   };
 
   @override
-  String get typeName => createsNewType ? _requireAssignedName() : dartType;
+  String get typeName => createsNewType ? _requireAssignedName() : dartTypeName;
 
   // Boolean is the only PodType with a `is bool` test that's distinct
   // from the other JSON storage types (the date/uri/uuid/etc. all
@@ -2645,7 +2619,7 @@ class RenderPod extends RenderSchema {
       const Import('package:uri/uri.dart', shown: ['UriTemplate']),
   ];
 
-  /// Converts `value` (of type [dartType]) to its JSON representation.
+  /// Converts `value` (of type [dartTypeName]) to its JSON representation.
   /// Used both at the inline use site and inside the newtype's toJson.
   String _valueToJsonBody(String name, {required bool nameIsNullable}) {
     final nameCall = nameIsNullable ? '$name?' : name;
@@ -2661,7 +2635,7 @@ class RenderPod extends RenderSchema {
     };
   }
 
-  /// Converts `json` (of type jsonStorageType) to [dartType]. Used inside
+  /// Converts `json` (of type jsonStorageType) to [dartTypeName]. Used inside
   /// the newtype's fromJson factory body and (non-nullable only) at the
   /// inline use site.
   String _jsonToValueBody(String jsonName) => switch (type) {
@@ -2745,7 +2719,7 @@ class RenderPod extends RenderSchema {
       'doc_comment': createDocComment(common: common),
       'typeName': typeName,
       'nullableTypeName': nullableTypeName(context),
-      'dartType': dartType,
+      'dartType': dartTypeName,
       'jsonType': jsonStorageType(isNullable: false),
       'fromJsonBody': _jsonToValueBody('json'),
       'toJsonBody': _valueToJsonBody('value', nameIsNullable: false),
@@ -3622,13 +3596,14 @@ class RenderObject extends RenderNewType {
     // if they accidentally call toJson on a multipart body.
     final hasNoJsonProperty = properties.values.any((p) => p is RenderNoJson);
     // The generated `operator[]` returns whichever value the key selects — a
-    // named property or the overflow — so its type must cover them all.
+    // named property or the overflow — so its type must cover them all, and it
+    // is always nullable (an absent key yields null).
     final operatorIndexType = valueSchema == null
         ? null
-        : tightestCommonType([
-            for (final property in properties.values) property.typeName,
-            valueSchema.typeName,
-          ]);
+        : DartType.commonType([
+            for (final property in properties.values) property.dartType,
+            valueSchema.dartType,
+          ]).asNullable().toString();
     return {
       'doc_comment': createDocComment(
         common: common,

--- a/test/render/dart_type_test.dart
+++ b/test/render/dart_type_test.dart
@@ -1,0 +1,108 @@
+import 'package:space_gen/src/render/dart_type.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DartType', () {
+    test('renders name, type arguments, and nullability', () {
+      expect(const DartType('String').toString(), 'String');
+      expect(const DartType('String', isNullable: true).toString(), 'String?');
+      expect(
+        const DartType('List', typeArguments: [DartType('int')]).toString(),
+        'List<int>',
+      );
+      expect(
+        const DartType(
+          'Map',
+          typeArguments: [DartType('String'), DartType('int')],
+          isNullable: true,
+        ).toString(),
+        'Map<String, int>?',
+      );
+    });
+
+    test('dynamic never renders a trailing `?`', () {
+      // `dynamic` is already nullable; `dynamic?` is a lint.
+      expect(DartType.dynamic_.toString(), 'dynamic');
+      expect(DartType.dynamic_.asNullable().toString(), 'dynamic');
+    });
+
+    test(
+      'asNullable / asNonNullable toggle nullability, preserve the rest',
+      () {
+        const list = DartType('List', typeArguments: [DartType('int')]);
+        expect(list.asNullable().toString(), 'List<int>?');
+        expect(list.asNullable().asNonNullable(), list);
+        expect(list.asNonNullable(), same(list));
+      },
+    );
+
+    test('equality is structural', () {
+      expect(
+        const DartType('List', typeArguments: [DartType('int')]),
+        const DartType('List', typeArguments: [DartType('int')]),
+      );
+      expect(
+        const DartType('List', typeArguments: [DartType('int')]),
+        isNot(const DartType('List', typeArguments: [DartType('String')])),
+      );
+    });
+
+    group('commonType', () {
+      test('single shared base type -> that type', () {
+        expect(
+          DartType.commonType([const DartType('String')]),
+          const DartType('String'),
+        );
+        expect(
+          DartType.commonType([
+            const DartType('String'),
+            const DartType('String'),
+          ]),
+          const DartType('String'),
+        );
+      });
+
+      test('any nullable input makes the result nullable', () {
+        expect(
+          DartType.commonType([
+            const DartType('String'),
+            const DartType('String', isNullable: true),
+          ]),
+          const DartType('String', isNullable: true),
+        );
+      });
+
+      test('mixed base types -> Object?', () {
+        expect(
+          DartType.commonType([
+            const DartType('String'),
+            const DartType('int'),
+          ]),
+          DartType.nullableObject,
+        );
+      });
+
+      test('dynamic / Object bases collapse to Object?', () {
+        expect(
+          DartType.commonType([DartType.dynamic_, DartType.dynamic_]),
+          DartType.nullableObject,
+        );
+        expect(
+          DartType.commonType([DartType.dynamic_, const DartType('String')]),
+          DartType.nullableObject,
+        );
+        expect(
+          DartType.commonType([
+            const DartType('Object'),
+            const DartType('Object'),
+          ]),
+          DartType.nullableObject,
+        );
+      });
+
+      test('empty set -> Object?', () {
+        expect(DartType.commonType(const []), DartType.nullableObject);
+      });
+    });
+  });
+}

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -6,36 +6,11 @@ import 'dart:convert';
 import 'package:mocktail/mocktail.dart';
 import 'package:space_gen/src/logger.dart';
 import 'package:space_gen/src/render.dart';
-import 'package:space_gen/src/render/render_tree.dart' show tightestCommonType;
 import 'package:test/test.dart';
 
 class _MockLogger extends Mock implements Logger {}
 
 void main() {
-  group('tightestCommonType', () {
-    test('single base type -> nullable that type', () {
-      expect(tightestCommonType(['String']), 'String?');
-      expect(tightestCommonType(['String', 'String']), 'String?');
-      expect(tightestCommonType(['List<int>', 'List<int>']), 'List<int>?');
-    });
-
-    test('mixed base types -> Object?', () {
-      expect(tightestCommonType(['String', 'int']), 'Object?');
-      expect(tightestCommonType(['Foo', 'Bar', 'String']), 'Object?');
-    });
-
-    test('dynamic / Object bases collapse to Object?', () {
-      // Avoids a redundant `dynamic?` and never claims a bare `Object`.
-      expect(tightestCommonType(['dynamic', 'dynamic']), 'Object?');
-      expect(tightestCommonType(['dynamic', 'String']), 'Object?');
-      expect(tightestCommonType(['Object', 'Object']), 'Object?');
-    });
-
-    test('empty bag -> Object?', () {
-      expect(tightestCommonType(<String>[]), 'Object?');
-    });
-  });
-
   group('renderSchema', () {
     test('smoke test', () {
       final schema = {

--- a/test/render/render_tree_test.dart
+++ b/test/render/render_tree_test.dart
@@ -1596,12 +1596,15 @@ void main() {
       expect(pod(PodType.date, createsNewType: true).typeName, 'FooBar');
     });
 
-    test('dartType is the underlying Dart type regardless of newtype', () {
-      expect(pod(PodType.dateTime).dartType, 'DateTime');
-      expect(pod(PodType.dateTime, createsNewType: true).dartType, 'DateTime');
-      expect(pod(PodType.email).dartType, 'String');
-      expect(pod(PodType.uuid).dartType, 'String');
-      expect(pod(PodType.date).dartType, 'DateTime');
+    test('dartTypeName is the underlying Dart type regardless of newtype', () {
+      expect(pod(PodType.dateTime).dartTypeName, 'DateTime');
+      expect(
+        pod(PodType.dateTime, createsNewType: true).dartTypeName,
+        'DateTime',
+      );
+      expect(pod(PodType.email).dartTypeName, 'String');
+      expect(pod(PodType.uuid).dartTypeName, 'String');
+      expect(pod(PodType.date).dartTypeName, 'DateTime');
     });
 
     test('toJsonExpression delegates to .toJson() when a newtype', () {


### PR DESCRIPTION
## Summary

First slice of a structured **`DartType`** model, so the generator does real type logic instead of string manipulation over `typeName` (`'\$typeName?'`, `'List<\$x>'`, `tightestCommonType` string-matching, …). Scoped to the one real consumer we already have — the `operator[]` return type — to prove the model out before migrating other call sites.

## What's here

- **`lib/src/render/dart_type.dart`** — `DartType(name, typeArguments, isNullable)` with `toString()` (single source of truth for rendering), `asNullable()`/`asNonNullable()`, structural equality, and `DartType.commonType(Iterable<DartType>)` (the least-upper-bound helper).
- **`RenderSchema.dartType`** — base default wraps `typeName` as a flat, non-nullable type. Enough for structural comparison + rendering today; generic schemas (list/map) will override to decompose in a later slice.
- **`operator[]` uses it** — the return type is now `DartType.commonType([...properties.dartType, overflow.dartType]).asNullable()`. This fixes the previous helper's two shortcomings *at the source*: it compares structured types (not name strings), and **nullability is the caller's decision** (`operator[]` applies `.asNullable()` because an absent key yields null) rather than hardcoded in the helper.
- **Rename** `RenderPod.dartType` (a `String` — the wrapped Dart type name) → `dartTypeName`, freeing `dartType` for the model. `dartType.name` can't substitute: for a *newtype* pod it's the newtype's own name, while the wrapped type (what the extension type stores) is distinct.

## Not here (follow-on slices)

2. Decompose generics into `dartType`, then derive `typeName`/`nullableTypeName` *from* it (retire the string-building).
3. Migrate other call sites (casts, field nullability, oneOf/anyOf common typing).
4. Carry a supertype link so `commonType` handles the hierarchy — retires the `TODO` in `commonType`.

## Test plan

- [x] `test/render/dart_type_test.dart` — `DartType` rendering/nullability/equality + `commonType` (single/nullable/mixed/dynamic/empty).
- [x] Existing `operator[]` render tests unchanged (`String?` homogeneous, `Object?` heterogeneous).
- [x] `dart analyze` (whole `lib`) clean; `dart test` — 572 pass.
- [x] **No output change**: GitHub regen identical (`Object?`), `dart analyze` clean; homogeneous-overflow probe still `String?`.