### PR TITLE
feat: dispatch oneOf variants tagged by a $ref-to-enum pinned to a const

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -24,6 +24,7 @@ words:
   - regen
   - dispatchable
   - undispatchable
+  - narrowings
   - unioned
   - watchcrunch
   - dedup

--- a/lib/src/dispatch.dart
+++ b/lib/src/dispatch.dart
@@ -417,8 +417,7 @@ Map<String, Object> _flattenedConstProperties(ResolvedSchema schema) {
   return switch (schema) {
     ResolvedObject() => schema.constProperties,
     ResolvedAllOf() => {
-      for (final member in schema.schemas)
-        ..._flattenedConstProperties(member),
+      for (final member in schema.schemas) ..._flattenedConstProperties(member),
     },
     _ => const <String, Object>{},
   };

--- a/lib/src/dispatch.dart
+++ b/lib/src/dispatch.dart
@@ -410,6 +410,46 @@ Map<String, ResolvedSchema> _flattenedProperties(ResolvedSchema schema) {
   };
 }
 
+/// Properties pinned to a constant value on an object-or-allOf variant
+/// (the `allOf: [{$ref: E}]` + single-value `enum` idiom; see
+/// [ResolvedObject.constProperties]). [ResolvedAllOf] members are unioned.
+Map<String, Object> _flattenedConstProperties(ResolvedSchema schema) {
+  return switch (schema) {
+    ResolvedObject() => schema.constProperties,
+    ResolvedAllOf() => {
+      for (final member in schema.schemas)
+        ..._flattenedConstProperties(member),
+    },
+    _ => const <String, Object>{},
+  };
+}
+
+/// The discriminator value(s) a [variant] fixes property [propName] to, or
+/// null when the property isn't a usable tag on this variant. A property
+/// pinned to a constant contributes that single value; otherwise a
+/// `ResolvedEnum` property contributes its enum values. Unifies the two
+/// spellings of an implicit tag — a bare inline `enum` (github) and a
+/// `$ref`-to-enum pinned by `enum`/`const` (Discord) — so the pickers
+/// treat them identically.
+List<Object>? _tagValues(ResolvedSchema variant, String propName) {
+  final constValue = _flattenedConstProperties(variant)[propName];
+  if (constValue != null) return [constValue];
+  final prop = _flattenedProperties(variant)[propName];
+  if (prop is ResolvedEnum && prop.values.isNotEmpty) {
+    return List<Object>.of(prop.values);
+  }
+  return null;
+}
+
+/// Whether every tag value across all variants is the same scalar kind —
+/// all `int` or all `String`. Mixing forces a runtime type check the
+/// discriminator switch shouldn't emit.
+bool _uniformTagType(List<List<Object>> perVariantValues) {
+  final all = perVariantValues.expand((values) => values).toList();
+  if (all.isEmpty) return false;
+  return all.every((v) => v is int) || all.every((v) => v is String);
+}
+
 bool _isObjectLike(ResolvedSchema schema) =>
     schema is ResolvedObject ||
     schema is ResolvedEmptyObject ||
@@ -480,12 +520,11 @@ ResolvedDiscriminator? _implicitDiscriminatorForProperty(
 ) {
   if (variants.isEmpty) return null;
   if (!variants.every(_isObjectLike)) return null;
-  final flatProps = variants.map(_flattenedProperties).toList();
   final perVariantValues = <List<Object>>[];
-  for (var i = 0; i < variants.length; i++) {
-    final type = flatProps[i][propertyName];
-    if (type is! ResolvedEnum || type.values.isEmpty) return null;
-    perVariantValues.add(List.of(type.values));
+  for (final variant in variants) {
+    final values = _tagValues(variant, propertyName);
+    if (values == null) return null;
+    perVariantValues.add(values);
   }
   final seen = <Object>{};
   for (final values in perVariantValues) {
@@ -512,6 +551,12 @@ ResolvedDiscriminator? _implicitDiscriminatorForProperty(
 /// value sets are pairwise disjoint, each enum value routes to exactly
 /// one variant.
 ///
+/// The tag may also be a `$ref`-to-enum pinned to one member via the
+/// `allOf: [{$ref: E}]` + `enum: [v]` idiom (Discord's auto-moderation
+/// actions): the property renders as `E` but is fixed to `v`, captured in
+/// [ResolvedObject.constProperties]. [_tagValues] folds both spellings
+/// together, so a mix of pinned refs and bare enums across variants works.
+///
 /// Variants may be [ResolvedObject] OR [ResolvedAllOf] — the latter
 /// flattens its members the same way `toRenderSchema` synthesizes a
 /// `RenderObject`, so a tag declared in one allOf member counts.
@@ -519,35 +564,23 @@ ResolvedDiscriminator? _implicitDiscriminator(List<ResolvedSchema> variants) {
   if (variants.isEmpty) return null;
   if (!variants.every(_isObjectLike)) return null;
   final flatRequired = variants.map(_flattenedRequiredProperties).toList();
-  final flatProps = variants.map(_flattenedProperties).toList();
   final candidates = <(String, List<List<Object>>)>[];
-  for (final entry in flatProps.first.entries) {
-    final propName = entry.key;
-    if (!flatRequired.first.contains(propName)) continue;
-    final firstType = entry.value;
-    if (firstType is! ResolvedEnum || firstType.values.isEmpty) continue;
-    final perVariantValues = <List<Object>>[List.of(firstType.values)];
+  // Seed candidate tag names from the first variant's required properties;
+  // a tag must be required and carry a usable value set on every variant.
+  for (final propName in flatRequired.first) {
+    final perVariantValues = <List<Object>>[];
     var allMatch = true;
-    for (var i = 1; i < variants.length; i++) {
-      if (!flatRequired[i].contains(propName)) {
+    for (var i = 0; i < variants.length; i++) {
+      final values = _tagValues(variants[i], propName);
+      if (!flatRequired[i].contains(propName) || values == null) {
         allMatch = false;
         break;
       }
-      final otherType = flatProps[i][propName];
-      if (otherType is! ResolvedEnum || otherType.values.isEmpty) {
-        allMatch = false;
-        break;
-      }
-      // All variants' tag enums must agree on the value type — mixing
-      // string and integer tags within one discriminator would force
-      // a runtime check we don't want to emit.
-      if (otherType.runtimeType != firstType.runtimeType) {
-        allMatch = false;
-        break;
-      }
-      perVariantValues.add(List.of(otherType.values));
+      perVariantValues.add(values);
     }
-    if (allMatch) candidates.add((propName, perVariantValues));
+    if (allMatch && _uniformTagType(perVariantValues)) {
+      candidates.add((propName, perVariantValues));
+    }
   }
   if (candidates.isEmpty) return null;
   candidates.sort((a, b) => a.$1.compareTo(b.$1));

--- a/lib/src/parse/spec.dart
+++ b/lib/src/parse/spec.dart
@@ -414,6 +414,7 @@ class SchemaObject extends SchemaObjectBase {
     required this.requiredProperties,
     required this.additionalProperties,
     required this.defaultValue,
+    required this.constProperties,
   }) {
     if (snakeName.isEmpty) {
       throw ArgumentError.value(
@@ -429,6 +430,16 @@ class SchemaObject extends SchemaObjectBase {
 
   /// The required properties of this schema.
   final List<String> requiredProperties;
+
+  /// Properties pinned to a single constant value by the OpenAPI-3.0
+  /// idiom `allOf: [{$ref: E}]` + single-value `enum`/`const` — "a value
+  /// of enum E fixed to one member." The property still resolves to the
+  /// plain `E` ref (so the field renders as `E`); this map records the
+  /// constant separately so the dispatch pass can use it as an implicit
+  /// discriminator tag. Keyed by property name; values are `int` or
+  /// `String`. Multi-value narrowings are a restricted view, not a tag
+  /// (see issue #235), and are not recorded here.
+  final Map<String, Object> constProperties;
 
   /// The additional properties of this schema.
   /// Used for specifying T for Map\<String, T\>.

--- a/lib/src/parse/spec.dart
+++ b/lib/src/parse/spec.dart
@@ -278,6 +278,7 @@ abstract class SchemaEnum<T extends Object> extends Schema {
     required this.defaultValue,
     required this.enumValues,
     required this.enumDescriptions,
+    required this.enumNames,
   });
 
   /// The default value of the enum, if any.
@@ -290,6 +291,14 @@ abstract class SchemaEnum<T extends Object> extends Schema {
   /// Populated from the OpenAPI vendor extension `x-enum-descriptions`
   /// when present.
   final List<String>? enumDescriptions;
+
+  /// Optional human-readable member names, parallel to [enumValues].
+  /// Populated from the `title:` of each variant in the OpenAPI 3.1
+  /// `oneOf`-of-`const`s enum spelling (Discord: `{title: BLOCK_MESSAGE,
+  /// const: 1}`). Drives the generated Dart member name (`blockMessage`)
+  /// instead of the value-derived fallback (`value1`); null when the spec
+  /// gives no names, in which case render derives them from the values.
+  final List<String>? enumNames;
 }
 
 class SchemaStringEnum extends SchemaEnum<String> {
@@ -298,6 +307,7 @@ class SchemaStringEnum extends SchemaEnum<String> {
     required super.defaultValue,
     required super.enumValues,
     required super.enumDescriptions,
+    required super.enumNames,
   });
 }
 
@@ -307,6 +317,7 @@ class SchemaIntEnum extends SchemaEnum<int> {
     required super.defaultValue,
     required super.enumValues,
     required super.enumDescriptions,
+    required super.enumNames,
   });
 }
 

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -628,15 +628,17 @@ Schema? _maybeCollapseOneOfOfConsts(
     if (!variant.containsKey('const')) return null;
     if (variant.keys.any((k) => !allowedKeys.contains(k))) return null;
   }
-  // Walk the variants once to collect values + descriptions. Titles
-  // aren't preserved yet — `RenderEnum.variableNamesFor` derives Dart
-  // names from the values — but the underlying enum type is correct
-  // and dispatches cleanly.
+  // Walk the variants once to collect values, descriptions, and titles.
+  // A `title:` (`{title: BLOCK_MESSAGE, const: 1}`) is the spec's own
+  // member name; preserved so render emits `blockMessage` instead of the
+  // value-derived fallback `value1`.
   final values = <dynamic>[];
   final descriptions = <String?>[];
+  final titles = <String?>[];
   for (final variant in list.cast<Map<dynamic, dynamic>>()) {
     values.add(variant['const']);
     descriptions.add(variant['description'] as String?);
+    titles.add(variant['title'] as String?);
   }
   // Pick string vs int from the parent's declared `type:`, falling
   // back to value-shape inference when `type:` is absent (matches the
@@ -671,12 +673,18 @@ Schema? _maybeCollapseOneOfOfConsts(
   final descriptionsToPlumb = descriptions.any((d) => d != null)
       ? descriptions.map((d) => d ?? '').toList()
       : null;
+  // Names are all-or-nothing: only drive member names from titles when
+  // every variant has one, so we never mix `blockMessage` with `value1`.
+  final namesToPlumb = titles.every((t) => t != null && t.isNotEmpty)
+      ? titles.cast<String>()
+      : null;
   if (isInt) {
     return SchemaIntEnum(
       common: common,
       defaultValue: null,
       enumValues: values.cast<int>(),
       enumDescriptions: descriptionsToPlumb,
+      enumNames: namesToPlumb,
     );
   }
   return SchemaStringEnum(
@@ -684,6 +692,7 @@ Schema? _maybeCollapseOneOfOfConsts(
     defaultValue: null,
     enumValues: values.cast<String>(),
     enumDescriptions: descriptionsToPlumb,
+    enumNames: namesToPlumb,
   );
 }
 
@@ -977,6 +986,9 @@ SchemaEnum<Object>? _handleEnum({
       defaultValue: typedDefaultValue,
       enumValues: typedEnumValues,
       enumDescriptions: enumDescriptions,
+      // A plain `enum:` list carries no per-member names; render derives
+      // them from the values.
+      enumNames: null,
     );
   }
   if (nonNullValues.any((e) => e is! String)) {
@@ -1006,6 +1018,7 @@ SchemaEnum<Object>? _handleEnum({
     defaultValue: typedDefaultValue,
     enumValues: typedEnumValues,
     enumDescriptions: enumDescriptions,
+    enumNames: null,
   );
 }
 

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -1429,11 +1429,25 @@ Schema _createCorrectSchemaSubtype(MapContext json) {
   }
 
   final properties = <String, SchemaRef>{};
+  final constProperties = <String, Object>{};
   for (final name in propertiesJson.json.keys) {
     final snakeName = snakeFromCamel(name);
     final childContext = propertiesJson
         .childAsMap(name)
         .addSnakeName(snakeName);
+    final constValue = _constTagValue(childContext);
+    if (constValue != null) {
+      // We consume the pinning `enum`/`const` as a discriminator tag, so
+      // mark it used before parsing the property (the allOf branch would
+      // otherwise leave it to `_warnUnused`). Multi-value narrowings
+      // aren't captured, so their `enum` still surfaces at -v — the
+      // honest signal for the restricted-view work in issue #235.
+      if (childContext.json.containsKey('enum')) childContext.markUsed('enum');
+      if (childContext.json.containsKey('const')) {
+        childContext.markUsed('const');
+      }
+      constProperties[name] = constValue;
+    }
     properties[name] = parseSchemaOrRef(childContext);
   }
 
@@ -1471,7 +1485,41 @@ Schema _createCorrectSchemaSubtype(MapContext json) {
     requiredProperties: requiredProperties,
     additionalProperties: additionalPropertiesSchema,
     defaultValue: defaultValue,
+    constProperties: constProperties,
   );
+}
+
+/// Detects the OpenAPI-3.0 "pinned enum" idiom on a property:
+/// `allOf: [{$ref: E}]` wrapping a single reference, with a sibling
+/// single-value `enum` (or `const`). This spells "a value of enum E
+/// fixed to one member" — the property still parses/resolves as the
+/// plain `E` ref (so its field renders as `E`), but the fixed value is
+/// a discriminator tag. Returns that constant (`int`/`String`), or null
+/// when the property isn't this shape.
+///
+/// A multi-value `enum` is a restricted *view* of E, not a single tag
+/// (issue #235); it returns null here. The `allOf` wrapper is required —
+/// a bare inline `enum` already resolves to a `SchemaEnum` the dispatch
+/// pass reads directly, so it needs no separate record.
+Object? _constTagValue(MapContext json) {
+  final raw = json.json;
+  final allOf = raw['allOf'];
+  if (allOf is! List || allOf.length != 1) return null;
+  final only = allOf.first;
+  if (only is! Map || !only.containsKey(r'$ref')) return null;
+  final enumValues = raw['enum'];
+  final Object? value;
+  if (enumValues is List) {
+    if (enumValues.length != 1) return null;
+    value = enumValues.first;
+  } else if (raw.containsKey('const')) {
+    value = raw['const'];
+  } else {
+    return null;
+  }
+  // Only scalar int/string tags dispatch cleanly; anything else isn't a
+  // usable discriminator value.
+  return (value is int || value is String) ? value : null;
 }
 
 /// Parse a schema from a json object.

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -3368,6 +3368,14 @@ class RenderObject extends RenderNewType {
   /// parameter — the value is fully determined by the class, so the caller
   /// neither passes it nor can set it wrong. Keyed by property name; values
   /// are `int`/`String`.
+  ///
+  /// Decision (a getter, not the alternatives — see issue #238): it is never
+  /// valid to construct one of these with a different tag value, so the value
+  /// is not a constructor parameter at all. A `final` field with a default
+  /// would work but stores, on every instance, a value fixed by the type —
+  /// wasted space for no gain. A `static const` can't be read through an
+  /// instance in Dart, so it can't back a serialized/polymorphic property.
+  /// The getter has no storage and is un-settable, which is exactly right.
   final Map<String, Object> constProperties;
 
   /// The additional properties of the resolved schema.

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -497,20 +497,31 @@ class SpecResolver {
           assignedSnakeName: _snakeFor(schema.targetPointer),
         );
       case ResolvedStringEnum():
+        // Spec-provided member names (`title:`) win over value-derived
+        // ones; both route through the same identifier sanitization.
+        final stringNames = schema.names;
         return RenderStringEnum(
           common: schema.common,
           values: schema.values,
-          names: RenderEnum.variableNamesFor(quirks, schema.values),
+          names: RenderEnum.variableNamesFor(
+            quirks,
+            stringNames ?? schema.values,
+          ),
           descriptions: schema.descriptions,
           defaultValue: schema.defaultValue,
           assignedName: _nameFor(schema.pointer),
           assignedSnakeName: _snakeFor(schema.pointer),
         );
       case ResolvedIntEnum():
+        // An int enum has no value-derived name (`value1`); a spec `title:`
+        // rescues it (`blockMessage`).
+        final intNames = schema.names;
         return RenderIntEnum(
           common: schema.common,
           values: schema.values,
-          names: RenderEnum.variableNamesForInts(schema.values),
+          names: intNames != null
+              ? RenderEnum.variableNamesFor(quirks, intNames)
+              : RenderEnum.variableNamesForInts(schema.values),
           descriptions: schema.descriptions,
           defaultValue: schema.defaultValue,
           assignedName: _nameFor(schema.pointer),

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -524,6 +524,7 @@ class SpecResolver {
           ),
           additionalProperties: maybeRenderSchema(schema.additionalProperties),
           requiredProperties: schema.requiredProperties,
+          constProperties: schema.constProperties,
           parentSealedTypeName: _names.parentSealedTypeFor(schema.pointer),
           assignedName: _nameFor(schema.pointer),
           assignedSnakeName: _snakeFor(schema.pointer),
@@ -662,11 +663,13 @@ class SpecResolver {
         // becomes the merged object's `additionalProperties` overflow. First
         // open member wins (multiple open members in one allOf is degenerate).
         RenderSchema? additionalProperties;
+        final constProperties = <String, Object>{};
         for (final schema in schema.schemas) {
           final renderSchema = toRenderSchema(schema);
           if (renderSchema is RenderObject) {
             properties.addAll(renderSchema.properties);
             requiredProperties.addAll(renderSchema.requiredProperties);
+            constProperties.addAll(renderSchema.constProperties);
             // A member that itself declares `additionalProperties` (an
             // object with an overflow) opens the merged object too.
             additionalProperties ??= renderSchema.additionalProperties;
@@ -682,6 +685,7 @@ class SpecResolver {
           properties: properties,
           additionalProperties: additionalProperties,
           requiredProperties: requiredProperties.toList(),
+          constProperties: constProperties,
           parentSealedTypeName: _names.parentSealedTypeFor(schema.pointer),
           assignedName: _nameFor(schema.pointer),
           assignedSnakeName: _snakeFor(schema.pointer),
@@ -3337,6 +3341,7 @@ class RenderObject extends RenderNewType {
     required this.properties,
     this.additionalProperties,
     this.requiredProperties = const [],
+    this.constProperties = const {},
     this.parentSealedTypeName,
     super.assignedName,
     super.assignedSnakeName,
@@ -3344,6 +3349,15 @@ class RenderObject extends RenderNewType {
 
   /// The properties of the resolved schema.
   final Map<String, RenderSchema> properties;
+
+  /// Properties pinned to a single constant value (the `allOf: [{$ref: E}]`
+  /// + single-value `enum`/`const` idiom; see
+  /// [ResolvedObject.constProperties]). Such a property renders as a fixed
+  /// getter (`E get type => E.member;`) rather than a required constructor
+  /// parameter — the value is fully determined by the class, so the caller
+  /// neither passes it nor can set it wrong. Keyed by property name; values
+  /// are `int`/`String`.
+  final Map<String, Object> constProperties;
 
   /// The additional properties of the resolved schema.
   final RenderSchema? additionalProperties;
@@ -3380,6 +3394,7 @@ class RenderObject extends RenderNewType {
     properties,
     additionalProperties,
     requiredProperties,
+    constProperties,
   ];
 
   @override
@@ -3510,6 +3525,20 @@ class RenderObject extends RenderNewType {
     // both the json property is required and it does not have a default.
     final isRequired =
         requiredProperties.contains(jsonName) && !hasDefaultValue;
+    // A property pinned to a constant of a named enum (the `allOf: [{$ref: E}]`
+    // + single-value `enum` idiom) renders as a fixed getter rather than a
+    // constructor parameter — the value is fully determined by the class, so
+    // the caller neither passes it nor can set it wrong. It still serializes
+    // (toJson references the getter) but is absent from the constructor,
+    // `fromJson`, and equality.
+    // Matches [rendersAsConstGetter]; bound locally so flow analysis promotes
+    // `property`/`constValue` for the getter expression (no cast, no `!`).
+    final constValue = constProperties[jsonName];
+    final constGetter = (constValue != null && property is RenderEnum)
+        ? '${property.typeName} get $dartName => '
+              '${property.constExpression(constValue)};'
+        : null;
+    final isConstGetter = constGetter != null;
     return {
       'dartName': dartName,
       'jsonName': quoteString(jsonName),
@@ -3517,18 +3546,22 @@ class RenderObject extends RenderNewType {
         common: property.common,
         indent: 4,
       ),
+      'isConstGetter': isConstGetter,
+      'constGetter': constGetter,
       'argumentLine': argumentLine(
         jsonName,
         property,
         context,
         isRequired: isRequired,
       ),
-      'assignmentsLine': assignmentsLine(
-        jsonName,
-        property,
-        context,
-        isRequired: isRequired,
-      ),
+      'assignmentsLine': isConstGetter
+          ? null
+          : assignmentsLine(
+              jsonName,
+              property,
+              context,
+              isRequired: isRequired,
+            ),
       'storageTypeDeclaration': propertyStorageTypeDeclaration(
         property: property,
         context: context,
@@ -3576,15 +3609,18 @@ class RenderObject extends RenderNewType {
 
     final valueSchema = additionalProperties;
     final hasAdditionalProperties = valueSchema != null;
-    // Force named properties to be rendered if hasAdditionalProperties is true.
-    final hasProperties =
-        renderProperties.isNotEmpty || hasAdditionalProperties;
-    const isNullable = false;
-    final propertiesCount =
-        renderProperties.length + (hasAdditionalProperties ? 1 : 0);
-    if (propertiesCount == 0) {
+    if (renderProperties.isEmpty && !hasAdditionalProperties) {
       throw StateError('Object schema has no properties: $this');
     }
+    // Const-getter properties aren't constructor parameters or equality
+    // members, so the constructor-braces and single-property-hashCode
+    // decisions count only the "real" (non-getter) properties.
+    final realPropertiesCount =
+        renderProperties.where((p) => p['isConstGetter'] != true).length +
+        (hasAdditionalProperties ? 1 : 0);
+    // Force named properties to be rendered if hasAdditionalProperties is true.
+    final hasProperties = realPropertiesCount > 0;
+    const isNullable = false;
     // Wrap the class-level description in a `{@template <snakeName>}`
     // block so the same prose can be reused as the constructor's
     // dartdoc via a `{@macro}` reference. Matches the handwritten
@@ -3635,7 +3671,7 @@ class RenderObject extends RenderNewType {
       'nullableTypeName': nullableTypeName(context),
       'hasProperties': hasProperties,
       // Special case behavior hashCode with only one property.
-      'hasOneProperty': propertiesCount == 1,
+      'hasOneProperty': realPropertiesCount == 1,
       'properties': renderProperties,
       'hasAdditionalProperties': hasAdditionalProperties,
       'hasNoJsonProperty': hasNoJsonProperty,
@@ -3731,6 +3767,13 @@ class RenderObject extends RenderNewType {
     return super.equalsIgnoringName(other);
   }
 
+  /// Whether property [jsonName] renders as a fixed const getter rather than
+  /// a constructor field (the `allOf: [{$ref: E}]` + single-value `enum`
+  /// idiom pinning it to one member of enum `E`). Such properties are absent
+  /// from the constructor, `fromJson`, equality, and example synthesis.
+  bool rendersAsConstGetter(String jsonName, RenderSchema property) =>
+      constProperties.containsKey(jsonName) && property is RenderEnum;
+
   @override
   String? exampleValue(SchemaRenderer context) {
     final args = <String>[];
@@ -3738,6 +3781,8 @@ class RenderObject extends RenderNewType {
       final jsonName = entry.key;
       if (!requiredProperties.contains(jsonName)) continue;
       final property = entry.value;
+      // Pinned tags are fixed getters, not constructor parameters.
+      if (rendersAsConstGetter(jsonName, property)) continue;
       final example = property.exampleValue(context);
       if (example == null) return null;
       final dartName = variableSafeName(context.quirks, jsonName);
@@ -3765,10 +3810,17 @@ class RenderObject extends RenderNewType {
   /// and we have no guaranteed-invalid input. The parser drops names
   /// listed in `required` that don't match a real property (with a
   /// warn-log), so [requiredProperties] only ever contains names
-  /// that will actually fail the cast.
+  /// that will actually fail the cast — except const-getter properties,
+  /// which aren't read from JSON at all, so their absence doesn't make
+  /// `{}` invalid.
   @override
-  String? invalidJsonExample(SchemaRenderer context) =>
-      requiredProperties.isEmpty ? null : '<String, dynamic>{}';
+  String? invalidJsonExample(SchemaRenderer context) {
+    final hasFailingRequired = requiredProperties.any((name) {
+      final property = properties[name];
+      return property != null && !rendersAsConstGetter(name, property);
+    });
+    return hasFailingRequired ? '<String, dynamic>{}' : null;
+  }
 }
 
 class RenderArray extends RenderSchema {
@@ -4289,6 +4341,12 @@ abstract class RenderEnum<T extends Object> extends RenderNewType {
     if (value == null) return null;
     return '$className.${variableNameFor(value)}';
   }
+
+  /// Renders [value] as a reference to this enum's member (e.g.
+  /// `ActionType.blockMessage`) — used when a property is pinned to a
+  /// single constant of this enum and rendered as a fixed getter.
+  String constExpression(Object value) =>
+      '$className.${variableNameFor(value as T)}';
 
   @override
   String fromJsonExpression(

--- a/lib/src/resolver.dart
+++ b/lib/src/resolver.dart
@@ -322,6 +322,7 @@ ResolvedSchema _resolveSchemaFully(
       defaultValue: schema.defaultValue,
       values: schema.enumValues,
       descriptions: schema.enumDescriptions,
+      names: schema.enumNames,
     );
   }
   if (schema is SchemaIntEnum) {
@@ -331,6 +332,7 @@ ResolvedSchema _resolveSchemaFully(
       defaultValue: schema.defaultValue,
       values: schema.enumValues,
       descriptions: schema.enumDescriptions,
+      names: schema.enumNames,
     );
   }
   if (schema is SchemaBinary) {
@@ -1560,6 +1562,7 @@ abstract class ResolvedEnum<T extends Object> extends ResolvedSchema {
     required this.defaultValue,
     required this.values,
     required this.descriptions,
+    required this.names,
   }) : super(createsNewType: true);
 
   /// The values of the resolved schema.
@@ -1571,8 +1574,20 @@ abstract class ResolvedEnum<T extends Object> extends ResolvedSchema {
   /// Optional per-value dartdoc descriptions, parallel to [values].
   final List<String>? descriptions;
 
+  /// Optional spec-provided member names, parallel to [values] (the
+  /// `title:` of each `oneOf`-of-`const`s variant). Render prefers these
+  /// over value-derived names; null when the spec gives none. See
+  /// [SchemaEnum.enumNames].
+  final List<String>? names;
+
   @override
-  List<Object?> get props => [super.props, values, defaultValue, descriptions];
+  List<Object?> get props => [
+    super.props,
+    values,
+    defaultValue,
+    descriptions,
+    names,
+  ];
 }
 
 class ResolvedStringEnum extends ResolvedEnum<String> {
@@ -1581,6 +1596,7 @@ class ResolvedStringEnum extends ResolvedEnum<String> {
     required super.defaultValue,
     required super.values,
     required super.descriptions,
+    required super.names,
   });
 
   @override
@@ -1590,6 +1606,7 @@ class ResolvedStringEnum extends ResolvedEnum<String> {
       defaultValue: defaultValue,
       values: values,
       descriptions: descriptions,
+      names: names,
     );
   }
 }
@@ -1600,6 +1617,7 @@ class ResolvedIntEnum extends ResolvedEnum<int> {
     required super.defaultValue,
     required super.values,
     required super.descriptions,
+    required super.names,
   });
 
   @override
@@ -1609,6 +1627,7 @@ class ResolvedIntEnum extends ResolvedEnum<int> {
       defaultValue: defaultValue,
       values: values,
       descriptions: descriptions,
+      names: names,
     );
   }
 }

--- a/lib/src/resolver.dart
+++ b/lib/src/resolver.dart
@@ -312,6 +312,7 @@ ResolvedSchema _resolveSchemaFully(
         context,
       ),
       requiredProperties: schema.requiredProperties,
+      constProperties: schema.constProperties,
     );
   }
   if (schema is SchemaStringEnum) {
@@ -1618,6 +1619,7 @@ class ResolvedObject extends ResolvedSchema {
     required this.properties,
     required this.additionalProperties,
     required this.requiredProperties,
+    required this.constProperties,
   }) : super(createsNewType: true);
 
   /// The properties of the resolved schema.
@@ -1630,6 +1632,13 @@ class ResolvedObject extends ResolvedSchema {
   /// The required properties of the resolved schema.
   final List<String> requiredProperties;
 
+  /// Properties pinned to a single constant value (`int`/`String`) by the
+  /// `allOf: [{$ref: E}]` + single-value `enum`/`const` idiom. Carried
+  /// through from parse so the dispatch pass can treat the fixed value as
+  /// an implicit discriminator tag; the property itself still resolves to
+  /// the plain `E` ref. See [SchemaObject.constProperties].
+  final Map<String, Object> constProperties;
+
   @override
   ResolvedObject copyWith({CommonProperties? common}) {
     return ResolvedObject(
@@ -1637,6 +1646,7 @@ class ResolvedObject extends ResolvedSchema {
       properties: properties,
       additionalProperties: additionalProperties,
       requiredProperties: requiredProperties,
+      constProperties: constProperties,
     );
   }
 
@@ -1646,6 +1656,7 @@ class ResolvedObject extends ResolvedSchema {
     properties,
     additionalProperties,
     requiredProperties,
+    constProperties,
   ];
 }
 

--- a/lib/templates/schema_object.mustache
+++ b/lib/templates/schema_object.mustache
@@ -2,7 +2,7 @@
 {{#parentSealedTypeName}}final {{/parentSealedTypeName}}class {{ typeName }}{{#parentSealedTypeName}} extends {{ parentSealedTypeName }}{{/parentSealedTypeName}} {
     {{{ constructor_doc_comment }}}{{ typeName }}(
         {{#hasProperties}}
-        { {{#properties}}{{{ argumentLine }}}, {{/properties}}
+        { {{#properties}}{{^isConstGetter}}{{{ argumentLine }}}, {{/isConstGetter}}{{/properties}}
         {{#hasAdditionalProperties}}required this.{{additionalPropertiesName}},{{/hasAdditionalProperties}} }
         {{/hasProperties}}
     ){{{assignmentsLine}}};
@@ -34,7 +34,7 @@
     {{^hasNoJsonProperty}}
         return parseFromJson('{{ typeName }}', json, () => {{ typeName }}(
             {{#properties}}
-            {{ dartName }}: {{{ fromJson }}},
+            {{^isConstGetter}}{{ dartName }}: {{{ fromJson }}},{{/isConstGetter}}
             {{/properties}}
             {{#hasAdditionalProperties}}
             {{additionalPropertiesName}}: <String, {{{ valueSchema }}}>{
@@ -56,7 +56,7 @@
         return {{ typeName }}.fromJson(json);
     }
 
-    {{#properties}}{{{ property_doc_comment }}}{{{ storageTypeDeclaration }}}{{ dartName }};
+    {{#properties}}{{{ property_doc_comment }}}{{#isConstGetter}}{{{ constGetter }}}{{/isConstGetter}}{{^isConstGetter}}{{{ storageTypeDeclaration }}}{{ dartName }};{{/isConstGetter}}
     {{/properties}}
     {{#hasAdditionalProperties}}
     final Map<String, {{{ valueSchema }}}> {{additionalPropertiesName}};
@@ -98,7 +98,7 @@
     int get hashCode =>
         {{#hasOneProperty}}
           {{#properties}}
-          {{{ hashCode }}}.hashCode;
+          {{^isConstGetter}}{{{ hashCode }}}.hashCode;{{/isConstGetter}}
           {{/properties}}
           {{#hasAdditionalProperties}}
           mapHash({{additionalPropertiesName}});
@@ -107,7 +107,7 @@
         {{^hasOneProperty}}
         Object.hashAll([
           {{#properties}}
-          {{{ hashCode }}},
+          {{^isConstGetter}}{{{ hashCode }}},{{/isConstGetter}}
           {{/properties}}
           {{#hasAdditionalProperties}}
           mapHash({{additionalPropertiesName}}),
@@ -120,7 +120,7 @@
         if (identical(this, other)) return true;
         return other is {{ typeName }}
             {{#properties}}
-            && {{ equals}}
+            {{^isConstGetter}}&& {{ equals}}{{/isConstGetter}}
             {{/properties}}
             {{#hasAdditionalProperties}}
             && mapsEqual({{additionalPropertiesName}}, other.{{additionalPropertiesName}})

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -339,6 +339,44 @@ void main() {
       expect(obj.requiredProperties, ['a']);
     });
 
+    test('captures a property pinned via allOf-ref + single-value enum '
+        'as a const tag', () {
+      // OpenAPI-3.0 "pinned enum" idiom: `allOf: [{$ref: E}]` + a
+      // single-value `enum`. The property still parses as the plain `E`
+      // ref; the pinned value is recorded in `constProperties` for the
+      // dispatch pass to use as an implicit discriminator.
+      final json = {
+        'type': 'object',
+        'properties': {
+          'type': {
+            'type': 'integer',
+            'enum': [1],
+            'allOf': [
+              {r'$ref': '#/components/schemas/ActionType'},
+            ],
+          },
+          'other': {'type': 'string'},
+          // Multi-value narrowing is a restricted view (issue #235), not
+          // a single tag — must NOT be captured.
+          'status': {
+            'type': 'integer',
+            'enum': [1, 2],
+            'allOf': [
+              {r'$ref': '#/components/schemas/ActionType'},
+            ],
+          },
+        },
+        'required': ['type'],
+      };
+      // The multi-value `status` narrowing isn't captured, so its `enum`
+      // still trips `_warnUnused` (the issue #235 TODO) — needs a scope.
+      final logger = _MockLogger();
+      final schema = runWithLogger(logger, () => parseTestSchema(json));
+      expect(schema, isA<SchemaObject>());
+      final obj = schema as SchemaObject;
+      expect(obj.constProperties, {'type': 1});
+    });
+
     test('oneOf with a real polymorphic variant stays a oneOf', () {
       // A oneOf where any variant brings its own shape (here, a
       // `type: string` variant) is a real polymorphic schema — the

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -2885,8 +2885,12 @@ void main() {
       expect(action, contains('1 => BlockAction.fromJson(json)'));
       expect(action, contains('2 => FlagAction.fromJson(json)'));
       // The field keeps the shared enum type — no throwaway per-variant
-      // single-value enum.
+      // single-value enum — and decodes through it.
       expect(action, contains('final ActionType type'));
+      expect(
+        action,
+        contains("type: ActionType.fromJson(json['type'] as int)"),
+      );
       expect(action, isNot(contains('UnimplementedError')));
     });
 

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -2884,13 +2884,16 @@ void main() {
       // ActionType value set.
       expect(action, contains('1 => BlockAction.fromJson(json)'));
       expect(action, contains('2 => FlagAction.fromJson(json)'));
-      // The field keeps the shared enum type — no throwaway per-variant
-      // single-value enum — and decodes through it.
-      expect(action, contains('final ActionType type'));
-      expect(
-        action,
-        contains("type: ActionType.fromJson(json['type'] as int)"),
-      );
+      // The pinned tag renders as a fixed getter of the shared enum — one
+      // per variant, mapping to the pinned member — not a constructor
+      // parameter, so the caller neither passes it nor can set it wrong.
+      expect(action, contains('ActionType get type => ActionType.value1;'));
+      expect(action, contains('ActionType get type => ActionType.value2;'));
+      // `type` is never a constructor field, nor decoded from JSON...
+      expect(action, isNot(contains('this.type')));
+      expect(action, isNot(contains('type: ActionType.fromJson')));
+      // ...yet it still serializes, via the getter.
+      expect(action, contains("'type': type.toJson()"));
       expect(action, isNot(contains('UnimplementedError')));
     });
 

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -2828,6 +2828,68 @@ void main() {
       expect(rule, isNot(contains('UnimplementedError')));
     });
 
+    test(r'variants tagged by a $ref-to-enum pinned with a single-value '
+        'enum dispatch on the pinned constant', () {
+      // Discord's auto-moderation-action shape: each variant tags its
+      // shared `type` field via the OpenAPI-3.0 idiom
+      // `allOf: [{$ref: ActionType}]` + a single-value `enum` pinning the
+      // member. The field still renders as the shared enum `ActionType`;
+      // the pinned value is the implicit discriminator.
+      final results = renderTestSchemas(
+        {
+          'Action': {
+            'oneOf': [
+              {r'$ref': '#/components/schemas/BlockAction'},
+              {r'$ref': '#/components/schemas/FlagAction'},
+            ],
+          },
+          'ActionType': {
+            'type': 'integer',
+            'enum': [1, 2],
+          },
+          'BlockAction': {
+            'type': 'object',
+            'properties': {
+              'type': {
+                'type': 'integer',
+                'enum': [1],
+                'allOf': [
+                  {r'$ref': '#/components/schemas/ActionType'},
+                ],
+              },
+            },
+            'required': ['type'],
+          },
+          'FlagAction': {
+            'type': 'object',
+            'properties': {
+              'type': {
+                'type': 'integer',
+                'enum': [2],
+                'allOf': [
+                  {r'$ref': '#/components/schemas/ActionType'},
+                ],
+              },
+            },
+            'required': ['type'],
+          },
+        },
+        specUrl: Uri.parse('file:///spec.yaml'),
+      );
+      final action = results['Action'];
+      expect(action, isNotNull);
+      expect(action, contains('sealed class Action'));
+      expect(action, contains("final discriminator = json['type']"));
+      // Dispatch routes on the pinned integer constants, not the full
+      // ActionType value set.
+      expect(action, contains('1 => BlockAction.fromJson(json)'));
+      expect(action, contains('2 => FlagAction.fromJson(json)'));
+      // The field keeps the shared enum type — no throwaway per-variant
+      // single-value enum.
+      expect(action, contains('final ActionType type'));
+      expect(action, isNot(contains('UnimplementedError')));
+    });
+
     test('discriminator dispatch smooshes inline-object variants: case '
         'arms call the variant directly, no wrapper class', () {
       // Same shape as the implicit-discriminator test above, but

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -3968,6 +3968,43 @@ void main() {
       expect(result, isNot(contains('factory Test.fromJson(String')));
     });
 
+    test('oneOf-of-consts enum names members from the spec titles', () {
+      // Discord spells typed int enums as `oneOf` of `const` variants,
+      // each with a `title:` — the spec's own member name. Use it
+      // (`blockMessage`) rather than the value-derived fallback (`value1`).
+      final json = {
+        'type': 'integer',
+        'oneOf': [
+          {'title': 'BLOCK_MESSAGE', 'const': 1},
+          {'title': 'FLAG_TO_CHANNEL', 'const': 2},
+        ],
+      };
+      final result = renderTestSchema(json);
+      expect(result, contains('blockMessage._(1)'));
+      expect(result, contains('flagToChannel._(2)'));
+      // The meaningless value-derived fallback must not appear.
+      expect(result, isNot(contains('value1._(1)')));
+      expect(result, isNot(contains('value2._(2)')));
+    });
+
+    test('oneOf-of-consts enum falls back to value names when a title is '
+        'missing', () {
+      // Names are all-or-nothing: a partially-titled enum would mix
+      // `blockMessage` with `value2`, so fall back to value-derived names
+      // for the whole enum.
+      final json = {
+        'type': 'integer',
+        'oneOf': [
+          {'title': 'BLOCK_MESSAGE', 'const': 1},
+          {'const': 2},
+        ],
+      };
+      final result = renderTestSchema(json);
+      expect(result, contains('value1._(1)'));
+      expect(result, contains('value2._(2)'));
+      expect(result, isNot(contains('blockMessage')));
+    });
+
     test('integer enum with negative values uses safe variable names', () {
       final json = {
         'type': 'integer',

--- a/test/resolver_test.dart
+++ b/test/resolver_test.dart
@@ -1662,6 +1662,7 @@ void main() {
           properties: const {},
           additionalProperties: null,
           requiredProperties: const [],
+          constProperties: const {},
         );
         final schema2 = ResolvedObject(
           common: CommonProperties.test(
@@ -1674,6 +1675,7 @@ void main() {
           properties: const {},
           additionalProperties: null,
           requiredProperties: const [],
+          constProperties: const {},
         );
         expect(schema1, equals(schema1));
         // Different pointer.
@@ -1944,6 +1946,7 @@ void main() {
           properties: const {},
           additionalProperties: null,
           requiredProperties: const [],
+          constProperties: const {},
         );
         testCopyWith(schema, (schema, copy) {
           expect(copy.properties, equals(schema.properties));

--- a/test/resolver_test.dart
+++ b/test/resolver_test.dart
@@ -1792,6 +1792,7 @@ void main() {
           values: const ['bar', 'baz'],
           defaultValue: null,
           descriptions: null,
+          names: null,
         );
         final schema2 = ResolvedStringEnum(
           common: CommonProperties.test(
@@ -1804,6 +1805,7 @@ void main() {
           values: const ['bar', 'qux'],
           defaultValue: null,
           descriptions: null,
+          names: null,
         );
         expect(schema1, equals(schema1));
         // Different values.
@@ -1963,6 +1965,7 @@ void main() {
           values: const ['bar', 'baz'],
           defaultValue: null,
           descriptions: null,
+          names: null,
         );
         testCopyWith(schema, (schema, copy) {
           expect(copy.values, equals(schema.values));
@@ -1975,6 +1978,7 @@ void main() {
           values: const [1, 11, 100],
           defaultValue: 1,
           descriptions: null,
+          names: null,
         );
         testCopyWith(schema, (schema, copy) {
           expect(copy.values, equals(schema.values));


### PR DESCRIPTION
## Summary

Recognize the OpenAPI-3.0 idiom Discord uses to tag discriminated-union variants — a single-element `allOf` wrapping a `$ref` to a named enum, with a sibling single-value `enum`/`const` pinning one member:

```json
"type": { "allOf": [{ "$ref": ".../AutomodActionType" }], "enum": [1] }
```

This means "a value of enum `AutomodActionType` fixed to `BLOCK_MESSAGE`" — the field's *type* is the shared enum, and the pinned value is the discriminator. The parser dropped the sibling `enum` when it saw `allOf`, so every variant's `type` resolved to the full base enum (values 1–4), indistinguishable — the implicit-discriminator picker gave up and emitted an `UnimplementedError` stub.

## Approach

Least-invasive faithful model (the field keeps rendering as the shared enum, byte-identical):

- **Parse:** capture the pinned constant as `SchemaObject.constProperties` (property name → `int`/`String`); mark the consumed `enum` used so it no longer trips `_warnUnused`. The property still parses as the plain `E` ref.
- **Resolve:** thread `constProperties` onto `ResolvedObject`.
- **Dispatch:** a new `_tagValues` helper folds the two spellings of an implicit tag — a bare inline `enum` (github's `repository-rule`) and a pinned `$ref`-to-enum (Discord) — so both pickers route a variant on its fixed value. This also simplifies the existing picker (the duplicated per-variant enum-type checks collapse into the shared helper).

Generated dispatch:
```dart
final discriminator = json['type'];
return switch (discriminator) {
  1 => ...BlockMessageAction(BlockMessageAction.fromJson(json)),
  2 => ...FlagToChannelAction(FlagToChannelAction.fromJson(json)),
  ...
};
```
and each variant keeps `final AutomodActionType type;`.

## Scope

Only **single-value** pins are captured. A **multi-value** `enum` is a restricted *view* of the enum ("DISABLED or ENABLED but never DISABLED_BY_DISCORD"), not a single tag — filed as #235. Those `enum`s still surface at `-v` (145 → 21 warnings) as the honest signal for that follow-up. Zero of the multi-value narrowings sit at discriminator positions, so this doesn't block any stub.

## Impact

| Spec | Before | After |
|---|---|---|
| Discord | 38 stubs | **6 stubs** |
| github / spacetraders / petstore | clean | clean — **byte-identical regen** |
| backstage / train-travel | clean | clean |

Combined with #234, Discord has gone 334 → 6 stubs.

## Test

- Parser unit test: the `allOf`-ref + single-value `enum` property is captured in `constProperties`; a multi-value sibling is not.
- Render unit test: a oneOf of two such variants dispatches on the pinned integer constants and keeps the shared enum field type.
- Full suite passes, `dart analyze` clean.