### PR TITLE
refactor: don't parenthesize a bare numeric cast in fromJson

### DIFF
--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -3224,7 +3224,14 @@ abstract class RenderNumeric<T extends num> extends RenderSchema {
       dartIsNullable: dartIsNullable,
     );
     final toDartCall = jsonToDartCall(jsonIsNullable: jsonIsNullable);
-    return '($jsonValue as $jsonType)$toDartCall$orDefault';
+    final cast = '$jsonValue as $jsonType';
+    // A bare cast needs no parens (`unnecessary_parenthesis`). Keep them
+    // to bind a trailing `.toX()` tighter than `as`
+    // (`(json['x'] as num).toDouble()`), or around a `?? default` where
+    // the analyzer leaves the parens for readability
+    // (`(json['x'] as int?) ?? 0`).
+    if (toDartCall.isEmpty && orDefault.isEmpty) return cast;
+    return '($cast)$toDartCall$orDefault';
   }
 
   @override

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -3429,7 +3429,7 @@ void main() {
         '        json) {\n'
         "        return parseFromJson('Test', json, () => Test(\n"
         "            mString: (json['m_string'] as Map<String, dynamic>?)?.map((key, value) => MapEntry(key, value as String)),\n"
-        "            mInt: (json['m_int'] as Map<String, dynamic>?)?.map((key, value) => MapEntry(key, (value as int))),\n"
+        "            mInt: (json['m_int'] as Map<String, dynamic>?)?.map((key, value) => MapEntry(key, value as int)),\n"
         "            mNumber: (json['m_number'] as Map<String, dynamic>?)?.map((key, value) => MapEntry(key, (value as num).toDouble())),\n"
         "            mBoolean: (json['m_boolean'] as Map<String, dynamic>?)?.map((key, value) => MapEntry(key, value as bool)),\n"
         "            mDateTime: (json['m_date_time'] as Map<String, dynamic>?)?.map((key, value) => MapEntry(key, DateTime.parse(value as String))),\n"


### PR DESCRIPTION
## Summary

`RenderNumeric.fromJsonExpression` always wrapped the cast in parens —
`(json['id'] as int)` — but for a type that needs no `.toX()` conversion
(`int`) and has no `?? default`, the parens are noise:
`unnecessary_parenthesis`, **778 on the github regen**.

Emit the bare cast (`json['id'] as int`) in that case. The parens are
kept where they matter:

- binding a trailing `.toX()` tighter than `as` —
  `(json['x'] as num).toDouble()`;
- around a `?? default` — `(json['x'] as int?) ?? 0` — which the analyzer
  leaves alone for readability and `dart fix` never stripped.

## Impact

- github raw (fix-disabled) `unnecessary_parenthesis`: **778 → 0**.
- Final post-fix output differs from before in a **single file** by
  benign formatting only: the shorter bare cast lets `dart_style` lay a
  `() => Foo(subIssueId: json['x'] as int)` constructor arg on one line
  instead of the old trailing-comma-wrapped block — tokens identical.
  Keeping the `?? default` parens holds every other file byte-for-byte.
- analyze-clean across github, discord, backstage, petstore,
  spacetraders. petstore/discord generated suites pass.

## Not a perf win (context)

`dart fix` stays analysis-bound. Output-quality cleanup. Remaining
largest: `avoid_redundant_argument_values` (~681), then the const
call-site tail (`prefer_const_constructors` ~987 in generated tests,
`prefer_const_literals_to_create_immutables` ~169).

## Verification

- `fromJson` int-cast assertions updated to the bare form; the
  `?? default` and `.toDouble()` cases keep their parens.
- Full `dart test` green; `dart analyze` + `dart format` clean.
- github regen: one benign-formatting file, rest byte-identical; five
  specs analyze-clean.