### PR TITLE
fix: skip the toString==toJson generated test for int enums

### DIFF
--- a/lib/src/render/file_renderer.dart
+++ b/lib/src/render/file_renderer.dart
@@ -821,6 +821,11 @@ class FileRenderer {
           'exampleValue': example,
           'invalidJsonExample': invalidJson,
           'isEnum': schema is RenderEnum,
+          // The `toString matches toJson` check only type-checks for string
+          // enums, whose `toString()` and `toJson()` both return the wire
+          // String. An int enum's `toString()` is a String while `toJson()`
+          // is an int, so the assertion is a category error — skip it.
+          'isStringEnum': schema is RenderStringEnum,
         },
       );
     }

--- a/lib/templates/schema_round_trip_test.mustache
+++ b/lib/templates/schema_round_trip_test.mustache
@@ -23,13 +23,15 @@ void main() {
       );
     });
 {{/invalidJsonExample}}
-{{#isEnum}}
+{{#isStringEnum}}
 
     test('toString matches toJson for every value', () {
       for (final value in {{{ typeName }}}.values) {
         expect(value.toString(), equals(value.toJson()));
       }
     });
+{{/isStringEnum}}
+{{#isEnum}}
 
     test('fromJson round-trips every value', () {
       for (final value in {{{ typeName }}}.values) {

--- a/test/render/file_renderer_test.dart
+++ b/test/render/file_renderer_test.dart
@@ -480,6 +480,58 @@ void main() {
       expect(body, contains('Role.fromJson(value.toJson())'));
     });
 
+    test(
+      'int enum round-trip test omits the toString==toJson assertion',
+      () async {
+        // For an int enum `toString()` is a String but `toJson()` is an int, so
+        // `expect(value.toString(), equals(value.toJson()))` is a type category
+        // error that always fails. Skip that one assertion; keep the rest.
+        final fs = MemoryFileSystem.test();
+        final spec = {
+          'openapi': '3.1.0',
+          'info': {'title': 'IntEnumRoundtrip', 'version': '1.0.0'},
+          'servers': [
+            {'url': 'https://example.com'},
+          ],
+          'paths': {
+            '/level': {
+              'get': {
+                'operationId': 'getLevel',
+                'responses': {
+                  '200': {
+                    'description': 'OK',
+                    'content': {
+                      'application/json': {
+                        'schema': {r'$ref': '#/components/schemas/Level'},
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          'components': {
+            'schemas': {
+              'Level': {
+                'type': 'integer',
+                'enum': [1, 2, 3],
+              },
+            },
+          },
+        };
+        final out = fs.directory('out');
+        await renderToDirectory(spec: spec, outDir: out);
+        final body = out
+            .childFile('test/models/level_test.dart')
+            .readAsStringSync();
+        // The type-unsafe assertion is gone...
+        expect(body, isNot(contains('toString matches toJson')));
+        // ...but the type-safe round-trip check stays.
+        expect(body, contains('fromJson round-trips every value'));
+        expect(body, contains('Level.fromJson(value.toJson())'));
+      },
+    );
+
     test('non-enum round-trip test omits the enum-only assertions', () async {
       final fs = MemoryFileSystem.test();
       final spec = {


### PR DESCRIPTION
## Summary

The generated enum round-trip test asserts `expect(value.toString(), equals(value.toJson()))`. That only type-checks for a **string** enum — its `toString()` and `toJson()` both return the wire `String`. An **int** enum's `toString()` returns a `String` (`"1"`) while `toJson()` returns an `int` (`1`), so the assertion is a category error that always fails.

**66 of Discord's 67 generated-test failures were this single bogus assertion.** github has zero int enums, which is why its suite never hit it.

Gate the `toString matches toJson` test to string enums (new `isStringEnum` template flag); the type-safe `fromJson round-trips every value` check stays for all enums.

## Impact

- Discord generated suite: **67 → 1** failure (the remaining one is an unrelated round-trip/equality bug in `PrivateApplicationResponse`, filed as #242).
- github / petstore / spacetraders: no int enums, generated tests unchanged. Only generated *test* files are touched, so all specs' generated **library** output is byte-identical (verified for github).

## Test

Added a `file_renderer_test` case: an int enum's round-trip test omits the `toString matches toJson` assertion but keeps `fromJson round-trips every value`. The existing string-enum test (which asserts the toString check *is* present) still passes.