### PR TITLE
refactor: scalar JSON codec as an extension on DartType (slice 5)

### DIFF
--- a/doc/dart_type.md
+++ b/doc/dart_type.md
@@ -80,11 +80,13 @@ generic value never sees it (cf. the `uriTemplate` TODO in `dart_type.dart`).
 Some behavior is a pure function of the Dart type (rendering, JSON wire type,
 the codec for `Uri`/`UriTemplate`/`String`/`bool`); the rest needs the *spec*
 type (`PodType`) because a many-to-one spec→Dart mapping loses information Dart
-can't recover. Today the only lossy cases are: `date` vs `date-time` (both
-`DartType.dateTime`, but different serialize/parse) and example/invalid-JSON
-fixtures (`email` vs `uuid` differ only there). Rule: **codec lives on the
-`DartType` extension, except where two spec formats collapse to one Dart type**
-— that residue stays keyed off `PodType` on the owning render node.
+can't recover. The remaining lossy case is example/invalid-JSON fixtures:
+`email` vs `uuid` are both `String` and differ only there. (`format: date` used
+to collapse onto `DartType.dateTime` alongside `date-time`, but it now has its
+own `Date` type — see `date_type.md` — so `DateTime` is 1:1 with `date-time`.)
+Rule: **codec lives on the `DartType` extension, except where two spec formats
+collapse to one Dart type** — that residue stays keyed off `PodType` on the
+owning render node.
 
 ## Remaining work
 
@@ -124,14 +126,16 @@ lives *on the render node*, `DartType` stays a pure value expression.
 and `bool` (JSON-native, identity), `Uri` and `UriTemplate` (`.toString()` /
 `Uri.parse` / `UriTemplate(…)`). `RenderPod` keeps exhaustive `PodType` cases
 (so a new format still won't compile until handled) but delegates their bodies
-to the extension; `date`/`date-time` stay resolved off `PodType` because the
-Dart type can't tell them apart. Unhandled types throw rather than guess.
+to the extension; `date-time` stays resolved off `PodType` for now (its codec
+hasn't been moved onto the extension yet — see below). Unhandled types throw
+rather than guess.
 
 Remaining folds toward the zod-like IR:
 
-- **`DateTime`** — decide whether the `date`/`date-time` split is worth pulling
-  into the codec (would need a spec-type discriminator the extension can see,
-  since both are `DartType.dateTime`), or whether it stays on `RenderPod`.
+- **`DateTime`** — now that `format: date` is split off into its own `Date` type
+  (#229), `DateTime` is 1:1 with `date-time`, so its codec (`DateTime.parse` /
+  `.toIso8601String()` / `maybeParseDateTime`) is a pure function of the Dart
+  type and could move onto the extension. Not yet done.
 - **Collection / object / enum conversion** — `RenderArray` / `RenderMap` /
   `RenderObject` / `RenderEnum` still hand-roll `fromJsonExpression` /
   `toJsonExpression`. These depend on context, nullability, and defaults, so

--- a/doc/dart_type.md
+++ b/doc/dart_type.md
@@ -62,12 +62,29 @@ vocabulary), and #226 (string surfaces inverted to derive from DartType).
 The direction this is heading: `DartType` becomes a small, zod-like type IR
 that the whole pipeline translates *into*. Much of what the generator does is
 "read a generic type spec (JSON/YAML) → emit an idiomatic Dart type"; the more
-that logic lives as *behavior on `DartType`* (rendering, nullability,
-common-type, and eventually JSON conversion) rather than per-node `switch`
-statements over `PodType`/subclass, the thinner the `Render*` layer gets.
-Inverting the last string surfaces (above) was the precondition: you can't
-safely hang behavior on `DartType` while some nodes still compute their type as
-a bare string that bypasses it.
+that logic lives as *behavior keyed off `DartType`* (rendering, nullability,
+common-type, JSON conversion) rather than per-node `switch` statements over
+`PodType`/subclass, the thinner the `Render*` layer gets. Inverting the last
+string surfaces (above) was the precondition: you can't safely hang behavior on
+`DartType` while some nodes still compute their type as a bare string that
+bypasses it.
+
+**Home vs. key.** `DartType` (`dart_type.dart`) stays a pure value that a
+future generic type system could reuse — codegen behavior does *not* go on the
+class. Render-only behavior lives in an `extension on DartType` in the render
+layer (`render_tree.dart`), so "keyed off `DartType`" and "method on
+`DartType`" stop being in tension: the extension dispatches on the type but the
+generic value never sees it (cf. the `uriTemplate` TODO in `dart_type.dart`).
+
+**Spec-type vs. Dart-type boundary.** Not everything can key off `DartType`.
+Some behavior is a pure function of the Dart type (rendering, JSON wire type,
+the codec for `Uri`/`UriTemplate`/`String`/`bool`); the rest needs the *spec*
+type (`PodType`) because a many-to-one spec→Dart mapping loses information Dart
+can't recover. Today the only lossy cases are: `date` vs `date-time` (both
+`DartType.dateTime`, but different serialize/parse) and example/invalid-JSON
+fixtures (`email` vs `uuid` differ only there). Rule: **codec lives on the
+`DartType` extension, except where two spec formats collapse to one Dart type**
+— that residue stays keyed off `PodType` on the owning render node.
 
 ## Remaining work
 
@@ -100,12 +117,22 @@ not a field on the value type. `dartTypeName` renders from it for templates
 that need the bare identifier. This confirmed the design: structured type data
 lives *on the render node*, `DartType` stays a pure value expression.
 
-### Fold JSON conversion onto DartType (next)
+### Scalar JSON codec on a DartType extension (started — #227)
 
-The largest remaining `switch`-heavy surface is per-node
-`fromJsonExpression` / `toJsonExpression`. As the pipeline moves toward the
-zod-like IR (see **North star**), these are the natural next candidates to
-become behavior driven by a `DartType` (+ its `jsonStorageDartType`) codec
-pair rather than per-subclass overrides. Not yet attempted; they also depend on
-context, nullability, and defaults, so this is a larger step than the string
-inversions.
+`DartTypeCodec` (`extension on DartType`, render layer) owns `toJsonScalar` /
+`fromJsonScalar` for the leaf types the Dart type fully determines: `String`
+and `bool` (JSON-native, identity), `Uri` and `UriTemplate` (`.toString()` /
+`Uri.parse` / `UriTemplate(…)`). `RenderPod` keeps exhaustive `PodType` cases
+(so a new format still won't compile until handled) but delegates their bodies
+to the extension; `date`/`date-time` stay resolved off `PodType` because the
+Dart type can't tell them apart. Unhandled types throw rather than guess.
+
+Remaining folds toward the zod-like IR:
+
+- **`DateTime`** — decide whether the `date`/`date-time` split is worth pulling
+  into the codec (would need a spec-type discriminator the extension can see,
+  since both are `DartType.dateTime`), or whether it stays on `RenderPod`.
+- **Collection / object / enum conversion** — `RenderArray` / `RenderMap` /
+  `RenderObject` / `RenderEnum` still hand-roll `fromJsonExpression` /
+  `toJsonExpression`. These depend on context, nullability, and defaults, so
+  they're a larger step than the scalar codec.

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -429,6 +429,55 @@ abstract final class ModelHelpers {
   ];
 }
 
+/// Rendering-only JSON codec for the scalar leaf [DartType]s whose conversion
+/// the Dart type *fully determines* — `String`/`bool` (JSON-native, identity),
+/// `Uri`, and `UriTemplate`.
+///
+/// Lives in the render layer as an extension, not on [DartType] itself, so the
+/// value type stays a pure, potentially-generic expression — the generic type
+/// system never sees these codegen helpers (cf. the `uriTemplate` TODO in
+/// `dart_type.dart`).
+///
+/// Types where two spec formats collapse to one Dart type are deliberately
+/// *not* handled here: today that is only `DateTime` (`date` vs `date-time`
+/// serialize and parse differently but are both [DartType.dateTime]), so the
+/// Dart type can't distinguish them — [RenderPod] resolves that codec itself
+/// off [PodType]. Unhandled types throw rather than guessing.
+extension DartTypeCodec on DartType {
+  /// The JSON representation of a Dart value expression [name] of this type.
+  /// [nullable] guards the member access on non-native types.
+  String toJsonScalar(String name, {required bool nullable}) {
+    if (this == DartType.uri || this == DartType.uriTemplate) {
+      return '${nullable ? '$name?' : name}.toString()';
+    }
+    // String- and bool-backed types are JSON-native: no conversion.
+    if (this == DartType.string || this == DartType.bool_) {
+      return name;
+    }
+    throw UnsupportedError('No scalar toJson codec for $this');
+  }
+
+  /// A Dart value of this type from an already-cast JSON expression
+  /// [castValue]. When [nullable], parses through the null-tolerant helper so
+  /// the result stays a single nullable-aware expression.
+  String fromJsonScalar(String castValue, {required bool nullable}) {
+    if (this == DartType.uri) {
+      return nullable
+          ? '${ModelHelpers.maybeParseUri}($castValue)'
+          : 'Uri.parse($castValue)';
+    }
+    if (this == DartType.uriTemplate) {
+      return nullable
+          ? '${ModelHelpers.maybeParseUriTemplate}($castValue)'
+          : 'UriTemplate($castValue)';
+    }
+    if (this == DartType.string || this == DartType.bool_) {
+      return castValue;
+    }
+    throw UnsupportedError('No scalar fromJson codec for $this');
+  }
+}
+
 class SpecResolver {
   SpecResolver(this.quirks);
 
@@ -2636,11 +2685,16 @@ class RenderPod extends RenderSchema {
     final nameCall = nameIsNullable ? '$name?' : name;
     return switch (type) {
       PodType.dateTime => '$nameCall.toIso8601String()',
-      PodType.uri => '$nameCall.toString()',
-      PodType.uriTemplate => '$nameCall.toString()',
-      // String- and bool-backed types: no conversion; `name` already
-      // has the correct nullable/non-nullable type.
-      PodType.email || PodType.uuid || PodType.boolean => name,
+      // Uri/UriTemplate (.toString()) and String/bool (identity) are fully
+      // determined by the Dart type — delegate to the DartType codec.
+      PodType.uri ||
+      PodType.uriTemplate ||
+      PodType.email ||
+      PodType.uuid ||
+      PodType.boolean => wrappedType.toJsonScalar(
+        name,
+        nullable: nameIsNullable,
+      ),
     };
   }
 
@@ -2649,9 +2703,11 @@ class RenderPod extends RenderSchema {
   /// inline use site.
   String _jsonToValueBody(String jsonName) => switch (type) {
     PodType.dateTime => 'DateTime.parse($jsonName)',
-    PodType.uri => 'Uri.parse($jsonName)',
-    PodType.uriTemplate => 'UriTemplate($jsonName)',
-    PodType.email || PodType.uuid || PodType.boolean => jsonName,
+    PodType.uri ||
+    PodType.uriTemplate ||
+    PodType.email ||
+    PodType.uuid ||
+    PodType.boolean => wrappedType.fromJsonScalar(jsonName, nullable: false),
   };
 
   @override
@@ -2686,30 +2742,27 @@ class RenderPod extends RenderSchema {
       return '$typeName.$jsonMethod($castedValue)$orDefault';
     }
 
-    // Inline: convert json String -> Dart value at the use site. For
-    // nullable values we call a helper (so the expression remains a
-    // single nullable-aware expression), for non-nullable we inline.
-    switch (type) {
-      case PodType.dateTime:
-        if (jsonIsNullable) {
-          return '${ModelHelpers.maybeParseDateTime}($castedValue)$orDefault';
-        }
-        return 'DateTime.parse($castedValue)';
-      case PodType.uri:
-        if (jsonIsNullable) {
-          return '${ModelHelpers.maybeParseUri}($castedValue)$orDefault';
-        }
-        return 'Uri.parse($castedValue)';
-      case PodType.uriTemplate:
-        if (jsonIsNullable) {
-          final call = '${ModelHelpers.maybeParseUriTemplate}($castedValue)';
-          return '$call$orDefault';
-        }
-        return 'UriTemplate($castedValue)';
-      case PodType.boolean || PodType.email || PodType.uuid:
-        // 'as' has higher precedence than '??' so no parens are needed.
-        return '$castedValue$orDefault';
-    }
+    // Inline: convert the cast JSON value to the Dart value at the use site.
+    // `date-time` collapses to `DateTime`, so its codec is resolved here off
+    // [PodType]; everything else is fully determined by the Dart type and
+    // delegates to the DartType codec. `orDefault` is empty when the JSON is
+    // non-nullable, so appending it unconditionally is safe ('as' has higher
+    // precedence than '??', so no parens are needed).
+    final conversion = switch (type) {
+      PodType.dateTime =>
+        jsonIsNullable
+            ? '${ModelHelpers.maybeParseDateTime}($castedValue)'
+            : 'DateTime.parse($castedValue)',
+      PodType.uri ||
+      PodType.uriTemplate ||
+      PodType.email ||
+      PodType.uuid ||
+      PodType.boolean => wrappedType.fromJsonScalar(
+        castedValue,
+        nullable: jsonIsNullable,
+      ),
+    };
+    return '$conversion$orDefault';
   }
 
   @override

--- a/test/render/render_tree_test.dart
+++ b/test/render/render_tree_test.dart
@@ -1919,4 +1919,55 @@ void main() {
       expect(() => binary.jsonStorageDartType, throwsUnsupportedError);
     });
   });
+
+  group('DartTypeCodec', () {
+    test(
+      'toJsonScalar: Uri/UriTemplate call toString, natives are identity',
+      () {
+        expect(DartType.uri.toJsonScalar('v', nullable: false), 'v.toString()');
+        expect(DartType.uri.toJsonScalar('v', nullable: true), 'v?.toString()');
+        expect(
+          DartType.uriTemplate.toJsonScalar('v', nullable: false),
+          'v.toString()',
+        );
+        expect(DartType.string.toJsonScalar('v', nullable: true), 'v');
+        expect(DartType.bool_.toJsonScalar('v', nullable: false), 'v');
+      },
+    );
+
+    test('fromJsonScalar: nullable parses via the null-tolerant helper', () {
+      expect(DartType.uri.fromJsonScalar('j', nullable: false), 'Uri.parse(j)');
+      expect(
+        DartType.uri.fromJsonScalar('j', nullable: true),
+        'maybeParseUri(j)',
+      );
+      expect(
+        DartType.uriTemplate.fromJsonScalar('j', nullable: false),
+        'UriTemplate(j)',
+      );
+      expect(
+        DartType.uriTemplate.fromJsonScalar('j', nullable: true),
+        'maybeParseUriTemplate(j)',
+      );
+      expect(DartType.string.fromJsonScalar('j', nullable: false), 'j');
+      expect(DartType.bool_.fromJsonScalar('j', nullable: true), 'j');
+    });
+
+    test('throws for types it does not fully determine (e.g. DateTime)', () {
+      // `DateTime` is intentionally unhandled: `date` vs `date-time` share the
+      // Dart type but serialize differently, so RenderPod owns that codec.
+      expect(
+        () => DartType.dateTime.toJsonScalar('v', nullable: false),
+        throwsUnsupportedError,
+      );
+      expect(
+        () => DartType.dateTime.fromJsonScalar('j', nullable: false),
+        throwsUnsupportedError,
+      );
+      expect(
+        () => DartType.int_.fromJsonScalar('j', nullable: false),
+        throwsUnsupportedError,
+      );
+    });
+  });
 }


### PR DESCRIPTION
## Summary

Introduces `DartTypeCodec` — a render-layer `extension on DartType` that owns JSON conversion for the leaf types the Dart type *fully determines*: `String`/`bool` (JSON-native, identity), `Uri`, and `UriTemplate` (`.toString()` / `Uri.parse` / `UriTemplate(…)`, with null-tolerant helpers when nullable).

`RenderPod`'s `_valueToJsonBody`, `_jsonToValueBody`, and the inline `fromJsonExpression` delegate their `uri`/`uriTemplate`/`email`/`uuid`/`boolean` cases to the extension. The `PodType` switches stay exhaustive (a new format still won't compile until handled), and `date`/`date-time` stay resolved off `PodType` — both are `DartType.dateTime`, so the Dart type can't distinguish them. That's the spec-type-vs-Dart-type boundary: codec lives on the DartType extension, except where two spec formats collapse to one Dart type.

The extension lives in the render layer, not on `DartType` itself, so the value type stays a pure, potentially-generic expression — "keyed off DartType" without putting codegen knowledge on the class. Unhandled types throw rather than guess.

Output-identical. First step of the zod-like north star recorded in `doc/dart_type.md`; follow-ups (DateTime split, collection/object/enum conversion) noted there.

## Testing

- `dart analyze` clean
- `dart format` clean
- `dart test` — all 580 tests pass (adds `DartTypeCodec` unit tests)