### PR TITLE
feat: DartType for the JSON wire type, + core-type constants & list/map constructors (slice 3)

### DIFF
--- a/lib/src/render/dart_type.dart
+++ b/lib/src/render/dart_type.dart
@@ -16,6 +16,18 @@ class DartType extends Equatable {
     this.isNullable = false,
   });
 
+  /// A `List<T>` type. [element] defaults to `dynamic` (`List<dynamic>`).
+  DartType.list([DartType? element])
+    : name = 'List',
+      typeArguments = [element ?? dynamic_],
+      isNullable = false;
+
+  /// A `Map<K, V>` type.
+  DartType.map(DartType key, DartType value)
+    : name = 'Map',
+      typeArguments = [key, value],
+      isNullable = false;
+
   /// The base identifier: `String`, `List`, `Map`, `DateTime`, or a generated
   /// class name. No type arguments, no trailing `?`.
   final String name;
@@ -40,6 +52,21 @@ class DartType extends Equatable {
 
   /// `Uint8List` (`dart:typed_data`) — binary field types.
   static const uint8List = DartType('Uint8List');
+
+  /// The `String` type.
+  static const string = DartType('String');
+
+  /// The `bool` type.
+  static const bool_ = DartType('bool');
+
+  /// The `int` type.
+  static const int_ = DartType('int');
+
+  /// The `double` type.
+  static const double_ = DartType('double');
+
+  /// The `num` type.
+  static const num_ = DartType('num');
 
   /// This type made nullable.
   DartType asNullable() => isNullable

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -24,10 +24,7 @@ String avoidReservedWord(String value) {
 
 /// `Map<String, dynamic>` — the JSON wire type of an arbitrary object. The
 /// storage type for objects, maps, and object-shaped composites.
-const _jsonWireMap = DartType(
-  'Map',
-  typeArguments: [DartType('String'), DartType.dynamic_],
-);
+final _jsonWireMap = DartType.map(DartType.string, DartType.dynamic_);
 
 Never _unimplemented(String message, JsonPointer pointer) {
   throw UnimplementedError('$message at $pointer');
@@ -2601,8 +2598,8 @@ class RenderPod extends RenderSchema {
     PodType.uriTemplate ||
     PodType.email ||
     PodType.uuid ||
-    PodType.date => const DartType('String'),
-    PodType.boolean => const DartType('bool'),
+    PodType.date => DartType.string,
+    PodType.boolean => DartType.bool_,
   };
 
   /// The default value of this schema as a string.
@@ -2840,7 +2837,7 @@ class RenderString extends RenderSchema {
 
   @override
   DartType get dartType =>
-      DartType(createsNewType ? _requireAssignedName() : 'String');
+      createsNewType ? DartType(_requireAssignedName()) : DartType.string;
 
   /// The default value of this schema as a string.
   @override
@@ -2881,7 +2878,7 @@ class RenderString extends RenderSchema {
       createsNewType ? null : _inlinePodConversion('String');
 
   @override
-  DartType get jsonStorageDartType => const DartType('String');
+  DartType get jsonStorageDartType => DartType.string;
 
   String newTypeFromJsonExpression(
     String jsonValue,
@@ -3218,7 +3215,7 @@ class RenderNumber extends RenderNumeric<double> {
 
   @override
   DartType get dartType =>
-      DartType(createsNewType ? _requireAssignedName() : 'double');
+      createsNewType ? DartType(_requireAssignedName()) : DartType.double_;
 
   @override
   String? get wrapperTag => createsNewType ? null : 'Num';
@@ -3238,7 +3235,7 @@ class RenderNumber extends RenderNumeric<double> {
       createsNewType ? null : _inlinePodConversion('num');
 
   @override
-  DartType get jsonStorageDartType => const DartType('num');
+  DartType get jsonStorageDartType => DartType.num_;
 
   @override
   String jsonToDartCall({required bool jsonIsNullable}) =>
@@ -3267,7 +3264,7 @@ class RenderInteger extends RenderNumeric<int> {
 
   @override
   DartType get dartType =>
-      DartType(createsNewType ? _requireAssignedName() : 'int');
+      createsNewType ? DartType(_requireAssignedName()) : DartType.int_;
 
   @override
   String? get wrapperTag => createsNewType ? null : 'Int';
@@ -3280,7 +3277,7 @@ class RenderInteger extends RenderNumeric<int> {
       createsNewType ? null : _inlinePodConversion('int');
 
   @override
-  DartType get jsonStorageDartType => const DartType('int');
+  DartType get jsonStorageDartType => DartType.int_;
 
   // jsonType and dartType are both int, so we don't need to do anything.
   @override
@@ -3877,7 +3874,7 @@ class RenderArray extends RenderSchema {
 
   /// The type name of this schema.
   @override
-  DartType get dartType => DartType('List', typeArguments: [items.dartType]);
+  DartType get dartType => DartType.list(items.dartType);
 
   @override
   String equalsExpression(String name, SchemaRenderer context) =>
@@ -3905,8 +3902,7 @@ class RenderArray extends RenderSchema {
   }
 
   @override
-  DartType get jsonStorageDartType =>
-      const DartType('List', typeArguments: [DartType.dynamic_]);
+  DartType get jsonStorageDartType => DartType.list();
 
   @override
   String toJsonExpression(
@@ -4076,12 +4072,9 @@ class RenderMap extends RenderSchema {
   }
 
   @override
-  DartType get dartType => DartType(
-    'Map',
-    typeArguments: [
-      keySchema?.dartType ?? const DartType('String'),
-      valueSchema.dartType,
-    ],
+  DartType get dartType => DartType.map(
+    keySchema?.dartType ?? DartType.string,
+    valueSchema.dartType,
   );
 
   @override
@@ -5752,7 +5745,7 @@ class RenderBase64Bytes extends RenderSchema {
   bool get shouldCallToJson => false;
 
   @override
-  DartType get jsonStorageDartType => const DartType('String');
+  DartType get jsonStorageDartType => DartType.string;
 
   @override
   String equalsExpression(String name, SchemaRenderer context) =>

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -22,6 +22,13 @@ String avoidReservedWord(String value) {
   return value;
 }
 
+/// `Map<String, dynamic>` — the JSON wire type of an arbitrary object. The
+/// storage type for objects, maps, and object-shaped composites.
+const _jsonWireMap = DartType(
+  'Map',
+  typeArguments: [DartType('String'), DartType.dynamic_],
+);
+
 Never _unimplemented(String message, JsonPointer pointer) {
   throw UnimplementedError('$message at $pointer');
 }
@@ -2413,7 +2420,16 @@ abstract class RenderSchema extends Equatable implements ToTemplateContext {
   /// deep-equality `==`.
   String hashCodeExpression(String name) => name;
 
-  String jsonStorageType({required bool isNullable});
+  /// The non-nullable JSON wire type this schema stores as — the type of its
+  /// value inside the parsed `Map<String, dynamic>`. Often differs from
+  /// [dartType]: a `DateTime` field stores as `String`, an object as
+  /// `Map<String, dynamic>`.
+  DartType get jsonStorageDartType;
+
+  /// The JSON wire type name, made nullable when [isNullable].
+  String jsonStorageType({required bool isNullable}) =>
+      (isNullable ? jsonStorageDartType.asNullable() : jsonStorageDartType)
+          .toString();
 
   String toJsonExpression(
     String dartName,
@@ -2579,17 +2595,15 @@ class RenderPod extends RenderSchema {
   }
 
   @override
-  String jsonStorageType({required bool isNullable}) {
-    return switch (type) {
-      PodType.dateTime ||
-      PodType.uri ||
-      PodType.uriTemplate ||
-      PodType.email ||
-      PodType.uuid ||
-      PodType.date => isNullable ? 'String?' : 'String',
-      PodType.boolean => isNullable ? 'bool?' : 'bool',
-    };
-  }
+  DartType get jsonStorageDartType => switch (type) {
+    PodType.dateTime ||
+    PodType.uri ||
+    PodType.uriTemplate ||
+    PodType.email ||
+    PodType.uuid ||
+    PodType.date => const DartType('String'),
+    PodType.boolean => const DartType('bool'),
+  };
 
   /// The default value of this schema as a string.
   @override
@@ -2867,8 +2881,7 @@ class RenderString extends RenderSchema {
       createsNewType ? null : _inlinePodConversion('String');
 
   @override
-  String jsonStorageType({required bool isNullable}) =>
-      isNullable ? 'String?' : 'String';
+  DartType get jsonStorageDartType => const DartType('String');
 
   String newTypeFromJsonExpression(
     String jsonValue,
@@ -3225,8 +3238,7 @@ class RenderNumber extends RenderNumeric<double> {
       createsNewType ? null : _inlinePodConversion('num');
 
   @override
-  String jsonStorageType({required bool isNullable}) =>
-      isNullable ? 'num?' : 'num';
+  DartType get jsonStorageDartType => const DartType('num');
 
   @override
   String jsonToDartCall({required bool jsonIsNullable}) =>
@@ -3268,8 +3280,7 @@ class RenderInteger extends RenderNumeric<int> {
       createsNewType ? null : _inlinePodConversion('int');
 
   @override
-  String jsonStorageType({required bool isNullable}) =>
-      isNullable ? 'int?' : 'int';
+  DartType get jsonStorageDartType => const DartType('int');
 
   // jsonType and dartType are both int, so we don't need to do anything.
   @override
@@ -3385,9 +3396,7 @@ class RenderObject extends RenderNewType {
   bool get defaultCanConstConstruct => false;
 
   @override
-  String jsonStorageType({required bool isNullable}) {
-    return isNullable ? 'Map<String, dynamic>?' : 'Map<String, dynamic>';
-  }
+  DartType get jsonStorageDartType => _jsonWireMap;
 
   @override
   Iterable<Import> get additionalImports => [
@@ -3896,9 +3905,8 @@ class RenderArray extends RenderSchema {
   }
 
   @override
-  String jsonStorageType({required bool isNullable}) {
-    return isNullable ? 'List<dynamic>?' : 'List<dynamic>';
-  }
+  DartType get jsonStorageDartType =>
+      const DartType('List', typeArguments: [DartType.dynamic_]);
 
   @override
   String toJsonExpression(
@@ -4084,8 +4092,7 @@ class RenderMap extends RenderSchema {
   String hashCodeExpression(String name) => '${ModelHelpers.mapHash}($name)';
 
   @override
-  String jsonStorageType({required bool isNullable}) =>
-      isNullable ? 'Map<String, dynamic>?' : 'Map<String, dynamic>';
+  DartType get jsonStorageDartType => _jsonWireMap;
 
   @override
   String toJsonExpression(
@@ -4257,9 +4264,7 @@ abstract class RenderEnum<T extends Object> extends RenderNewType {
   ];
 
   @override
-  String jsonStorageType({required bool isNullable}) {
-    return isNullable ? '$valueDartType?' : valueDartType;
-  }
+  DartType get jsonStorageDartType => DartType(valueDartType);
 
   /// Template context for an enum schema.
   @override
@@ -4465,12 +4470,8 @@ class RenderOneOf extends RenderNewType {
   }
 
   @override
-  String jsonStorageType({required bool isNullable}) {
-    if (schemas.any((s) => s is RenderPod)) {
-      return 'dynamic';
-    }
-    return isNullable ? 'Map<String, dynamic>?' : 'Map<String, dynamic>';
-  }
+  DartType get jsonStorageDartType =>
+      schemas.any((s) => s is RenderPod) ? DartType.dynamic_ : _jsonWireMap;
 
   /// Looks up the wrapper subclass class name assigned by the naming
   /// pass for [variant]. Variant identity is by index in [schemas]
@@ -5593,7 +5594,7 @@ class RenderUnknown extends RenderSchema {
   bool get shouldCallToJson => false;
 
   @override
-  String jsonStorageType({required bool isNullable}) => 'dynamic';
+  DartType get jsonStorageDartType => DartType.dynamic_;
 
   // We might need to jsonDecode(jsonEncode(dartName)) to get everything into
   // json types.
@@ -5656,6 +5657,13 @@ abstract class RenderNoJson extends RenderSchema {
 
   @override
   bool get shouldCallToJson => false;
+
+  // No JSON representation: [jsonStorageType] is overridden to emit a `throw`
+  // expression where a type name would go, so [jsonStorageDartType] is never
+  // rendered.
+  @override
+  DartType get jsonStorageDartType =>
+      throw UnsupportedError('$runtimeType has no JSON storage type');
 
   @override
   String jsonStorageType({required bool isNullable}) =>
@@ -5744,8 +5752,7 @@ class RenderBase64Bytes extends RenderSchema {
   bool get shouldCallToJson => false;
 
   @override
-  String jsonStorageType({required bool isNullable}) =>
-      isNullable ? 'String?' : 'String';
+  DartType get jsonStorageDartType => const DartType('String');
 
   @override
   String equalsExpression(String name, SchemaRenderer context) =>
@@ -5825,8 +5832,7 @@ class RenderEmptyObject extends RenderNewType {
       _newtypeConversion(typeName);
 
   @override
-  String jsonStorageType({required bool isNullable}) =>
-      isNullable ? 'Map<String, dynamic>?' : 'Map<String, dynamic>';
+  DartType get jsonStorageDartType => _jsonWireMap;
 
   @override
   String toJsonExpression(
@@ -5900,8 +5906,7 @@ class RenderRecursiveRef extends RenderSchema {
   DartType get dartType => DartType(_requireAssignedName());
 
   @override
-  String jsonStorageType({required bool isNullable}) =>
-      isNullable ? 'Map<String, dynamic>?' : 'Map<String, dynamic>';
+  DartType get jsonStorageDartType => _jsonWireMap;
 
   @override
   String toJsonExpression(

--- a/test/render/dart_type_test.dart
+++ b/test/render/dart_type_test.dart
@@ -3,20 +3,23 @@ import 'package:test/test.dart';
 
 void main() {
   group('DartType', () {
+    // `Foo` / `Bar` are used for the generic constructor/equality/commonType
+    // tests so they exercise the constructor rather than a named constant
+    // (which the `use_named_constants` lint would otherwise require).
     test('renders name, type arguments, and nullability', () {
-      expect(const DartType('String').toString(), 'String');
-      expect(const DartType('String', isNullable: true).toString(), 'String?');
+      expect(const DartType('Foo').toString(), 'Foo');
+      expect(const DartType('Foo', isNullable: true).toString(), 'Foo?');
       expect(
-        const DartType('List', typeArguments: [DartType('int')]).toString(),
-        'List<int>',
+        const DartType('List', typeArguments: [DartType('Bar')]).toString(),
+        'List<Bar>',
       );
       expect(
         const DartType(
           'Map',
-          typeArguments: [DartType('String'), DartType('int')],
+          typeArguments: [DartType('Foo'), DartType('Bar')],
           isNullable: true,
         ).toString(),
-        'Map<String, int>?',
+        'Map<Foo, Bar>?',
       );
     });
 
@@ -25,6 +28,31 @@ void main() {
       expect(DartType.nullableObject.toString(), 'Object?');
       expect(DartType.void_.toString(), 'void');
       expect(DartType.uint8List.toString(), 'Uint8List');
+      expect(DartType.string.toString(), 'String');
+      expect(DartType.bool_.toString(), 'bool');
+      expect(DartType.int_.toString(), 'int');
+      expect(DartType.double_.toString(), 'double');
+      expect(DartType.num_.toString(), 'num');
+    });
+
+    test('DartType.list builds List<T>, defaulting the element to dynamic', () {
+      expect(DartType.list(DartType.string).toString(), 'List<String>');
+      expect(DartType.list().toString(), 'List<dynamic>');
+      expect(
+        DartType.list(DartType.list(DartType.int_)).toString(),
+        'List<List<int>>',
+      );
+    });
+
+    test('DartType.map builds Map<K, V>', () {
+      expect(
+        DartType.map(DartType.string, DartType.dynamic_).toString(),
+        'Map<String, dynamic>',
+      );
+      expect(
+        DartType.map(DartType.string, DartType.int_).toString(),
+        'Map<String, int>',
+      );
     });
 
     test('dynamic never renders a trailing `?`', () {
@@ -36,8 +64,8 @@ void main() {
     test(
       'asNullable / asNonNullable toggle nullability, preserve the rest',
       () {
-        const list = DartType('List', typeArguments: [DartType('int')]);
-        expect(list.asNullable().toString(), 'List<int>?');
+        const list = DartType('List', typeArguments: [DartType('Foo')]);
+        expect(list.asNullable().toString(), 'List<Foo>?');
         expect(list.asNullable().asNonNullable(), list);
         expect(list.asNonNullable(), same(list));
       },
@@ -45,46 +73,40 @@ void main() {
 
     test('equality is structural', () {
       expect(
-        const DartType('List', typeArguments: [DartType('int')]),
-        const DartType('List', typeArguments: [DartType('int')]),
+        const DartType('List', typeArguments: [DartType('Foo')]),
+        const DartType('List', typeArguments: [DartType('Foo')]),
       );
       expect(
-        const DartType('List', typeArguments: [DartType('int')]),
-        isNot(const DartType('List', typeArguments: [DartType('String')])),
+        const DartType('List', typeArguments: [DartType('Foo')]),
+        isNot(const DartType('List', typeArguments: [DartType('Bar')])),
       );
     });
 
     group('commonType', () {
       test('single shared base type -> that type', () {
         expect(
-          DartType.commonType([const DartType('String')]),
-          const DartType('String'),
+          DartType.commonType([const DartType('Foo')]),
+          const DartType('Foo'),
         );
         expect(
-          DartType.commonType([
-            const DartType('String'),
-            const DartType('String'),
-          ]),
-          const DartType('String'),
+          DartType.commonType([const DartType('Foo'), const DartType('Foo')]),
+          const DartType('Foo'),
         );
       });
 
       test('any nullable input makes the result nullable', () {
         expect(
           DartType.commonType([
-            const DartType('String'),
-            const DartType('String', isNullable: true),
+            const DartType('Foo'),
+            const DartType('Foo', isNullable: true),
           ]),
-          const DartType('String', isNullable: true),
+          const DartType('Foo', isNullable: true),
         );
       });
 
       test('mixed base types -> Object?', () {
         expect(
-          DartType.commonType([
-            const DartType('String'),
-            const DartType('int'),
-          ]),
+          DartType.commonType([const DartType('Foo'), const DartType('Bar')]),
           DartType.nullableObject,
         );
       });
@@ -95,7 +117,7 @@ void main() {
           DartType.nullableObject,
         );
         expect(
-          DartType.commonType([DartType.dynamic_, const DartType('String')]),
+          DartType.commonType([DartType.dynamic_, const DartType('Foo')]),
           DartType.nullableObject,
         );
         expect(

--- a/test/render/render_tree_test.dart
+++ b/test/render/render_tree_test.dart
@@ -1839,5 +1839,35 @@ void main() {
       );
       expect(schema.typeName, 'CustomName');
     });
+
+    test('jsonStorageType: RenderArray stores as List<dynamic>', () {
+      const array = RenderArray(
+        common: CommonProperties.test(
+          snakeName: 'a',
+          pointer: JsonPointer.empty(),
+          description: 'Foo',
+        ),
+        items: RenderUnknown(
+          common: CommonProperties.test(
+            snakeName: 'a',
+            pointer: JsonPointer.empty(),
+            description: 'Foo',
+          ),
+        ),
+      );
+      expect(array.jsonStorageType(isNullable: false), 'List<dynamic>');
+      expect(array.jsonStorageType(isNullable: true), 'List<dynamic>?');
+    });
+
+    test('jsonStorageDartType throws for schemas with no JSON form', () {
+      const binary = RenderBinary(
+        common: CommonProperties.test(
+          snakeName: 'b',
+          pointer: JsonPointer.empty(),
+          description: 'Foo',
+        ),
+      );
+      expect(() => binary.jsonStorageDartType, throwsUnsupportedError);
+    });
   });
 }


### PR DESCRIPTION
## Summary

Slice 3 of the `DartType` model, in two parts.

### 1. `jsonStorageType` migrated onto `DartType`

The JSON wire type (the type of a value inside the parsed `Map<String, dynamic>`) now derives from an abstract `DartType get jsonStorageDartType`, with the base `jsonStorageType({isNullable})` applying nullability — **centralizing the `isNullable ? 'X?' : 'X'` threading** that was copy-pasted across ~14 subclasses. Each subclass declares its wire type structurally (pods→`String`/`bool`, objects/maps/oneOf→the shared wire map, arrays→`List<dynamic>`, etc.). `RenderNoJson` keeps its throw-hack override.

### 2. `DartType` vocabulary — constants & constructors

So the subclasses stop hand-constructing the same types:
- Scalar constants `string`, `bool_`, `int_`, `double_`, `num_` (trailing underscore for lowercase type names, matching `dynamic_`/`void_`; `string` since `String` is capitalized).
- `DartType.list([DartType? element])` (element defaults to `dynamic`) and `DartType.map(key, value)`.
- `_jsonWireMap` (`Map<String, dynamic>`) now builds via `DartType.map`; `RenderArray`/`RenderMap`/etc. use `.list`/`.map`/the constants instead of raw `DartType('List', typeArguments: […])`.

## Scope note

The "oneOf/anyOf common typing" originally floated for slice 3 has **no existing consumer**, so it's dropped (it'd be net-new logic, not a migration). The type-graph LUB remains slice 4.

## Test plan

- [x] `dart analyze` (whole `lib` + tests) clean; `dart test` — all pass (new `DartType` constant/constructor/`.list`/`.map` unit tests).
- [x] **Pure refactor — byte-identical GitHub output**: full regen on this branch vs `main` reports **0 real differences** across all 1872 files (package-name normalized).