### PR TITLE
refactor: stop emitting redundant default argument values

### DIFF
--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -1316,7 +1316,10 @@ class Endpoint implements ToTemplateContext {
         ],
         final RenderRequestBodySimple body => [
           '${indent}body: ${body.bodyExpression(context)},',
-          '${indent}bodyContentType: ${body.bodyContentTypeExpression},',
+          // invokeApi defaults bodyContentType to BodyContentType.json,
+          // so only pass it for the non-default content types.
+          if (!body.isDefaultBodyContentType)
+            '${indent}bodyContentType: ${body.bodyContentTypeExpression},',
         ],
       };
 
@@ -1963,6 +1966,12 @@ abstract class RenderRequestBodySimple extends RenderRequestBody {
   /// body, passed to `ApiClient.invokeApi(bodyContentType: ...)`.
   String get bodyContentTypeExpression;
 
+  /// Whether [bodyContentTypeExpression] is `invokeApi`'s default
+  /// (`BodyContentType.json`). When true the operation renderer omits
+  /// the redundant `bodyContentType:` argument
+  /// (`avoid_redundant_argument_values`).
+  bool get isDefaultBodyContentType => false;
+
   /// The Dart expression for the `body:` argument to `invokeApi`. For
   /// JSON: the map/list the client will `jsonEncode`. For octet-stream
   /// or text/plain: the parameter itself, passed through as-is.
@@ -1997,6 +2006,9 @@ class RenderRequestBodyJson extends RenderRequestBodySimple {
 
   @override
   String get bodyContentTypeExpression => 'BodyContentType.json';
+
+  @override
+  bool get isDefaultBodyContentType => true;
 
   @override
   String bodyExpression(SchemaRenderer context) => schema.toJsonExpression(
@@ -2807,7 +2819,9 @@ class RenderPod extends RenderSchema {
   String? exampleValue(SchemaRenderer context) {
     final raw = switch (type) {
       PodType.boolean => 'false',
-      PodType.dateTime => 'DateTime.utc(2024, 1, 1)',
+      // `month`/`day` default to 1, so passing them is redundant
+      // (`avoid_redundant_argument_values`).
+      PodType.dateTime => 'DateTime.utc(2024)',
       PodType.uri => "Uri.parse('https://example.com')",
       PodType.uriTemplate => "UriTemplate('https://example.com/{id}')",
       PodType.email => "'user@example.com'",
@@ -3877,6 +3891,15 @@ class RenderObject extends RenderNewType {
       if (rendersAsConstGetter(jsonName, property)) continue;
       final example = property.exampleValue(context);
       if (example == null) return null;
+      // A JSON-required property that also has a default renders as an
+      // optional constructor param `= <default>`; passing an example
+      // equal to that default is redundant
+      // (`avoid_redundant_argument_values`), so omit it — the field
+      // still takes the same value. Only a const default's string can
+      // match the example here (a `?? DateTime.parse(...)` initializer
+      // reads differently from `DateTime.utc(...)`), so this can't drop
+      // a genuinely-needed argument.
+      if (property.defaultValueString(context) == example) continue;
       final dartName = variableSafeName(context.quirks, jsonName);
       args.add('$dartName: $example');
     }

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -1918,6 +1918,15 @@ final class MultiStatusReturn extends OperationReturn {
   final String wrapperTypeName;
 }
 
+/// The `bodyContentType` value `ApiClient.invokeApi` defaults to (see
+/// the `bodyContentType` parameter default in `api_client.dart`). This
+/// describes the *client's* default, not any one body's content type —
+/// a body whose own `bodyContentTypeExpression` equals it omits the
+/// redundant `bodyContentType:` argument at the call site. It happens to
+/// be JSON today, but a JSON body still declares its type literally, so
+/// the two would diverge cleanly if the default ever changed.
+const defaultBodyContentTypeExpression = 'BodyContentType.json';
+
 /// Sealed so the endpoint arg-builder can pattern-match exhaustively on
 /// the body shape: the multipart path emits `fields:`/`files:`, every
 /// other subclass emits `body:`/`bodyContentType:`. Adding a fifth shape
@@ -1966,11 +1975,11 @@ abstract class RenderRequestBodySimple extends RenderRequestBody {
   /// body, passed to `ApiClient.invokeApi(bodyContentType: ...)`.
   String get bodyContentTypeExpression;
 
-  /// Whether [bodyContentTypeExpression] is `invokeApi`'s default
-  /// (`BodyContentType.json`). When true the operation renderer omits
-  /// the redundant `bodyContentType:` argument
-  /// (`avoid_redundant_argument_values`).
-  bool get isDefaultBodyContentType => false;
+  /// Whether [bodyContentTypeExpression] is the value `invokeApi`
+  /// defaults `bodyContentType` to. When true the operation renderer
+  /// omits the redundant argument (`avoid_redundant_argument_values`).
+  bool get isDefaultBodyContentType =>
+      bodyContentTypeExpression == defaultBodyContentTypeExpression;
 
   /// The Dart expression for the `body:` argument to `invokeApi`. For
   /// JSON: the map/list the client will `jsonEncode`. For octet-stream
@@ -2006,9 +2015,6 @@ class RenderRequestBodyJson extends RenderRequestBodySimple {
 
   @override
   String get bodyContentTypeExpression => 'BodyContentType.json';
-
-  @override
-  bool get isDefaultBodyContentType => true;
 
   @override
   String bodyExpression(SchemaRenderer context) => schema.toJsonExpression(

--- a/test/render/file_renderer_test.dart
+++ b/test/render/file_renderer_test.dart
@@ -433,6 +433,59 @@ void main() {
       expect(body, contains('parsed.hashCode'));
     });
 
+    test('round-trip example omits args that match a default value', () async {
+      final fs = MemoryFileSystem.test();
+      final spec = {
+        'openapi': '3.1.0',
+        'info': {'title': 'Roundtrip', 'version': '1.0.0'},
+        'servers': [
+          {'url': 'https://example.com'},
+        ],
+        'paths': {
+          '/things': {
+            'get': {
+              'operationId': 'getThing',
+              'responses': {
+                '200': {
+                  'description': 'OK',
+                  'content': {
+                    'application/json': {
+                      'schema': {r'$ref': '#/components/schemas/Thing'},
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        'components': {
+          'schemas': {
+            'Thing': {
+              'type': 'object',
+              'required': ['id', 'private', 'createdAt'],
+              'properties': {
+                'id': {'type': 'integer'},
+                // JSON-required but has a default -> optional ctor param
+                // `= false`; the example (`false`) must not be passed.
+                'private': {'type': 'boolean', 'default': false},
+                // A date-time example uses DateTime.utc's own defaulted
+                // month/day, so no redundant `1, 1`.
+                'createdAt': {'type': 'string', 'format': 'date-time'},
+              },
+            },
+          },
+        },
+      };
+      final out = fs.directory('out');
+      await renderToDirectory(spec: spec, outDir: out);
+      final body = out
+          .childFile('test/models/thing_test.dart')
+          .readAsStringSync();
+      expect(body, contains('createdAt: DateTime.utc(2024)'));
+      expect(body, isNot(contains('DateTime.utc(2024, 1, 1)')));
+      expect(body, isNot(contains('private:')));
+    });
+
     test('enum round-trip test exercises toString and every value', () async {
       final fs = MemoryFileSystem.test();
       final spec = {

--- a/test/render/render_operation_test.dart
+++ b/test/render/render_operation_test.dart
@@ -437,6 +437,32 @@ void main() {
         '}\n',
       );
     });
+
+    test('application/json omits the default bodyContentType argument', () {
+      // invokeApi defaults bodyContentType to BodyContentType.json, so a
+      // JSON body passes only `body:` (avoid_redundant_argument_values).
+      final operation = {
+        'tags': ['pet'],
+        'operationId': 'createPet',
+        'requestBody': {
+          'content': {
+            'application/json': {
+              'schema': {'type': 'string'},
+            },
+          },
+        },
+        'responses': {
+          '200': {'description': 'OK'},
+        },
+      };
+      final result = renderTestOperation(
+        path: '/pet',
+        operationJson: operation,
+        serverUrl: Uri.parse('https://example.com'),
+      );
+      expect(result, contains('body: string,'));
+      expect(result, isNot(contains('bodyContentType:')));
+    });
   });
 
   group('multiple responses', () {


### PR DESCRIPTION
## Summary

Closes the three sources of `avoid_redundant_argument_values` on the
github regen (**681 total**):

1. **`bodyContentType` (277)** — `invokeApi` defaults `bodyContentType`
   to `BodyContentType.json`, so a JSON body was passing it needlessly. A
   `defaultBodyContentTypeExpression` constant names the *client's*
   default; `isDefaultBodyContentType` compares each body's own content
   type against it. The JSON body still declares `BodyContentType.json`
   literally (it's json because it's a json body), so it drops the
   argument while octet-stream / text-plain keep theirs — and the two
   would diverge cleanly if the default ever changed.
2. **DateTime example (~300)** — the round-trip example emitted
   `DateTime.utc(2024, 1, 1)`, but `DateTime.utc`'s `month`/`day` already
   default to `1` → `DateTime.utc(2024)`.
3. **const field defaults (~30)** — a JSON-required property with a
   default (e.g. `bool`, `default: false`) renders as an optional ctor
   param `= false`; the round-trip example passed the matching value.
   Skip an example arg when it equals the property's default string —
   only a *const* default's string can match here (a
   `?? DateTime.parse(...)` initializer reads differently from
   `DateTime.utc(...)`), so no genuinely-needed argument is dropped.

## Impact

- github raw (fix-disabled) `avoid_redundant_argument_values`: **681 → 0**.
- `dart fix` was already applying all three, so the **final post-fix
  output — `lib/` AND generated tests — is byte-identical** (0-diff
  normalized A/B).
- analyze-clean across github, discord, backstage, petstore,
  spacetraders. petstore (28) and discord (1530) generated round-trip
  suites pass — the example-arg skip never drops a required value.

## Not a perf win (context)

`dart fix` stays analysis-bound. Output-quality cleanup. After this, the
big remaining chunk is the const call-site tail
(`prefer_const_constructors` ~987, mostly generated tests +
`prefer_const_literals_to_create_immutables` ~169) from the const-ctor
cascade — closing it would get the count low enough to seriously weigh
dropping the `dart fix` call.

## Verification

- New tests: JSON body omits `bodyContentType:`; round-trip example uses
  `DateTime.utc(2024)` and omits a default-matching bool arg.
- Full `dart test` green; `dart analyze` + `dart format` clean.
- Byte-identical github regen (lib + tests); five specs analyze-clean;
  petstore + discord generated suites pass.


