### PR TITLE
refactor: emit const constructors for immutable model classes

### DIFF
--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -3734,6 +3734,15 @@ class RenderObject extends RenderNewType {
       'hasAdditionalProperties': hasAdditionalProperties,
       'hasNoJsonProperty': hasNoJsonProperty,
       'assignmentsLine': assignmentsLine,
+      // The constructor can be `const` when the class is `@immutable`
+      // (fields are `final`) and there's no initializer list — the only
+      // initializers we emit are `this.x = x ?? <non-const default>`,
+      // which reference the runtime parameter and so aren't const.
+      // Const-constructible `@immutable` classes trip
+      // `prefer_const_constructors_in_immutables` otherwise. The sealed
+      // parent of a smooshed variant already declares `const`, so
+      // variants can be const too.
+      'canBeConst': !context.quirks.mutableModels && assignmentsLine == null,
       'additionalPropertiesName': 'entries', // Matching OpenAPI.
       'valueSchema': valueSchema?.typeName,
       'operatorIndexType': operatorIndexType,

--- a/lib/templates/schema_object.mustache
+++ b/lib/templates/schema_object.mustache
@@ -1,6 +1,6 @@
 {{{ doc_comment }}}{{^mutableModels}}@immutable{{/mutableModels}}
 {{#parentSealedTypeName}}final {{/parentSealedTypeName}}class {{ typeName }}{{#parentSealedTypeName}} extends {{ parentSealedTypeName }}{{/parentSealedTypeName}} {
-    {{{ constructor_doc_comment }}}{{ typeName }}(
+    {{{ constructor_doc_comment }}}{{#canBeConst}}const {{/canBeConst}}{{ typeName }}(
         {{#hasProperties}}
         { {{#properties}}{{^isConstGetter}}{{{ argumentLine }}}, {{/isConstGetter}}{{/properties}}
         {{#hasAdditionalProperties}}required this.{{additionalPropertiesName}},{{/hasAdditionalProperties}} }

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -22,7 +22,7 @@ void main() {
         result,
         '@immutable\n'
         'class Test {\n'
-        '    Test(\n'
+        '    const Test(\n'
         '        { this.foo, \n'
         '         }\n'
         '    );\n'
@@ -498,7 +498,7 @@ void main() {
           result,
           '@immutable\n'
           'class Test {\n'
-          '    Test(\n'
+          '    const Test(\n'
           '        { required this.foo, \n'
           '         }\n'
           '    );\n'
@@ -647,7 +647,7 @@ void main() {
           result,
           '@immutable\n'
           'class Test {\n'
-          '    Test(\n'
+          '    const Test(\n'
           '        { required this.foo, \n'
           '         }\n'
           '    );\n'
@@ -717,7 +717,7 @@ void main() {
         result,
         '@immutable\n'
         'class Test {\n'
-        '    Test(\n'
+        '    const Test(\n'
         '        { this.foo, this.bar, \n'
         '         }\n'
         '    );\n'
@@ -3271,7 +3271,7 @@ void main() {
           user,
           '@immutable\n'
           'class User {\n'
-          '    User(\n'
+          '    const User(\n'
           '        { required this.foo, \n'
           '         }\n'
           '    );\n'
@@ -3333,7 +3333,7 @@ void main() {
         result,
         '@immutable\n'
         'class Test {\n'
-        '    Test(\n'
+        '    const Test(\n'
         '        { this.map, \n'
         '         }\n'
         '    );\n'
@@ -3429,7 +3429,7 @@ void main() {
         result,
         '@immutable\n'
         'class Test {\n'
-        '    Test(\n'
+        '    const Test(\n'
         '        { this.mString, this.mInt, this.mNumber, this.mBoolean, this.mDateTime, this.mUri, this.mMapOfString, this.mEnum, this.mUnknown, \n'
         '         }\n'
         '    );\n'
@@ -3570,7 +3570,7 @@ void main() {
         result,
         '@immutable\n'
         'class Test {\n'
-        '    Test(\n'
+        '    const Test(\n'
         '        { this.aString = const [], this.aInt = const [], this.aNumber = const [], this.aBoolean = const [], this.aDateTime = const [], this.aUri = const [], this.aArrayOfString = const [], this.aEnum = const [], this.aUnknown = const [], \n'
         '         }\n'
         '    );\n'
@@ -3698,7 +3698,7 @@ void main() {
         result,
         '@immutable\n'
         'class Test {\n'
-        '    Test(\n'
+        '    const Test(\n'
         '        { this.a, \n'
         '         }\n'
         '    );\n'
@@ -3895,7 +3895,7 @@ void main() {
         result,
         '@immutable\n'
         'class Test {\n'
-        '    Test(\n'
+        '    const Test(\n'
         "        { this.a = const <String>['a', 'b'], \n"
         '         }\n'
         '    );\n'
@@ -4084,7 +4084,7 @@ void main() {
         result,
         '@immutable\n'
         'class Test {\n'
-        '    Test(\n'
+        '    const Test(\n'
         '        { this.fooBar, this.notPrivate, this.barBaz, this.n123, this.plus1, this.minus1, this.dont, this.default_, \n'
         '         }\n'
         '    );\n'
@@ -4307,7 +4307,7 @@ void main() {
           result,
           '@immutable\n'
           'class Test {\n'
-          '    Test(\n'
+          '    const Test(\n'
           '        { this.a = 1.2, \n'
           '         }\n'
           '    );\n'
@@ -4475,7 +4475,7 @@ void main() {
           result,
           '@immutable\n'
           'class Test {\n'
-          '    Test(\n'
+          '    const Test(\n'
           '        { this.a = 1, \n'
           '         }\n'
           '    );\n'
@@ -4667,7 +4667,7 @@ void main() {
           '@immutable\n'
           'class Test {\n'
           '    /// {@macro test}\n'
-          '    Test(\n'
+          '    const Test(\n'
           '        { this.a, this.b, \n'
           '         }\n'
           '    );\n'
@@ -4734,7 +4734,7 @@ void main() {
           result,
           '@immutable\n'
           'class Test {\n'
-          '    Test(\n'
+          '    const Test(\n'
           '        { @deprecated this.a, \n'
           '         }\n'
           '    );\n'
@@ -4799,7 +4799,7 @@ void main() {
           renderTestSchema(json, asComponent: true),
           '@immutable\n'
           'class Test {\n'
-          '    Test(\n'
+          '    const Test(\n'
           '        { required this.reqNull, this.optNull, required this.req, this.opt, \n'
           '         }\n'
           '    );\n'
@@ -4888,7 +4888,7 @@ void main() {
           renderTestSchema(json),
           '@immutable\n'
           'class Test {\n'
-          '    Test(\n'
+          '    const Test(\n'
           '        { this.a, \n'
           '         }\n'
           '    );\n'


### PR DESCRIPTION
## Summary

Generated `@immutable` model classes had non-`const` constructors,
tripping `prefer_const_constructors_in_immutables` — **1,185 on the
github regen**, the largest remaining category.

The constructor is const-able whenever the class is `@immutable` (fields
are `final`) and there's no initializer list — the only initializers the
generator emits are `this.x = x ?? <non-const default>` (for
datetime/uri/uriTemplate defaults), which reference the runtime
parameter and so can't be const. A new `canBeConst` flag
(`!mutableModels && assignmentsLine == null`) gates the keyword.

Smooshed variants are covered too: the sealed parent already declares
`const Parent();`, so a variant's implicit `super()` call stays const.

## Impact

- github raw (fix-disabled) `prefer_const_constructors_in_immutables`:
  **1,185 → 0**.
- `dart fix` was already adding `const` to these constructors, so the
  **final post-fix output is byte-identical** (0-diff normalized A/B).
- Making constructors const now lets call sites be const, so
  `prefer_const_constructors` rises in the *pre-fix* output (mostly in
  generated tests). `dart fix` still cleans those, so the final output is
  unchanged; const-ing those call sites at generation is a natural
  follow-up.
- analyze-clean across github, discord, backstage, petstore,
  spacetraders. petstore/discord generated round-trip suites pass —
  `const` doesn't affect behavior.

## Not a perf win (context)

Output-neutral after fix; `dart fix` stays analysis-bound. This is the
largest remaining output-quality cleanup (the generator now emits const
value types, as handwritten Dart would). Remaining largest:
`always_put_required_named_parameters_first` (~946), `unnecessary_parenthesis`
(~778), `avoid_redundant_argument_values` (~681).

## Verification

- Existing exact-match render tests updated to the `const` constructor
  form; the 3 non-const-able cases (datetime/uri/uriTemplate defaults)
  correctly stay bare.
- Full `dart test` green; `dart analyze` + `dart format` clean.
- Byte-identical github regen (post-fix); five specs analyze-clean.