### PR TITLE
chore: regenerate in-repo gen_tests goldens

### DIFF
--- a/gen_tests/multipart/lib/api/default_api.dart
+++ b/gen_tests/multipart/lib/api/default_api.dart
@@ -16,9 +16,7 @@ class DefaultApi {
   final ApiClient client;
 
   /// Upload a file as the whole request body.
-  Future<void> uploadPlain(
-    UploadPlainRequest uploadPlainRequest,
-  ) async {
+  Future<void> uploadPlain(UploadPlainRequest uploadPlainRequest) async {
     final multipartFields = <String, String>{};
     final multipartFiles = <http.MultipartFile>[
       http.MultipartFile.fromBytes(
@@ -43,12 +41,8 @@ class DefaultApi {
   }
 
   /// Upload a file with metadata.
-  Future<void> uploadMixed(
-    UploadMixedRequest uploadMixedRequest,
-  ) async {
-    final multipartFields = <String, String>{
-      'name': uploadMixedRequest.name,
-    };
+  Future<void> uploadMixed(UploadMixedRequest uploadMixedRequest) async {
+    final multipartFields = <String, String>{'name': uploadMixedRequest.name};
     final multipartFiles = <http.MultipartFile>[
       http.MultipartFile.fromBytes(
         'file',

--- a/gen_tests/multipart/lib/api_client.dart
+++ b/gen_tests/multipart/lib/api_client.dart
@@ -56,16 +56,28 @@ class ApiClient {
 
   Uri _resolveUri({
     required String path,
-    required Map<String, String> queryParameters,
+    required Map<String, List<String>> queryParameters,
     required ResolvedAuth auth,
   }) {
     // baseUri can contain a path, so we need to resolve the passed path
     // relative to it.  The passed path will always be absolute (leading slash)
     // but should be interpreted as relative to the baseUri.
     final uri = Uri.parse('$baseUri$path');
-    // baseUri can also include query parameters, so we need to merge them.
-    final mergedParameters = {...baseUri.queryParameters, ...queryParameters};
+    // Single-shape map: every value is a `List<String>`. `Uri.replace`
+    // spreads each list across repeated keys, so a 1-element list yields
+    // `?k=v` and an N-element list yields `?k=v1&k=v2&…` (the OpenAPI
+    // default style=form, explode=true). baseUri's pre-parsed parameters
+    // arrive as `Map<String, List<String>>` via `queryParametersAll`, so
+    // they merge cleanly without per-key wrapping.
+    final mergedParameters = <String, List<String>>{
+      ...baseUri.queryParametersAll,
+      ...queryParameters,
+    };
     auth.applyToParams(mergedParameters);
+    // `Uri.replace(queryParameters: {})` always appends a trailing `?`,
+    // so skip it when there's nothing to add — endpoints with no query
+    // params would otherwise ship URLs ending in `?` for no reason.
+    if (mergedParameters.isEmpty) return uri;
     return uri.replace(queryParameters: mergedParameters);
   }
 
@@ -149,7 +161,7 @@ class ApiClient {
   Future<Response> invokeApi({
     required Method method,
     required String path,
-    Map<String, String> queryParameters = const {},
+    Map<String, List<String>> queryParameters = const {},
     // Body is nullable to allow for post requests which have an optional body
     // to not have to generate two separate calls depending on whether the
     // body is present or not.
@@ -206,7 +218,7 @@ class ApiClient {
     required String path,
     required Map<String, String> fields,
     required List<MultipartFile> files,
-    Map<String, String> queryParameters = const {},
+    Map<String, List<String>> queryParameters = const {},
     Map<String, String> headerParameters = const {},
     AuthRequest? authRequest,
   }) async {

--- a/gen_tests/multipart/lib/auth.dart
+++ b/gen_tests/multipart/lib/auth.dart
@@ -38,9 +38,15 @@ class ResolvedAuth {
     headers.addAll(this.headers);
   }
 
-  /// Apply the resolved auth to the given parameters.
-  void applyToParams(Map<String, String> params) {
-    params.addAll(this.params);
+  /// Apply the resolved auth to the given parameters. The generated
+  /// client builds a `Map<String, List<String>>` (every value a list, so
+  /// `Uri.replace` can spread arrays across repeated keys). Auth-injected
+  /// values are always single scalar strings, so they wrap into a
+  /// 1-element list at the boundary.
+  void applyToParams(Map<String, List<String>> params) {
+    for (final entry in this.params.entries) {
+      params[entry.key] = [entry.value];
+    }
   }
 
   /// Merge the given [ResolvedAuth] with the current [ResolvedAuth].

--- a/gen_tests/multipart/lib/model/upload_mixed_request.dart
+++ b/gen_tests/multipart/lib/model/upload_mixed_request.dart
@@ -41,12 +41,7 @@ class UploadMixedRequest {
   }
 
   @override
-  int get hashCode => Object.hashAll([
-    listHash(file),
-    name,
-    description,
-    size,
-  ]);
+  int get hashCode => Object.hashAll([listHash(file), name, description, size]);
 
   @override
   bool operator ==(Object other) {

--- a/gen_tests/multipart/lib/model/upload_multi_file_request.dart
+++ b/gen_tests/multipart/lib/model/upload_multi_file_request.dart
@@ -2,10 +2,7 @@ import 'dart:typed_data';
 import 'package:multipart/model_helpers.dart';
 
 class UploadMultiFileRequest {
-  UploadMultiFileRequest({
-    required this.primary,
-    this.thumbnail,
-  });
+  UploadMultiFileRequest({required this.primary, this.thumbnail});
 
   /// Converts a `Map<String, dynamic>` to a [UploadMultiFileRequest].
   factory UploadMultiFileRequest.fromJson(dynamic jsonArg) {
@@ -37,10 +34,7 @@ class UploadMultiFileRequest {
   }
 
   @override
-  int get hashCode => Object.hashAll([
-    listHash(primary),
-    listHash(thumbnail),
-  ]);
+  int get hashCode => Object.hashAll([listHash(primary), listHash(thumbnail)]);
 
   @override
   bool operator ==(Object other) {

--- a/gen_tests/multipart/lib/model/upload_optional_request.dart
+++ b/gen_tests/multipart/lib/model/upload_optional_request.dart
@@ -2,10 +2,7 @@ import 'dart:typed_data';
 import 'package:multipart/model_helpers.dart';
 
 class UploadOptionalRequest {
-  UploadOptionalRequest({
-    required this.file,
-    this.note,
-  });
+  UploadOptionalRequest({required this.file, this.note});
 
   /// Converts a `Map<String, dynamic>` to a [UploadOptionalRequest].
   factory UploadOptionalRequest.fromJson(dynamic jsonArg) {
@@ -37,10 +34,7 @@ class UploadOptionalRequest {
   }
 
   @override
-  int get hashCode => Object.hashAll([
-    listHash(file),
-    note,
-  ]);
+  int get hashCode => Object.hashAll([listHash(file), note]);
 
   @override
   bool operator ==(Object other) {

--- a/gen_tests/multipart/lib/model/upload_plain_request.dart
+++ b/gen_tests/multipart/lib/model/upload_plain_request.dart
@@ -2,9 +2,7 @@ import 'dart:typed_data';
 import 'package:multipart/model_helpers.dart';
 
 class UploadPlainRequest {
-  UploadPlainRequest({
-    required this.file,
-  });
+  UploadPlainRequest({required this.file});
 
   /// Converts a `Map<String, dynamic>` to a [UploadPlainRequest].
   factory UploadPlainRequest.fromJson(dynamic jsonArg) {

--- a/gen_tests/multipart/lib/model/upload_rich_scalars_request.dart
+++ b/gen_tests/multipart/lib/model/upload_rich_scalars_request.dart
@@ -42,12 +42,8 @@ class UploadRichScalarsRequest {
   }
 
   @override
-  int get hashCode => Object.hashAll([
-    listHash(file),
-    visibility,
-    capturedAt,
-    tag,
-  ]);
+  int get hashCode =>
+      Object.hashAll([listHash(file), visibility, capturedAt, tag]);
 
   @override
   bool operator ==(Object other) {

--- a/gen_tests/multipart/lib/model/upload_rich_scalars_request_visibility.dart
+++ b/gen_tests/multipart/lib/model/upload_rich_scalars_request_visibility.dart
@@ -5,7 +5,7 @@ enum UploadRichScalarsRequestVisibility {
 
   const UploadRichScalarsRequestVisibility._(this.value);
 
-  /// Creates a UploadRichScalarsRequestVisibility from a json string.
+  /// Creates a UploadRichScalarsRequestVisibility from a json value.
   factory UploadRichScalarsRequestVisibility.fromJson(String json) {
     return UploadRichScalarsRequestVisibility.values.firstWhere(
       (value) => value.value == json,
@@ -15,7 +15,7 @@ enum UploadRichScalarsRequestVisibility {
     );
   }
 
-  /// Convenience to create a nullable type from a nullable json object.
+  /// Convenience to create a nullable type from a nullable json value.
   /// Useful when parsing optional fields.
   static UploadRichScalarsRequestVisibility? maybeFromJson(String? json) {
     if (json == null) {
@@ -24,14 +24,14 @@ enum UploadRichScalarsRequestVisibility {
     return UploadRichScalarsRequestVisibility.fromJson(json);
   }
 
-  /// The value of the enum, as a string.  This is the exact value
+  /// The value of the enum.  This is the exact value
   /// from the OpenAPI spec and will be used for network transport.
   final String value;
 
-  /// Converts the enum to a json string.
+  /// Converts the enum to its json value.
   String toJson() => value;
 
-  /// Returns the string value of the enum.
+  /// Returns the string form of the enum.
   @override
   String toString() => value;
 }

--- a/gen_tests/security/lib/api_client.dart
+++ b/gen_tests/security/lib/api_client.dart
@@ -56,16 +56,28 @@ class ApiClient {
 
   Uri _resolveUri({
     required String path,
-    required Map<String, String> queryParameters,
+    required Map<String, List<String>> queryParameters,
     required ResolvedAuth auth,
   }) {
     // baseUri can contain a path, so we need to resolve the passed path
     // relative to it.  The passed path will always be absolute (leading slash)
     // but should be interpreted as relative to the baseUri.
     final uri = Uri.parse('$baseUri$path');
-    // baseUri can also include query parameters, so we need to merge them.
-    final mergedParameters = {...baseUri.queryParameters, ...queryParameters};
+    // Single-shape map: every value is a `List<String>`. `Uri.replace`
+    // spreads each list across repeated keys, so a 1-element list yields
+    // `?k=v` and an N-element list yields `?k=v1&k=v2&…` (the OpenAPI
+    // default style=form, explode=true). baseUri's pre-parsed parameters
+    // arrive as `Map<String, List<String>>` via `queryParametersAll`, so
+    // they merge cleanly without per-key wrapping.
+    final mergedParameters = <String, List<String>>{
+      ...baseUri.queryParametersAll,
+      ...queryParameters,
+    };
     auth.applyToParams(mergedParameters);
+    // `Uri.replace(queryParameters: {})` always appends a trailing `?`,
+    // so skip it when there's nothing to add — endpoints with no query
+    // params would otherwise ship URLs ending in `?` for no reason.
+    if (mergedParameters.isEmpty) return uri;
     return uri.replace(queryParameters: mergedParameters);
   }
 
@@ -149,7 +161,7 @@ class ApiClient {
   Future<Response> invokeApi({
     required Method method,
     required String path,
-    Map<String, String> queryParameters = const {},
+    Map<String, List<String>> queryParameters = const {},
     // Body is nullable to allow for post requests which have an optional body
     // to not have to generate two separate calls depending on whether the
     // body is present or not.
@@ -206,7 +218,7 @@ class ApiClient {
     required String path,
     required Map<String, String> fields,
     required List<MultipartFile> files,
-    Map<String, String> queryParameters = const {},
+    Map<String, List<String>> queryParameters = const {},
     Map<String, String> headerParameters = const {},
     AuthRequest? authRequest,
   }) async {

--- a/gen_tests/security/lib/auth.dart
+++ b/gen_tests/security/lib/auth.dart
@@ -38,9 +38,15 @@ class ResolvedAuth {
     headers.addAll(this.headers);
   }
 
-  /// Apply the resolved auth to the given parameters.
-  void applyToParams(Map<String, String> params) {
-    params.addAll(this.params);
+  /// Apply the resolved auth to the given parameters. The generated
+  /// client builds a `Map<String, List<String>>` (every value a list, so
+  /// `Uri.replace` can spread arrays across repeated keys). Auth-injected
+  /// values are always single scalar strings, so they wrap into a
+  /// 1-element list at the boundary.
+  void applyToParams(Map<String, List<String>> params) {
+    for (final entry in this.params.entries) {
+      params[entry.key] = [entry.value];
+    }
   }
 
   /// Merge the given [ResolvedAuth] with the current [ResolvedAuth].

--- a/gen_tests/security/lib/model/user.dart
+++ b/gen_tests/security/lib/model/user.dart
@@ -1,20 +1,12 @@
 import 'package:security/model_helpers.dart';
 
 class User {
-  User({
-    required this.id,
-  });
+  User({required this.id});
 
   /// Converts a `Map<String, dynamic>` to a [User].
   factory User.fromJson(dynamic jsonArg) {
     final json = jsonArg as Map<String, dynamic>;
-    return parseFromJson(
-      'User',
-      json,
-      () => User(
-        id: json['id'] as String,
-      ),
-    );
+    return parseFromJson('User', json, () => User(id: json['id'] as String));
   }
 
   /// Convenience to create a nullable type from a nullable json object.
@@ -30,9 +22,7 @@ class User {
 
   /// Converts a [User] to a `Map<String, dynamic>`.
   Map<String, dynamic> toJson() {
-    return {
-      'id': id,
-    };
+    return {'id': id};
   }
 
   @override

--- a/gen_tests/types/lib/api/default_api.dart
+++ b/gen_tests/types/lib/api/default_api.dart
@@ -13,10 +13,7 @@ class DefaultApi {
 
   /// Get types
   Future<Types200Response> types() async {
-    final response = await client.invokeApi(
-      method: Method.get,
-      path: '/types',
-    );
+    final response = await client.invokeApi(method: Method.get, path: '/types');
 
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException<Object?>(

--- a/gen_tests/types/lib/api_client.dart
+++ b/gen_tests/types/lib/api_client.dart
@@ -74,6 +74,10 @@ class ApiClient {
       ...queryParameters,
     };
     auth.applyToParams(mergedParameters);
+    // `Uri.replace(queryParameters: {})` always appends a trailing `?`,
+    // so skip it when there's nothing to add — endpoints with no query
+    // params would otherwise ship URLs ending in `?` for no reason.
+    if (mergedParameters.isEmpty) return uri;
     return uri.replace(queryParameters: mergedParameters);
   }
 

--- a/gen_tests/types/lib/model/status.dart
+++ b/gen_tests/types/lib/model/status.dart
@@ -5,7 +5,7 @@ enum Status {
 
   const Status._(this.value);
 
-  /// Creates a Status from a json string.
+  /// Creates a Status from a json value.
   factory Status.fromJson(String json) {
     return Status.values.firstWhere(
       (value) => value.value == json,
@@ -13,7 +13,7 @@ enum Status {
     );
   }
 
-  /// Convenience to create a nullable type from a nullable json object.
+  /// Convenience to create a nullable type from a nullable json value.
   /// Useful when parsing optional fields.
   static Status? maybeFromJson(String? json) {
     if (json == null) {
@@ -22,14 +22,14 @@ enum Status {
     return Status.fromJson(json);
   }
 
-  /// The value of the enum, as a string.  This is the exact value
+  /// The value of the enum.  This is the exact value
   /// from the OpenAPI spec and will be used for network transport.
   final String value;
 
-  /// Converts the enum to a json string.
+  /// Converts the enum to its json value.
   String toJson() => value;
 
-  /// Returns the string value of the enum.
+  /// Returns the string form of the enum.
   @override
   String toString() => value;
 }

--- a/gen_tests/types/lib/model/types200_response.dart
+++ b/gen_tests/types/lib/model/types200_response.dart
@@ -1,9 +1,3 @@
-// Spec descriptions copy prose verbatim into dartdoc, where `<x>`
-// is parsed as an HTML tag start even when it is not HTML (e.g.
-// placeholder tokens like `<sha1hex>`).
-// Suppress file-locally so the lint stays live elsewhere; spec
-// authors do not always escape angle brackets.
-// ignore_for_file: unintended_html_in_doc_comment
 import 'package:types/date.dart';
 import 'package:types/model/email_type.dart';
 import 'package:types/model/status.dart';

--- a/gen_tests/types/lib/model/widget.dart
+++ b/gen_tests/types/lib/model/widget.dart
@@ -7,11 +7,7 @@ import 'package:types/model_helpers.dart';
 
 class Widget {
   /// {@macro widget}
-  Widget({
-    required this.id,
-    required this.attributes,
-    this.tags = const [],
-  });
+  Widget({required this.id, required this.attributes, this.tags = const []});
 
   /// Converts a `Map<String, dynamic>` to a [Widget].
   factory Widget.fromJson(dynamic jsonArg) {
@@ -44,19 +40,11 @@ class Widget {
 
   /// Converts a [Widget] to a `Map<String, dynamic>`.
   Map<String, dynamic> toJson() {
-    return {
-      'id': id,
-      'tags': tags,
-      'attributes': attributes,
-    };
+    return {'id': id, 'tags': tags, 'attributes': attributes};
   }
 
   @override
-  int get hashCode => Object.hashAll([
-    id,
-    listHash(tags),
-    mapHash(attributes),
-  ]);
+  int get hashCode => Object.hashAll([id, listHash(tags), mapHash(attributes)]);
 
   @override
   bool operator ==(Object other) {

--- a/gen_tests/unsupported_auth/lib/api_client.dart
+++ b/gen_tests/unsupported_auth/lib/api_client.dart
@@ -56,16 +56,28 @@ class ApiClient {
 
   Uri _resolveUri({
     required String path,
-    required Map<String, String> queryParameters,
+    required Map<String, List<String>> queryParameters,
     required ResolvedAuth auth,
   }) {
     // baseUri can contain a path, so we need to resolve the passed path
     // relative to it.  The passed path will always be absolute (leading slash)
     // but should be interpreted as relative to the baseUri.
     final uri = Uri.parse('$baseUri$path');
-    // baseUri can also include query parameters, so we need to merge them.
-    final mergedParameters = {...baseUri.queryParameters, ...queryParameters};
+    // Single-shape map: every value is a `List<String>`. `Uri.replace`
+    // spreads each list across repeated keys, so a 1-element list yields
+    // `?k=v` and an N-element list yields `?k=v1&k=v2&…` (the OpenAPI
+    // default style=form, explode=true). baseUri's pre-parsed parameters
+    // arrive as `Map<String, List<String>>` via `queryParametersAll`, so
+    // they merge cleanly without per-key wrapping.
+    final mergedParameters = <String, List<String>>{
+      ...baseUri.queryParametersAll,
+      ...queryParameters,
+    };
     auth.applyToParams(mergedParameters);
+    // `Uri.replace(queryParameters: {})` always appends a trailing `?`,
+    // so skip it when there's nothing to add — endpoints with no query
+    // params would otherwise ship URLs ending in `?` for no reason.
+    if (mergedParameters.isEmpty) return uri;
     return uri.replace(queryParameters: mergedParameters);
   }
 
@@ -149,7 +161,7 @@ class ApiClient {
   Future<Response> invokeApi({
     required Method method,
     required String path,
-    Map<String, String> queryParameters = const {},
+    Map<String, List<String>> queryParameters = const {},
     // Body is nullable to allow for post requests which have an optional body
     // to not have to generate two separate calls depending on whether the
     // body is present or not.
@@ -206,7 +218,7 @@ class ApiClient {
     required String path,
     required Map<String, String> fields,
     required List<MultipartFile> files,
-    Map<String, String> queryParameters = const {},
+    Map<String, List<String>> queryParameters = const {},
     Map<String, String> headerParameters = const {},
     AuthRequest? authRequest,
   }) async {

--- a/gen_tests/unsupported_auth/lib/auth.dart
+++ b/gen_tests/unsupported_auth/lib/auth.dart
@@ -38,9 +38,15 @@ class ResolvedAuth {
     headers.addAll(this.headers);
   }
 
-  /// Apply the resolved auth to the given parameters.
-  void applyToParams(Map<String, String> params) {
-    params.addAll(this.params);
+  /// Apply the resolved auth to the given parameters. The generated
+  /// client builds a `Map<String, List<String>>` (every value a list, so
+  /// `Uri.replace` can spread arrays across repeated keys). Auth-injected
+  /// values are always single scalar strings, so they wrap into a
+  /// 1-element list at the boundary.
+  void applyToParams(Map<String, List<String>> params) {
+    for (final entry in this.params.entries) {
+      params[entry.key] = [entry.value];
+    }
   }
 
   /// Merge the given [ResolvedAuth] with the current [ResolvedAuth].


### PR DESCRIPTION
## Summary

Regenerate the committed `gen_tests/` golden output, which had drifted
behind several landed generator changes. No generator code changes —
just the emitted fixtures catching up to `main`.

The drift, by source:

- **Multi-value query params** — `api_client`/`auth` now thread
  `Map<String, List<String>>` (OpenAPI `style=form, explode=true`),
  merging `baseUri.queryParametersAll` and skipping the trailing-`?`
  empty-query case.
- **`dart_style` tall style** — short constructors, maps, and argument
  lists collapse to single lines.
- **Int-enum doc wording** — `"json string"` → `"json value"` etc.,
  from the `SchemaStringEnum`/`SchemaIntegerEnum` split (#192).
- **#237** — the spurious `unintended_html_in_doc_comment` suppression
  is now gone from `security/model/user.dart` (no longer added) and
  `types/model/types200_response.dart` (removed); their only angle
  brackets are `` `Map<String, dynamic>` `` inside code spans.

## Verification

- Regenerated via `dart run tool/gen_tests.dart`.
- All four packages — `multipart`, `security`, `types`,
  `unsupported_auth` — `dart analyze` clean.
- Generated tests pass: multipart (5), security (3), types (18); the
  `gen_tests/tests` suite passes too. `unsupported_auth` has no tests.
- No golden carries the html suppression after regen.