### PR TITLE
refactor: drop noop .toString() on values already String

### DIFF
--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -20,6 +20,15 @@ import 'package:space_gen/src/types.dart';
 /// (`'$x'` rather than `'${x}'`).
 final _bareIdentifier = RegExp(r'^[a-zA-Z_$][\w$]*$');
 
+/// Coerces [expr] — the wire value of [schema] — to a `String`, adding
+/// `.toString()` only when the value isn't already one. Query/header
+/// params must hand `String`s to the client; calling `.toString()` on a
+/// value that is already a `String` (raw strings, dateTime/date/uri
+/// pods that serialize to `String`, string enums) is a
+/// `noop_primitive_operations` lint.
+String _stringifyWireValue(RenderSchema schema, String expr) =>
+    schema.jsonStorageDartType == DartType.string ? expr : '$expr.toString()';
+
 String avoidReservedWord(String value) {
   if (isReservedWord(value)) {
     return '${value}_';
@@ -1277,7 +1286,8 @@ class Endpoint implements ToTemplateContext {
         context,
         dartIsNullable: false,
       );
-      final items = '$dartName.map((e) => $itemsToJson.toString())';
+      final item = _stringifyWireValue(paramType.items, itemsToJson);
+      final items = '$dartName.map((e) => $item)';
       // `explode: false` (style=form) comma-joins the array into a single
       // value (`?k=a,b,c`) rather than repeating the key. Wrap the joined
       // string in a 1-element list so it flows through the same
@@ -1289,7 +1299,7 @@ class Endpoint implements ToTemplateContext {
         context,
         dartIsNullable: false,
       );
-      value = '[$scalarToJson.toString()]';
+      value = '[${_stringifyWireValue(paramType, scalarToJson)}]';
     }
     if (p.isNullable) {
       return "${innerIndent}if ($dartName != null) '${p.name}': $value,";
@@ -1342,7 +1352,8 @@ class Endpoint implements ToTemplateContext {
         context,
         dartIsNullable: false,
       );
-      final mapCall = ".map((e) => $itemsToJson.toString()).join(',')";
+      final item = _stringifyWireValue(paramType.items, itemsToJson);
+      final mapCall = ".map((e) => $item).join(',')";
       final value = p.isNullable ? '?$dartName?$mapCall' : '$dartName$mapCall';
       return "$innerIndent'${p.name}': $value,";
     }
@@ -4384,6 +4395,9 @@ abstract class RenderEnum<T extends Object> extends RenderNewType {
       'typeName': typeName,
       'nullableTypeName': nullableTypeName(context),
       'valueDartType': valueDartType,
+      // A string enum's `value` is already a `String`, so `toString()`
+      // returns it directly; an int enum must convert (see the template).
+      'valueIsString': jsonStorageDartType == DartType.string,
       'enumValues': [
         for (var i = 0; i < values.length; i++) enumValueToTemplateContext(i),
       ],

--- a/lib/templates/api.mustache
+++ b/lib/templates/api.mustache
@@ -25,12 +25,12 @@
             {{#hasErrorType}}
             throw ApiException<{{{ errorType }}}>(
                 response.statusCode,
-                response.body.toString(),
+                response.body,
                 body: {{{ errorFromJson }}},
             );
             {{/hasErrorType}}
             {{^hasErrorType}}
-            throw ApiException<Object?>(response.statusCode, response.body.toString());
+            throw ApiException<Object?>(response.statusCode, response.body);
             {{/hasErrorType}}
         }
 {{^isVoidReturn}}

--- a/lib/templates/schema_enum.mustache
+++ b/lib/templates/schema_enum.mustache
@@ -33,5 +33,5 @@
 
     /// Returns the string form of the enum.
     @override
-    String toString() => value.toString();
+    String toString() => value{{^valueIsString}}.toString(){{/valueIsString}};
 }

--- a/test/render/render_operation_test.dart
+++ b/test/render/render_operation_test.dart
@@ -70,7 +70,7 @@ void main() {
         '        );\n'
         '\n'
         '        if (response.statusCode >= HttpStatus.badRequest) {\n'
-        '            throw ApiException<Object?>(response.statusCode, response.body.toString());\n'
+        '            throw ApiException<Object?>(response.statusCode, response.body);\n'
         '        }\n'
         '    }\n'
         '}\n',
@@ -108,6 +108,40 @@ void main() {
       expect(result, contains(".replaceAll('{name}', name)"));
       expect(result, isNot(contains(r"'${ name }'")));
       expect(result, isNot(contains(r"'$name'")));
+    });
+
+    test('String query parameter is not stringified with .toString()', () {
+      // A String query param already produces a String, so no
+      // `.toString()` (which would trip noop_primitive_operations). An
+      // int param keeps it, since it genuinely converts.
+      final operation = {
+        'tags': ['pet'],
+        'operationId': 'search',
+        'parameters': [
+          {
+            'name': 'q',
+            'in': 'query',
+            'schema': {'type': 'string'},
+          },
+          {
+            'name': 'page',
+            'in': 'query',
+            'schema': {'type': 'integer'},
+          },
+        ],
+        'responses': {
+          '200': {'description': 'ok'},
+        },
+      };
+      final result = renderTestOperation(
+        path: '/search',
+        operationJson: operation,
+        serverUrl: Uri.parse('https://example.com'),
+      );
+      expect(result, contains("'q': [q],"));
+      expect(result, isNot(contains('q.toString()')));
+      // int param still converts.
+      expect(result, contains("'page': [page.toString()],"));
     });
 
     test('multipart/form-data with required file only', () {
@@ -397,7 +431,7 @@ void main() {
         '        );\n'
         '\n'
         '        if (response.statusCode >= HttpStatus.badRequest) {\n'
-        '            throw ApiException<Object?>(response.statusCode, response.body.toString());\n'
+        '            throw ApiException<Object?>(response.statusCode, response.body);\n'
         '        }\n'
         '    }\n'
         '}\n',
@@ -444,7 +478,7 @@ void main() {
         '        );\n'
         '\n'
         '        if (response.statusCode >= HttpStatus.badRequest) {\n'
-        '            throw ApiException<Object?>(response.statusCode, response.body.toString());\n'
+        '            throw ApiException<Object?>(response.statusCode, response.body);\n'
         '        }\n'
         '    }\n'
         '}\n',
@@ -533,7 +567,7 @@ void main() {
           '        );\n'
           '\n'
           '        if (response.statusCode >= HttpStatus.badRequest) {\n'
-          '            throw ApiException<Object?>(response.statusCode, response.body.toString());\n'
+          '            throw ApiException<Object?>(response.statusCode, response.body);\n'
           '        }\n'
           '\n'
           '        return switch (response.statusCode) {\n'
@@ -589,7 +623,7 @@ void main() {
         '        );\n'
         '\n'
         '        if (response.statusCode >= HttpStatus.badRequest) {\n'
-        '            throw ApiException<Object?>(response.statusCode, response.body.toString());\n'
+        '            throw ApiException<Object?>(response.statusCode, response.body);\n'
         '        }\n'
         '\n'
         '        if (response.body.isNotEmpty) {\n'
@@ -824,7 +858,7 @@ void main() {
         '        );\n'
         '\n'
         '        if (response.statusCode >= HttpStatus.badRequest) {\n'
-        '            throw ApiException<Object?>(response.statusCode, response.body.toString());\n'
+        '            throw ApiException<Object?>(response.statusCode, response.body);\n'
         '        }\n'
         '\n'
         '        if (response.body.isNotEmpty) {\n'
@@ -866,7 +900,7 @@ void main() {
         '        );\n'
         '\n'
         '        if (response.statusCode >= HttpStatus.badRequest) {\n'
-        '            throw ApiException<Object?>(response.statusCode, response.body.toString());\n'
+        '            throw ApiException<Object?>(response.statusCode, response.body);\n'
         '        }\n'
         '    }\n'
         '}\n',
@@ -979,12 +1013,12 @@ void main() {
         '            method: Method.post,\n'
         "            path: '/users',\n"
         '            queryParameters: {\n'
-        "                if (foo != null) 'foo': [foo.toString()],\n"
+        "                if (foo != null) 'foo': [foo],\n"
         '            },\n'
         '        );\n'
         '\n'
         '        if (response.statusCode >= HttpStatus.badRequest) {\n'
-        '            throw ApiException<Object?>(response.statusCode, response.body.toString());\n'
+        '            throw ApiException<Object?>(response.statusCode, response.body);\n'
         '        }\n'
         '    }\n'
         '}\n',
@@ -1038,12 +1072,12 @@ void main() {
         '            method: Method.post,\n'
         "            path: '/users',\n"
         '            queryParameters: {\n'
-        "                if (foo != null) 'foo': foo.map((e) => e.toString()).toList(),\n"
+        "                if (foo != null) 'foo': foo.map((e) => e).toList(),\n"
         '            },\n'
         '        );\n'
         '\n'
         '        if (response.statusCode >= HttpStatus.badRequest) {\n'
-        '            throw ApiException<Object?>(response.statusCode, response.body.toString());\n'
+        '            throw ApiException<Object?>(response.statusCode, response.body);\n'
         '        }\n'
         '    }\n'
         '}\n',
@@ -1079,7 +1113,7 @@ void main() {
       // string is wrapped in a 1-element list for the Map<String, List<String>>.
       expect(
         result,
-        contains("'foo': [foo.map((e) => e.toString()).join(',')],"),
+        contains("'foo': [foo.map((e) => e).join(',')],"),
       );
     });
 
@@ -1130,7 +1164,7 @@ void main() {
         '        );\n'
         '\n'
         '        if (response.statusCode >= HttpStatus.badRequest) {\n'
-        '            throw ApiException<Object?>(response.statusCode, response.body.toString());\n'
+        '            throw ApiException<Object?>(response.statusCode, response.body);\n'
         '        }\n'
         '    }\n'
         '}\n',
@@ -1218,14 +1252,14 @@ void main() {
         '            method: Method.post,\n'
         "            path: '/users',\n"
         '            queryParameters: {\n'
-        "                if (foo != null) 'foo': [foo.toString()],\n"
+        "                if (foo != null) 'foo': [foo],\n"
         "                if (bar != null) 'bar': [bar.toString()],\n"
         "                if (baz != null) 'baz': [baz.toString()],\n"
         '            },\n'
         '        );\n'
         '\n'
         '        if (response.statusCode >= HttpStatus.badRequest) {\n'
-        '            throw ApiException<Object?>(response.statusCode, response.body.toString());\n'
+        '            throw ApiException<Object?>(response.statusCode, response.body);\n'
         '        }\n'
         '    }\n'
         '}\n',
@@ -1277,7 +1311,7 @@ void main() {
           '        );\n'
           '\n'
           '        if (response.statusCode >= HttpStatus.badRequest) {\n'
-          '            throw ApiException<Object?>(response.statusCode, response.body.toString());\n'
+          '            throw ApiException<Object?>(response.statusCode, response.body);\n'
           '        }\n'
           '    }\n'
           '}\n',
@@ -1330,7 +1364,7 @@ void main() {
         '        );\n'
         '\n'
         '        if (response.statusCode >= HttpStatus.badRequest) {\n'
-        '            throw ApiException<Object?>(response.statusCode, response.body.toString());\n'
+        '            throw ApiException<Object?>(response.statusCode, response.body);\n'
         '        }\n'
         '\n'
         '        if (response.body.isNotEmpty) {\n'
@@ -1442,7 +1476,7 @@ void main() {
         '        );\n'
         '\n'
         '        if (response.statusCode >= HttpStatus.badRequest) {\n'
-        '            throw ApiException<Object?>(response.statusCode, response.body.toString());\n'
+        '            throw ApiException<Object?>(response.statusCode, response.body);\n'
         '        }\n'
         '\n'
         '        if (response.body.isNotEmpty) {\n'
@@ -1510,7 +1544,7 @@ void main() {
         '        );\n'
         '\n'
         '        if (response.statusCode >= HttpStatus.badRequest) {\n'
-        '            throw ApiException<Object?>(response.statusCode, response.body.toString());\n'
+        '            throw ApiException<Object?>(response.statusCode, response.body);\n'
         '        }\n'
         '\n'
         '        if (response.body.isNotEmpty) {\n'
@@ -1585,7 +1619,7 @@ void main() {
         '        );\n'
         '\n'
         '        if (response.statusCode >= HttpStatus.badRequest) {\n'
-        '            throw ApiException<Object?>(response.statusCode, response.body.toString());\n'
+        '            throw ApiException<Object?>(response.statusCode, response.body);\n'
         '        }\n'
         '\n'
         '        if (response.body.isNotEmpty) {\n'
@@ -1724,7 +1758,7 @@ void main() {
         '        if (response.statusCode >= HttpStatus.badRequest) {\n'
         '            throw ApiException<GetWidgetsDefaultResponse>(\n'
         '                response.statusCode,\n'
-        '                response.body.toString(),\n'
+        '                response.body,\n'
         '                body: GetWidgetsDefaultResponse.fromJson(jsonDecode(response.body) as Map<String, dynamic>),\n'
         '            );\n'
         '        }\n'
@@ -1849,7 +1883,7 @@ void main() {
           result,
           contains(
             'throw ApiException<Object?>(response.statusCode, '
-            'response.body.toString());',
+            'response.body);',
           ),
         );
       },

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -3984,7 +3984,7 @@ void main() {
         '\n'
         '    /// Returns the string form of the enum.\n'
         '    @override\n'
-        '    String toString() => value.toString();\n'
+        '    String toString() => value;\n'
         '}\n',
       );
     });
@@ -5003,7 +5003,7 @@ void main() {
           expect(
             result,
             contains(
-              "                if (tags != null) 'tags': tags.map((e) => e.toString()).toList(),",
+              "                if (tags != null) 'tags': tags.map((e) => e).toList(),",
             ),
           );
           // The buggy old emission must be gone — `?tags?.toString()` would
@@ -5040,7 +5040,7 @@ void main() {
         expect(
           result,
           contains(
-            "                'X-Tags': xTags.map((e) => e.toString()).join(','),",
+            "                'X-Tags': xTags.map((e) => e).join(','),",
           ),
         );
       });
@@ -5102,7 +5102,7 @@ void main() {
           '        );\n'
           '\n'
           '        if (response.statusCode >= HttpStatus.badRequest) {\n'
-          '            throw ApiException<Object?>(response.statusCode, response.body.toString());\n'
+          '            throw ApiException<Object?>(response.statusCode, response.body);\n'
           '        }\n'
           '    }\n'
           '}\n',
@@ -5179,7 +5179,7 @@ void main() {
         '        );\n'
         '\n'
         '        if (response.statusCode >= HttpStatus.badRequest) {\n'
-        '            throw ApiException<Object?>(response.statusCode, response.body.toString());\n'
+        '            throw ApiException<Object?>(response.statusCode, response.body);\n'
         '        }\n'
         '    }\n'
         '}\n',


### PR DESCRIPTION
## Summary

Three render sites called `.toString()` on values that are *already*
`String`, tripping `noop_primitive_operations` — **2,045 fixes on the
github regen**, the largest remaining category:

1. **Error handling** — `throw ApiException(status, response.body.toString())`.
   `response.body` is a `String`; now passed directly (**1,035 sites**).
2. **Query/header params** — every scalar and array item ran through
   `.toString()` to satisfy the `Map<String, List<String>>` /
   `Map<String, String>` shape, a no-op when the wire value is already a
   `String`. A shared `_stringifyWireValue(schema, expr)` helper appends
   `.toString()` only when the wire type isn't `String` — `int`/`double`/
   `bool` params still convert.
3. **Enum `toString()`** — `String toString() => value.toString()` is a
   no-op for a *string* enum (`value` is already a `String`). Gated on a
   new `valueIsString` flag: string enums emit `=> value`, int enums keep
   `=> value.toString()`.

## Impact

- github raw (fix-disabled) `noop_primitive_operations`: **2,045 → 0**.
- **Final post-fix output is byte-identical** except error-throw lines
  that no longer needlessly wrap — the shorter expression now fits on one
  line (the old `.toString()` form was pushed over 80 cols and left
  permanently wrapped by `dart fix` + `dart format`). Verified by
  normalized A/B: every changed line is a collapsed `ApiException`
  one-liner, no content differences.
- analyze-clean across github, discord, backstage, petstore,
  spacetraders. Discord (int enums) and petstore generated round-trip
  suites pass — the string/int enum `toString()` split is correct.

## Not a perf win (context)

`dart fix` remains analysis-bound, so this doesn't move its wall-clock
meaningfully. It's the largest remaining output-quality cleanup. Next
distinct targets: `prefer_const_constructors_in_immutables` (~1,185),
`always_put_required_named_parameters_first` (~946).

## Verification

- New test: a String query param emits `'q': [q]` (no `.toString()`),
  while an int param keeps `.toString()`; existing enum `toString` test
  updated to the string-enum `=> value` form.
- Full `dart test` green; `dart analyze` + `dart format` clean.
- Byte-identical github regen (post-fix); five specs analyze-clean;
  discord + petstore generated suites pass.