### PR TITLE
fix: don't suppress unintended_html on angle brackets in code spans

### DIFF
--- a/lib/src/render/formatting.dart
+++ b/lib/src/render/formatting.dart
@@ -140,12 +140,29 @@ String maybeAddUnintendedHtmlIgnore(String content) {
 /// digit, not a letter. Self-closing `<br/>`-style tags and closing
 /// `</foo>` tags both match via the leading `/` arm only when a
 /// letter follows (so `</` followed by whitespace won't match).
+///
+/// Angle brackets inside a code span or fenced code block are
+/// **not** matched: dartdoc renders those verbatim, so the
+/// `unintended_html_in_doc_comment` lint doesn't fire on
+/// `` `Map<String, dynamic>` `` or a ` ``` `-fenced sample. Inline
+/// spans are stripped before the tag check; fenced regions (opened
+/// and closed by a `` ``` `` line) are skipped entirely.
 bool _dartdocHasHtmlTag(String content) {
   final tagRe = RegExp('</?[A-Za-z]');
+  final fenceRe = RegExp('^`{3,}');
+  final inlineCodeRe = RegExp('`[^`]*`');
+  var inFence = false;
   for (final line in content.split('\n')) {
     final stripped = line.trimLeft();
     if (!stripped.startsWith('///')) continue;
-    if (tagRe.hasMatch(stripped)) return true;
+    // Doc text after the `///` marker and any leading whitespace.
+    final doc = stripped.substring(3).trimLeft();
+    if (fenceRe.hasMatch(doc)) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) continue;
+    if (tagRe.hasMatch(doc.replaceAll(inlineCodeRe, ''))) return true;
   }
   return false;
 }

--- a/test/render/formatting_test.dart
+++ b/test/render/formatting_test.dart
@@ -306,6 +306,48 @@ void main() {
         startsWith('$unintendedHtmlInDocCommentIgnoreBlock\n'),
       );
     });
+
+    test('does not fire on angle brackets inside an inline code span', () {
+      // dartdoc renders code spans verbatim, so the lint never fires on
+      // `Map<String, dynamic>` inside backticks.
+      const content =
+          '/// Serializes to `Map<String, dynamic>`.\n'
+          'class Foo {}\n';
+      expect(maybeAddUnintendedHtmlIgnore(content), content);
+    });
+
+    test('still fires on a raw tag outside a code span on the same line', () {
+      const content =
+          '/// Use `Map<String, int>` not <foo>.\n'
+          'class Foo {}\n';
+      expect(
+        maybeAddUnintendedHtmlIgnore(content),
+        startsWith('$unintendedHtmlInDocCommentIgnoreBlock\n'),
+      );
+    });
+
+    test('does not fire on angle brackets inside a fenced code block', () {
+      const content =
+          '/// Example:\n'
+          '/// ```\n'
+          '/// Map<String, int> m;\n'
+          '/// ```\n'
+          'class Foo {}\n';
+      expect(maybeAddUnintendedHtmlIgnore(content), content);
+    });
+
+    test('fires again once the fence closes', () {
+      const content =
+          '/// ```\n'
+          '/// Map<String, int> m;\n'
+          '/// ```\n'
+          '/// Then see <sha1hex>.\n'
+          'class Foo {}\n';
+      expect(
+        maybeAddUnintendedHtmlIgnore(content),
+        startsWith('$unintendedHtmlInDocCommentIgnoreBlock\n'),
+      );
+    });
   });
 
   group('DartFileFormatter', () {


### PR DESCRIPTION
## Summary

Strip inline code spans and skip fenced code blocks before the
`unintended_html_in_doc_comment` HTML-tag check, so the spurious
file-local suppression is no longer prepended to files whose only
`<...>` tokens live inside backticks (e.g. `` `Map<String, dynamic>` ``).

`_dartdocHasHtmlTag` previously matched any `<tag>`-shaped token on a
`///` line, including inside code spans and fenced blocks — but dartdoc
renders those verbatim, so the lint never fires there. Confirmed against
`dart analyze` with the rule enabled: it flags a raw `<sha1hex>` but not
`` `Map<String, dynamic>` `` nor a fenced sample.

## Impact

- Removes the suppression block from **1145 github + 422 Discord**
  generated files. Both specs stay `dart analyze`-clean afterward,
  proving every removed suppression was a false positive.
- Genuine raw tags (Backstage's `location:default/generated-<sha1hex>`)
  still fire, keeping the lint live for real cases — covered by the
  retained test plus new ones for the same-line raw-tag-after-code-span
  case.

## Verification

- New unit tests: inline code span, raw tag after a code span on the
  same line, fenced block, and fire-again-after-fence-closes.
- Full `dart test` suite green; `dart analyze` + `dart format` clean.
- github regen diff vs `main` (package name normalized): **0 added
  lines**, every removed line belongs to the 6-line suppression block
  across exactly 1145 files — no other content changed.

Closes #237.