### PR TITLE
refactor: invert the last string type surfaces to derive from DartType (slice 4)

### DIFF
--- a/doc/dart_type.md
+++ b/doc/dart_type.md
@@ -44,9 +44,27 @@ so `.list` and `.map` are non-const; the scalar / well-known types stay const.
 derives from `jsonStorageDartType`. The generated `operator[]`'s return type
 comes from `DartType.commonType`.
 
+Every remaining string-typed type surface now *derives* from a `DartType`
+rather than being a parallel source of truth: `RenderPod.dartTypeName` renders
+from `RenderPod.wrappedType` (a `DartType`), and `RenderEnum.valueDartType`
+renders from `jsonStorageDartType` (an enum's value type *is* its JSON wire
+type). DartType is the single source of truth for "what Dart type is this."
+
 Landed across PRs #222 (model + `operator[]` common-type), #223 (`dartType`
-made authoritative), and #224 (JSON wire type + the constant/constructor
-vocabulary). The string-typed surfaces are converted.
+made authoritative), #224 (JSON wire type + the constant/constructor
+vocabulary), and #226 (string surfaces inverted to derive from DartType).
+
+## North star
+
+The direction this is heading: `DartType` becomes a small, zod-like type IR
+that the whole pipeline translates *into*. Much of what the generator does is
+"read a generic type spec (JSON/YAML) → emit an idiomatic Dart type"; the more
+that logic lives as *behavior on `DartType`* (rendering, nullability,
+common-type, and eventually JSON conversion) rather than per-node `switch`
+statements over `PodType`/subclass, the thinner the `Render*` layer gets.
+Inverting the last string surfaces (above) was the precondition: you can't
+safely hang behavior on `DartType` while some nodes still compute their type as
+a bare string that bypasses it.
 
 ## Remaining work
 
@@ -71,10 +89,20 @@ fields and `additionalProperties` value all share a single type — and no spec
 in the test set has one, so building it now is speculative (see the
 require-a-real-validation-target rule).
 
-### Newtype wrapped type
+### Newtype wrapped type (done — #226)
 
-A newtype's wrapped underlying type (e.g. a `DateTime`-backed newtype) is a
-`RenderPod` concern — `RenderPod.dartTypeName` (a `String`) today — not a
-`DartType` accessor. It could become a structured `wrappedType` field *on
-`RenderPod`* if newtype rendering migrates onto `DartType`, but it stays off
-the value type.
+A newtype's wrapped underlying type (e.g. a `DateTime`-backed newtype) is now
+`RenderPod.wrappedType` — a `DartType` on `RenderPod`, not a bare string and
+not a field on the value type. `dartTypeName` renders from it for templates
+that need the bare identifier. This confirmed the design: structured type data
+lives *on the render node*, `DartType` stays a pure value expression.
+
+### Fold JSON conversion onto DartType (next)
+
+The largest remaining `switch`-heavy surface is per-node
+`fromJsonExpression` / `toJsonExpression`. As the pipeline moves toward the
+zod-like IR (see **North star**), these are the natural next candidates to
+become behavior driven by a `DartType` (+ its `jsonStorageDartType`) codec
+pair rather than per-subclass overrides. Not yet attempted; they also depend on
+context, nullability, and defaults, so this is a larger step than the string
+inversions.

--- a/doc/dart_type.md
+++ b/doc/dart_type.md
@@ -25,7 +25,10 @@ structure rather than string manipulation.
 Vocabulary:
 
 - **Constants:** `dynamic_`, `nullableObject` (`Object?`), `void_`,
-  `uint8List`, `string`, `bool_`, `int_`, `double_`, `num_`. Naming convention:
+  `uint8List`, `dateTime`, `uri`, `uriTemplate`, `string`, `bool_`, `int_`,
+  `double_`, `num_`. All name Dart SDK types except `uriTemplate`
+  (`package:uri`) — flagged with a TODO to move out if `DartType` ever
+  generalizes into a project-agnostic type model. Naming convention:
   a trailing `_` for the lowercase type names (`dynamic` / `void` / `bool` /
   `int` / `double` / `num`), plain lowercase `string` for the capitalized
   `String`.

--- a/lib/src/render/dart_type.dart
+++ b/lib/src/render/dart_type.dart
@@ -53,6 +53,21 @@ class DartType extends Equatable {
   /// `Uint8List` (`dart:typed_data`) — binary field types.
   static const uint8List = DartType('Uint8List');
 
+  /// `DateTime` (`dart:core`) — `format: date` / `date-time` fields.
+  static const dateTime = DartType('DateTime');
+
+  /// `Uri` (`dart:core`) — `format: uri` fields.
+  static const uri = DartType('Uri');
+
+  /// `UriTemplate` (`package:uri`) — `format: uri-template` fields.
+  //
+  // TODO(eseidel): Unlike the other constants, this names a type from a
+  // third-party package, not the Dart SDK. If DartType ever generalizes into a
+  // project-agnostic type model, this project-specific constant should move out
+  // of the core class (e.g. a space_gen-side constant, or built at the use
+  // site) rather than living alongside the language-level types.
+  static const uriTemplate = DartType('UriTemplate');
+
   /// The `String` type.
   static const string = DartType('String');
 

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -2560,13 +2560,13 @@ class RenderPod extends RenderSchema {
   /// and [dartTypeName].
   DartType get wrappedType => switch (type) {
     PodType.boolean => DartType.bool_,
-    PodType.dateTime => const DartType('DateTime'),
-    PodType.uri => const DartType('Uri'),
-    PodType.uriTemplate => const DartType('UriTemplate'),
+    PodType.dateTime => DartType.dateTime,
+    PodType.uri => DartType.uri,
+    PodType.uriTemplate => DartType.uriTemplate,
     // email and uuid are String subsets.
     PodType.email => DartType.string,
     PodType.uuid => DartType.string,
-    PodType.date => const DartType('DateTime'),
+    PodType.date => DartType.dateTime,
   };
 
   /// The name of [wrappedType], for templates that need the bare identifier.

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -2555,22 +2555,26 @@ class RenderPod extends RenderSchema {
   @override
   List<Object?> get props => [super.props, type, defaultValue];
 
-  /// The name of the Dart type that represents this pod at the use site
-  /// (when inline) or that the newtype wraps (when a newtype).
-  String get dartTypeName => switch (type) {
-    PodType.boolean => 'bool',
-    PodType.dateTime => 'DateTime',
-    PodType.uri => 'Uri',
-    PodType.uriTemplate => 'UriTemplate',
+  /// The Dart type this pod represents at the use site (when inline) or that
+  /// the newtype wraps (when a newtype). The source of truth for [dartType]
+  /// and [dartTypeName].
+  DartType get wrappedType => switch (type) {
+    PodType.boolean => DartType.bool_,
+    PodType.dateTime => const DartType('DateTime'),
+    PodType.uri => const DartType('Uri'),
+    PodType.uriTemplate => const DartType('UriTemplate'),
     // email and uuid are String subsets.
-    PodType.email => 'String',
-    PodType.uuid => 'String',
-    PodType.date => 'DateTime',
+    PodType.email => DartType.string,
+    PodType.uuid => DartType.string,
+    PodType.date => const DartType('DateTime'),
   };
+
+  /// The name of [wrappedType], for templates that need the bare identifier.
+  String get dartTypeName => wrappedType.toString();
 
   @override
   DartType get dartType =>
-      DartType(createsNewType ? _requireAssignedName() : dartTypeName);
+      createsNewType ? DartType(_requireAssignedName()) : wrappedType;
 
   // Boolean is the only PodType with a `is bool` test that's distinct
   // from the other JSON storage types (the date/uri/uuid/etc. all
@@ -4234,8 +4238,9 @@ abstract class RenderEnum<T extends Object> extends RenderNewType {
 
   /// The bare Dart type name of the enum's underlying value (e.g.
   /// `String`, `int`). Drives the template's `final <type> value`
-  /// declaration and `<type> toJson()` return type.
-  String get valueDartType;
+  /// declaration and `<type> toJson()` return type. Derived from
+  /// [jsonStorageDartType] — an enum's value type is its JSON wire type.
+  String get valueDartType => jsonStorageDartType.toString();
 
   @override
   String? get wrapperTag => typeName;
@@ -4255,9 +4260,6 @@ abstract class RenderEnum<T extends Object> extends RenderNewType {
     defaultValue,
     descriptions,
   ];
-
-  @override
-  DartType get jsonStorageDartType => DartType(valueDartType);
 
   /// Template context for an enum schema.
   @override
@@ -4347,7 +4349,7 @@ class RenderStringEnum extends RenderEnum<String> {
   String enumValueLiteral(String value) => quoteString(value);
 
   @override
-  String get valueDartType => 'String';
+  DartType get jsonStorageDartType => DartType.string;
 
   @override
   String? invalidJsonExample(SchemaRenderer context) =>
@@ -4369,7 +4371,7 @@ class RenderIntEnum extends RenderEnum<int> {
   String enumValueLiteral(int value) => value.toString();
 
   @override
-  String get valueDartType => 'int';
+  DartType get jsonStorageDartType => DartType.int_;
 
   @override
   String? invalidJsonExample(SchemaRenderer context) {

--- a/test/render/render_tree_test.dart
+++ b/test/render/render_tree_test.dart
@@ -1598,14 +1598,14 @@ void main() {
     });
 
     test('wrappedType is the underlying Dart type regardless of newtype', () {
-      expect(pod(PodType.dateTime).wrappedType, const DartType('DateTime'));
+      expect(pod(PodType.dateTime).wrappedType, DartType.dateTime);
       expect(
         pod(PodType.dateTime, createsNewType: true).wrappedType,
-        const DartType('DateTime'),
+        DartType.dateTime,
       );
       expect(pod(PodType.email).wrappedType, DartType.string);
       expect(pod(PodType.uuid).wrappedType, DartType.string);
-      expect(pod(PodType.date).wrappedType, const DartType('DateTime'));
+      expect(pod(PodType.date).wrappedType, DartType.dateTime);
     });
 
     test('toJsonExpression delegates to .toJson() when a newtype', () {

--- a/test/render/render_tree_test.dart
+++ b/test/render/render_tree_test.dart
@@ -1,4 +1,5 @@
 import 'package:space_gen/src/quirks.dart';
+import 'package:space_gen/src/render/dart_type.dart';
 import 'package:space_gen/src/render/render_tree.dart';
 import 'package:space_gen/src/render/schema_renderer.dart';
 import 'package:space_gen/src/render/templates.dart';
@@ -1596,15 +1597,15 @@ void main() {
       expect(pod(PodType.date, createsNewType: true).typeName, 'FooBar');
     });
 
-    test('dartTypeName is the underlying Dart type regardless of newtype', () {
-      expect(pod(PodType.dateTime).dartTypeName, 'DateTime');
+    test('wrappedType is the underlying Dart type regardless of newtype', () {
+      expect(pod(PodType.dateTime).wrappedType, const DartType('DateTime'));
       expect(
-        pod(PodType.dateTime, createsNewType: true).dartTypeName,
-        'DateTime',
+        pod(PodType.dateTime, createsNewType: true).wrappedType,
+        const DartType('DateTime'),
       );
-      expect(pod(PodType.email).dartTypeName, 'String');
-      expect(pod(PodType.uuid).dartTypeName, 'String');
-      expect(pod(PodType.date).dartTypeName, 'DateTime');
+      expect(pod(PodType.email).wrappedType, DartType.string);
+      expect(pod(PodType.uuid).wrappedType, DartType.string);
+      expect(pod(PodType.date).wrappedType, const DartType('DateTime'));
     });
 
     test('toJsonExpression delegates to .toJson() when a newtype', () {


### PR DESCRIPTION
## Summary

Makes `DartType` the single source of truth for "what Dart type is this" by inverting the two remaining string-typed type accessors so they render *from* a `DartType` instead of being a parallel source:

- `RenderPod` gains `wrappedType` (a `DartType`); `dartTypeName` and `dartType` both derive from it. This closes the doc's "newtype wrapped type" remaining item — structured type data lives on the render node, the value type stays pure.
- `RenderEnum.valueDartType` now renders from `jsonStorageDartType` (an enum's value type *is* its JSON wire type); the string→`DartType` direction is reversed. `RenderStringEnum`/`RenderIntEnum` override `jsonStorageDartType` directly.

Output-identical (`wrappedType.toString()` reproduces the old `dartTypeName` switch; `jsonStorageDartType.toString()` reproduces the old `valueDartType`). The precondition for hanging JSON-conversion behavior on `DartType` next — you can't safely do that while some nodes still compute their type as a bare string that bypasses it.

`doc/dart_type.md` records the zod-like north star and names the next fold (per-node `fromJsonExpression`/`toJsonExpression` → a `DartType` codec pair).

## Testing

- `dart analyze` clean
- `dart format` clean
- `dart test` — all 577 tests pass