### PR TITLE
feat: emit const example instances in generated round-trip tests

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -10,6 +10,7 @@ words:
   - impls
   - regens
   - spacetraders
+  - unrepresentable
   - newtype
   - newtypes
   - eseidel

--- a/doc/dart_type.md
+++ b/doc/dart_type.md
@@ -191,8 +191,15 @@ schema *structure*, not of `DartType`:
   structure) **and** every field example is const (recursion over the object's
   fields). `DartType` (a name + type args) deliberately doesn't carry fields.
 
-So when the const-example refactor happens (making the generated round-trip
-tests' example instances `const` to close `prefer_const_constructors` — see the
-`spec-iteration` skill's state doc), it is a `bool exampleValueIsConst(context)`
-**sibling to `exampleValue` on `RenderSchema`**, recursive through composites —
-not anything on `DartType`.
+This landed as `ExampleValue` (`lib/src/render/example_value.dart`) — a
+`(code, isConst)` value type that `exampleValue` returns, recursive through
+composites, on `RenderSchema` and not on `DartType`.
+
+It is deliberately **one** method returning both halves rather than the
+`exampleValue` / `bool exampleValueIsConst(context)` sibling pair this section
+originally proposed. `exampleValue` returns `null` for "no example possible"
+(recursive refs, `RenderUnknown`, oneOf), and that `null` propagates through
+every composite. A separate const-ness recursion would have to mirror each of
+those bail-outs by hand, in ~15 implementations; the two disagreeing emits a
+`const` declaration around a non-constant initializer, which doesn't compile.
+Returning both from one recursion makes that class of bug unrepresentable.

--- a/lib/src/render/example_value.dart
+++ b/lib/src/render/example_value.dart
@@ -1,0 +1,51 @@
+import 'package:equatable/equatable.dart';
+import 'package:meta/meta.dart';
+
+/// A synthesized example expression for a schema, plus whether that
+/// expression is a compile-time constant.
+///
+/// Generated round-trip tests construct one instance per schema
+/// (`final instance = <exampleValue>;`). Since #253 made model
+/// constructors `const`, those constructions trip
+/// `prefer_const_constructors` unless they are constant — but only when
+/// every part of the expression really is const-able (`Uri.parse(...)`,
+/// `DateTime.utc(...)` and a validating newtype's constructor are not).
+///
+/// [code] and [isConst] travel together deliberately. They are computed
+/// by the same recursion over the render tree, so a composite's
+/// const-ness can never disagree with the expression it was derived
+/// from — a split into two parallel methods would have to mirror every
+/// `null` bail-out ("no example possible") in lockstep, and a
+/// disagreement emits a `const` declaration around a non-constant
+/// initializer, which is a compile error in the generated package.
+///
+/// [code] is always the bare expression, never `const`-prefixed. The
+/// single consumer is a variable declaration, so const-ness is spent on
+/// the *declaration* keyword (`const instance = Foo(...)`) rather than
+/// on the initializer. That covers the whole expression tree at once:
+/// a const declaration is a const context, so nested constructors and
+/// collection literals become constant without their own keyword (an
+/// inner `const` would trip `unnecessary_const`), and it avoids
+/// `prefer_const_declarations` firing on a `final` with a constant
+/// initializer. It also sidesteps the fact that `const` is only legal
+/// before a constructor call or collection literal — `const
+/// UserRole.admin` and `const 'text'` are syntax errors, so prefixing
+/// the initializer could not have worked uniformly anyway.
+@immutable
+class ExampleValue extends Equatable {
+  const ExampleValue(this.code, {required this.isConst});
+
+  /// The Dart expression, without any `const` prefix.
+  final String code;
+
+  /// Whether [code] is a compile-time constant expression, and so
+  /// whether it can be assigned to a `const` variable and used inside
+  /// an enclosing constant expression.
+  final bool isConst;
+
+  @override
+  List<Object?> get props => [code, isConst];
+
+  @override
+  String toString() => 'ExampleValue($code, isConst: $isConst)';
+}

--- a/lib/src/render/example_value.dart
+++ b/lib/src/render/example_value.dart
@@ -33,7 +33,20 @@ import 'package:meta/meta.dart';
 /// the initializer could not have worked uniformly anyway.
 @immutable
 class ExampleValue extends Equatable {
+  /// For expressions whose const-ness is *computed* — a composite
+  /// inheriting from its children, or a newtype gated on whether the
+  /// schema declares validations. Prefer [ExampleValue.constant] /
+  /// [ExampleValue.notConst] when the answer is known outright.
   const ExampleValue(this.code, {required this.isConst});
+
+  /// A constant expression: literals, enum members, and constructor
+  /// calls whose arguments are all themselves constant.
+  const ExampleValue.constant(this.code) : isConst = true;
+
+  /// An expression that can never be constant — `Uri.parse(...)`,
+  /// `DateTime.utc(...)`, `Uint8List.fromList(...)`, or a validating
+  /// newtype constructor.
+  const ExampleValue.notConst(this.code) : isConst = false;
 
   /// The Dart expression, without any `const` prefix.
   final String code;

--- a/lib/src/render/example_value.dart
+++ b/lib/src/render/example_value.dart
@@ -31,6 +31,39 @@ import 'package:meta/meta.dart';
 /// before a constructor call or collection literal — `const
 /// UserRole.admin` and `const 'text'` are syntax errors, so prefixing
 /// the initializer could not have worked uniformly anyway.
+// TODO(eseidel): Replace `code` with a real expression IR.
+//
+// Carrying Dart code as a `String` is the same mistake `DartType`
+// exists to fix, one layer up: we stopped writing `'$typeName?'` for
+// types, but expressions are still built by concatenation. The tell is
+// `isConst` — const-ness is a *derived* property of an expression's
+// structure (a constructor invocation is const iff its constructor is
+// const and every argument is), so with a tree it would be a computed
+// getter instead of a field every composite has to thread by hand.
+// Two bugs during this class's own development came from exactly that
+// gap: `const` was emitted before an enum member (`const
+// UserRole.admin` is a syntax error — a static member reference is not
+// a constructor invocation), and const-ness was first attached to the
+// initializer rather than the declaration. A tree answers both
+// structurally.
+//
+// This isn't only about examples. `defaultValueString` is compared to
+// `code` by *rendered text* in `RenderObject.exampleValue` — structural
+// equality spelled as string equality — and `fromJsonExpression` /
+// `toJsonExpression` plus the dispatch `caseExpression`s are all
+// string-composed too. #255 (don't parenthesize a bare numeric cast)
+// and #256 (drop redundant argument values) were string-level fixes to
+// what are structural questions.
+//
+// Evaluate `package:code_builder` first — it is the Dart team's
+// answer for building Dart source programmatically and has an
+// `Expression` type with `.property()` / `.call()` / `.constInstance()`.
+// If its `Expression` won't answer "is this const?", a small
+// home-grown IR (literals, identifiers, property access, invocation,
+// collection literals) is a few hundred lines and mirrors how
+// `DartType` earned its place. Not `package:analyzer`'s AST: that is a
+// parsing representation built around tokens, offsets and resolution,
+// and is painful to construct synthetically.
 @immutable
 class ExampleValue extends Equatable {
   /// For expressions whose const-ness is *computed* — a composite

--- a/lib/src/render/file_renderer.dart
+++ b/lib/src/render/file_renderer.dart
@@ -864,7 +864,11 @@ class FileRenderer {
           'packageName': packageName,
           'barrelImportPath': testBarrelImport(),
           'typeName': schema.typeName,
-          'exampleValue': example,
+          // Const-ness is spent on the declaration keyword rather
+          // than the initializer, so the expression stays bare — see
+          // [ExampleValue].
+          'exampleValue': example.code,
+          'exampleIsConst': example.isConst,
           'invalidJsonExample': invalidJson,
           'isEnum': schema is RenderEnum,
           // `toString()` returns a String for every enum, but `toJson()`
@@ -919,7 +923,8 @@ class FileRenderer {
       if (example == null) continue;
       variants.add({
         'variantTypeName': variant.typeName,
-        'exampleValue': example,
+        'exampleValue': example.code,
+        'exampleIsConst': example.isConst,
       });
     }
     if (variants.isEmpty) return;

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -2548,7 +2548,7 @@ abstract class RenderSchema extends Equatable implements ToTemplateContext {
   /// unconditionally const.
   @protected
   ExampleValue newtypeWrappedExample(String literal) {
-    if (!createsNewType) return ExampleValue(literal, isConst: true);
+    if (!createsNewType) return ExampleValue.constant(literal);
     return ExampleValue(
       '$typeName($literal)',
       isConst: validationCalls.isEmpty,
@@ -4391,7 +4391,7 @@ class RenderMap extends RenderSchema {
     // const; otherwise the key's own const-ness applies.
     final key =
         keySchema?.exampleValue(context) ??
-        const ExampleValue("'key'", isConst: true);
+        const ExampleValue.constant("'key'");
     return ExampleValue(
       '{${key.code}: ${value.code}}',
       isConst: key.isConst && value.isConst,
@@ -4585,7 +4585,7 @@ abstract class RenderEnum<T extends Object> extends RenderNewType {
     // also reads better in the generated test.
     final first = names.firstOrNull;
     if (first == null) return null;
-    return ExampleValue('$typeName.$first', isConst: true);
+    return ExampleValue.constant('$typeName.$first');
   }
 }
 
@@ -5874,7 +5874,7 @@ class RenderUnknown extends RenderSchema {
 
   @override
   ExampleValue? exampleValue(SchemaRenderer context) =>
-      const ExampleValue('<String, dynamic>{}', isConst: true);
+      const ExampleValue.constant('<String, dynamic>{}');
 }
 
 class RenderVoid extends RenderNoJson {
@@ -6051,7 +6051,7 @@ class RenderBase64Bytes extends RenderSchema {
   @override
   ExampleValue? exampleValue(SchemaRenderer context) =>
       // `Uint8List.fromList` is a factory, so this isn't a constant.
-      const ExampleValue('Uint8List.fromList(<int>[0])', isConst: false);
+      const ExampleValue.notConst('Uint8List.fromList(<int>[0])');
 
   @override
   Map<String, dynamic> toTemplateContext(SchemaRenderer context) =>
@@ -6124,7 +6124,7 @@ class RenderDate extends RenderSchema {
   @override
   ExampleValue? exampleValue(SchemaRenderer context) =>
       // The generated `Date` has a const constructor (`date.dart`).
-      const ExampleValue('Date(2024, 1, 1)', isConst: true);
+      const ExampleValue.constant('Date(2024, 1, 1)');
 
   // `Date.fromJson` parses through `DateTime.parse`, which rejects garbage
   // with a FormatException — so the round-trip test has a guaranteed-invalid
@@ -6202,7 +6202,7 @@ class RenderEmptyObject extends RenderNewType {
       // Bare, not `const`-prefixed: the outermost caller applies the
       // keyword, so a nested empty object can't trip
       // `unnecessary_const` inside an enclosing const expression.
-      ExampleValue('$typeName()', isConst: true);
+      ExampleValue.constant('$typeName()');
 }
 
 /// A cycle-break marker: appears where a $ref would otherwise recurse back

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -8,6 +8,7 @@ import 'package:space_gen/src/naming.dart';
 import 'package:space_gen/src/parse/spec.dart' show StatusCodeRange;
 import 'package:space_gen/src/quirks.dart';
 import 'package:space_gen/src/render/dart_type.dart';
+import 'package:space_gen/src/render/example_value.dart';
 // Any code that depends on SchemaRenderer probably should be moved out
 // of this file and into the schema_renderer.dart file.
 import 'package:space_gen/src/render/schema_renderer.dart';
@@ -2532,7 +2533,27 @@ abstract class RenderSchema extends Equatable implements ToTemplateContext {
   /// [RenderRecursiveRef] in a non-nullable slot would loop forever.
   /// Callers treat `null` as a signal to skip emitting a round-trip
   /// test for the enclosing type.
-  String? exampleValue(SchemaRenderer context);
+  ///
+  /// The returned [ExampleValue] carries both the expression and whether
+  /// it is const-able; see that class for why the two travel together.
+  ExampleValue? exampleValue(SchemaRenderer context);
+
+  /// Wrap a scalar [literal] in this schema's newtype constructor, when
+  /// it creates one. Shared by the string and numeric newtypes, whose
+  /// generated constructor is `const` only when the schema declares no
+  /// validations — the same `hasValidations` gate the templates use. A
+  /// validating constructor has a body, so it cannot be const.
+  ///
+  /// Not used by [RenderPod], whose newtype constructor is
+  /// unconditionally const.
+  @protected
+  ExampleValue newtypeWrappedExample(String literal) {
+    if (!createsNewType) return ExampleValue(literal, isConst: true);
+    return ExampleValue(
+      '$typeName($literal)',
+      isConst: validationCalls.isEmpty,
+    );
+  }
 
   /// A Dart expression of type [jsonStorageType] that is guaranteed to
   /// fail this schema's `fromJson`/`maybeFromJson` with a
@@ -2822,18 +2843,25 @@ class RenderPod extends RenderSchema {
       super.equalsIgnoringName(other);
 
   @override
-  String? exampleValue(SchemaRenderer context) {
-    final raw = switch (type) {
-      PodType.boolean => 'false',
+  ExampleValue? exampleValue(SchemaRenderer context) {
+    // Const-ness is per-type: `DateTime` has no const constructor, and
+    // `Uri.parse` / `UriTemplate` parse their argument at runtime.
+    final (raw, rawIsConst) = switch (type) {
+      PodType.boolean => ('false', true),
       // `month`/`day` default to 1, so passing them is redundant
       // (`avoid_redundant_argument_values`).
-      PodType.dateTime => 'DateTime.utc(2024)',
-      PodType.uri => "Uri.parse('https://example.com')",
-      PodType.uriTemplate => "UriTemplate('https://example.com/{id}')",
-      PodType.email => "'user@example.com'",
-      PodType.uuid => "'00000000-0000-0000-0000-000000000000'",
+      PodType.dateTime => ('DateTime.utc(2024)', false),
+      PodType.uri => ("Uri.parse('https://example.com')", false),
+      PodType.uriTemplate => ("UriTemplate('https://example.com/{id}')", false),
+      PodType.email => ("'user@example.com'", true),
+      PodType.uuid => ("'00000000-0000-0000-0000-000000000000'", true),
     };
-    return createsNewType ? '$typeName($raw)' : raw;
+    // A pod newtype's constructor is unconditionally `const`
+    // (`schema_pod_newtype.mustache`), so wrapping preserves const-ness.
+    return ExampleValue(
+      createsNewType ? '$typeName($raw)' : raw,
+      isConst: rawIsConst,
+    );
   }
 
   /// Only dateTime pods parse through `DateTime.parse`, which rejects garbage
@@ -3036,12 +3064,8 @@ class RenderString extends RenderSchema {
   }
 
   @override
-  String? exampleValue(SchemaRenderer context) {
-    final value = validStringExample();
-    return createsNewType
-        ? '$typeName(${quoteString(value)})'
-        : quoteString(value);
-  }
+  ExampleValue? exampleValue(SchemaRenderer context) =>
+      newtypeWrappedExample(quoteString(validStringExample()));
 }
 
 /// Pick the first `String`-typed entry from `common.example` or
@@ -3321,10 +3345,8 @@ class RenderNumber extends RenderNumeric<double> {
       jsonIsNullable ? '?.toDouble()' : '.toDouble()';
 
   @override
-  String? exampleValue(SchemaRenderer context) {
-    final value = _validNumberExample(common, this).toString();
-    return createsNewType ? '$typeName($value)' : value;
-  }
+  ExampleValue? exampleValue(SchemaRenderer context) =>
+      newtypeWrappedExample(_validNumberExample(common, this).toString());
 }
 
 class RenderInteger extends RenderNumeric<int> {
@@ -3363,10 +3385,9 @@ class RenderInteger extends RenderNumeric<int> {
   String jsonToDartCall({required bool jsonIsNullable}) => '';
 
   @override
-  String? exampleValue(SchemaRenderer context) {
-    final value = _validNumberExample(common, this).toInt().toString();
-    return createsNewType ? '$typeName($value)' : value;
-  }
+  ExampleValue? exampleValue(SchemaRenderer context) => newtypeWrappedExample(
+    _validNumberExample(common, this).toInt().toString(),
+  );
 }
 
 /// Pick a numeric value satisfying [schema]'s declared bounds. Prefers
@@ -3787,7 +3808,7 @@ class RenderObject extends RenderNewType {
       // `prefer_const_constructors_in_immutables` otherwise. The sealed
       // parent of a smooshed variant already declares `const`, so
       // variants can be const too.
-      'canBeConst': !context.quirks.mutableModels && assignmentsLine == null,
+      'canBeConst': canBeConst(context),
       'additionalPropertiesName': 'entries', // Matching OpenAPI.
       'valueSchema': valueSchema?.typeName,
       'operatorIndexType': operatorIndexType,
@@ -3886,9 +3907,30 @@ class RenderObject extends RenderNewType {
   bool rendersAsConstGetter(String jsonName, RenderSchema property) =>
       constProperties.containsKey(jsonName) && property is RenderEnum;
 
+  /// Whether the generated constructor is declared `const`.
+  ///
+  /// Equivalent to the template's gate (`!mutableModels &&
+  /// assignmentsLine == null`) but stated directly against the
+  /// properties, so it can be asked before the per-property template
+  /// contexts are built. A mutable model has non-final fields; an
+  /// aggregate assignments line exists exactly when some property that
+  /// isn't a const getter has a non-const default (see
+  /// [assignmentsLine] and [buildAssignmentsLine]).
+  bool canBeConst(SchemaRenderer context) {
+    if (context.quirks.mutableModels) return false;
+    return !properties.entries.any(
+      (entry) =>
+          !rendersAsConstGetter(entry.key, entry.value) &&
+          entry.value.hasNonConstDefaultValue(context),
+    );
+  }
+
   @override
-  String? exampleValue(SchemaRenderer context) {
+  ExampleValue? exampleValue(SchemaRenderer context) {
     final args = <String>[];
+    // An argument that isn't const makes the whole construction
+    // non-const, even when the constructor itself is `const`.
+    var argsAreConst = true;
     for (final entry in properties.entries) {
       final jsonName = entry.key;
       if (!requiredProperties.contains(jsonName)) continue;
@@ -3905,9 +3947,14 @@ class RenderObject extends RenderNewType {
       // match the example here (a `?? DateTime.parse(...)` initializer
       // reads differently from `DateTime.utc(...)`), so this can't drop
       // a genuinely-needed argument.
-      if (property.defaultValueString(context) == example) continue;
+      //
+      // Compares the rendered code only, not the whole [ExampleValue]:
+      // the question is whether the two spell the same argument, and
+      // const-ness doesn't change that.
+      if (property.defaultValueString(context) == example.code) continue;
       final dartName = variableSafeName(context.quirks, jsonName);
-      args.add('$dartName: $example');
+      args.add('$dartName: ${example.code}');
+      argsAreConst &= example.isConst;
     }
     // When the schema has `additionalProperties`, the generated class
     // carries a synthetic required `entries` Map field whose value type
@@ -3920,9 +3967,14 @@ class RenderObject extends RenderNewType {
     // family on the GitHub spec all hit this.
     final additional = additionalProperties;
     if (additional != null) {
+      // An empty map literal is a constant expression, so this argument
+      // never costs const-ness.
       args.add('entries: <String, ${additional.typeName}>{}');
     }
-    return '$typeName(${args.join(', ')})';
+    return ExampleValue(
+      '$typeName(${args.join(', ')})',
+      isConst: canBeConst(context) && argsAreConst,
+    );
   }
 
   /// Empty map: any required property will fail its type cast inside
@@ -4152,10 +4204,13 @@ class RenderArray extends RenderSchema {
   }
 
   @override
-  String? exampleValue(SchemaRenderer context) {
+  ExampleValue? exampleValue(SchemaRenderer context) {
     final inner = items.exampleValue(context);
     if (inner == null) return null;
-    return '<${items.typeName}>[$inner]';
+    return ExampleValue(
+      '<${items.typeName}>[${inner.code}]',
+      isConst: inner.isConst,
+    );
   }
 }
 
@@ -4329,11 +4384,18 @@ class RenderMap extends RenderSchema {
   }
 
   @override
-  String? exampleValue(SchemaRenderer context) {
+  ExampleValue? exampleValue(SchemaRenderer context) {
     final value = valueSchema.exampleValue(context);
     if (value == null) return null;
-    final key = keySchema?.exampleValue(context) ?? "'key'";
-    return '{$key: $value}';
+    // A map with no key schema uses a plain string literal, which is
+    // const; otherwise the key's own const-ness applies.
+    final key =
+        keySchema?.exampleValue(context) ??
+        const ExampleValue("'key'", isConst: true);
+    return ExampleValue(
+      '{${key.code}: ${value.code}}',
+      isConst: key.isConst && value.isConst,
+    );
   }
 }
 
@@ -4516,7 +4578,15 @@ abstract class RenderEnum<T extends Object> extends RenderNewType {
   }
 
   @override
-  String? exampleValue(SchemaRenderer context) => '$typeName.values.first';
+  ExampleValue? exampleValue(SchemaRenderer context) {
+    // Name the first member directly rather than going through
+    // `values.first`: a static member reference is a constant
+    // expression, where `values.first` is a getter call and isn't. It
+    // also reads better in the generated test.
+    final first = names.firstOrNull;
+    if (first == null) return null;
+    return ExampleValue('$typeName.$first', isConst: true);
+  }
 }
 
 class RenderStringEnum extends RenderEnum<String> {
@@ -5121,7 +5191,7 @@ class RenderOneOf extends RenderNewType {
   dynamic get defaultValue => null;
 
   @override
-  String? exampleValue(SchemaRenderer context) {
+  ExampleValue? exampleValue(SchemaRenderer context) {
     // A oneOf / anyOf currently renders as a sealed class with no
     // subclasses (the template at `schema_one_of.mustache` emits only
     // the base class and an `UnimplementedError`-throwing fromJson).
@@ -5803,7 +5873,8 @@ class RenderUnknown extends RenderSchema {
       throw UnimplementedError('RenderUnknown.toTemplateContext');
 
   @override
-  String? exampleValue(SchemaRenderer context) => '<String, dynamic>{}';
+  ExampleValue? exampleValue(SchemaRenderer context) =>
+      const ExampleValue('<String, dynamic>{}', isConst: true);
 }
 
 class RenderVoid extends RenderNoJson {
@@ -5833,7 +5904,7 @@ class RenderVoid extends RenderNoJson {
   // a void type, maybe we need a "return expression" value instead?
 
   @override
-  String? exampleValue(SchemaRenderer context) => null;
+  ExampleValue? exampleValue(SchemaRenderer context) => null;
 }
 
 /// A schema that represents a type which cannot be converted to json.
@@ -5876,7 +5947,7 @@ abstract class RenderNoJson extends RenderSchema {
   /// No-JSON types (void, binary) can't round-trip via JSON so they
   /// have no example value.
   @override
-  String? exampleValue(SchemaRenderer context) => null;
+  ExampleValue? exampleValue(SchemaRenderer context) => null;
 }
 
 class RenderBinary extends RenderNoJson {
@@ -5978,8 +6049,9 @@ class RenderBase64Bytes extends RenderSchema {
   }
 
   @override
-  String? exampleValue(SchemaRenderer context) =>
-      'Uint8List.fromList(<int>[0])';
+  ExampleValue? exampleValue(SchemaRenderer context) =>
+      // `Uint8List.fromList` is a factory, so this isn't a constant.
+      const ExampleValue('Uint8List.fromList(<int>[0])', isConst: false);
 
   @override
   Map<String, dynamic> toTemplateContext(SchemaRenderer context) =>
@@ -6050,7 +6122,9 @@ class RenderDate extends RenderSchema {
   }) => dartIsNullable ? '$dartName?.toJson()' : '$dartName.toJson()';
 
   @override
-  String? exampleValue(SchemaRenderer context) => 'Date(2024, 1, 1)';
+  ExampleValue? exampleValue(SchemaRenderer context) =>
+      // The generated `Date` has a const constructor (`date.dart`).
+      const ExampleValue('Date(2024, 1, 1)', isConst: true);
 
   // `Date.fromJson` parses through `DateTime.parse`, which rejects garbage
   // with a FormatException — so the round-trip test has a guaranteed-invalid
@@ -6124,7 +6198,11 @@ class RenderEmptyObject extends RenderNewType {
   };
 
   @override
-  String? exampleValue(SchemaRenderer context) => 'const $typeName()';
+  ExampleValue? exampleValue(SchemaRenderer context) =>
+      // Bare, not `const`-prefixed: the outermost caller applies the
+      // keyword, so a nested empty object can't trip
+      // `unnecessary_const` inside an enclosing const expression.
+      ExampleValue('$typeName()', isConst: true);
 }
 
 /// A cycle-break marker: appears where a $ref would otherwise recurse back
@@ -6206,7 +6284,7 @@ class RenderRecursiveRef extends RenderSchema {
   /// Returning null here propagates up the tree so the enclosing
   /// schema opts out of test generation.
   @override
-  String? exampleValue(SchemaRenderer context) => null;
+  ExampleValue? exampleValue(SchemaRenderer context) => null;
 
   @override
   List<Object?> get props => [super.props, targetPointer];

--- a/lib/templates/schema_oneof_round_trip_test.mustache
+++ b/lib/templates/schema_oneof_round_trip_test.mustache
@@ -6,7 +6,7 @@ void main() {
   group('{{{ typeName }}}', () {
 {{#variants}}
     test('{{{ variantTypeName }}} round-trips via maybeFromJson/toJson', () {
-      final instance = {{{ exampleValue }}};
+      {{#exampleIsConst}}const{{/exampleIsConst}}{{^exampleIsConst}}final{{/exampleIsConst}} instance = {{{ exampleValue }}};
       final parsed = {{{ variantTypeName }}}.maybeFromJson(instance.toJson())!;
       expect(parsed, equals(instance));
       expect(parsed.hashCode, equals(instance.hashCode));

--- a/lib/templates/schema_round_trip_test.mustache
+++ b/lib/templates/schema_round_trip_test.mustache
@@ -5,7 +5,7 @@ import 'package:test/test.dart';
 void main() {
   group('{{{ typeName }}}', () {
     test('round-trips via maybeFromJson/toJson', () {
-      final instance = {{{ exampleValue }}};
+      {{#exampleIsConst}}const{{/exampleIsConst}}{{^exampleIsConst}}final{{/exampleIsConst}} instance = {{{ exampleValue }}};
       final parsed = {{{ typeName }}}.maybeFromJson(instance.toJson())!;
       expect(parsed, equals(instance));
       expect(parsed.hashCode, equals(instance.hashCode));

--- a/test/render/render_tree_test.dart
+++ b/test/render/render_tree_test.dart
@@ -1,5 +1,6 @@
 import 'package:space_gen/src/quirks.dart';
 import 'package:space_gen/src/render/dart_type.dart';
+import 'package:space_gen/src/render/example_value.dart';
 import 'package:space_gen/src/render/render_tree.dart';
 import 'package:space_gen/src/render/schema_renderer.dart';
 import 'package:space_gen/src/render/templates.dart';
@@ -1522,9 +1523,10 @@ void main() {
         pattern: null,
         assignedName: 'Foo',
       );
-      final example = schema.exampleValue(context);
-      expect(example?.code, "Foo('example')");
-      expect(example?.isConst, isTrue);
+      expect(
+        schema.exampleValue(context),
+        const ExampleValue.constant("Foo('example')"),
+      );
     });
 
     test('a validating newtype is not constant', () {
@@ -1576,9 +1578,10 @@ void main() {
         descriptions: null,
         assignedName: 'Foo',
       );
-      final example = schema.exampleValue(context);
-      expect(example?.code, 'Foo.a');
-      expect(example?.isConst, isTrue);
+      expect(
+        schema.exampleValue(context),
+        const ExampleValue.constant('Foo.a'),
+      );
     });
 
     test('an array is constant only when its element is', () {
@@ -1629,7 +1632,31 @@ void main() {
 
     test('base64 bytes are not constant', () {
       const schema = RenderBase64Bytes(common: common);
-      expect(schema.exampleValue(context)?.isConst, isFalse);
+      expect(
+        schema.exampleValue(context),
+        const ExampleValue.notConst('Uint8List.fromList(<int>[0])'),
+      );
+    });
+
+    test('equal code with differing const-ness are not equal', () {
+      // Const-ness is part of the value: the same expression reached
+      // via a validating vs non-validating newtype is a different
+      // answer, and `==` has to see that.
+      expect(
+        const ExampleValue.constant('Foo(1)'),
+        isNot(const ExampleValue.notConst('Foo(1)')),
+      );
+      expect(
+        const ExampleValue('Foo(1)', isConst: true),
+        const ExampleValue.constant('Foo(1)'),
+      );
+    });
+
+    test('toString shows the code and its const-ness', () {
+      expect(
+        const ExampleValue.constant('Foo.a').toString(),
+        'ExampleValue(Foo.a, isConst: true)',
+      );
     });
   });
 

--- a/test/render/render_tree_test.dart
+++ b/test/render/render_tree_test.dart
@@ -1154,7 +1154,7 @@ void main() {
 
     test('date format produces a Date value-class literal', () {
       const schema = RenderDate(common: common, defaultValue: null);
-      expect(schema.exampleValue(context), 'Date(2024, 1, 1)');
+      expect(schema.exampleValue(context)?.code, 'Date(2024, 1, 1)');
     });
 
     test('uri format produces a Uri.parse literal', () {
@@ -1164,7 +1164,7 @@ void main() {
         createsNewType: false,
       );
       expect(
-        schema.exampleValue(context),
+        schema.exampleValue(context)?.code,
         "Uri.parse('https://example.com')",
       );
     });
@@ -1176,7 +1176,7 @@ void main() {
         createsNewType: false,
       );
       expect(
-        schema.exampleValue(context),
+        schema.exampleValue(context)?.code,
         "UriTemplate('https://example.com/{id}')",
       );
     });
@@ -1187,7 +1187,7 @@ void main() {
         type: PodType.email,
         createsNewType: false,
       );
-      expect(schema.exampleValue(context), "'user@example.com'");
+      expect(schema.exampleValue(context)?.code, "'user@example.com'");
     });
 
     test('uuid format produces a uuid string literal', () {
@@ -1197,24 +1197,24 @@ void main() {
         createsNewType: false,
       );
       expect(
-        schema.exampleValue(context),
+        schema.exampleValue(context)?.code,
         "'00000000-0000-0000-0000-000000000000'",
       );
     });
 
     test('unknown returns an empty dynamic map literal', () {
       const schema = RenderUnknown(common: common);
-      expect(schema.exampleValue(context), '<String, dynamic>{}');
+      expect(schema.exampleValue(context)?.code, '<String, dynamic>{}');
     });
 
     test('void returns null (no round-trip possible)', () {
       const schema = RenderVoid(common: common);
-      expect(schema.exampleValue(context), isNull);
+      expect(schema.exampleValue(context)?.code, isNull);
     });
 
     test('binary (NoJson) returns null', () {
       const schema = RenderBinary(common: common);
-      expect(schema.exampleValue(context), isNull);
+      expect(schema.exampleValue(context)?.code, isNull);
     });
 
     test('recursive ref returns null', () {
@@ -1222,7 +1222,7 @@ void main() {
         common: common,
         targetPointer: JsonPointer.empty(),
       );
-      expect(schema.exampleValue(context), isNull);
+      expect(schema.exampleValue(context)?.code, isNull);
     });
 
     test('oneOf returns null (sealed class, no constructable subtype)', () {
@@ -1251,7 +1251,7 @@ void main() {
         discriminator: null,
         source: null,
       );
-      expect(schema.exampleValue(context), isNull);
+      expect(schema.exampleValue(context)?.code, isNull);
     });
 
     test('map with keySchema uses its exampleValue', () {
@@ -1275,8 +1275,9 @@ void main() {
         valueSchema: inner,
         keySchema: keySchema,
       );
-      // Key example is the enum's first value; value is the string example.
-      expect(map.exampleValue(context), "{Foo.values.first: 'example'}");
+      // Key example names the enum's first member; value is the string
+      // example.
+      expect(map.exampleValue(context)?.code, "{Foo.a: 'example'}");
     });
 
     test('string with spec example uses it verbatim', () {
@@ -1292,7 +1293,7 @@ void main() {
         pattern: r'^refs/(heads|tags|pull)/.*$',
         createsNewType: false,
       );
-      expect(schema.exampleValue(context), "'refs/heads/main'");
+      expect(schema.exampleValue(context)?.code, "'refs/heads/main'");
     });
 
     test('string falls back to first String entry from examples list', () {
@@ -1308,7 +1309,7 @@ void main() {
         pattern: null,
         createsNewType: false,
       );
-      expect(schema.exampleValue(context), "'second'");
+      expect(schema.exampleValue(context)?.code, "'second'");
     });
 
     test('string synthesizes a value matching simple character-class '
@@ -1328,7 +1329,7 @@ void main() {
         pattern: r'^[0-9a-fA-F]+$',
         createsNewType: false,
       );
-      expect(schema.exampleValue(context), "'${'a' * 40}'");
+      expect(schema.exampleValue(context)?.code, "'${'a' * 40}'");
     });
 
     test('string synthesizes for an alternation pattern by trying '
@@ -1346,7 +1347,7 @@ void main() {
         createsNewType: false,
       );
       // `'a'` doesn't match; `'0'` does (the 0 alternative).
-      expect(schema.exampleValue(context), "'0'");
+      expect(schema.exampleValue(context)?.code, "'0'");
     });
 
     test('string truncates a too-long fallback to maxLength', () {
@@ -1361,7 +1362,7 @@ void main() {
         pattern: null,
         createsNewType: false,
       );
-      expect(schema.exampleValue(context), "'exam'");
+      expect(schema.exampleValue(context)?.code, "'exam'");
     });
 
     test('string falls back when no candidate matches the pattern', () {
@@ -1380,7 +1381,7 @@ void main() {
         pattern: r'^Z+$',
         createsNewType: false,
       );
-      expect(schema.exampleValue(context), "'example'");
+      expect(schema.exampleValue(context)?.code, "'example'");
     });
 
     test('string falls back when the spec pattern is invalid regex', () {
@@ -1397,7 +1398,7 @@ void main() {
         pattern: '(',
         createsNewType: false,
       );
-      expect(schema.exampleValue(context), "'example'");
+      expect(schema.exampleValue(context)?.code, "'example'");
     });
 
     test('integer with spec example uses it', () {
@@ -1415,7 +1416,7 @@ void main() {
         multipleOf: null,
         createsNewType: false,
       );
-      expect(schema.exampleValue(context), '42');
+      expect(schema.exampleValue(context)?.code, '42');
     });
 
     test('integer with no spec example picks minimum', () {
@@ -1432,7 +1433,7 @@ void main() {
         multipleOf: null,
         createsNewType: false,
       );
-      expect(schema.exampleValue(context), '5');
+      expect(schema.exampleValue(context)?.code, '5');
     });
 
     test('integer falls back to first num in examples list when example '
@@ -1451,7 +1452,7 @@ void main() {
         multipleOf: null,
         createsNewType: false,
       );
-      expect(schema.exampleValue(context), '7');
+      expect(schema.exampleValue(context)?.code, '7');
     });
 
     test('integer with negative max picks the upper bound when zero is '
@@ -1469,7 +1470,7 @@ void main() {
         multipleOf: null,
         createsNewType: false,
       );
-      expect(schema.exampleValue(context), '-5');
+      expect(schema.exampleValue(context)?.code, '-5');
     });
 
     test('integer rounds candidate up to the next multipleOf', () {
@@ -1486,7 +1487,149 @@ void main() {
         multipleOf: 5,
         createsNewType: false,
       );
-      expect(schema.exampleValue(context), '10');
+      expect(schema.exampleValue(context)?.code, '10');
+    });
+  });
+
+  group('exampleValue const-ness', () {
+    final context = SchemaRenderer(
+      templates: TemplateProvider.defaultLocation(),
+    );
+    const common = CommonProperties.test(
+      snakeName: 'foo',
+      pointer: JsonPointer.empty(),
+    );
+
+    test('a plain string literal is constant', () {
+      const schema = RenderString(
+        createsNewType: false,
+        common: common,
+        defaultValue: null,
+        maxLength: null,
+        minLength: null,
+        pattern: null,
+      );
+      expect(schema.exampleValue(context)?.isConst, isTrue);
+    });
+
+    test('a newtype with no validations is constant', () {
+      const schema = RenderString(
+        createsNewType: true,
+        common: common,
+        defaultValue: null,
+        maxLength: null,
+        minLength: null,
+        pattern: null,
+        assignedName: 'Foo',
+      );
+      final example = schema.exampleValue(context);
+      expect(example?.code, "Foo('example')");
+      expect(example?.isConst, isTrue);
+    });
+
+    test('a validating newtype is not constant', () {
+      // A validating newtype's generated constructor has a body
+      // (`hasValidations`), so it cannot be declared const.
+      const schema = RenderString(
+        createsNewType: true,
+        common: common,
+        defaultValue: null,
+        maxLength: null,
+        minLength: 3,
+        pattern: null,
+        assignedName: 'Foo',
+      );
+      expect(schema.exampleValue(context)?.isConst, isFalse);
+    });
+
+    test('DateTime and Uri pods are not constant', () {
+      for (final type in [PodType.dateTime, PodType.uri]) {
+        final schema = RenderPod(
+          common: common,
+          type: type,
+          createsNewType: false,
+        );
+        expect(
+          schema.exampleValue(context)?.isConst,
+          isFalse,
+          reason: '$type has no const constructor',
+        );
+      }
+    });
+
+    test('a bool pod is constant', () {
+      const schema = RenderPod(
+        common: common,
+        type: PodType.boolean,
+        createsNewType: false,
+      );
+      expect(schema.exampleValue(context)?.isConst, isTrue);
+    });
+
+    test('an enum names its first member rather than values.first', () {
+      // `values.first` is a getter call, so it isn't a constant
+      // expression; a static member reference is.
+      final schema = RenderStringEnum(
+        common: common,
+        values: const ['a', 'b'],
+        names: const ['a', 'b'],
+        descriptions: null,
+        assignedName: 'Foo',
+      );
+      final example = schema.exampleValue(context);
+      expect(example?.code, 'Foo.a');
+      expect(example?.isConst, isTrue);
+    });
+
+    test('an array is constant only when its element is', () {
+      const constElement = RenderString(
+        createsNewType: false,
+        common: common,
+        defaultValue: null,
+        maxLength: null,
+        minLength: null,
+        pattern: null,
+      );
+      const nonConstElement = RenderPod(
+        common: common,
+        type: PodType.dateTime,
+        createsNewType: false,
+      );
+      expect(
+        const RenderArray(
+          common: common,
+          items: constElement,
+        ).exampleValue(context)?.isConst,
+        isTrue,
+      );
+      expect(
+        const RenderArray(
+          common: common,
+          items: nonConstElement,
+        ).exampleValue(context)?.isConst,
+        isFalse,
+      );
+    });
+
+    test('a map is constant only when key and value both are', () {
+      const nonConstValue = RenderPod(
+        common: common,
+        type: PodType.uri,
+        createsNewType: false,
+      );
+      expect(
+        const RenderMap(
+          common: common,
+          valueSchema: nonConstValue,
+          keySchema: null,
+        ).exampleValue(context)?.isConst,
+        isFalse,
+      );
+    });
+
+    test('base64 bytes are not constant', () {
+      const schema = RenderBase64Bytes(common: common);
+      expect(schema.exampleValue(context)?.isConst, isFalse);
     });
   });
 
@@ -1614,7 +1757,7 @@ void main() {
     });
 
     test('example is a Date value-class literal', () {
-      expect(date.exampleValue(context), 'Date(2024, 1, 1)');
+      expect(date.exampleValue(context)?.code, 'Date(2024, 1, 1)');
       expect(date.invalidJsonExample(context), "'not a date'");
     });
 


### PR DESCRIPTION

## Summary

Generated round-trip tests now declare their example instance `const`
when the expression is a compile-time constant, closing the
`prefer_const_constructors` cascade that #253 created by making model
constructors const. On the github regen, raw lints (with `dart fix`
disabled) drop from ~1,143 to 279 — a 76% cut, and
`prefer_const_declarations` goes to zero.

`RenderSchema.exampleValue` now returns an `ExampleValue` (`code` +
`isConst`) instead of a bare `String?`. One recursion computes both
halves, so a composite's const-ness can't disagree with the expression
it came from. The alternative — a `bool exampleValueIsConst` sibling
method — would have had to mirror `exampleValue`'s `null` bail-outs
("no example possible") across ~15 implementations, and any drift emits
a `const` declaration around a non-constant initializer, which doesn't
compile.

Const-ness is spent on the *declaration* keyword (`const instance =
Foo(...)`) rather than on the initializer. That covers the whole
expression tree at once, avoids `unnecessary_const` on nested values,
and avoids trading `prefer_const_constructors` for
`prefer_const_declarations`. It also sidesteps `const` being illegal
before a literal or enum member (`const UserRole.admin` is a syntax
error).

Per-schema const-ness: pods are const except `DateTime`/`Uri`/
`UriTemplate`; string and numeric newtypes are const only without
validations (a validating constructor has a body); objects are const
when `canBeConst` holds and every argument is; arrays and maps inherit
from their children; `Uint8List.fromList` never is.

Enums now name their first member (`Color.red`) instead of
`Color.values.first`, which is a getter call and so not constant. It
reads better in the generated test regardless.

`RenderObject.canBeConst` is lifted out of `toTemplateContext` into a
method both it and `exampleValue` call, stated directly against the
properties rather than against the already-built per-property template
contexts.

## Validation

- github, discord, backstage, petstore, spacetraders all regen
  analyze-clean.
- Generated suites pass: github 6080, discord 1530, petstore 28.
- Remaining const lints on github are 229 in tests (const-able
  subtrees under an outer forced to `final` by one non-const field —
  needs a maximal-const-subtree pass) and 2 in lib (`throw
  FormatException(...)`, unrelated to examples).

