### PR TITLE
refactor: generate == without redundant this. qualifier

### DIFF
--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -2247,6 +2247,15 @@ class RenderDefaultResponse {
   final String? contentType;
 }
 
+/// The receiver for a field named [name] inside a generated
+/// `bool operator ==(Object other)` body. Bare `$name` reads the
+/// field for every name except `other` — which the `Object other`
+/// parameter shadows, so a field literally named `other` must keep
+/// the `this.` qualifier to stay unambiguous. Every other field omits
+/// it (the analyzer's `unnecessary_this` lint would otherwise strip
+/// it post-generation).
+String _equalsReceiver(String name) => name == 'other' ? 'this.$name' : name;
+
 abstract class RenderSchema extends Equatable implements ToTemplateContext {
   const RenderSchema({
     required this.common,
@@ -2435,7 +2444,7 @@ abstract class RenderSchema extends Equatable implements ToTemplateContext {
   }
 
   String equalsExpression(String name, SchemaRenderer context) =>
-      'this.$name == other.$name';
+      '${_equalsReceiver(name)} == other.$name';
 
   /// Expression to feed into the generated `hashCode` `Object.hashAll(...)`
   /// call for a field named [name]. Default is the field itself —
@@ -3952,7 +3961,7 @@ class RenderArray extends RenderSchema {
 
   @override
   String equalsExpression(String name, SchemaRenderer context) =>
-      '${ModelHelpers.listsEqual}(this.$name, other.$name)';
+      '${ModelHelpers.listsEqual}(${_equalsReceiver(name)}, other.$name)';
 
   @override
   String hashCodeExpression(String name) => '${ModelHelpers.listHash}($name)';
@@ -4157,7 +4166,7 @@ class RenderMap extends RenderSchema {
 
   @override
   String equalsExpression(String name, SchemaRenderer context) =>
-      '${ModelHelpers.mapsEqual}(this.$name, other.$name)';
+      '${ModelHelpers.mapsEqual}(${_equalsReceiver(name)}, other.$name)';
 
   @override
   String hashCodeExpression(String name) => '${ModelHelpers.mapHash}($name)';
@@ -5791,7 +5800,7 @@ class RenderBinary extends RenderNoJson {
 
   @override
   String equalsExpression(String name, SchemaRenderer context) =>
-      '${ModelHelpers.listsEqual}(this.$name, other.$name)';
+      '${ModelHelpers.listsEqual}(${_equalsReceiver(name)}, other.$name)';
 
   @override
   String hashCodeExpression(String name) => '${ModelHelpers.listHash}($name)';
@@ -5836,7 +5845,7 @@ class RenderBase64Bytes extends RenderSchema {
 
   @override
   String equalsExpression(String name, SchemaRenderer context) =>
-      '${ModelHelpers.listsEqual}(this.$name, other.$name)';
+      '${ModelHelpers.listsEqual}(${_equalsReceiver(name)}, other.$name)';
 
   @override
   String hashCodeExpression(String name) => '${ModelHelpers.listHash}($name)';

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -61,11 +61,32 @@ void main() {
         '    bool operator ==(Object other) {\n'
         '        if (identical(this, other)) return true;\n'
         '        return other is Test\n'
-        '            && this.foo == other.foo\n'
+        '            && foo == other.foo\n'
         '        ;\n'
         '    }\n'
         '}\n',
       );
+    });
+    test('a field named `other` keeps this. in ==; others drop it', () {
+      // In `bool operator ==(Object other)`, the parameter `other`
+      // shadows a field also named `other`, so that field's `==`
+      // receiver must stay `this.other`. Every other field omits the
+      // redundant `this.` (which `unnecessary_this` would otherwise
+      // strip). A map-typed `other` exercises the mapsEqual path too.
+      final schema = {
+        'type': 'object',
+        'properties': {
+          'foo': <String, dynamic>{},
+          'other': {
+            'type': 'object',
+            'additionalProperties': {'type': 'string'},
+          },
+        },
+      };
+      final result = renderTestSchema(schema);
+      expect(result, contains('&& foo == other.foo'));
+      expect(result, contains('&& mapsEqual(this.other, other.other)'));
+      expect(result, isNot(contains('mapsEqual(other, other.other)')));
     });
     test('property with `type: null` renders as dynamic', () {
       // JSON Schema 2020-12 / OpenAPI 3.1 allows `{"type": "null"}` —
@@ -394,7 +415,7 @@ void main() {
         '    bool operator ==(Object other) {\n'
         '        if (identical(this, other)) return true;\n'
         '        return other is Test\n'
-        '            && this.foo == other.foo\n'
+        '            && foo == other.foo\n'
         '        ;\n'
         '    }\n'
         '}\n',
@@ -457,7 +478,7 @@ void main() {
           '    bool operator ==(Object other) {\n'
           '        if (identical(this, other)) return true;\n'
           '        return other is Test\n'
-          '            && this.foo == other.foo\n'
+          '            && foo == other.foo\n'
           '        ;\n'
           '    }\n'
           '}\n',
@@ -516,7 +537,7 @@ void main() {
           '    bool operator ==(Object other) {\n'
           '        if (identical(this, other)) return true;\n'
           '        return other is Test\n'
-          '            && this.foo == other.foo\n'
+          '            && foo == other.foo\n'
           '        ;\n'
           '    }\n'
           '}\n',
@@ -606,7 +627,7 @@ void main() {
           '    bool operator ==(Object other) {\n'
           '        if (identical(this, other)) return true;\n'
           '        return other is Test\n'
-          '            && this.foo == other.foo\n'
+          '            && foo == other.foo\n'
           '        ;\n'
           '    }\n'
           '}\n',
@@ -665,7 +686,7 @@ void main() {
           '    bool operator ==(Object other) {\n'
           '        if (identical(this, other)) return true;\n'
           '        return other is Test\n'
-          '            && this.foo == other.foo\n'
+          '            && foo == other.foo\n'
           '        ;\n'
           '    }\n'
           '}\n',
@@ -741,8 +762,8 @@ void main() {
         '    bool operator ==(Object other) {\n'
         '        if (identical(this, other)) return true;\n'
         '        return other is Test\n'
-        '            && this.foo == other.foo\n'
-        '            && this.bar == other.bar\n'
+        '            && foo == other.foo\n'
+        '            && bar == other.bar\n'
         '        ;\n'
         '    }\n'
         '}\n',
@@ -3289,7 +3310,7 @@ void main() {
           '    bool operator ==(Object other) {\n'
           '        if (identical(this, other)) return true;\n'
           '        return other is User\n'
-          '            && this.foo == other.foo\n'
+          '            && foo == other.foo\n'
           '        ;\n'
           '    }\n'
           '}\n',
@@ -3351,7 +3372,7 @@ void main() {
         '    bool operator ==(Object other) {\n'
         '        if (identical(this, other)) return true;\n'
         '        return other is Test\n'
-        '            && mapsEqual(this.map, other.map)\n'
+        '            && mapsEqual(map, other.map)\n'
         '        ;\n'
         '    }\n'
         '}\n',
@@ -3481,15 +3502,15 @@ void main() {
         '    bool operator ==(Object other) {\n'
         '        if (identical(this, other)) return true;\n'
         '        return other is Test\n'
-        '            && mapsEqual(this.mString, other.mString)\n'
-        '            && mapsEqual(this.mInt, other.mInt)\n'
-        '            && mapsEqual(this.mNumber, other.mNumber)\n'
-        '            && mapsEqual(this.mBoolean, other.mBoolean)\n'
-        '            && mapsEqual(this.mDateTime, other.mDateTime)\n'
-        '            && mapsEqual(this.mUri, other.mUri)\n'
-        '            && mapsEqual(this.mMapOfString, other.mMapOfString)\n'
-        '            && mapsEqual(this.mEnum, other.mEnum)\n'
-        '            && mapsEqual(this.mUnknown, other.mUnknown)\n'
+        '            && mapsEqual(mString, other.mString)\n'
+        '            && mapsEqual(mInt, other.mInt)\n'
+        '            && mapsEqual(mNumber, other.mNumber)\n'
+        '            && mapsEqual(mBoolean, other.mBoolean)\n'
+        '            && mapsEqual(mDateTime, other.mDateTime)\n'
+        '            && mapsEqual(mUri, other.mUri)\n'
+        '            && mapsEqual(mMapOfString, other.mMapOfString)\n'
+        '            && mapsEqual(mEnum, other.mEnum)\n'
+        '            && mapsEqual(mUnknown, other.mUnknown)\n'
         '        ;\n'
         '    }\n'
         '}\n',
@@ -3622,15 +3643,15 @@ void main() {
         '    bool operator ==(Object other) {\n'
         '        if (identical(this, other)) return true;\n'
         '        return other is Test\n'
-        '            && listsEqual(this.aString, other.aString)\n'
-        '            && listsEqual(this.aInt, other.aInt)\n'
-        '            && listsEqual(this.aNumber, other.aNumber)\n'
-        '            && listsEqual(this.aBoolean, other.aBoolean)\n'
-        '            && listsEqual(this.aDateTime, other.aDateTime)\n'
-        '            && listsEqual(this.aUri, other.aUri)\n'
-        '            && listsEqual(this.aArrayOfString, other.aArrayOfString)\n'
-        '            && listsEqual(this.aEnum, other.aEnum)\n'
-        '            && listsEqual(this.aUnknown, other.aUnknown)\n'
+        '            && listsEqual(aString, other.aString)\n'
+        '            && listsEqual(aInt, other.aInt)\n'
+        '            && listsEqual(aNumber, other.aNumber)\n'
+        '            && listsEqual(aBoolean, other.aBoolean)\n'
+        '            && listsEqual(aDateTime, other.aDateTime)\n'
+        '            && listsEqual(aUri, other.aUri)\n'
+        '            && listsEqual(aArrayOfString, other.aArrayOfString)\n'
+        '            && listsEqual(aEnum, other.aEnum)\n'
+        '            && listsEqual(aUnknown, other.aUnknown)\n'
         '        ;\n'
         '    }\n'
         '}\n',
@@ -3716,7 +3737,7 @@ void main() {
         '    bool operator ==(Object other) {\n'
         '        if (identical(this, other)) return true;\n'
         '        return other is Test\n'
-        '            && this.a == other.a\n'
+        '            && a == other.a\n'
         '        ;\n'
         '    }\n'
         '}\n',
@@ -3913,7 +3934,7 @@ void main() {
         '    bool operator ==(Object other) {\n'
         '        if (identical(this, other)) return true;\n'
         '        return other is Test\n'
-        '            && listsEqual(this.a, other.a)\n'
+        '            && listsEqual(a, other.a)\n'
         '        ;\n'
         '    }\n'
         '}\n',
@@ -4132,14 +4153,14 @@ void main() {
         '    bool operator ==(Object other) {\n'
         '        if (identical(this, other)) return true;\n'
         '        return other is Test\n'
-        '            && this.fooBar == other.fooBar\n'
-        '            && this.notPrivate == other.notPrivate\n'
-        '            && this.barBaz == other.barBaz\n'
-        '            && this.n123 == other.n123\n'
-        '            && this.plus1 == other.plus1\n'
-        '            && this.minus1 == other.minus1\n'
-        '            && this.dont == other.dont\n'
-        '            && this.default_ == other.default_\n'
+        '            && fooBar == other.fooBar\n'
+        '            && notPrivate == other.notPrivate\n'
+        '            && barBaz == other.barBaz\n'
+        '            && n123 == other.n123\n'
+        '            && plus1 == other.plus1\n'
+        '            && minus1 == other.minus1\n'
+        '            && dont == other.dont\n'
+        '            && default_ == other.default_\n'
         '        ;\n'
         '    }\n'
         '}\n',
@@ -4325,7 +4346,7 @@ void main() {
           '    bool operator ==(Object other) {\n'
           '        if (identical(this, other)) return true;\n'
           '        return other is Test\n'
-          '            && this.a == other.a\n'
+          '            && a == other.a\n'
           '        ;\n'
           '    }\n'
           '}\n',
@@ -4493,7 +4514,7 @@ void main() {
           '    bool operator ==(Object other) {\n'
           '        if (identical(this, other)) return true;\n'
           '        return other is Test\n'
-          '            && this.a == other.a\n'
+          '            && a == other.a\n'
           '        ;\n'
           '    }\n'
           '}\n',
@@ -4691,8 +4712,8 @@ void main() {
           '    bool operator ==(Object other) {\n'
           '        if (identical(this, other)) return true;\n'
           '        return other is Test\n'
-          '            && this.a == other.a\n'
-          '            && this.b == other.b\n'
+          '            && a == other.a\n'
+          '            && b == other.b\n'
           '        ;\n'
           '    }\n'
           '}\n',
@@ -4753,7 +4774,7 @@ void main() {
           '    bool operator ==(Object other) {\n'
           '        if (identical(this, other)) return true;\n'
           '        return other is Test\n'
-          '            && this.a == other.a\n'
+          '            && a == other.a\n'
           '        ;\n'
           '    }\n'
           '}\n',
@@ -4831,10 +4852,10 @@ void main() {
           '    bool operator ==(Object other) {\n'
           '        if (identical(this, other)) return true;\n'
           '        return other is Test\n'
-          '            && this.reqNull == other.reqNull\n'
-          '            && this.optNull == other.optNull\n'
-          '            && this.req == other.req\n'
-          '            && this.opt == other.opt\n'
+          '            && reqNull == other.reqNull\n'
+          '            && optNull == other.optNull\n'
+          '            && req == other.req\n'
+          '            && opt == other.opt\n'
           '        ;\n'
           '    }\n'
           '}\n',
@@ -4906,7 +4927,7 @@ void main() {
           '    bool operator ==(Object other) {\n'
           '        if (identical(this, other)) return true;\n'
           '        return other is Test\n'
-          '            && this.a == other.a\n'
+          '            && a == other.a\n'
           '        ;\n'
           '    }\n'
           '}\n',


### PR DESCRIPTION
## Summary

Emit the generated `bool operator ==` body's field receiver as the bare
field name instead of `this.field`. The `this.` was always redundant
there (the only in-scope shadow is the `Object other` parameter), so
`dart fix --apply` was stripping it post-generation — **6,307 fixes on
the github regen alone**, the single largest `unnecessary_this`
contributor. Now the generator produces the final form directly.

The one exception: a field literally named `other` *is* shadowed by the
parameter, so it must keep `this.other`. A new `_equalsReceiver(name)`
guard handles this. `dart fix` had silently been keeping `this.other`,
so an unconditional strip would have generated `mapsEqual(other, other.other)`
— a semantically broken `==`. Covered by a regression test.

## Output effect

Analyze-clean on all tracked specs (github, discord, backstage,
petstore, spacetraders). Byte-diff vs the previous github output: **3
files change**, all improvements — list/map equality lines that the old
`this.` pushed over 80 cols (and that `dart format` then left
permanently wrapped, because `dart fix` removed `this.` but left the
trailing comma) now render inline:

```
-        listsEqual(
-          restrictedFileExtensions,
-          other.restrictedFileExtensions,
-        );
+        listsEqual(restrictedFileExtensions, other.restrictedFileExtensions);
```

## Not a perf win (context)

This came out of profiling generation speed. The headline finding: for
large specs, `dart fix --apply` dominates wall-clock (46.9s of github's
57s), and it's **analysis-bound** — repeated analyze→apply rounds over
1000+ files. Removing this one category of ~15 leaves `dart fix` time
essentially unchanged (46.9s → 46.4s). A real speedup would require
generating fix-clean code across *every* category and dropping the
`dart fix` call entirely (`dart fix` is load-bearing for the
analyze-clean promise, since the generated package uses
`very_good_analysis`). That's a larger arc; this PR lands the cleanest
piece of it as a standalone quality improvement.

## Verification

- New regression test: a field named `other` keeps `this.other` (map
  path exercised); a normal field drops `this.`.
- Full `dart test` suite green; `dart analyze` + `dart format` clean.
- Regen rotation: all five tracked specs analyze-clean, no broken `==`.