### PR TITLE
docs: add Backstage catalog to the tested-specs list

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,9 @@ and its synthesized round-trip tests are expected to pass.
 - **[SpaceTraders](https://spacetraders.io)** — Complete.
 - **[Train Travel API](https://github.com/bump-sh-examples/train-travel-api)**
   (YAML, OpenAPI 3.1) — Complete.
+- **[Backstage catalog API](https://github.com/backstage/backstage/blob/master/plugins/catalog-backend/src/schema/openapi.yaml)**
+  (YAML, OpenAPI 3.1) — Complete. Exercises `JsonObject` / open-object `allOf`
+  members and `properties: {}` + `additionalProperties` maps.
 - **[Petstore](https://github.com/swagger-api/swagger-petstore)** (the
   OpenAPI canonical example) — Complete.
 


### PR DESCRIPTION
Backstage's catalog-backend OpenAPI spec now generates a clean client with no patches — the three issues it surfaced (JsonObject/open-object `allOf` member, `properties: {}` + `additionalProperties` map, `<sha1hex>` dartdoc angle brackets) were fixed in #219 / #218 / #215. Verified: generated client `dart analyze`s clean and all 134 round-trip tests pass. Adds it to the tested-specs list marked Complete.