### PR TITLE
fix: decode List<Uri>/List<DateTime> via map, not a broken cast

### DIFF
--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -3912,7 +3912,12 @@ class RenderArray extends RenderSchema {
   _VariantConversion? _variantConversion(SchemaRenderer context) {
     final itemTypeName = items.typeName;
     final String fromJson;
-    if (items.createsNewType) {
+    // `shouldCallToJson` is the symmetric "this item needs JSON conversion"
+    // predicate — true for newtypes/enums AND for pods whose Dart type differs
+    // from their wire type (`Uri`, `DateTime`, `uriTemplate`). A bare
+    // `.cast<Uri>()` over a `List<String>` is a lazy view that throws on
+    // access; those items must be mapped through `fromJsonExpression`.
+    if (items.shouldCallToJson) {
       final itemFrom = items.fromJsonExpression(
         'e',
         context,
@@ -4017,8 +4022,12 @@ class RenderArray extends RenderSchema {
       // Unless itemSchema itself has a nullable type this is always false.
       jsonIsNullable: false,
     );
-    // If it doesn't create a new type we can just cast the list.
-    if (!items.createsNewType) {
+    // Only a truly json-native item (Dart type == wire type: String, int,
+    // bool, num) can be cast directly. Items that need conversion — newtypes,
+    // enums, and pods like `Uri`/`DateTime` whose wire type is a String —
+    // must be mapped through `fromJsonExpression`; a bare `.cast<Uri>()` is a
+    // lazy view over the wire Strings that throws on element access.
+    if (!items.shouldCallToJson) {
       return '$castAsList.cast<$itemTypeName>()$orDefault';
     }
     return '$castAsList.map<$itemTypeName>('

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -522,6 +522,32 @@ void main() {
           '}\n',
         );
       });
+
+      test('List<Uri> maps through Uri.parse rather than casting', () {
+        // A `List<Uri>` decodes from a JSON `List<String>`; each element
+        // needs `Uri.parse`. A bare `.cast<Uri>()` is a lazy view over the
+        // wire Strings that throws on element access (issue #242).
+        final schema = {
+          'type': 'object',
+          'properties': {
+            'uris': {
+              'type': 'array',
+              'items': {'type': 'string', 'format': 'uri'},
+            },
+            // A json-native element type still casts (byte-identical).
+            'names': {
+              'type': 'array',
+              'items': {'type': 'string'},
+            },
+          },
+          'required': ['uris', 'names'],
+        };
+        final result = renderTestSchema(schema);
+        expect(result, contains('.map<Uri>((e) => Uri.parse(e as String))'));
+        expect(result, isNot(contains('.cast<Uri>()')));
+        // A plain String list is json-native — a direct cast is correct.
+        expect(result, contains('.cast<String>()'));
+      });
     });
 
     group('uriTemplate', () {
@@ -3536,8 +3562,8 @@ void main() {
         "            aInt: (json['a_int'] as List?)?.cast<int>() ?? const [],\n"
         "            aNumber: (json['a_number'] as List?)?.cast<double>() ?? const [],\n"
         "            aBoolean: (json['a_boolean'] as List?)?.cast<bool>() ?? const [],\n"
-        "            aDateTime: (json['a_date_time'] as List?)?.cast<DateTime>() ?? const [],\n"
-        "            aUri: (json['a_uri'] as List?)?.cast<Uri>() ?? const [],\n"
+        "            aDateTime: (json['a_date_time'] as List?)?.map<DateTime>((e) => DateTime.parse(e as String)).toList() ?? const [],\n"
+        "            aUri: (json['a_uri'] as List?)?.map<Uri>((e) => Uri.parse(e as String)).toList() ?? const [],\n"
         "            aArrayOfString: (json['a_array_of_string'] as List?)?.cast<List<String>>() ?? const [],\n"
         "            aEnum: (json['a_enum'] as List?)?.map<TestAEnumInner>((e) => TestAEnumInner.fromJson(e as String)).toList() ?? const [],\n"
         "            aUnknown: (json['a_unknown'] as List?)?.cast<dynamic>() ?? const [],\n"


### PR DESCRIPTION
## Summary

An array whose element type needs wire→Dart conversion (`Uri`, `DateTime`, `uriTemplate`) decoded via:

```dart
redirectUris: (json['redirect_uris'] as List).cast<Uri>(),
```

That's a **lazy view** over the wire `String`s that throws `type 'String' is not a subtype of type 'Uri'` the moment an element is accessed (e.g. by `==`). The item's `toJson` already mapped correctly (`e.toString()`), so these fields serialized fine but blew up on decode.

## Root cause

The list-`fromJson` gate used `items.createsNewType`, but the symmetric "needs JSON conversion" predicate is `items.shouldCallToJson` — the one `toJson` already uses. Unlike `createsNewType`, it's true for `Uri`/`DateTime`/`uriTemplate` pods (whose Dart type differs from their String wire type). Both list-`fromJson` cast sites now use `shouldCallToJson`, so they map through the item's `fromJsonExpression`:

```dart
redirectUris: (json['redirect_uris'] as List)
    .map<Uri>((e) => Uri.parse(e as String))
    .toList(),
```

A json-native element (`String`/`int`/`bool`/`num`) still casts directly — byte-identical.

## Impact

- **Discord's generated suite is now fully green** (0 failures). The last failure (#242) was exactly `PrivateApplicationResponse.redirectUris: List<Uri>`.
- **github** had the same latent bug on **one** field — but it's optional, so the example synthesizer never filled it and the round-trip test never exercised it. Now fixed too.
- All specs (github/petstore/spacetraders/backstage/train-travel) analyze clean with **zero** remaining `.cast<Uri|DateTime|UriTemplate>()` sites.

## Test

New `render_schema_test` case: a `List<Uri>` maps through `Uri.parse` (not `.cast<Uri>()`) while a `List<String>` still casts directly. Updated the `array type with pod types` snapshot for the `List<DateTime>`/`List<Uri>` fields.

Closes #242.