### PR TITLE
fix: restore int-enum toString() coverage with a type-safe assertion

### DIFF
--- a/lib/src/render/file_renderer.dart
+++ b/lib/src/render/file_renderer.dart
@@ -827,7 +827,7 @@ class FileRenderer {
           // the assertion type-checks (and keeps exercising `toString()`) for
           // both. For string enums this is exactly `value.toJson()`, so their
           // output is unchanged.
-          'toStringComparand': schema is RenderStringEnum
+          'toJsonAsString': schema is RenderStringEnum
               ? 'value.toJson()'
               : 'value.toJson().toString()',
         },

--- a/lib/src/render/file_renderer.dart
+++ b/lib/src/render/file_renderer.dart
@@ -821,11 +821,15 @@ class FileRenderer {
           'exampleValue': example,
           'invalidJsonExample': invalidJson,
           'isEnum': schema is RenderEnum,
-          // The `toString matches toJson` check only type-checks for string
-          // enums, whose `toString()` and `toJson()` both return the wire
-          // String. An int enum's `toString()` is a String while `toJson()`
-          // is an int, so the assertion is a category error — skip it.
-          'isStringEnum': schema is RenderStringEnum,
+          // `toString()` returns a String for every enum, but `toJson()`
+          // returns the wire type — String for a string enum, int for an int
+          // enum. Compare `toString()` against the *stringified* wire value so
+          // the assertion type-checks (and keeps exercising `toString()`) for
+          // both. For string enums this is exactly `value.toJson()`, so their
+          // output is unchanged.
+          'toStringComparand': schema is RenderStringEnum
+              ? 'value.toJson()'
+              : 'value.toJson().toString()',
         },
       );
     }

--- a/lib/templates/schema_round_trip_test.mustache
+++ b/lib/templates/schema_round_trip_test.mustache
@@ -27,7 +27,7 @@ void main() {
 
     test('toString matches toJson for every value', () {
       for (final value in {{{ typeName }}}.values) {
-        expect(value.toString(), equals({{{ toStringComparand }}}));
+        expect(value.toString(), equals({{{ toJsonAsString }}}));
       }
     });
 

--- a/lib/templates/schema_round_trip_test.mustache
+++ b/lib/templates/schema_round_trip_test.mustache
@@ -23,15 +23,13 @@ void main() {
       );
     });
 {{/invalidJsonExample}}
-{{#isStringEnum}}
+{{#isEnum}}
 
     test('toString matches toJson for every value', () {
       for (final value in {{{ typeName }}}.values) {
-        expect(value.toString(), equals(value.toJson()));
+        expect(value.toString(), equals({{{ toStringComparand }}}));
       }
     });
-{{/isStringEnum}}
-{{#isEnum}}
 
     test('fromJson round-trips every value', () {
       for (final value in {{{ typeName }}}.values) {

--- a/test/render/file_renderer_test.dart
+++ b/test/render/file_renderer_test.dart
@@ -481,11 +481,12 @@ void main() {
     });
 
     test(
-      'int enum round-trip test omits the toString==toJson assertion',
+      'int enum toString test compares against the stringified value',
       () async {
         // For an int enum `toString()` is a String but `toJson()` is an int, so
-        // `expect(value.toString(), equals(value.toJson()))` is a type category
-        // error that always fails. Skip that one assertion; keep the rest.
+        // comparing them directly is a type category error that always fails.
+        // Compare against the stringified wire value instead — type-safe, and
+        // it keeps `toString()` covered.
         final fs = MemoryFileSystem.test();
         final spec = {
           'openapi': '3.1.0',
@@ -524,9 +525,14 @@ void main() {
         final body = out
             .childFile('test/models/level_test.dart')
             .readAsStringSync();
-        // The type-unsafe assertion is gone...
-        expect(body, isNot(contains('toString matches toJson')));
-        // ...but the type-safe round-trip check stays.
+        // The toString test is present (so toString() stays covered)...
+        expect(body, contains('toString matches toJson for every value'));
+        // ...comparing against the stringified wire value, not the raw int...
+        expect(
+          body,
+          contains('equals(value.toJson().toString())'),
+        );
+        // ...and the fromJson round-trip check stays too.
         expect(body, contains('fromJson round-trips every value'));
         expect(body, contains('Level.fromJson(value.toJson())'));
       },


### PR DESCRIPTION
## Summary

Follow-up to #241. That PR fixed the bogus `toString == toJson` int-enum test by **removing** it — but that test was the *only* caller of the enum's `toString()`, so int-enum `toString()` dropped to **0 coverage**:

```
# Discord ActivityActionTypes, post-#241:
DA:37,0   →  String toString() => value.toString();   // never exercised
```

The generated round-trip tests exist to fully exercise generated code, so leaving `toString()` uncovered is a regression (thanks @eseidel for catching it).

## Fix

Emit the `toString matches toJson` test for **every** enum again, but compare `toString()` against the **stringified** wire value:

```dart
expect(value.toString(), equals(value.toJson().toString()));
```

- **int enum**: `"1" == 1.toString()` → type-safe, and `toString()` is exercised.
- **string enum**: the comparand is exactly `value.toJson()` (a String), so the emitted test is **unchanged** — github is byte-identical, generated tests included.

## Verification

- Discord `ActivityActionTypes.toString()`: **0 → 2** hits (`DA:37,2`).
- Discord generated suite: still just **1** failure (the unrelated #242 round-trip bug); the returned int-enum `toString` tests pass (+66 passing).
- github regen **byte-identical**, generated test files included.
- Added a `file_renderer_test` case asserting the int-enum test is present and compares against `value.toJson().toString()`.

This is the assertion #241 should have used; it both fixes the type error and keeps coverage.