### PR TITLE
refactor: substitute String path params bare, don't over-interpolate

### DIFF
--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -15,6 +15,11 @@ import 'package:space_gen/src/resolver.dart';
 import 'package:space_gen/src/string.dart';
 import 'package:space_gen/src/types.dart';
 
+/// A Dart expression that is a single bare identifier — no member
+/// access, call, or operator — so it can be interpolated without braces
+/// (`'$x'` rather than `'${x}'`).
+final _bareIdentifier = RegExp(r'^[a-zA-Z_$][\w$]*$');
+
 String avoidReservedWord(String value) {
   if (isReservedWord(value)) {
     return '${value}_';
@@ -1212,12 +1217,26 @@ class Endpoint implements ToTemplateContext {
     for (final p in parameters) {
       if (p.inLocation != ParameterLocation.path) continue;
       buffer.write(
-        ".replaceAll('${p.bracketedName}', "
-        "'\${ ${p.toJsonExpression(context)} }')",
+        ".replaceAll('${p.bracketedName}', ${_pathReplacement(p, context)})",
       );
     }
     buffer.write(',');
     return buffer.toString();
+  }
+
+  /// The `replaceAll` replacement expression for path parameter [p]. It
+  /// must evaluate to a `String`.
+  ///
+  /// When the parameter's wire type is already `String`, the bare
+  /// expression is used directly — wrapping it in an interpolation
+  /// (`'${x}'`) is redundant (`unnecessary_string_interpolations`).
+  /// Otherwise the value is interpolated to stringify it, with the
+  /// braces dropped for a bare identifier
+  /// (`unnecessary_brace_in_string_interps`).
+  String _pathReplacement(RenderParameter p, SchemaRenderer context) {
+    final expr = p.toJsonExpression(context);
+    if (p.type.jsonStorageDartType == DartType.string) return expr;
+    return _bareIdentifier.hasMatch(expr) ? "'\$$expr'" : "'\${$expr}'";
   }
 
   List<String> _queryParamsLines(

--- a/test/render/render_operation_test.dart
+++ b/test/render/render_operation_test.dart
@@ -64,7 +64,7 @@ void main() {
         '    ) async {\n'
         '        final response = await client.invokeApi(\n'
         '            method: Method.post,\n'
-        "            path: '/pet/{petId}/uploadImage'.replaceAll('{petId}', '\${ petId }'),\n"
+        "            path: '/pet/{petId}/uploadImage'.replaceAll('{petId}', '\$petId'),\n"
         '            body: uint8List,\n'
         '            bodyContentType: BodyContentType.octetStream,\n'
         '        );\n'
@@ -75,6 +75,39 @@ void main() {
         '    }\n'
         '}\n',
       );
+    });
+
+    test('String path parameter substitutes bare, without interpolation', () {
+      // A String path parameter is already a String, so it substitutes
+      // directly — no `'${...}'` wrapper (which would trip
+      // unnecessary_string_interpolations / _brace_in_string_interps).
+      final operation = {
+        'tags': ['pet'],
+        'summary': 'Get by name.',
+        'operationId': 'getByName',
+        'parameters': [
+          {
+            'name': 'name',
+            'in': 'path',
+            'required': true,
+            'schema': {'type': 'string'},
+          },
+        ],
+        'responses': {
+          '200': {'description': 'ok'},
+        },
+      };
+      final result = runWithLogger(
+        _MockLogger(),
+        () => renderTestOperation(
+          path: '/pet/{name}',
+          operationJson: operation,
+          serverUrl: Uri.parse('https://example.com'),
+        ),
+      );
+      expect(result, contains(".replaceAll('{name}', name)"));
+      expect(result, isNot(contains(r"'${ name }'")));
+      expect(result, isNot(contains(r"'$name'")));
     });
 
     test('multipart/form-data with required file only', () {


### PR DESCRIPTION
## Summary

`_pathArgLine` wrapped every path-parameter substitution in an
interpolation:

```dart
path: '/orgs/{org}/...'.replaceAll('{org}', '${ org }'),
```

For a `String`-typed parameter the value is *already* a `String`, so both
the interpolation and its braces are redundant. That single expression
was the entire source of two lint categories on the github regen:
**2,014 `unnecessary_brace_in_string_interps` + 1,617
`unnecessary_string_interpolations` = 3,631 fixes** — the largest
remaining cleanup.

Now the replacement is emitted by wire type:

```dart
// String param — already a String, substitute bare:
.replaceAll('{org}', org)
// non-String param — interpolate to stringify, braces dropped for a
// bare identifier:
.replaceAll('{petId}', '$petId')
```

Both forms are lint-clean.

## Impact

- github raw (fix-disabled): `unnecessary_brace_in_string_interps`
  **2,014 → 0** and `unnecessary_string_interpolations` **1,617 → 0**.
  Both categories fully eliminated.
- **Final post-fix output is byte-identical** except a handful of path
  lines that no longer needlessly wrap — the shorter bare expression now
  fits on one line (the old longer form was pushed over 80 cols and left
  permanently wrapped by `dart fix` + `dart format`). Verified by
  normalized A/B: every changed line is a collapsed `replaceAll`
  one-liner, no content differences.
- analyze-clean across github, discord, backstage, petstore,
  spacetraders.

## Not a perf win (context)

`dart fix` remains analysis-bound, so this doesn't move its wall-clock
meaningfully. It's an output-quality step (and the largest single lint
category left). `noop_primitive_operations` (~2,045, the
`response.body.toString()` pattern) is the next distinct target.

## Verification

- New test: a String path parameter substitutes bare (no `'${...}'`);
  existing int-param test updated to the braceless `'$petId'` form.
- Full `dart test` green; `dart analyze` + `dart format` clean.
- Byte-identical github regen (post-fix); all five specs analyze-clean.