### PR TITLE
feat: collapse the OpenAPI 3.1 nullable oneOf idiom to a nullable type

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -23,6 +23,7 @@ words:
   - octocat
   - regen
   - dispatchable
+  - undispatchable
   - unioned
   - watchcrunch
   - dedup

--- a/lib/src/resolver.dart
+++ b/lib/src/resolver.dart
@@ -222,6 +222,29 @@ ResolvedSchema resolveSchemaRef(SchemaRef ref, ResolveContext context) {
   });
 }
 
+/// The OpenAPI 3.1 nullable idiom spells a nullable `T` as a `oneOf`/`anyOf`
+/// with a `{type: null}` member (e.g. `oneOf: [{type: null}, {$ref: T}]`).
+/// That member resolves to a [ResolvedNull]; strip it so the surviving
+/// members render as a plain nullable type rather than a union carrying an
+/// undispatchable null arm. The `sawNull` flag reports whether one was
+/// removed so the caller can mark the survivors nullable.
+({List<ResolvedSchema> schemas, bool sawNull}) _stripNullVariants(
+  List<ResolvedSchema> schemas,
+) {
+  final sawNull = schemas.any((e) => e is ResolvedNull);
+  return (
+    schemas: sawNull
+        ? schemas.where((e) => e is! ResolvedNull).toList()
+        : schemas,
+    sawNull: sawNull,
+  );
+}
+
+/// Return [schema] marked nullable — used when a `type: null` union member
+/// collapses onto its sole surviving sibling.
+ResolvedSchema _markNullable(ResolvedSchema schema) =>
+    schema.copyWith(common: schema.common.copyWith(nullable: true));
+
 /// Resolve a [SchemaDiscriminator]: turn each mapping ref into a pointer
 /// match against [resolvedVariants], so the result shares identity with
 /// the corresponding ResolvedOneOf.schemas entry.
@@ -386,9 +409,16 @@ ResolvedSchema _resolveSchemaFully(
   if (schema is SchemaOneOf) {
     assert(createsNewType, 'SchemaOneOf should create a new type');
     final oneOf = schema;
-    final resolvedSchemas = oneOf.schemas
-        .map((e) => resolveSchemaRef(e, context))
-        .toList();
+    final stripped = _stripNullVariants(
+      oneOf.schemas.map((e) => resolveSchemaRef(e, context)).toList(),
+    );
+    final resolvedSchemas = stripped.schemas;
+    // `oneOf: [{type: null}, T]` — the OpenAPI 3.1 nullable idiom. With the
+    // null arm removed only `T` is left; elide the union and render `T?`
+    // instead of a sealed class whose `fromJson` can't dispatch on `null`.
+    if (stripped.sawNull && resolvedSchemas.length == 1) {
+      return _markNullable(resolvedSchemas.first);
+    }
     final discriminator = _resolveDiscriminator(
       oneOf.discriminator,
       resolvedSchemas,
@@ -396,7 +426,11 @@ ResolvedSchema _resolveSchemaFully(
     );
     return context.shareCollection(
       ResolvedOneOf(
-        common: resolvedCommon,
+        // A surviving null arm on a 3+ member union (`oneOf: [null, A, B]`)
+        // makes the whole union nullable.
+        common: stripped.sawNull
+            ? resolvedCommon.copyWith(nullable: true)
+            : resolvedCommon,
         schemas: resolvedSchemas,
         discriminator: discriminator,
       ),
@@ -434,13 +468,11 @@ ResolvedSchema _resolveSchemaFully(
   if (schema is SchemaAnyOf) {
     assert(createsNewType, 'SchemaAnyOf should create a new type');
     final anyOf = schema;
-    final schemas = anyOf.schemas
-        .map((e) => resolveSchemaRef(e, context))
-        .toList();
-    final forceNullable = schemas.any((e) => e is ResolvedNull);
-    if (forceNullable) {
-      schemas.removeWhere((e) => e is ResolvedNull);
-    }
+    final stripped = _stripNullVariants(
+      anyOf.schemas.map((e) => resolveSchemaRef(e, context)).toList(),
+    );
+    final schemas = stripped.schemas;
+    final forceNullable = stripped.sawNull;
     ResolvedSchema copyIfNeeded(
       ResolvedSchema schema, {
       bool forceNullable = false,

--- a/lib/src/resolver.dart
+++ b/lib/src/resolver.dart
@@ -222,21 +222,21 @@ ResolvedSchema resolveSchemaRef(SchemaRef ref, ResolveContext context) {
   });
 }
 
-/// The OpenAPI 3.1 nullable idiom spells a nullable `T` as a `oneOf`/`anyOf`
-/// with a `{type: null}` member (e.g. `oneOf: [{type: null}, {$ref: T}]`).
-/// That member resolves to a [ResolvedNull]; strip it so the surviving
-/// members render as a plain nullable type rather than a union carrying an
-/// undispatchable null arm. The `sawNull` flag reports whether one was
-/// removed so the caller can mark the survivors nullable.
-({List<ResolvedSchema> schemas, bool sawNull}) _stripNullVariants(
+/// The renderable members of a `oneOf`/`anyOf`, with the OpenAPI 3.1 nullable
+/// idiom folded out. A `{type: null}` member (e.g. `oneOf: [{type: null}, T]`)
+/// is not a variant to dispatch on — it only means the union accepts null — so
+/// it drops out of the returned `schemas` and instead surfaces as `nullable`.
+/// The caller renders the surviving members (a lone survivor collapses to a
+/// nullable type; several stay a union) and applies `nullable`.
+({List<ResolvedSchema> schemas, bool nullable}) _unionMembers(
   List<ResolvedSchema> schemas,
 ) {
-  final sawNull = schemas.any((e) => e is ResolvedNull);
+  final nullable = schemas.any((e) => e is ResolvedNull);
   return (
-    schemas: sawNull
+    schemas: nullable
         ? schemas.where((e) => e is! ResolvedNull).toList()
         : schemas,
-    sawNull: sawNull,
+    nullable: nullable,
   );
 }
 
@@ -409,14 +409,14 @@ ResolvedSchema _resolveSchemaFully(
   if (schema is SchemaOneOf) {
     assert(createsNewType, 'SchemaOneOf should create a new type');
     final oneOf = schema;
-    final stripped = _stripNullVariants(
+    final union = _unionMembers(
       oneOf.schemas.map((e) => resolveSchemaRef(e, context)).toList(),
     );
-    final resolvedSchemas = stripped.schemas;
+    final resolvedSchemas = union.schemas;
     // `oneOf: [{type: null}, T]` — the OpenAPI 3.1 nullable idiom. With the
-    // null arm removed only `T` is left; elide the union and render `T?`
+    // null arm folded out only `T` is left; elide the union and render `T?`
     // instead of a sealed class whose `fromJson` can't dispatch on `null`.
-    if (stripped.sawNull && resolvedSchemas.length == 1) {
+    if (union.nullable && resolvedSchemas.length == 1) {
       return _markNullable(resolvedSchemas.first);
     }
     final discriminator = _resolveDiscriminator(
@@ -426,9 +426,9 @@ ResolvedSchema _resolveSchemaFully(
     );
     return context.shareCollection(
       ResolvedOneOf(
-        // A surviving null arm on a 3+ member union (`oneOf: [null, A, B]`)
+        // A folded-out null arm on a 3+ member union (`oneOf: [null, A, B]`)
         // makes the whole union nullable.
-        common: stripped.sawNull
+        common: union.nullable
             ? resolvedCommon.copyWith(nullable: true)
             : resolvedCommon,
         schemas: resolvedSchemas,
@@ -468,11 +468,11 @@ ResolvedSchema _resolveSchemaFully(
   if (schema is SchemaAnyOf) {
     assert(createsNewType, 'SchemaAnyOf should create a new type');
     final anyOf = schema;
-    final stripped = _stripNullVariants(
+    final union = _unionMembers(
       anyOf.schemas.map((e) => resolveSchemaRef(e, context)).toList(),
     );
-    final schemas = stripped.schemas;
-    final forceNullable = stripped.sawNull;
+    final schemas = union.schemas;
+    final forceNullable = union.nullable;
     ResolvedSchema copyIfNeeded(
       ResolvedSchema schema, {
       bool forceNullable = false,

--- a/test/resolver_test.dart
+++ b/test/resolver_test.dart
@@ -568,6 +568,54 @@ void main() {
       );
     });
 
+    test('oneOf nullable idiom collapses to a nullable type', () {
+      // OpenAPI 3.1 spells `T?` as `oneOf: [{type: null}, T]` (Discord does
+      // this ~290 times). Strip the null arm and render the survivor
+      // nullable rather than a sealed class that can't dispatch on `null`.
+      final json = {
+        'oneOf': [
+          {'type': 'null'},
+          {'type': 'string'},
+        ],
+      };
+      final logger = _MockLogger();
+      final schema = runWithLogger(
+        logger,
+        () => parseAndResolveTestSchema(json),
+      );
+      expect(
+        schema,
+        isA<ResolvedString>().having(
+          (e) => e.common.nullable,
+          'nullable',
+          isTrue,
+        ),
+      );
+    });
+
+    test('oneOf nullable idiom keeps a real 3+ member union but nullable', () {
+      // With the null arm removed a genuine union survives; it stays a
+      // ResolvedOneOf, and the dropped null makes the union nullable.
+      final json = {
+        'oneOf': [
+          {'type': 'null'},
+          {'type': 'string'},
+          {'type': 'integer'},
+        ],
+      };
+      final logger = _MockLogger();
+      final schema = runWithLogger(
+        logger,
+        () => parseAndResolveTestSchema(json),
+      );
+      expect(
+        schema,
+        isA<ResolvedOneOf>()
+            .having((e) => e.schemas.length, 'schemas', equals(2))
+            .having((e) => e.common.nullable, 'nullable', isTrue),
+      );
+    });
+
     test('oneOf with discriminator + mapping resolves variants by '
         'identity', () {
       final json = {


### PR DESCRIPTION
## Summary

Collapse `oneOf: [{type: null}, T]` — the OpenAPI 3.1 way of spelling a nullable `T` — to a plain nullable type instead of a sealed class whose `fromJson` can't dispatch on `null`.

The resolver already stripped `type: null` members from a `SchemaAnyOf` and collapsed the survivor to a nullable type, but the `SchemaOneOf` path did not. Discord spells nullable this way ~290 times, so each one resolved to an undispatchable union and emitted an `UnimplementedError` stub.

The fix mirrors the anyOf null-collapse into the oneOf path via a shared `_stripNullVariants` helper:
- drop the `type: null` arm;
- when a single member survives, elide the union and render `T?` (the 290 two-member sites);
- when a genuine 3+ member union survives (`oneOf: [null, A, B]`, 7 sites), keep the union but mark it nullable.

Collapsed output reads as handwritten Dart:
```dart
final SnowflakeType? channelId;
// fromJson:
channelId: SnowflakeType.maybeFromJson(json['channel_id'] as String?),
// toJson:
'channel_id': channelId?.toJson(),
```

## Impact

| Spec | Before | After |
|---|---|---|
| Discord | 334 stubs | **38 stubs** |
| github | 3 stubs, clean | 3 stubs, clean — **byte-identical regen** |
| petstore / spacetraders / backstage / train-travel | clean | clean |

github, spacetraders, and petstore have zero of this pattern, so the primary bar is fully maintained (verified byte-identical). The 38 remaining Discord stubs are genuine multi-variant unions (`_actions_inner`, `_options_inner`, `_components_inner`) that need real dispatch — a separate concern.

## Test

New resolver unit tests cover both the two-member collapse (→ nullable `ResolvedString`) and the 3+ member case (→ nullable `ResolvedOneOf` with the null arm removed). Full suite passes, `dart analyze` clean.