### PR TITLE
feat: make DartType the source of truth for schema types (slice 2)

### DIFF
--- a/lib/src/render/dart_type.dart
+++ b/lib/src/render/dart_type.dart
@@ -35,6 +35,12 @@ class DartType extends Equatable {
   /// no tighter common supertype.
   static const nullableObject = DartType('Object', isNullable: true);
 
+  /// `void` — a schema with no value (e.g. an empty response body).
+  static const void_ = DartType('void');
+
+  /// `Uint8List` (`dart:typed_data`) — binary field types.
+  static const uint8List = DartType('Uint8List');
+
   /// This type made nullable.
   DartType asNullable() => isNullable
       ? this

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -2387,23 +2387,19 @@ abstract class RenderSchema extends Equatable implements ToTemplateContext {
     return '';
   }
 
-  /// This is the resolved Dart type name for the schema.
+  /// The structured Dart type for this schema — the single source of truth.
+  /// [typeName] and [nullableTypeName] render from it. Subclasses build it
+  /// directly: leaves as a flat name, list/map decomposing their arguments.
+  DartType get dartType;
+
+  /// The non-nullable Dart type name for the schema.
   /// e.g. 'String', 'Uri', or the class name of a new type.
-  String get typeName;
+  String get typeName => dartType.toString();
 
-  /// The structured [DartType] for this schema.
-  ///
-  /// The base implementation wraps [typeName] as a flat, non-nullable type,
-  /// which is enough for structural comparison and rendering. Generic schemas
-  /// (list/map) will override this to decompose their type arguments as the
-  /// model takes over from the `typeName` strings.
-  DartType get dartType => DartType(typeName);
-
-  /// This is the resolved Dart type name for the schema, with a ? if it is
-  /// nullable.
+  /// The Dart type name for the schema, made nullable.
   /// e.g. 'String?', 'Uri?', or the ClassName? of a new type.
   String nullableTypeName(SchemaRenderer context) {
-    return typeName.endsWith('?') ? typeName : '$typeName?';
+    return dartType.asNullable().toString();
   }
 
   String equalsExpression(String name, SchemaRenderer context) =>
@@ -2560,7 +2556,8 @@ class RenderPod extends RenderSchema {
   };
 
   @override
-  String get typeName => createsNewType ? _requireAssignedName() : dartTypeName;
+  DartType get dartType =>
+      DartType(createsNewType ? _requireAssignedName() : dartTypeName);
 
   // Boolean is the only PodType with a `is bool` test that's distinct
   // from the other JSON storage types (the date/uri/uuid/etc. all
@@ -2784,7 +2781,7 @@ abstract class RenderNewType extends RenderSchema {
   String get className => _requireAssignedName();
 
   @override
-  String get typeName => className;
+  DartType get dartType => DartType(className);
 
   @override
   String toJsonExpression(
@@ -2828,7 +2825,8 @@ class RenderString extends RenderSchema {
   List<Object?> get props => [super.props, defaultValue, maxLength, minLength];
 
   @override
-  String get typeName => createsNewType ? _requireAssignedName() : 'String';
+  DartType get dartType =>
+      DartType(createsNewType ? _requireAssignedName() : 'String');
 
   /// The default value of this schema as a string.
   @override
@@ -3206,7 +3204,8 @@ class RenderNumber extends RenderNumeric<double> {
   });
 
   @override
-  String get typeName => createsNewType ? _requireAssignedName() : 'double';
+  DartType get dartType =>
+      DartType(createsNewType ? _requireAssignedName() : 'double');
 
   @override
   String? get wrapperTag => createsNewType ? null : 'Num';
@@ -3255,7 +3254,8 @@ class RenderInteger extends RenderNumeric<int> {
   });
 
   @override
-  String get typeName => createsNewType ? _requireAssignedName() : 'int';
+  DartType get dartType =>
+      DartType(createsNewType ? _requireAssignedName() : 'int');
 
   @override
   String? get wrapperTag => createsNewType ? null : 'Int';
@@ -3868,7 +3868,7 @@ class RenderArray extends RenderSchema {
 
   /// The type name of this schema.
   @override
-  String get typeName => 'List<${items.typeName}>';
+  DartType get dartType => DartType('List', typeArguments: [items.dartType]);
 
   @override
   String equalsExpression(String name, SchemaRenderer context) =>
@@ -4068,10 +4068,13 @@ class RenderMap extends RenderSchema {
   }
 
   @override
-  String get typeName {
-    final keyType = keySchema?.typeName ?? 'String';
-    return 'Map<$keyType, ${valueSchema.typeName}>';
-  }
+  DartType get dartType => DartType(
+    'Map',
+    typeArguments: [
+      keySchema?.dartType ?? const DartType('String'),
+      valueSchema.dartType,
+    ],
+  );
 
   @override
   String equalsExpression(String name, SchemaRenderer context) =>
@@ -5580,7 +5583,7 @@ class RenderUnknown extends RenderSchema {
   dynamic get defaultValue => null;
 
   @override
-  String get typeName => 'dynamic';
+  DartType get dartType => DartType.dynamic_;
 
   @override
   bool get defaultCanConstConstruct => false;
@@ -5625,7 +5628,7 @@ class RenderVoid extends RenderNoJson {
       throw UnimplementedError('RenderVoid.defaultValue');
 
   @override
-  String get typeName => 'void';
+  DartType get dartType => const DartType('void');
 
   @override
   String equalsExpression(String name, SchemaRenderer context) =>
@@ -5696,7 +5699,7 @@ class RenderBinary extends RenderNoJson {
   ];
 
   @override
-  String get typeName => 'Uint8List';
+  DartType get dartType => const DartType('Uint8List');
 
   @override
   String equalsExpression(String name, SchemaRenderer context) =>
@@ -5735,7 +5738,7 @@ class RenderBase64Bytes extends RenderSchema {
   ];
 
   @override
-  String get typeName => 'Uint8List';
+  DartType get dartType => const DartType('Uint8List');
 
   @override
   bool get shouldCallToJson => false;
@@ -5894,7 +5897,7 @@ class RenderRecursiveRef extends RenderSchema {
   bool get shouldCallToJson => true;
 
   @override
-  String get typeName => _requireAssignedName();
+  DartType get dartType => DartType(_requireAssignedName());
 
   @override
   String jsonStorageType({required bool isNullable}) =>

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -5628,7 +5628,7 @@ class RenderVoid extends RenderNoJson {
       throw UnimplementedError('RenderVoid.defaultValue');
 
   @override
-  DartType get dartType => const DartType('void');
+  DartType get dartType => DartType.void_;
 
   @override
   String equalsExpression(String name, SchemaRenderer context) =>
@@ -5699,7 +5699,7 @@ class RenderBinary extends RenderNoJson {
   ];
 
   @override
-  DartType get dartType => const DartType('Uint8List');
+  DartType get dartType => DartType.uint8List;
 
   @override
   String equalsExpression(String name, SchemaRenderer context) =>
@@ -5738,7 +5738,7 @@ class RenderBase64Bytes extends RenderSchema {
   ];
 
   @override
-  DartType get dartType => const DartType('Uint8List');
+  DartType get dartType => DartType.uint8List;
 
   @override
   bool get shouldCallToJson => false;

--- a/test/render/dart_type_test.dart
+++ b/test/render/dart_type_test.dart
@@ -20,6 +20,13 @@ void main() {
       );
     });
 
+    test('well-known type constants render as expected', () {
+      expect(DartType.dynamic_.toString(), 'dynamic');
+      expect(DartType.nullableObject.toString(), 'Object?');
+      expect(DartType.void_.toString(), 'void');
+      expect(DartType.uint8List.toString(), 'Uint8List');
+    });
+
     test('dynamic never renders a trailing `?`', () {
       // `dynamic` is already nullable; `dynamic?` is a lint.
       expect(DartType.dynamic_.toString(), 'dynamic');

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -44,7 +44,7 @@ void main() {
         '        return Test.fromJson(json);\n'
         '    }\n'
         '\n'
-        '    final dynamic? foo;\n'
+        '    final dynamic foo;\n'
         '\n'
         '    /// Converts a [Test] to a `Map<String, dynamic>`.\n'
         '    Map<String, dynamic> toJson() {\n'
@@ -82,8 +82,9 @@ void main() {
         },
       };
       final result = renderTestSchema(schema);
-      // Field emitted as `dynamic`, passthrough in toJson/fromJson.
-      expect(result, contains('final dynamic? placeholder;'));
+      // Field emitted as `dynamic` (not a redundant `dynamic?`), passthrough
+      // in toJson/fromJson.
+      expect(result, contains('final dynamic placeholder;'));
       expect(result, contains("placeholder: json['placeholder'],"));
       expect(result, contains("'placeholder': placeholder,"));
     });


### PR DESCRIPTION
## Summary

Slice 2 of the `DartType` model. Inverts the relationship from #222: `RenderSchema.dartType` is now **abstract and authoritative**, and `typeName` / `nullableTypeName` render *from* it — deleting the string-building.

## What changed

- `RenderSchema`: `dartType` is abstract; `typeName => dartType.toString()`, `nullableTypeName => dartType.asNullable().toString()`.
- Each subclass builds `dartType` directly instead of `typeName`:
  - `RenderArray` → `DartType('List', typeArguments: [items.dartType])` (was `'List<${items.typeName}>'`)
  - `RenderMap` → `DartType('Map', typeArguments: [key, value.dartType])` (was `'Map<$k, $v>'`)
  - leaves (`String`/`int`/`double`/pod/object/enum/oneOf/…) → `DartType(name)`
  - `RenderUnknown` → `DartType.dynamic_`, `RenderVoid` → `DartType.void_`, binary → `DartType.uint8List`
- Added `DartType.void_` / `DartType.uint8List` constants alongside `dynamic_` / `nullableObject` (consistency; `uint8List` DRYs the two binary call sites).

Generics and nullability are now **real structure** instead of string interpolation — which is what slice 3 (casts, field-nullability, oneOf/anyOf common typing) needs to build on.

## One intentional output delta

A nullable unknown-typed field now renders as `dynamic` instead of the redundant `dynamic?` (`DartType` never emits `dynamic?`). **GitHub has zero `dynamic?`, so its output is byte-identical** — verified by a full regen diff (0 real differences after normalizing the output-dir package name). Two synthetic render-test fixtures updated to `dynamic`.

## Test plan

- [x] `dart analyze` (whole `lib`) clean; `dart test` — 573 pass (new: `DartType` constants test).
- [x] **Byte-identical GitHub output**: regenerated the full client on this branch and on `main`; `diff` (package-name-normalized) reports **0 real differences**. `dart analyze` clean on the regen; `List<X>` / `Map<K,V>` / `DateTime` / newtypes render unchanged.