### PR TITLE
refactor: import only the types an api/model file names

### DIFF
--- a/lib/src/render/file_renderer.dart
+++ b/lib/src/render/file_renderer.dart
@@ -511,10 +511,18 @@ class FileRenderer {
   /// The `lib/date.dart` import for [schemas] iff any of them is a [RenderDate]
   /// (a `format: date` field). Marks [usedDate] so the support file and its
   /// barrel export are emitted.
-  Iterable<Import> _dateImportFor(Iterable<RenderSchema> schemas) {
+  Iterable<Import> _dateImportFor(
+    Iterable<RenderSchema> schemas, {
+    required bool bodyNamesDate,
+  }) {
     if (!schemas.any((s) => s is RenderDate)) return const [];
+    // A `RenderDate` anywhere in the tree means `lib/date.dart` gets
+    // emitted; that's independent of whether this particular file uses
+    // it. The import is only added when the body actually names `Date`.
     usedDate = true;
-    return [Import('package:$packageName/date.dart')];
+    return bodyNamesDate
+        ? [Import('package:$packageName/date.dart')]
+        : const [];
   }
 
   /// Emit `lib/model_helpers.dart` containing only the helpers that any
@@ -654,15 +662,34 @@ class FileRenderer {
       !schema.isSmooshed;
 
   @visibleForTesting
-  Iterable<Import> importsForApi(Api api, ApiUsage usage) {
-    // TODO(eseidel): Make type imports dynamic based on used schemas.
+  Iterable<Import> importsForApi(
+    Api api,
+    ApiUsage usage, {
+    required String body,
+  }) {
+    // Import only what the rendered [body] actually names. Each fixed
+    // import is gated on a sentinel identifier that must appear if the
+    // import is used (e.g. `HttpStatus` for `dart:io`), and each model
+    // newtype on its own class name. Keeping an import requires the
+    // token to be present, so a used import is never dropped; the
+    // effect is purely to stop emitting imports the api file never
+    // references (which `dart fix` would otherwise strip).
+    final referenced = referencedIdentifiers(body);
+    bool names(String token) => referenced.contains(token);
+
     final imports = {
-      const Import('dart:async'),
-      const Import('dart:convert'), // jsonDecode, for decoding response body.
-      const Import('dart:io'), // HttpStatus, emitted by api.mustache.
-      Import('package:$packageName/api_client.dart'),
-      Import('package:$packageName/api_exception.dart'),
-      const Import('package:http/http.dart', asName: 'http'),
+      if (names('Future')) const Import('dart:async'),
+      // jsonDecode, for decoding response body.
+      if (names('jsonDecode')) const Import('dart:convert'),
+      // HttpStatus, emitted by api.mustache.
+      if (names('HttpStatus')) const Import('dart:io'),
+      if (names('ApiClient')) Import('package:$packageName/api_client.dart'),
+      if (names('ApiException'))
+        Import('package:$packageName/api_exception.dart'),
+      // `as http` is only ever used via the `http.` prefix; gate on that
+      // so a bare `http` token in a URL doc-comment doesn't keep it.
+      if (body.contains('http.'))
+        const Import('package:http/http.dart', asName: 'http'),
       ...usage.importsFor(packageName),
     };
 
@@ -673,17 +700,19 @@ class FileRenderer {
     // except smooshed variants, which are emitted inline in their
     // sealed parent's file. The sealed parent is itself imported
     // here, so the variant's class name resolves through that import.
+    // A newtype under the api that the body never names (e.g. a type
+    // nested inside another model, referenced only in that model's own
+    // file) is not imported.
     final importedSchemas = apiSchemas
         .where((s) => s.createsNewType)
-        .where(
-          (s) => !s.isSmooshed,
-        );
+        .where((s) => !s.isSmooshed)
+        .where((s) => names(s.typeName));
     final apiImports = importedSchemas
         .map((s) => Import(modelPackageImport(this, s)))
         .toList();
     imports.addAll({
       ...inlineSchemas.expand((s) => s.additionalImports),
-      ..._dateImportFor(inlineSchemas),
+      ..._dateImportFor(inlineSchemas, bodyNamesDate: names('Date')),
       ...apiImports,
     });
     return imports;
@@ -699,7 +728,11 @@ class FileRenderer {
     for (final api in apis) {
       final renderedApi = schemaRenderer.renderApi(api);
       usedModelHelpers.addAll(renderedApi.usage.modelHelpers);
-      final imports = importsForApi(api, renderedApi.usage);
+      final imports = importsForApi(
+        api,
+        renderedApi.usage,
+        body: renderedApi.body,
+      );
       final importsContext = imports
           .sortedBy((i) => i.path)
           .map((i) => i.toTemplateContext())
@@ -735,19 +768,25 @@ class FileRenderer {
   }
 
   @visibleForTesting
-  Iterable<Import> importsForModel(RenderSchema schema, SchemaUsage usage) {
+  Iterable<Import> importsForModel(
+    RenderSchema schema,
+    SchemaUsage usage, {
+    required String body,
+  }) {
+    final referenced = referencedIdentifiers(body);
     final referencedSchemas = collectSchemasUnderSchema(schema);
     final localSchemas = referencedSchemas.where(
       (s) => !s.createsNewType,
     );
     // Every newtype (including RenderRecursiveRef) imports the target's
     // file — except smooshed variants, which the sealed parent emits
-    // inline (same library, no separate file to import).
+    // inline (same library, no separate file to import). A newtype the
+    // body never names (a type nested inside another model, referenced
+    // only in that model's own file) is not imported.
     final importedSchemas = referencedSchemas
         .where((s) => s.createsNewType)
-        .where(
-          (s) => !s.isSmooshed,
-        )
+        .where((s) => !s.isSmooshed)
+        .where((s) => referenced.contains(s.typeName))
         .toSet();
     final referencedImports = importedSchemas
         .map((s) => Import(modelPackageImport(this, s)))
@@ -757,7 +796,10 @@ class FileRenderer {
       ...usage.importsFor(packageName),
       ...schema.additionalImports,
       ...localSchemas.expand((s) => s.additionalImports),
-      ..._dateImportFor(localSchemas),
+      ..._dateImportFor(
+        localSchemas,
+        bodyNamesDate: referenced.contains('Date'),
+      ),
       ...referencedImports,
     };
     // A file never imports itself.
@@ -770,7 +812,11 @@ class FileRenderer {
     for (final schema in schemas) {
       final rendered = schemaRenderer.renderSchema(schema);
       usedModelHelpers.addAll(rendered.usage.modelHelpers);
-      final imports = importsForModel(schema, rendered.usage);
+      final imports = importsForModel(
+        schema,
+        rendered.usage,
+        body: rendered.body,
+      );
       final importsContext = imports
           .sortedBy((i) => i.path)
           .map((i) => i.toTemplateContext())

--- a/lib/src/render/schema_renderer.dart
+++ b/lib/src/render/schema_renderer.dart
@@ -8,6 +8,19 @@ final _identifierPattern = RegExp(r'[a-zA-Z_$][\w$]*');
 /// [ModelHelpers.all] as a set, for O(1) membership while scanning.
 final Set<String> _helperNames = ModelHelpers.all.toSet();
 
+/// Every whole-identifier token appearing in [body].
+///
+/// Used to prune an emitted file's imports down to the symbols it
+/// actually names: an import is kept only when its type/sentinel token
+/// is in this set. Tokenizing (rather than `body.contains(name)`)
+/// avoids substring false positives — the same whole-identifier
+/// discipline [_referencedModelHelpers] relies on. Keeping an import on
+/// *any* appearance (including doc comments) is deliberately
+/// conservative: it can never drop a genuinely-used import, so it can
+/// never break compilation.
+Set<String> referencedIdentifiers(String body) =>
+    _identifierPattern.allMatches(body).map((m) => m[0]!).toSet();
+
 /// The subset of [ModelHelpers.all] that [body] references as whole
 /// identifiers.
 ///

--- a/test/render/file_renderer_test.dart
+++ b/test/render/file_renderer_test.dart
@@ -2668,12 +2668,76 @@ void main() {
           usesMetaAnnotations: true,
           modelHelpers: {ModelHelpers.parseFromJson},
         ),
+        body: 'class Foo {}',
       );
       expect(imports, {
         const Import('package:meta/meta.dart'),
         const Import('package:spacetraders/model_helpers.dart'),
         const Import('dart:typed_data'), // Uint8List from RenderBinary.
       });
+    });
+
+    test('importsForModel imports a newtype field the body names, not '
+        'types nested only inside it', () {
+      final templates = TemplateProvider.defaultLocation();
+      final schemaRenderer = SchemaRenderer(templates: templates);
+      final formatter = Formatter();
+      final spellChecker = SpellChecker();
+      final fileRenderer = FileRenderer(
+        FileRendererConfig(
+          packageName: 'spacetraders',
+          schemaRenderer: schemaRenderer,
+          templates: templates,
+          formatter: formatter,
+          fileWriter: FileWriter(
+            outDir: MemoryFileSystem.test().directory('spacetraders'),
+          ),
+          spellChecker: spellChecker,
+        ),
+      );
+      // Outer names a Nested-typed field; Nested itself owns a
+      // Deep-typed field. Outer's file references Nested but never Deep
+      // (that lives in Nested's own file), so only Nested is imported.
+      final deep = RenderObject(
+        common: CommonProperties.test(
+          snakeName: 'deep',
+          pointer: JsonPointer.parse('#/components/schemas/deep'),
+          description: 'Deep',
+        ),
+        assignedName: 'Deep',
+        properties: const {},
+      );
+      final nested = RenderObject(
+        common: CommonProperties.test(
+          snakeName: 'nested',
+          pointer: JsonPointer.parse('#/components/schemas/nested'),
+          description: 'Nested',
+        ),
+        assignedName: 'Nested',
+        properties: {'deep': deep},
+      );
+      final outer = RenderObject(
+        common: CommonProperties.test(
+          snakeName: 'outer',
+          pointer: JsonPointer.parse('#/components/schemas/outer'),
+          description: 'Outer',
+        ),
+        assignedName: 'Outer',
+        properties: {'nested': nested},
+      );
+      final imports = fileRenderer.importsForModel(
+        outer,
+        const SchemaUsage(),
+        body: 'class Outer { final Nested nested; }',
+      );
+      expect(
+        imports,
+        contains(const Import('package:spacetraders/models/nested.dart')),
+      );
+      expect(
+        imports,
+        isNot(contains(const Import('package:spacetraders/models/deep.dart'))),
+      );
     });
 
     test('SchemaUsage.fromBody detects validateXxx calls and adds the '
@@ -2800,7 +2864,23 @@ void main() {
           ),
         ],
       );
-      final imports = fileRenderer.importsForApi(api, const ApiUsage());
+      // A body that names every fixed-import sentinel keeps them all.
+      const fullBody =
+          'class FooApi {\n'
+          '  FooApi(ApiClient? client) : client = client ?? ApiClient();\n'
+          '  Future<void> bar() async {\n'
+          '    final response = await client.upload(http.MultipartFile(...));\n'
+          '    if (response.statusCode >= HttpStatus.badRequest) {\n'
+          '      throw ApiException<Object?>(response.statusCode, "");\n'
+          '    }\n'
+          '    return jsonDecode(response.body) as Map<String, dynamic>;\n'
+          '  }\n'
+          '}\n';
+      final imports = fileRenderer.importsForApi(
+        api,
+        const ApiUsage(),
+        body: fullBody,
+      );
       expect(imports, {
         const Import('dart:async'),
         const Import('dart:convert'),
@@ -2810,6 +2890,39 @@ void main() {
         const Import('package:http/http.dart', asName: 'http'),
         const Import('dart:typed_data'), // Uint8List from RenderBinary.
       });
+    });
+
+    test('imports for api prunes fixed imports the body never names', () {
+      final templates = TemplateProvider.defaultLocation();
+      final schemaRenderer = SchemaRenderer(templates: templates);
+      final formatter = Formatter();
+      final spellChecker = SpellChecker();
+      final fileRenderer = FileRenderer(
+        FileRendererConfig(
+          packageName: 'spacetraders',
+          schemaRenderer: schemaRenderer,
+          templates: templates,
+          formatter: formatter,
+          fileWriter: FileWriter(
+            outDir: MemoryFileSystem.test().directory('spacetraders'),
+          ),
+          spellChecker: spellChecker,
+        ),
+      );
+      const api = Api(
+        snakeName: 'foo',
+        description: 'Foo description',
+        removePrefix: null,
+        endpoints: [],
+      );
+      // A body that references none of the sentinels drops every fixed
+      // import — an empty api file needs nothing.
+      final imports = fileRenderer.importsForApi(
+        api,
+        const ApiUsage(),
+        body: 'class FooApi {}\n',
+      );
+      expect(imports, isEmpty);
     });
   });
 }


### PR DESCRIPTION
## Summary

`importsForApi` and `importsForModel` imported every newtype in the
file's entire schema subtree (a full `RenderTreeWalker` walk) plus a
fixed set of `dart:`/`package:` imports. But a generated file only
references the types named in its own signatures and bodies — nested
types (a type inside another model, referenced only in *that* model's
file) and unused fixed imports were emitted anyway, then stripped by
`dart fix --apply` (**4,337 `unused_import` fixes on the github regen,
97.6% of them model imports**).

Now each file imports only what its rendered body names. A shared
`referencedIdentifiers` token scan — the same whole-identifier
discipline `_referencedModelHelpers` already uses — gates every import:

- model/message newtypes on their class name;
- each fixed import on a sentinel token (`HttpStatus` → `dart:io`,
  `ApiException` → `api_exception.dart`, `http.` → the http import,
  `jsonDecode` → `dart:convert`, `Date` → `date.dart`, …).

Keeping an import *requires* its token to be present, so a genuinely-used
import can never be dropped — the change only stops emitting ones the
file never references. Closes the pre-existing `TODO(eseidel)` on
`importsForApi`.

## Impact

- github raw (pre-fix) `unused_import`: **4,337 → 11** (99.75%). The
  tail is doc-comment `[Type]` references + `meta` that `dart fix` still
  cleans.
- **Final post-fix output is byte-identical** to before (`dart fix` was
  already removing these) — verified by normalized A/B diff, 0 files
  differ.
- Analyze-clean across github, discord, backstage, petstore,
  spacetraders.

## Not a perf win (context)

This came out of profiling generation speed, where `dart fix --apply`
dominates (≈47s of github's 57s). It's **analysis-bound**: removing
~4,300 fixes shaved only **~2.6s / 5.5%** off `dart fix`. The real
speedup needs *every* fix category gone so the `dart fix` call can be
dropped. This lands as the largest single output-quality step toward
that — files read as hand-written, with far less reliance on the fix
crutch.

## Verification

- New tests: api imports pruned when the body names no sentinel;
  `importsForModel` imports a named newtype field but not a type nested
  only inside it.
- Full `dart test` green; `dart analyze` + `dart format` clean.
- Byte-identical github regen (post-fix); all five specs analyze-clean.