### PR TITLE
docs: record + trim the spec-iteration skill (dart-fix arc)

### DIFF
--- a/.claude/skills/spec-iteration/SKILL.md
+++ b/.claude/skills/spec-iteration/SKILL.md
@@ -14,7 +14,7 @@ description: |
   any spec-driven follow-up.
 ---
 
-# State as of 2026-07-06 (the `dart fix` reduction arc)
+# Current state — the `dart fix` reduction arc (2026-07-06)
 
 This block supersedes the older sections for current status. It
 documents an in-progress arc; earlier blocks are retained for
@@ -186,200 +186,32 @@ the tiny categories.
   petstore (28) + discord (1530) generated round-trip suites are
   the fast correctness check.
 
-# State as of 2026-07-06 (Discord generated suite fully green)
+# What space_gen is / validation targets
 
-The `2026-04-30` section below is retained for history; this block
-supersedes it for current status.
+Iterate toward a best-in-class Dart OpenAPI generator: run real
+specs through it, fix one gap per PR, leave every tracked spec at
+least as good as before.
 
-## Headline
+**Validation targets** live in `~/Documents/GitHub/personal/gen_tests/`
+(parallel to the repo, not checked in; see the external-tracker
+memory). Regen each after an output-changing PR:
 
-**Discord went from 334 `UnimplementedError` stubs + 67 failing
-generated round-trip tests to 6 stubs and a 100%-passing generated
-test suite** over the 2026-07-05/06 session. github stayed the bar
-throughout (analyze-clean; byte-identical except two intentional
-bug fixes noted below).
+- **github** (`api.github.com.json`, ~1000 ops) — the primary
+  punching bag and the bar: `dart analyze`-clean with all generated
+  round-trip tests passing. Exercises oneOf, discriminators,
+  multi-status, big enums, recursion, status-code ranges.
+- **discord** (`discord.json`, ~511 schemas, OpenAPI 3.1) — integer
+  enums, regex-pattern string newtypes; generated suite green
+  (1530 tests), 6 genuine multi-variant-union stubs remain.
+- **backstage** (`backstage.yaml`) — analyze-clean, zero stubs.
+- **petstore** / **spacetraders** / **train-travel** — smoke + YAML
+  coverage. Plus `private_gen_tests/watchcrunch-api.json` (a
+  user-reported third-party spec).
 
-## Landed this session
-
-| PR | What |
-|---|---|
-| #234 | Collapse the OpenAPI 3.1 nullable idiom `oneOf: [{type: null}, T]` → `T?` (resolver: the `SchemaAnyOf` null-collapse existed but `SchemaOneOf` didn't; Discord spells all 290 sites as `oneOf`). Discord 334→38 stubs. |
-| #236 | Dispatch oneOf variants tagged by a `$ref`-to-enum pinned to a const (`allOf:[{$ref:E}] + enum:[v]` — the OpenAPI-3.0 "pinned enum" idiom). Parser captures the pin as `SchemaObject.constProperties`; `_tagValues` unifies it with bare-enum tags in the implicit-discriminator picker. **Also**: pinned tag renders as a fixed getter (`E get type => E.member`), not a ctor param (decision recorded in code + closed #238); and oneOf-of-consts enum members are named from spec `title:` (`AutomodActionType.blockMessage`, was `value1`). Discord 38→6 stubs. |
-| #241 | Skip the bogus `toString == toJson` generated test for int enums (String vs int category error). |
-| #243 | Restore int-enum `toString()` coverage #241 dropped, via a type-safe assertion (`equals(value.toJson().toString())`). |
-| #244 | Decode `List<Uri>`/`List<DateTime>` via `.map((e) => parse(e))`, not a broken `.cast<Uri>()` lazy view. Root cause: list-`fromJson` gated on `createsNewType` instead of the symmetric `shouldCallToJson` that `toJson` uses. Fixed a latent github bug too (one optional, un-exercised field). Discord generated suite → 0 failures. |
-
-## Open issues filed this session (the queue)
-
-- **#235** — model the multi-value enum restriction `allOf:[{$ref:E}]
-  + enum:[subset]` (a *restricted view* of an enum; 16 Discord sites,
-  none discriminators — a field-fidelity gap, not a stub).
-- **#237** — spurious `ignore_for_file:
-  unintended_html_in_doc_comment` fires on `<...>` inside backtick
-  code spans (`` `Map<String, dynamic>` ``). ~1145 github + 422
-  Discord files carry it, mostly false positives. Fix: strip code
-  spans before the tag check in `_dartdocHasHtmlTag`.
-- **#239** — detect "single legal value" properties *semantically*
-  (resolved-schema cardinality-1), not via the narrow `allOf`-ref
-  syntax that `_constTagValue` matches. Would unify github's ~299
-  bare single-value-enum tags with Discord's pinned refs and delete
-  `_constTagValue` — but changes github output (a scope decision).
-- **#240** — a lone scalar `const: "list"` becomes a single-value
-  *enum type + file* instead of a plain constant. The non-enum
-  sibling of the #236 pinned-const work.
-- **#238** — CLOSED. Kept the bespoke const getter over
-  final-with-default / static; rationale recorded in
-  `RenderObject.constProperties`.
-
-## Lessons worth keeping
-
-- **Deleting a failing generated test can silently drop coverage.**
-  #241 removed the int-enum `toString` test (the only caller of the
-  enum's `toString()`) → `DA:0`. #243 fixed it by correcting the
-  *assertion*, not removing the test. When a generated test fails,
-  ask "is this the only thing exercising that generated method?"
-  before deleting.
-- **`createsNewType` is NOT the "needs JSON conversion" predicate;
-  `shouldCallToJson` is.** They diverge for pods whose Dart type
-  differs from their wire type (`Uri`/`DateTime`/`uriTemplate`).
-  A `fromJson` gate must match its `toJson` gate — #244 was a
-  one-directional bug from using the wrong one.
-- **Recognize the semantic, not the syntax.** `_constTagValue`
-  (raw-JSON `allOf`-ref matcher) is a deliberately narrow, graceful
-  recognizer — fine for one idiom, but the honest model is
-  cardinality-1 at the resolved-schema level (#239). Documented as
-  such at the code; promote it if it needs to generalize.
-- **Branch fresh off `origin/main` every PR.** Committed onto an
-  already-merged branch once this session; recovered by
-  cherry-picking onto a fresh branch.
-
-## What's next (pick from here)
-
-- **The 6 remaining Discord stubs** — genuine multi-variant unions
-  (`*_actions_inner`, `*_options_inner`, `*_components_inner`,
-  `error_details`) that need real dispatch (no single-tag
-  discriminator). The last stub frontier.
-- **The const-modeling arc** — #239 (semantic cardinality-1) is the
-  keystone; #240 (lone const → plain const) rides on it.
-- **#237** — cheap, high-file-count cleanup (spurious lint
-  suppression); independent of everything else.
-- Regenerate the `~/Documents/GitHub/personal/gen_tests` tracker
-  after landing output-changing PRs (kept current through #244).
-
----
-
-# State as of 2026-04-30 (Discord blockers cleared)
-
-## What this is
-
-space_gen is iterating toward a "fantastic" Dart OpenAPI generator.
-The methodology: run real-world specs through it, see what breaks
-or reads ugly, fix one thing per PR. Each PR should leave every
-tracked spec at least as good as it was — ideally better.
-
-**Validation targets** (in `~/Documents/GitHub/personal/gen_tests/`,
-parallel to the repo, not checked in):
-
-- **github** — `api.github.com.json`, ~1000 operations, the primary
-  punching bag. Exercises everything (oneOf, discriminators,
-  multi-status responses, big enums, recursion, status code ranges,
-  complex error handling). Currently `dart analyze` clean on the
-  regen with all 6100+ generated round-trip tests passing — the
-  bar to maintain.
-- **Discord** — `discord.json`, ~511 schemas / 141 paths. OpenAPI
-  3.1. Snowflake IDs are `type: string` with a numeric pattern (so
-  no int64 wire-format trap), but exposes patterns github doesn't:
-  bitfield-style integer enums (132 sites, closed by #192), and
-  `type: string` newtype schemas with regex patterns (327
-  `validatePattern` call sites, closed by #194). Both blockers
-  cleared as of 2026-04-30 — Discord regen progresses well past
-  the parser-throw and the validation-call-site bug. Remaining
-  failures are different gaps surfaced by the now-deeper traversal.
-- **petstore** — `petstore.json`, the OpenAPI canonical example.
-  Smoke test for the basics.
-- **spacetraders** — `spacetraders.json`. Smaller real spec.
-- **train-travel** — `train-travel.yaml`. YAML-format coverage.
-
-There's also `private_gen_tests/watchcrunch-api.json` — a user-
-reported spec used as a third-party validation target (not Eric's
-own service).
-
-A "gap" can be any of:
-- `UnimplementedError` stub in generated code (always wrong).
-- Generated Dart that doesn't compile, doesn't analyze clean, or
-  fails its own round-trip tests.
-- Output that's correct but ugly (double-prefix names, redundant
-  `?`, fake oneOf wrappers, blank lines, etc.).
-- Missing OpenAPI feature (cookie params, multipart edge cases,
-  spec-side `nullable: true` quirks, etc.).
-- A lint that fires on the generated code (`comment_references`,
-  `prefer_single_quotes`, `lines_longer_than_80_chars`).
-- A real-spec author hits a snag and reports it.
-
-**Github status:** `dart analyze` clean on the regen. **3 stubs
-remain** (Group C only — the enumless anyOfs the skill suggests
-skipping). Stub Groups A (validation-error twins) and B (labels
-requestBody) closed in PRs #177 and #183. Generated test suite:
-6100+ tests, all passing — 41 round-trip-correctness bugs fixed
-in #184. Smoosh series complete: #168–#170 (predicate /
-discriminator / shape+hybrid dispatch), #179 (exclusive-by-use
-top-level $refs), #189 (inline allOf — `RepositoryRuleDetailed`'s
-21 wrappers folded into the sealed parent). Naming and dispatch
-arcs settled; structural dedup of operation-synthesized oneOfs
-landed in #180.
-
-**Discord status:** Both pre-existing parser/render blockers are
-now closed:
-
-- **Integer enums (132 sites)** — closed by **#192**. Generalized
-  `SchemaEnum.enumValues` from `List<String>` to a typed family
-  (`SchemaStringEnum` / `SchemaIntegerEnum`) mirroring the existing
-  `SchemaNumeric<T>` split. Composes with the multi-value-enum
-  implicit discriminator picker from #182.
-- **Pattern validation on newtype Strings (327 call sites)** —
-  closed by **#194**, taking the principled route. Validation now
-  lives in the newtype's own constructor (validate once at
-  construction) rather than at every API call site. Required
-  making synthesized example values actually satisfy their schema
-  (regex-aware candidate testing for strings, range/multipleOf-
-  aware for numerics) so the auto-generated round-trip tests
-  don't throw `ArgumentError` from `const Foo('example')` against
-  a regex newtype.
-
-The next thing to do with Discord is **regen and assess** — the
-deeper traversal will surface gaps that the parser-throw was
-masking. Run a `-v` regen and tally the warnings (see "Discovery"
-below).
-
-Discord notably does NOT motivate the int64/web design call from
-issue #185: their snowflake IDs are JSON strings with a numeric
-pattern, not `format: int64` — they sidestepped the precision
-problem by design. Only 7 int64 sites in the spec total, and one
-schema is literally named `Int53Type` to acknowledge the JS limit.
-
-**The picture beyond stubs and visible-output ugliness.** A `-v`
-regen surfaces feature gaps the skill historically didn't track.
-The github 2026-04-29 baseline:
-
-| Count | Category | What | Status |
-|------:|---|---|---|
-| 246 | `Ignoring: format=int64 (String)` | int64 transmitted as JSON string for precision | tracked in **issue #185** (web-aware codegen — needs design) |
-| 81 | `Unused: readOnly=true` | response-only fields not marked as such | tracked in **issue #186** (request/response split) |
-| 19 | `Unused: x-multi-segment=true` | github vendor extension (path-segment hint) | known; `-v` log only — no action needed |
-| 12 | `Ignoring: readOnly=…` (non-property slots) | readOnly outside a property — composes with #186 | tracked in **issue #186** |
-| 8 | `Unused: readOnly=false` | spec noise — explicit `false` matches default | acceptable noise |
-| 57 | `<Parent>OneOf<i>` wrappers in regen | naming gap — variants the heuristics don't catch | open (low priority — see "Naming polish") |
-| 6 | `_1` collision suffixes | snake-name collision resolution | open (low priority) |
-| 3 | enumless-anyOf stubs | Group C — skill says skip (try-each is order-dependent) | parked |
-| 2 | `Ignoring: required (List<…>)` | parser drops `required: [foo]` when `foo` isn't a real property | landed in #184; the warn-log is the feature |
-| various | unknown formats | `repo.nwo`, `timestamp` | open (low value) |
-
-Gen one of these and you'll likely find more than one PR's worth
-of work. **Mine the verbose log first** — see "Discovery" below
-under "Open gaps". The naming/smoosh/dispatch arc has settled;
-the next high-leverage tracks are issue #185 (web-aware codegen)
-and issue #186 (readOnly request/response split) — both need
-design passes before code.
+A "gap" is any of: an `UnimplementedError` stub; generated Dart
+that doesn't compile / analyze-clean / pass its round-trip tests;
+correct-but-ugly output; a missing OpenAPI feature; a lint that
+fires on generated code; or a real-spec author's reported snag.
 
 ## Architecture
 
@@ -507,74 +339,6 @@ its switch arm — pre-composed in render code so the template just
 splices it. Smooshed: `<Variant>.fromJson(<arg>)`. Non-smooshed:
 `<Wrapper>(<Variant>.fromJson(<arg>))`.
 
-## Recent PRs
-
-The 2026-04-28/29 fan-out (12 PRs in one night, 11 landed):
-
-| PR | What |
-|---|---|
-| #173 | _closed — replaced by issue #185._ Initial framing of `format=int64` was github-specific (assumed `int` was correct on VM, glossed over dart2js precision loss). |
-| #174 | Handle inline `oneOf`/`anyOf` at property schema slots (precedence fix: explicit `oneOf` wins over multi-type-array expansion) |
-| #175 | _closed — replaced by issues #186, #187._ readOnly doc-comment marker was a half-measure; real fix needs request/response split (#186), and the Equatable plumbing it added is the start of cleanup #187. |
-| #176 | Detail-log spec-author quirks (`required` on array, `maxProperties`, etc.); drop the silent vendor-extension filter (`x-*` shows in `-v` for discoverability) |
-| #177 | Dispatch validation-error twins via new `PropertyArrayItemShape` predicate; closes 2 stubs |
-| #178 | Surface spec `example:` values in generated doc comments (51 sites) |
-| #179 | Smoosh top-level `$ref` variants used by exactly one parent (RepositoryRule family + others; 25 fewer model files) |
-| #180 | Dedup structurally-identical operation-synthesized oneOf trees (`/user` × 3 → 1; component-internal collections preserved) |
-| #181 | Synthesize round-trip tests for smooshed oneOf variants |
-| #182 | Don't drop `properties`/`required` when `oneOf` is a sibling (parse-time merge) + multi-value-enum implicit discriminator + propertyName-without-mapping synthesis + anyOf+discriminator plumb |
-| #183 | Dispatch labels-requestBody (multi-array hybrid sub-dispatch + `_pickPropertyArrayElementShape` picker); closes 2 stubs |
-| #184 | Round-trip correctness: nullable oneOf null-cast, EmptyObject delegation, additionalProperties named-key collision (`mapHash` for hashCode), parser drops `required` entries naming nonexistent properties — 41 → 0 generated test failures |
-
-Follow-on PRs landed since (after the 2026-04-29 wave):
-
-| PR | What |
-|---|---|
-| #189 | Smoosh inline allOf variants — `RepositoryRuleDetailed`'s 21 inline `allOf` oneOf variants fold into the sealed parent; structural smoosh predicate now accepts `ResolvedAllOf` for inline cases |
-| #190 | Strip dead Equatable from 18 parse-tree types (`Schema` family, `Operation`, `OpenApi`, etc.); resolver/render Equatable kept (load-bearing for `_collectionCache` and `_ModelCollector`); coverage tests added pinning the load-bearing usages |
-| #191 | Reframe spec-iteration skill from github-primary to a rotation across all gen_tests specs; add Discord with its blockers documented |
-| #192 | Parse and render integer enums (`type: integer, enum: [...]`); typed `SchemaStringEnum` / `SchemaIntegerEnum` family. Closes Discord's first blocker |
-| #194 | Synthesize valid example values + move newtype validation into the newtype's constructor (regex-aware string synthesizer; range/multipleOf-aware numeric synthesizer). Closes Discord's second blocker |
-
-The earlier dispatch + naming + smoosh arc (#157–#170, #172):
-
-| PR | What |
-|---|---|
-| #157–#160 | Dispatch mode → IR + sealed `DispatchDecision` family |
-| #161–#163, #165–#167 | Naming pass introduced + multi-tier preferences + title-derived names |
-| #168–#170 | Smoosh series — variant data class extends sealed parent directly under predicate / discriminator / shape+hybrid dispatch |
-| #172 | Refresh skill: surface verbose-log mining as primary discovery channel |
-
-**Stub count: 7 → 3** across the night (Groups A and B closed;
-Group C parked). **Wrapper count: 49 → 57** (the 8 increase is
-new variants from #182's parse-time merge — `checks_create_request`
-now generates typed variant classes that previously didn't exist
-as a stub). **Generated test suite: 41 broken → all 6146 pass.**
-
-Open issues filed during the night that should drive next iteration:
-
-- **#185** — strategy needed for web/dart2js-aware codegen
-  (`format=int64` is the immediate trigger). Needs a real
-  validation target with near-2^63 numeric values to motivate.
-  **Discord doesn't qualify** (their snowflakes are JSON strings,
-  not int64). Stripe is the next candidate to pull and check.
-  Until a target lands, stay with current `int` behavior. Eric's
-  preference if/when this ships: `Int64` from `package:fixnum`,
-  no opt-in flag.
-- **#186** — split request/response classes when properties are
-  marked `readOnly: true`. Correctness issue (servers can reject
-  requests with readOnly fields), not just ergonomics. Eric's
-  preference: per-class duplication (`UserRequest` /
-  `UserResponse`) over dual-constructor.
-- **#187** — remove unused Equatable `props` from tree types.
-  **Partially closed by #190**: the parse-tree (18 classes) was
-  genuinely dead and got stripped. Render-tree and resolver-tree
-  Equatable turned out to be load-bearing (`_collectionCache` for
-  #180 dedup, `_ModelCollector` Set dedup) — kept, with explicit
-  coverage tests added. The skill doc framing of "the auto-
-  generated `==` is dead infrastructure" was wrong about render
-  and resolver.
-
 ## Open gaps (pick from here)
 
 ### Discovery: don't pick from this list blind — regen first
@@ -602,90 +366,36 @@ Warnings come from `_warnUnused` / `_warnIgnored` in
 `lib/src/parser.dart`. To see what fields a parser visit *handles*
 vs ignores, search there.
 
-### Discord — what's next
+### Backlog beyond the `dart fix` arc
 
-Both pre-existing blockers are closed (#192 + #194). The next
-useful step is: regen Discord with `-v`, tally the warnings (see
-"Discovery" command above), and pick from there. Whatever now
-surfaces past the deeper traversal is a feature gap that wasn't
-visible while the parser was throwing.
+Mine a `-v` regen (Discovery above) for fresh gaps first — the tally
+is usually more current than any list here. Standing tracks:
 
-### Tracking issues (the high-leverage tracks, partially open)
-
-- **#185** — Strategy needed for web/dart2js-aware code generation.
-  Trigger: `format=int64` (246 sites in github) silently produces
-  broken code on dart2js for specs with near-2^63 IDs. Discord
-  was investigated as a target and didn't qualify (snowflakes are
-  JSON strings, not int64). Stripe is the next candidate — pull
-  the spec, check whether amounts use int64 or string-encoding
-  before coding. Eric's preference if/when this ships: `Int64`
-  from `package:fixnum`, no opt-in flag.
-
-- **#186** — Split request/response classes when properties are
-  `readOnly: true`. Correctness issue: servers can reject requests
-  that include readOnly fields. 81 sites in github, plus
-  `Unused: readOnly=…` in `allOf` (3 more) and non-property slots
-  (12 more). Eric's preference: per-class duplication
-  (`UserRequest` / `UserResponse`) over dual-constructor. Should
-  also handle `writeOnly: true` symmetrically. PR #175 laid the
-  parser-side foundation (captures `SchemaObject.readOnlyProperties`)
-  before being closed; rebuild on top of that.
-
-- **#187** — _Partially closed by #190._ Parse-tree Equatable was
-  stripped (18 classes); render-tree and resolver-tree Equatable
-  are load-bearing (`_collectionCache` for #180 dedup,
-  `_ModelCollector` Set dedup for file-emission dedup) and stay,
-  with explicit coverage tests now pinning them.
-
-### Smaller open gaps
-
-- **`<Parent>Variant<i>` doubling-fallback wrapper** — only 1 left
-  in github (`GistsCreateRequestPublicVariant1`, an inline string-
-  enum). Down from 22 before #189. Closing that last one would
-  need smoosh extending to inline `ResolvedEnum` variants too —
-  unclear if worth the complexity for a single site.
-
-- **2 `_1` collision suffixes that actually render** — `metadata_1`
-  (the anyOf at `metadata.additionalProperties`, a String/num/Bool
-  union) and `code_scanning_variant_analysis_status_1` (an inline
-  enum that's a subset of the top-level enum with the same name).
-  The resolver's snake-name collision handling appends `_1`
-  mechanically; could pick a more descriptive parent-context
-  disambiguator. Two other `_1` allocations (`codespace_machine_1`,
-  `repository_ruleset_conditions_1` — the Group C stub) don't
-  actually render their own files. Low leverage.
-
-- **3 enumless-anyOf stubs (Group C)**: `timeline-issue-events`
-  (22 variants), `issue-event-for-issue` (15), `repository-
-  ruleset-conditions-1`. All variants share an `event: string`
-  field but no `enum` to dispatch on. **Skill says skip** —
-  try-each is order-dependent and inferring values from variant
-  titles is fragile.
-
-- **Synthesized typeName collisions.** `<op>_response` could
-  collide with a schema named that way in the spec. The naming
-  pass enumerates both; multi-tier preferences would let the
-  synthesized name fall back to `<op>_response_2` on collision,
-  but no caller currently passes that fallback list. Tiny
-  widening of the op-response claim list.
-
-- **Error-status response unions.** Multi-status dispatch only
-  kicks in for 2xx variation. 4xx/5xx with structurally-different
-  bodies still falls back to untyped `ApiException<Object?>`.
-
-- **Range-mixed multi-status fallback.** When 2XX range mixes
-  with explicit 2xx codes, render synthesizes a `RenderOneOf`
-  with `source: null` that always emits the legacy stub. Closing
-  this needs the synthesized oneOf to participate in dispatch.
-
-- **anyOf+`additionalProperties` with `anyOf` body**. github's
-  `metadata` schema. PR #174 may have already covered it via the
-  precedence fix at the additionalProperties slot — verify with
-  a `-v` regen check before opening a PR.
-
-- **Unknown formats** like `repo.nwo` and `timestamp`. Low value
-  to handle directly; could surface as typedef hints in doc
-  comments. Probably skip until a real user asks.
+- **Discord's 6 remaining stubs** — genuine multi-variant unions
+  (`*_actions_inner`, `*_options_inner`, `*_components_inner`,
+  `error_details`) with no single-tag discriminator; need real
+  dispatch. The last stub frontier.
+- **Const-modeling arc** — #239 (recognize single-legal-value
+  properties by resolved-schema cardinality-1, not the narrow
+  `allOf`-ref syntax `_constTagValue` matches; would delete it and
+  unify github's ~299 bare single-value-enum tags with Discord's
+  pinned refs, but changes github output) and #240 (a lone scalar
+  `const` → a plain constant, not a single-value enum type + file).
+- **#185 — web/dart2js-aware codegen.** `format: int64` (246 github
+  sites) silently breaks on dart2js for near-2^63 IDs. Needs a real
+  target with such values (Discord doesn't qualify — snowflakes are
+  JSON strings; Stripe is the next candidate to check). Eric's
+  preference: `Int64` from `package:fixnum`, no opt-in flag.
+- **#186 — request/response split for `readOnly`/`writeOnly`.**
+  Servers can reject requests carrying readOnly fields (81 github
+  sites). Eric's preference: per-class duplication (`UserRequest` /
+  `UserResponse`). PR #175 laid parser-side groundwork before being
+  closed; rebuild on it.
+- **Error-status response unions** — multi-status dispatch only
+  handles 2xx variation; 4xx/5xx with distinct bodies still fall
+  back to `ApiException<Object?>`. Related: a `2XX` range mixed with
+  explicit 2xx codes synthesizes a `source: null` `RenderOneOf` that
+  emits the legacy stub.
 
 ## Conventions
 

--- a/.claude/skills/spec-iteration/SKILL.md
+++ b/.claude/skills/spec-iteration/SKILL.md
@@ -14,6 +14,178 @@ description: |
   any spec-driven follow-up.
 ---
 
+# State as of 2026-07-06 (the `dart fix` reduction arc)
+
+This block supersedes the older sections for current status. It
+documents an in-progress arc; earlier blocks are retained for
+history.
+
+## The arc: stop leaning on `dart fix`
+
+Profiling generation speed (via the Dart VM profiler, and by
+timing the internal subprocess logs) found that **`dart fix
+--apply` dominates wall-clock**: ~47s of github's ~57s total, vs
+~7s for space_gen's own Dart code and ~3s for the two `dart
+format` passes. github is the slowest spec; discord ~23s
+(fix ~14s).
+
+**The pivotal finding: `dart fix` is _analysis-bound_, not
+apply-bound.** Its cost is repeated whole-package static-analysis
+passes over 1000+ files, essentially independent of how many
+fixes it applies. Removing ~4,300 `unused_import` fixes (#250)
+shaved only ~2.6s / 5.5% off it. So closing one lint category at
+the generator gives **~no wall-clock win on its own** — the payoff
+only lands at the *very end*, when every category is clean enough
+that the generated package is `dart analyze`-clean without fix and
+the `_runDart(['fix', ...])` call in
+`lib/src/render/formatting.dart` (`Formatter.formatAndFix`) can be
+deleted. Even a fully-clean package pays ~7s for `dart fix` to
+confirm nothing, so dropping the call reclaims that too. Target:
+github ~57s → ~10s.
+
+`dart fix` is **load-bearing** for the "analyze-clean output"
+promise: the generated package includes `very_good_analysis`, so
+every category fix currently cleans would otherwise fail a
+consumer's `dart analyze` (fix-disabled petstore alone has 112
+issues; github ~35k). So the categories can't just be ignored —
+they must be emitted clean.
+
+Each PR in the arc moves one lint category from "laundered by
+`dart fix`" to "emitted clean by the generator." Because `dart
+fix` was already applying the transform, the **final post-fix
+output stays byte-identical** — that's the validation gate (see
+below). These are output-quality / correct-generation wins, not
+individually perf wins.
+
+## Landed this arc (all merged unless noted)
+
+| PR | Lint closed (github raw count) | Where / fix |
+|---|---|---|
+| #249 | `unnecessary_this` (6307) | `==` body emitted `this.field == other.field`; drop `this.` except for a field literally named `other` (which the `Object other` param shadows — a real bug caught in A/B: `mapsEqual(other, other.other)`). `equalsExpression` + `_equalsReceiver` guard. |
+| #250 | `unused_import` (4337; 97.6% model imports) | `importsForApi`/`importsForModel` imported the whole schema subtree; now gate each import on a `referencedIdentifiers(body)` token scan (mirrors `_referencedModelHelpers`). Closed the pre-existing TODO. |
+| #251 | `unnecessary_brace_in_string_interps` (2014) + `unnecessary_string_interpolations` (1617) | `_pathArgLine` wrapped path params in `'${x}'`; String params substitute bare (`replaceAll('{org}', org)`), non-String interpolate braceless (`'$petId'`). One fix, two categories. |
+| #252 | `noop_primitive_operations` (2045) | `.toString()` on already-`String` values: `response.body.toString()` → `response.body` (template); query/header param `_stringifyWireValue` helper; enum `toString()` gated on new `valueIsString` (int enums keep `.toString()`). |
+| #253 | `prefer_const_constructors_in_immutables` (1185) | `@immutable` model ctors now `const` via `canBeConst` = `!mutableModels && assignmentsLine == null`. Smooshed variants covered (sealed parent already `const`). **Cascade:** making ctors const raised `prefer_const_constructors` at call sites (40→987, mostly generated tests) — see "what's next." |
+| #254 | `always_put_required_named_parameters_first` (946) | Constructor params partitioned required-first (stable); only the ctor reorders (fields/toJson/etc. keep spec order). `entries` (additionalProperties, always required) renders between the two groups. |
+| #255 | `unnecessary_parenthesis` (778) | `RenderNumeric.fromJsonExpression` wrapped bare casts: `(json['id'] as int)`. Drop parens only when no `.toDouble()` and no `?? default` (keeping `(x as int?) ?? 0` matches fix). |
+| #256 | `avoid_redundant_argument_values` (681) | Three sources: `bodyContentType: BodyContentType.json` (invokeApi default — `defaultBodyContentTypeExpression` constant + `isDefaultBodyContentType` compare; the JSON body still declares json *literally*); `DateTime.utc(2024, 1, 1)` → `DateTime.utc(2024)` (month/day default to 1); example args equal to a const field default skipped in `RenderObject.exampleValue`. |
+| #257 | `prefer_final_locals` (68) — **OPEN as of this writing** | Shape-dispatch `switch` patterns emitted `Map<String, dynamic> v =>` without `final`; other dispatch sections already had it. One-word template fix. |
+
+Also this session: #246 (unintended_html lint on code spans),
+#247 (regen in-repo gen_tests goldens), **#248 (release 1.3.0 —
+published to pub.dev)**.
+
+## Remaining lint tail (github, fix-disabled, after #256/#257)
+
+~1,143 lints, **91% the const cascade**:
+
+| count | lint | where |
+|---:|---|---|
+| 987 | `prefer_const_constructors` | 985 generated **tests**, 2 lib/messages |
+| 169 | `prefer_const_literals_to_create_immutables` | tests |
+| 18 | `unnecessary_lambdas` | |
+| 11 | `unused_import` | doc-comment `[Type]` refs + meta tail |
+| 9 | `prefer_int_literals` | |
+| 8 | `prefer_const_declarations` | |
+| 4 | `avoid_escaping_inner_quotes` | |
+| 3 | `unnecessary_this` | (residual, not `==`) |
+| 2 | `use_raw_strings` | |
+
+## The const-example refactor (the big remaining lever — design settled, not started)
+
+Closing `prefer_const_constructors` (987) + `prefer_const_literals`
+(169) means making the generated round-trip tests'
+example-instance construction `const` (`Widget(id: 0, name: '...')` →
+`const Widget(...)`). This is the const-ctor cascade from #253.
+
+**It does NOT need `DartType`** (a question that came up — see
+`doc/dart_type.md` note added alongside this). Const-example-ness
+is an *expression/structure* property, and `dart_type.md`'s North
+star explicitly keeps that class of thing off `DartType` (same as
+`fromJson`/`toJson`; #227 prototyped scalar-codec-on-`DartType` and
+dropped it — "doesn't generalize"). `DartType` can't see an
+object's fields.
+
+**Design:** a `bool exampleValueIsConst(context)` sibling to
+`exampleValue` on `RenderSchema`, recursive:
+
+- `RenderPod`: `false` for uri/uriTemplate (`Uri.parse`,
+  `UriTemplate(...)` aren't const), `true` for bool/dateTime/
+  email/uuid.
+- `RenderString`/`RenderNumber`/`RenderInteger`/`RenderDate`/
+  `RenderEmptyObject`: `true`.
+- `RenderEnum`: `false` today (`values.first` is a getter call) —
+  or make it `true` by emitting the first member (`Type.member`,
+  which *is* const).
+- `RenderArray`/`RenderMap`: the element/value's.
+- `RenderObject`: `canBeConst && every property.exampleValueIsConst
+  && entries-const`.
+- `RenderOneOf`: the chosen variant's; `RenderBase64Bytes`:
+  `false` (`Uint8List.fromList`).
+
+Then prefix `const` **at the outermost const-able point only** (a
+`const` context makes nested literals const automatically; an
+inner `const` would trip `unnecessary_const`). Watch the
+round-trip template (`schema_round_trip_test.mustache`, `final
+instance = {{{ exampleValue }}}`) and the object arg builder.
+
+~15 `exampleValue` impls to touch; intricate but all in the
+`Render*` layer. Entirely affects generated tests.
+
+## What's next — an open decision the user is weighing
+
+1. **Grind the const refactor** — biggest dent (~1,164), most
+   complex, tests-only.
+2. **Keep clearing small categories** — `unnecessary_lambdas`
+   (18), `unused_import` doc-tail (11), `prefer_int_literals` (9),
+   etc.; clean one-shots (some touch lib), but each closes little
+   and the tail is long (~7 more categories) before `dart fix` can
+   be dropped.
+3. **Bank the wins and stop** — ~20k of the original ~35k fix
+   operations already moved to the generator; the rest is a long
+   thin tail that only pays off when the `dart fix` call is
+   actually deleted.
+
+Dropping `dart fix` requires **all** categories clean (the package
+must be analyze-clean without it). That's the whole tail, including
+the tiny categories.
+
+## Methodology learnings (reuse these)
+
+- **Measure raw lint counts by disabling fix.** Temporarily comment
+  out the `_runDart(['fix', '.', '--apply'], ...)` line in
+  `formatting.dart`, regen, `dart analyze` the output. Restore
+  after. Tally: `dart analyze 2>&1 | grep -oE '[a-z_]+$' | sort |
+  uniq -c | sort -rn`.
+- **Byte-identical-after-fix is the validation gate.** Regen
+  `origin/main` (old) vs branch (new) into two dirs, normalize the
+  package name (`sed 's/package:OLD/package:PKG/'` both ways), then
+  `diff -rq`. Expect 0 — *content* — differences.
+- **Benign `dart_style` reflows are expected and OK.** When the
+  generator emits a *shorter* expression than the old `dart fix`
+  produced, `dart_style` sometimes lays it out on one line instead
+  of a trailing-comma-wrapped block. A handful of files differ by
+  whitespace + a trailing comma only. Confirm with: strip
+  whitespace and `,)`→`)`, compare — must be identical. Seen in
+  #249, #251, #255, #257.
+- **`dart fix` is analysis-bound.** Don't expect a category PR to
+  cut wall-clock. Proven: #250 removed 4,315 fixes, saved ~2.6s.
+- **A/B diffs catch real bugs.** #249's blind `this.` strip broke a
+  field named `other` (`mapsEqual(other, other.other)`); only the
+  byte-diff surfaced it (fix had been *keeping* `this.other`, which
+  masked the generator bug). Always A/B, don't trust "fix removed
+  it so it's fine."
+- **Commit messages with backticks: use `git commit -F <file>`**,
+  not `-m "..."`. Backticks inside double-quoted `-m` trigger shell
+  command substitution and silently eat text (`` `default: false`
+  `` → empty). Same for `gh pr create --body-file`.
+- **github regen is ~57s each** (fix-dominated) — two regens for an
+  A/B exceed a 2-min Bash timeout; run them as separate commands.
+- **Rotation after each change:** github (the bar) + discord +
+  backstage + petstore + spacetraders must stay analyze-clean;
+  petstore (28) + discord (1530) generated round-trip suites are
+  the fast correctness check.
+
 # State as of 2026-07-06 (Discord generated suite fully green)
 
 The `2026-04-30` section below is retained for history; this block

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -4,6 +4,10 @@ ignorePaths:
   - "coverage/**"
   - "*.txt" # ignore text files at the root of the project
 words:
+  - interps
+  - goldens
+  - impls
+  - regens
   - spacetraders
   - newtype
   - newtypes

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -4,6 +4,7 @@ ignorePaths:
   - "coverage/**"
   - "*.txt" # ignore text files at the root of the project
 words:
+  - subtyping
   - interps
   - goldens
   - impls

--- a/doc/dart_type.md
+++ b/doc/dart_type.md
@@ -126,3 +126,24 @@ Two reasons it didn't earn its keep:
 `RenderPod` keeps its inline per-`PodType` codec. If a *second* caller ever
 appears — e.g. parameter serialization needing a scalar's wire form without a
 `RenderSchema` in hand — revisit.
+
+### Example-value generation (and its const-ness) stays off DartType
+
+Same rule as JSON conversion, for the same reason. Generating a schema's
+example value (`RenderSchema.exampleValue`, used by the round-trip tests) and
+deciding whether that example is a compile-time **constant** are functions of
+schema *structure*, not of `DartType`:
+
+- Scalars are a pure function of the type (`'false'`, `DateTime.utc(2024)`,
+  `Uri.parse(...)`), so const-ness *could* live on `DartType` — but that's the
+  scalar-only case that #227 showed doesn't generalize.
+- An object's example is `Foo(field: <field example>, ...)`, const iff its
+  constructor is const (`canBeConst` = `assignmentsLine == null`, schema
+  structure) **and** every field example is const (recursion over the object's
+  fields). `DartType` (a name + type args) deliberately doesn't carry fields.
+
+So when the const-example refactor happens (making the generated round-trip
+tests' example instances `const` to close `prefer_const_constructors` — see the
+`spec-iteration` skill's state doc), it is a `bool exampleValueIsConst(context)`
+**sibling to `exampleValue` on `RenderSchema`**, recursive through composites —
+not anything on `DartType`.

--- a/doc/dart_type.md
+++ b/doc/dart_type.md
@@ -75,6 +75,35 @@ newtype/enum with `fromJson`/`toJson` — which `DartType` (a name + type args)
 deliberately doesn't carry. So conversion stays on the render nodes; see the
 dropped codec-extension note under **Remaining work**.
 
+### Longer arc: the missing Dart schema library (motivation, not a mandate)
+
+Dart lacks a Zod — a standalone, analyzer-free, community-neutral type/schema
+library. Every codegen tool (freezed, json_serializable, space_gen) reinvents a
+private version internally.
+
+The Zod mapping locates the pieces: Zod's `ZodType` (structure + codec +
+validation) is `RenderSchema`; Zod's `z.infer` (the derived static type, with no
+runtime behavior) is `DartType`. Zod hangs everything on the schema and nothing
+on the inferred type — which is *exactly* why codec / example / validation
+belong on `RenderSchema`, not `DartType`. Same factoring, not a contradiction.
+
+Why Dart has no Zod: `z.infer` — deriving a static type *from* a runtime schema
+value — needs TypeScript's structural typing plus type-level computation, which
+Dart doesn't have. So a real Dart-Zod is **codegen**-shaped (define schema →
+generate typed class + codec), not runtime-dynamic. That makes space_gen's
+spec-agnostic kernel — `DartType` + composite structure + codec/example/
+validation — precisely the substrate such a library would sit on.
+`RenderSchema` today is that kernel *fused with an OpenAPI frontend* (allOf
+merge, discriminator detection, readOnly, dispatch-strategy selection, smoosh /
+file layout, naming, doc-comment prose); the fusion line is the extraction seam,
+pulled apart when a **second consumer** appears (another spec frontend, or a
+Dart-Frog-style runtime request-typing library). Two seeds at different
+maturities:
+`DartType`-as-a-standalone-value (a tiny, build-free "Dart type as a value" the
+community keeps reinventing) is nearly extractable and useful alone; the schema
+kernel is later. Discipline: grow both under real use, extract on the second
+consumer — the same require-a-validation-target rule.
+
 ## Remaining work
 
 ### Type-graph least-upper-bound (deferred)
@@ -97,6 +126,26 @@ like `Node -> Node`). The `commonType` doc comment records this too.
 fields and `additionalProperties` value all share a single type — and no spec
 in the test set has one, so building it now is speculative (see the
 require-a-real-validation-target rule).
+
+**The bigger picture this belongs to.** `DartType` today is a type *reference
+and renderer*, not a type *system*: it can name a type and do name-equality
+common-type, but it can't answer the relational questions (subtype? real LUB?
+shared supertype?). The environment/graph above is the missing half — and it is
+the single biggest gap between "nice codegen type-reference" and "a type system
+the community could build on." The analyzer proves the shape (its `DartType`
+value vs. its `TypeSystem`/`TypeProvider` that holds the hierarchy); a
+lightweight, standalone version of *that separation* is what's wanted.
+
+Note this is a burden a Dart-Zod carries that a TS one never does: TypeScript
+subtyping is structural and the compiler computes it for free, so Zod never
+models a class hierarchy. Dart is nominal with no codegen-time compiler, so the
+hierarchy must be modeled explicitly. Today that relational knowledge is
+scattered — `RenderObject.parentSealedTypeName`, the dispatch decisions, the
+sealed-class generation — and the sealed-class/smoosh machinery is partly a
+*workaround* for not having a queryable tree (it emits a sealed class and
+pattern-matches instead of typing a union as its shared supertype).
+Consolidating that into the type environment is the "understand the type tree"
+work; it would likely simplify parts of dispatch as a side effect.
 
 ### Newtype wrapped type (done — #226)
 


### PR DESCRIPTION
## Summary

Docs only — persist this session's context so it can be picked up later.
Three threads:

### 1. The `dart fix` reduction arc (`spec-iteration` state doc)

New current-state section: the arc (`dart fix` dominates generation
wall-clock and is *analysis-bound*, so each lint category moved to the
generator is byte-identical after fix but not an individual perf win —
the payoff is deleting the `dart fix` call once every category is
clean), landed PRs #249–257 with per-category counts, the remaining
~1,143-lint tail (91% const cascade), the settled const-example refactor
design, the open grind/clear/stop decision, and reusable methodology
(fix-disable measurement, byte-identical-after-fix validation, benign
`dart_style` reflows, the commit-backtick gotcha).

### 2. Trim the skill's history (1014 → 724 lines)

Cut the two superseded dated "State as of" narratives, the "Recent PRs"
tables (#157–#244), resolved-bug postmortems, int64/readOnly status
tables, and the stale low-priority gap list — that archaeology lives in
git history and closed issues. Kept verbatim: Architecture, the
`-v`-regen Discovery method, Conventions, Working rhythm, Don't, Helpful
one-shots, Where to look. Condensed to forward-looking form: "what
space_gen is / validation targets" and a "Backlog beyond the arc"
(Discord's 6 stubs, const-modeling #239/#240, #185 int64/web, #186
readOnly split, error-status unions).

### 3. DartType design north star (`doc/dart_type.md`)

- **Example-value generation and its const-ness stay on `RenderSchema`,
  not `DartType`** — same structural reason as JSON conversion (per
  #227's dropped scalar-codec fold). The const-example refactor is a
  `bool exampleValueIsConst(context)` sibling to `exampleValue`, not
  anything on `DartType`.
- **The Zod-for-Dart north star** (motivation, not a mandate): Dart
  lacks a Zod. The mapping — Zod's `ZodType` is `RenderSchema`, `z.infer`
  is `DartType` — is exactly why codec/example/validation live on
  `RenderSchema`. Dart has no Zod because `z.infer` needs TS structural
  typing + type-level computation, so a real one is *codegen*-shaped, and
  space_gen's spec-agnostic kernel is the substrate. `RenderSchema` =
  kernel fused with an OpenAPI frontend; extract on a second consumer.
- **The type-tree gap**: `DartType` is a type reference/renderer, not a
  type system — no subtyping/LUB. The hierarchy belongs in a separate
  type environment (the analyzer's `DartType` vs `TypeSystem` split), not
  fields on `DartType`. A burden a Dart-Zod carries that a TS one
  doesn't; today the knowledge is scattered and the sealed-class
  machinery is partly a workaround for not having a queryable tree.

`cspell.config.yaml`: `impls`, `regens`, `interps`, `goldens`,
`subtyping`.
