### PR TITLE
feat: honor explode: false on query array parameters

### DIFF
--- a/lib/src/parse/spec.dart
+++ b/lib/src/parse/spec.dart
@@ -27,6 +27,7 @@ class Parameter implements HasPointer, Parseable {
     required this.pointer,
     required this.example,
     required this.examples,
+    required this.explode,
   });
 
   /// The name of the parameter.
@@ -44,6 +45,11 @@ class Parameter implements HasPointer, Parseable {
   /// The "in" of the parameter.
   /// e.g. query, header, path, cookie.
   final ParameterLocation inLocation;
+
+  /// The effective OpenAPI `explode` (explicit value, or the per-location
+  /// default). Honored for query array parameters: `explode: false` comma-joins
+  /// into a single value (`?k=a,b,c`) instead of repeating the key.
+  final bool explode;
 
   /// The type of the parameter.
   final SchemaRef type;

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -245,13 +245,14 @@ bool _parameterExplode(MapContext json, ParameterLocation location) =>
     _optional<bool>(json, 'explode') ?? _defaultExplode(location);
 
 /// Warn about `style` / `explode` / `allowReserved` values the generator does
-/// not honor. [explode] is the already-resolved effective value (from
-/// [_parameterExplode]); spec-explicit defaults are consumed quietly.
+/// not honor. Reads (and so consumes) each keyword; spec-explicit defaults are
+/// consumed quietly. The honored value — `explode` — is read separately by
+/// [_parameterExplode]; re-reading a key here is a safe no-op (`markUsed` is
+/// idempotent).
 void _warnUnsupportedSerialization(
   MapContext json,
-  ParameterLocation location, {
-  required bool explode,
-}) {
+  ParameterLocation location,
+) {
   final style = _optional<String>(json, 'style');
   final defaultStyle = _defaultStyle(location);
   if (style != null && style != defaultStyle) {
@@ -267,9 +268,12 @@ void _warnUnsupportedSerialization(
   // here — tracked separately in https://github.com/eseidel/space_gen/issues/233
   // (query params need `_canBePathParameter`-style type validation). Other
   // locations only emit their default wire format, so a non-default value
-  // there still warns. (`explode != default` implies it was set explicitly.)
+  // there still warns.
+  final explode = _optional<bool>(json, 'explode');
   final defaultExplode = _defaultExplode(location);
-  if (explode != defaultExplode && location != ParameterLocation.query) {
+  if (explode != null &&
+      explode != defaultExplode &&
+      location != ParameterLocation.query) {
     _warn(
       json,
       'explode=$explode is not honored on ${location.name} parameters; '
@@ -320,8 +324,8 @@ Parameter parseParameter(MapContext json) {
   if (hasSchema && !hasContent) {
     // Schema fields.
     type = parseSchemaOrRef(schema);
+    _warnUnsupportedSerialization(json, inLocation);
     explode = _parameterExplode(json, inLocation);
-    _warnUnsupportedSerialization(json, inLocation, explode: explode);
     example = _optional<dynamic>(json, 'example');
     examples = _parseExamplesMap(json);
   } else if (!hasSchema && hasContent) {
@@ -371,11 +375,7 @@ Header parseHeader(MapContext json) {
   _ignored<bool>(json, 'allowEmptyValue');
   // Headers always comma-join arrays (style=simple, explode=false), so the
   // effective explode isn't stored — only the warnings matter here.
-  _warnUnsupportedSerialization(
-    json,
-    ParameterLocation.header,
-    explode: _parameterExplode(json, ParameterLocation.header),
-  );
+  _warnUnsupportedSerialization(json, ParameterLocation.header);
   final example = _optional<dynamic>(json, 'example');
   final examples = _parseExamplesMap(json);
 

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -237,18 +237,36 @@ bool _defaultExplode(ParameterLocation location) {
 }
 
 /// The effective OpenAPI `explode` for a parameter — its explicit value, or
-/// the per-location default. This is the one serialization keyword the
-/// generator honors (see the query renderer), so it's the only one threaded
-/// into the model. `style` / `allowReserved` are warn-only
-/// ([_warnUnsupportedSerialization]).
-bool _parameterExplode(MapContext json, ParameterLocation location) =>
-    _optional<bool>(json, 'explode') ?? _defaultExplode(location);
+/// the per-location default — warning when a non-default value can't be
+/// honored. `explode` is the only serialization keyword the generator honors,
+/// so it's the only one threaded into the model; `style` / `allowReserved` are
+/// warn-only ([_warnUnsupportedSerialization]).
+bool _parseExplode(MapContext json, ParameterLocation location) {
+  final explode = _optional<bool>(json, 'explode');
+  final defaultExplode = _defaultExplode(location);
+  // Query parameters honor both explode values *for scalars and arrays*
+  // (array + `explode: false` comma-joins into one value; see the query
+  // renderer). Object-shaped query params are not handled and no longer warn
+  // here — tracked separately in https://github.com/eseidel/space_gen/issues/233
+  // (query params need `_canBePathParameter`-style type validation). Other
+  // locations only emit their default wire format, so a non-default value
+  // there still warns.
+  if (explode != null &&
+      explode != defaultExplode &&
+      location != ParameterLocation.query) {
+    _warn(
+      json,
+      'explode=$explode is not honored on ${location.name} parameters; '
+      'generator emits the default (explode=$defaultExplode) wire format',
+    );
+  }
+  return explode ?? defaultExplode;
+}
 
-/// Warn about `style` / `explode` / `allowReserved` values the generator does
-/// not honor. Reads (and so consumes) each keyword; spec-explicit defaults are
-/// consumed quietly. The honored value — `explode` — is read separately by
-/// [_parameterExplode]; re-reading a key here is a safe no-op (`markUsed` is
-/// idempotent).
+/// Warn about `style` / `allowReserved` values the generator does not honor
+/// (`explode` — the one keyword we thread — is handled by [_parseExplode]).
+/// Reads (and so consumes) each keyword; spec-explicit defaults are consumed
+/// quietly.
 void _warnUnsupportedSerialization(
   MapContext json,
   ParameterLocation location,
@@ -260,24 +278,6 @@ void _warnUnsupportedSerialization(
       json,
       'style="$style" is not honored on ${location.name} parameters; '
       'generator emits the default ($defaultStyle) wire format',
-    );
-  }
-  // Query parameters honor both explode values *for scalars and arrays*
-  // (array + `explode: false` comma-joins into one value; see the query
-  // renderer). Object-shaped query params are not handled and no longer warn
-  // here — tracked separately in https://github.com/eseidel/space_gen/issues/233
-  // (query params need `_canBePathParameter`-style type validation). Other
-  // locations only emit their default wire format, so a non-default value
-  // there still warns.
-  final explode = _optional<bool>(json, 'explode');
-  final defaultExplode = _defaultExplode(location);
-  if (explode != null &&
-      explode != defaultExplode &&
-      location != ParameterLocation.query) {
-    _warn(
-      json,
-      'explode=$explode is not honored on ${location.name} parameters; '
-      'generator emits the default (explode=$defaultExplode) wire format',
     );
   }
   // `allowReserved` is deliberately NOT honored, and we don't intend to unless
@@ -324,8 +324,8 @@ Parameter parseParameter(MapContext json) {
   if (hasSchema && !hasContent) {
     // Schema fields.
     type = parseSchemaOrRef(schema);
+    explode = _parseExplode(json, inLocation);
     _warnUnsupportedSerialization(json, inLocation);
-    explode = _parameterExplode(json, inLocation);
     example = _optional<dynamic>(json, 'example');
     examples = _parseExamplesMap(json);
   } else if (!hasSchema && hasContent) {
@@ -374,7 +374,9 @@ Header parseHeader(MapContext json) {
   _ignored<bool>(json, 'deprecated');
   _ignored<bool>(json, 'allowEmptyValue');
   // Headers always comma-join arrays (style=simple, explode=false), so the
-  // effective explode isn't stored — only the warnings matter here.
+  // effective explode isn't stored — call `_parseExplode` only for its warning
+  // side effect (a non-default explode on a header is unsupported).
+  _parseExplode(json, ParameterLocation.header);
   _warnUnsupportedSerialization(json, ParameterLocation.header);
   final example = _optional<dynamic>(json, 'example');
   final examples = _parseExamplesMap(json);

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -252,9 +252,13 @@ bool _parseSerialization(MapContext json, ParameterLocation location) {
   }
   final explode = _optional<bool>(json, 'explode');
   final defaultExplode = _defaultExplode(location);
-  // Query parameters honor both explode values (array + `explode: false`
-  // comma-joins into one value; see the query renderer). Other locations only
-  // emit their default wire format, so a non-default value there still warns.
+  // Query parameters honor both explode values *for scalars and arrays*
+  // (array + `explode: false` comma-joins into one value; see the query
+  // renderer). Object-shaped query params are not handled and no longer warn
+  // here — tracked separately in https://github.com/eseidel/space_gen/issues/233
+  // (query params need `_canBePathParameter`-style type validation). Other
+  // locations only emit their default wire format, so a non-default value
+  // there still warns.
   if (explode != null &&
       explode != defaultExplode &&
       location != ParameterLocation.query) {

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -236,15 +236,11 @@ bool _defaultExplode(ParameterLocation location) {
   }
 }
 
-/// Read `style`, `explode`, and `allowReserved` and warn if any non-default
-/// value is set. The generator only honors the default wire format today;
-/// non-default values would silently produce wrong output, so we surface
-/// them as `_warn` (visible without --verbose). Spec-explicit defaults are
+/// Read `style`, `explode`, and `allowReserved` on a parameter; warn on any
+/// value the generator doesn't honor, and return the effective `explode`
+/// (explicit value, or the per-location default). Spec-explicit defaults are
 /// consumed quietly.
-void _warnUnsupportedSerialization(
-  MapContext json,
-  ParameterLocation location,
-) {
+bool _parseSerialization(MapContext json, ParameterLocation location) {
   final style = _optional<String>(json, 'style');
   final defaultStyle = _defaultStyle(location);
   if (style != null && style != defaultStyle) {
@@ -256,13 +252,27 @@ void _warnUnsupportedSerialization(
   }
   final explode = _optional<bool>(json, 'explode');
   final defaultExplode = _defaultExplode(location);
-  if (explode != null && explode != defaultExplode) {
+  // Query parameters honor both explode values (array + `explode: false`
+  // comma-joins into one value; see the query renderer). Other locations only
+  // emit their default wire format, so a non-default value there still warns.
+  if (explode != null &&
+      explode != defaultExplode &&
+      location != ParameterLocation.query) {
     _warn(
       json,
       'explode=$explode is not honored on ${location.name} parameters; '
       'generator emits the default (explode=$defaultExplode) wire format',
     );
   }
+  // `allowReserved` is deliberately NOT honored, and we don't intend to unless
+  // a real spec proves a server needs it. `Uri.replace(queryParameters:)`
+  // percent-encodes reserved chars uniformly with no per-param opt-out, so
+  // honoring it would mean hand-building that slice of the query string with a
+  // looser encoder — invasive, and a footgun (an unescaped `&`/`=` in a value
+  // breaks query parsing). It's also a practical no-op: servers percent-decode
+  // query values, so `a%3Ab` and `a:b` mean the same thing on the wire. We
+  // keep the WARN so the divergence is visible; revisit only on a concrete
+  // report.
   final allowReserved = _optional<bool>(json, 'allowReserved') ?? false;
   if (allowReserved) {
     _warn(
@@ -271,6 +281,7 @@ void _warnUnsupportedSerialization(
       'generator URL-encodes reserved characters',
     );
   }
+  return explode ?? defaultExplode;
 }
 
 /// Parse a parameter from a json object.
@@ -292,12 +303,13 @@ Parameter parseParameter(MapContext json) {
   _ignored<bool>(json, 'allowEmptyValue');
 
   final SchemaRef type;
+  final bool explode;
   dynamic example;
   List<dynamic>? examples;
   if (hasSchema && !hasContent) {
     // Schema fields.
     type = parseSchemaOrRef(schema);
-    _warnUnsupportedSerialization(json, inLocation);
+    explode = _parseSerialization(json, inLocation);
     example = _optional<dynamic>(json, 'example');
     examples = _parseExamplesMap(json);
   } else if (!hasSchema && hasContent) {
@@ -328,6 +340,7 @@ Parameter parseParameter(MapContext json) {
     type: type,
     example: example,
     examples: examples,
+    explode: explode,
   );
 }
 
@@ -344,7 +357,9 @@ Header parseHeader(MapContext json) {
   final description = _optional<String>(json, 'description');
   _ignored<bool>(json, 'deprecated');
   _ignored<bool>(json, 'allowEmptyValue');
-  _warnUnsupportedSerialization(json, ParameterLocation.header);
+  // Headers always comma-join arrays (style=simple, explode=false), so the
+  // returned effective explode isn't stored — only the warnings matter here.
+  _parseSerialization(json, ParameterLocation.header);
   final example = _optional<dynamic>(json, 'example');
   final examples = _parseExamplesMap(json);
 

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -236,11 +236,22 @@ bool _defaultExplode(ParameterLocation location) {
   }
 }
 
-/// Read `style`, `explode`, and `allowReserved` on a parameter; warn on any
-/// value the generator doesn't honor, and return the effective `explode`
-/// (explicit value, or the per-location default). Spec-explicit defaults are
-/// consumed quietly.
-bool _parseSerialization(MapContext json, ParameterLocation location) {
+/// The effective OpenAPI `explode` for a parameter — its explicit value, or
+/// the per-location default. This is the one serialization keyword the
+/// generator honors (see the query renderer), so it's the only one threaded
+/// into the model. `style` / `allowReserved` are warn-only
+/// ([_warnUnsupportedSerialization]).
+bool _parameterExplode(MapContext json, ParameterLocation location) =>
+    _optional<bool>(json, 'explode') ?? _defaultExplode(location);
+
+/// Warn about `style` / `explode` / `allowReserved` values the generator does
+/// not honor. [explode] is the already-resolved effective value (from
+/// [_parameterExplode]); spec-explicit defaults are consumed quietly.
+void _warnUnsupportedSerialization(
+  MapContext json,
+  ParameterLocation location, {
+  required bool explode,
+}) {
   final style = _optional<String>(json, 'style');
   final defaultStyle = _defaultStyle(location);
   if (style != null && style != defaultStyle) {
@@ -250,18 +261,15 @@ bool _parseSerialization(MapContext json, ParameterLocation location) {
       'generator emits the default ($defaultStyle) wire format',
     );
   }
-  final explode = _optional<bool>(json, 'explode');
-  final defaultExplode = _defaultExplode(location);
   // Query parameters honor both explode values *for scalars and arrays*
   // (array + `explode: false` comma-joins into one value; see the query
   // renderer). Object-shaped query params are not handled and no longer warn
   // here — tracked separately in https://github.com/eseidel/space_gen/issues/233
   // (query params need `_canBePathParameter`-style type validation). Other
   // locations only emit their default wire format, so a non-default value
-  // there still warns.
-  if (explode != null &&
-      explode != defaultExplode &&
-      location != ParameterLocation.query) {
+  // there still warns. (`explode != default` implies it was set explicitly.)
+  final defaultExplode = _defaultExplode(location);
+  if (explode != defaultExplode && location != ParameterLocation.query) {
     _warn(
       json,
       'explode=$explode is not honored on ${location.name} parameters; '
@@ -285,7 +293,6 @@ bool _parseSerialization(MapContext json, ParameterLocation location) {
       'generator URL-encodes reserved characters',
     );
   }
-  return explode ?? defaultExplode;
 }
 
 /// Parse a parameter from a json object.
@@ -313,7 +320,8 @@ Parameter parseParameter(MapContext json) {
   if (hasSchema && !hasContent) {
     // Schema fields.
     type = parseSchemaOrRef(schema);
-    explode = _parseSerialization(json, inLocation);
+    explode = _parameterExplode(json, inLocation);
+    _warnUnsupportedSerialization(json, inLocation, explode: explode);
     example = _optional<dynamic>(json, 'example');
     examples = _parseExamplesMap(json);
   } else if (!hasSchema && hasContent) {
@@ -362,8 +370,12 @@ Header parseHeader(MapContext json) {
   _ignored<bool>(json, 'deprecated');
   _ignored<bool>(json, 'allowEmptyValue');
   // Headers always comma-join arrays (style=simple, explode=false), so the
-  // returned effective explode isn't stored — only the warnings matter here.
-  _parseSerialization(json, ParameterLocation.header);
+  // effective explode isn't stored — only the warnings matter here.
+  _warnUnsupportedSerialization(
+    json,
+    ParameterLocation.header,
+    explode: _parameterExplode(json, ParameterLocation.header),
+  );
   final example = _optional<dynamic>(json, 'example');
   final examples = _parseExamplesMap(json);
 

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -731,6 +731,7 @@ class SpecResolver {
       type: toRenderSchema(parameter.schema),
       example: parameter.example,
       examples: parameter.examples,
+      explode: parameter.explode,
     );
   }
 
@@ -1242,7 +1243,12 @@ class Endpoint implements ToTemplateContext {
         context,
         dartIsNullable: false,
       );
-      value = '$dartName.map((e) => $itemsToJson.toString()).toList()';
+      final items = '$dartName.map((e) => $itemsToJson.toString())';
+      // `explode: false` (style=form) comma-joins the array into a single
+      // value (`?k=a,b,c`) rather than repeating the key. Wrap the joined
+      // string in a 1-element list so it flows through the same
+      // `Map<String, List<String>>` shape.
+      value = p.explode ? '$items.toList()' : "[$items.join(',')]";
     } else {
       final scalarToJson = paramType.toJsonExpression(
         dartName,
@@ -5480,6 +5486,7 @@ class RenderParameter implements CanBeParameter {
     required this.inLocation,
     required this.example,
     required this.examples,
+    required this.explode,
   });
 
   /// The name of the parameter.
@@ -5496,6 +5503,10 @@ class RenderParameter implements CanBeParameter {
 
   /// The in location of the parameter.
   final ParameterLocation inLocation;
+
+  /// The effective OpenAPI `explode`. For a query array, `false` comma-joins
+  /// into a single value (`?k=a,b,c`) instead of repeating the key.
+  final bool explode;
 
   /// Whether the parameter is required.
   @override

--- a/lib/src/resolver.dart
+++ b/lib/src/resolver.dart
@@ -593,6 +593,7 @@ List<ResolvedParameter> _resolveParameters(
         schema: type,
         example: resolved.example,
         examples: resolved.examples,
+        explode: resolved.explode,
       );
     });
   }).toList();
@@ -1091,6 +1092,7 @@ class ResolvedParameter {
     required this.schema,
     required this.example,
     required this.examples,
+    required this.explode,
   });
 
   /// The name of the resolved parameter.
@@ -1098,6 +1100,9 @@ class ResolvedParameter {
 
   /// The in of the resolved parameter.
   final ParameterLocation inLocation;
+
+  /// The effective OpenAPI `explode` (see [Parameter.explode]).
+  final bool explode;
 
   /// The description of the resolved parameter.
   final String? description;

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -1345,19 +1345,16 @@ void main() {
         verifyNever(() => logger.warn(any()));
       });
 
-      test('non-default explode on query warns', () {
+      test('explode: false on query is honored (no warn)', () {
+        // The query renderer comma-joins arrays when explode is false, so the
+        // value is honored rather than warned about (render_tree's
+        // _queryParamEntry).
         final logger = _MockLogger();
         runWithLogger(
           logger,
           () => parseOpenApi(specWithQueryParam({'explode': false})),
         );
-        verify(
-          () => logger.warn(
-            'explode=false is not honored on query parameters; '
-            'generator emits the default (explode=true) wire format '
-            'in #/paths/~1users/get/parameters/0',
-          ),
-        ).called(1);
+        verifyNever(() => logger.warn(any()));
       });
 
       test('non-default style on query warns', () {

--- a/test/render/file_renderer_test.dart
+++ b/test/render/file_renderer_test.dart
@@ -2729,6 +2729,7 @@ void main() {
                   inLocation: ParameterLocation.query,
                   example: null,
                   examples: null,
+                  explode: true,
                 ),
               ],
               requestBody: null,

--- a/test/render/render_operation_test.dart
+++ b/test/render/render_operation_test.dart
@@ -1017,6 +1017,39 @@ void main() {
       );
     });
 
+    test('query array with explode: false comma-joins into one value', () {
+      final json = {
+        'summary': 'Get user',
+        'parameters': [
+          {
+            'name': 'foo',
+            'in': 'query',
+            'description': 'Foo',
+            'required': true,
+            'explode': false,
+            'schema': {
+              'type': 'array',
+              'items': {'type': 'string'},
+            },
+          },
+        ],
+        'responses': {
+          '200': {'description': 'OK'},
+        },
+      };
+      final result = renderTestOperation(
+        path: '/users',
+        operationJson: json,
+        serverUrl: Uri.parse('https://api.spacetraders.io/v2'),
+      );
+      // explode: false → one comma-joined value, not repeated keys. The joined
+      // string is wrapped in a 1-element list for the Map<String, List<String>>.
+      expect(
+        result,
+        contains("'foo': [foo.map((e) => e.toString()).join(',')],"),
+      );
+    });
+
     test('optional newtype parameters', () {
       final json = {
         'operationId': 'get-agents',

--- a/test/render/render_tree_test.dart
+++ b/test/render/render_tree_test.dart
@@ -80,6 +80,7 @@ void main() {
         inLocation: ParameterLocation.query,
         example: null,
         examples: null,
+        explode: true,
       );
       expect(parameter.dartParameterName(quirks), 'aB');
     });
@@ -104,6 +105,7 @@ void main() {
         inLocation: ParameterLocation.header,
         example: null,
         examples: null,
+        explode: true,
       );
       expect(parameter.dartParameterName(quirks), 'apiKey');
     });
@@ -141,6 +143,7 @@ void main() {
         inLocation: ParameterLocation.query,
         example: null,
         examples: null,
+        explode: true,
       );
       // The Dart-visible identifier gets `_` appended so it compiles;
       // the spec-side name and its bracketed form keep the original

--- a/test/templates/api_client_test.dart
+++ b/test/templates/api_client_test.dart
@@ -89,5 +89,82 @@ void main() {
         );
       },
     );
+
+    // The query renderer builds the `List<String>` for each param. These
+    // tests pin what the *actual* sent URL looks like for the two shapes it
+    // produces, exercising the real `Uri.replace` encoding — not the
+    // generated source string.
+    test('array param (explode=true shape) repeats the key', () async {
+      Uri? captured;
+      final client = ApiClient(
+        baseUri: Uri.parse('https://example.com'),
+        client: MockClient((req) async {
+          captured = req.url;
+          return Response('', 200);
+        }),
+      );
+      await client.invokeApi(
+        method: Method.get,
+        path: '/things',
+        queryParameters: {
+          'tags': ['a', 'b', 'c'],
+        },
+      );
+      expect(
+        captured.toString(),
+        'https://example.com/things?tags=a&tags=b&tags=c',
+      );
+      expect(captured!.queryParametersAll['tags'], ['a', 'b', 'c']);
+    });
+
+    test('comma-joined array (explode=false shape) is one param', () async {
+      // `explode: false` renders a 1-element list holding the joined value;
+      // `Uri.replace` percent-encodes the comma (%2C), which the server
+      // decodes back to `a,b,c`.
+      Uri? captured;
+      final client = ApiClient(
+        baseUri: Uri.parse('https://example.com'),
+        client: MockClient((req) async {
+          captured = req.url;
+          return Response('', 200);
+        }),
+      );
+      await client.invokeApi(
+        method: Method.get,
+        path: '/things',
+        queryParameters: {
+          'tags': ['a,b,c'],
+        },
+      );
+      expect(captured.toString(), 'https://example.com/things?tags=a%2Cb%2Cc');
+      // A single value, and it decodes back to the comma-joined string.
+      expect(captured!.queryParametersAll['tags'], ['a,b,c']);
+    });
+
+    test('reserved characters in a value are percent-encoded', () async {
+      // Pins the `allowReserved: false` (default, and only) behavior we honor:
+      // reserved chars are escaped, so the URL is always valid and the server
+      // decodes them back. See parser `_parseSerialization`.
+      Uri? captured;
+      final client = ApiClient(
+        baseUri: Uri.parse('https://example.com'),
+        client: MockClient((req) async {
+          captured = req.url;
+          return Response('', 200);
+        }),
+      );
+      await client.invokeApi(
+        method: Method.get,
+        path: '/things',
+        queryParameters: {
+          'ref': ['kind:default/name'],
+        },
+      );
+      expect(
+        captured.toString(),
+        'https://example.com/things?ref=kind%3Adefault%2Fname',
+      );
+      expect(captured!.queryParametersAll['ref'], ['kind:default/name']);
+    });
   });
 }


### PR DESCRIPTION
## Summary

`explode: false` on a query parameter now comma-joins an array into a single value (`?tags=a,b,c`) instead of the default `explode: true` repeated-key form (`?tags=a&tags=b&tags=c`). Those are genuinely different wire formats a server won't silently normalize, so ignoring `explode: false` was a real correctness bug — surfaced by Backstage's `fields`/`filter` params.

The effective `explode` (explicit value, or the per-location default) is threaded through the parameter model (`Parameter` → `ResolvedParameter` → `RenderParameter`). The query renderer wraps the comma-joined string in a 1-element list so it still flows through the client's `Map<String, List<String>>` shape. Non-query locations are unchanged (headers already comma-join; a non-default `explode` elsewhere still warns).

While here, `allowReserved` is left **deliberately unhonored**, now with a comment explaining why we don't intend to unless a real spec proves a server needs it: `Uri.replace(queryParameters:)` percent-encodes reserved chars uniformly with no per-param opt-out, so honoring it means hand-building the query string with a looser encoder — invasive, and a footgun (an unescaped `&`/`=` in a value breaks parsing). It's also a practical no-op since servers percent-decode query values. The WARN stays so the divergence stays visible.

## Testing

- New render test: a query array with `explode: false` emits `'foo': [foo.map(...).join(',')]`.
- Parser test updated: query `explode: false` is now honored (no warn); other locations still warn.
- Verified end-to-end on the Backstage catalog spec: the `explode` WARN is gone, `fields` comma-joins, and the generated client `dart analyze`s clean.
- `dart analyze` / `dart format` clean; full suite (587) green.