### PR TITLE
docs: record the expression-IR decision; drop the code_builder rec

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -144,6 +144,13 @@ common-type — are a small structured `DartType` value (name + type arguments +
 nullability) rather than strings composed by hand. See
 [`doc/dart_type.md`](doc/dart_type.md) for the model and remaining work.
 
+**Expression model (planned).** Dart *expressions* are still composed as
+strings (`'$typeName($literal)'`, `'{$key: $value}'`, `"$json as $type"`) —
+the same problem `DartType` solved for types, one layer up. The decision to
+build a small home-grown sealed expression IR, and why `package:code_builder`
+was evaluated and rejected, is recorded in
+[`doc/dart_expression.md`](doc/dart_expression.md).
+
 **Linkage to dispatch.** `RenderOneOf` carries a back-reference to
 the source `ResolvedSchemaCollection` it was built from. When a
 oneOf renders, it calls `decideDispatch(source)` to retrieve the

--- a/doc/dart_expression.md
+++ b/doc/dart_expression.md
@@ -1,0 +1,150 @@
+# Dart expression IR — decision record
+
+**Status:** accepted, not yet implemented.
+**Date:** 2026-07-18 (after #259).
+**Sibling:** [`doc/dart_type.md`](dart_type.md) — the same argument, one layer
+down, already implemented.
+
+## Context
+
+The generator builds Dart **expressions** by string concatenation:
+
+```dart
+'$typeName($literal)'          // constructor invocation
+'<${items.typeName}>[$inner]'  // list literal
+'{$key: $value}'               // map literal
+"$jsonValue as $jsonType"      // cast
+```
+
+`DartType` (#222–#226) removed this for *types* — nullability is data, not a
+`'$name?'` append, and `toString()` is the single rendering source of truth.
+Expressions never got the same treatment. There are ~30 expression-building
+members across `lib/src/render/render_tree.dart` and `lib/src/dispatch.dart`.
+
+Two symptoms make the cost concrete.
+
+**Derived properties have to be stored and threaded by hand.**
+`ExampleValue.isConst` (#259) is the clear case. Whether an expression is a
+compile-time constant is a *structural* property — a constructor invocation is
+const iff its constructor is const and every argument is const — but with no
+tree to derive it from, it is a `bool` field every composite must combine
+correctly. Two bugs during #259 came from exactly that gap: `const` was emitted
+before an enum member (`const UserRole.admin` is a syntax error, because a
+static member reference is not a constructor invocation), and const-ness was
+first attached to the initializer rather than the declaration, trading 987
+`prefer_const_constructors` for 1486 `prefer_const_declarations`.
+
+**Consumers recover producers' decisions by re-reading text.** Eight families,
+about twenty concrete sites. Representative ones:
+
+| site | what it does |
+|---|---|
+| `render_tree.dart:1249` | regex `^[a-zA-Z_$][\w$]*$` to ask "is this a bare identifier?", choosing `'$x'` vs `'${x}'` |
+| `render_tree.dart:1604` | `source == 'response.body'` — recovers which branch the producer took |
+| `render_tree.dart:2222` | `jsonType == 'String'` — the same question `_stringifyWireValue` (`:30`) answers structurally via `DartType` |
+| `render_tree.dart:3952` | `defaultValueString(context) == example.code` — structural equality spelled as string equality |
+| `render_tree.dart:1982` | `bodyContentTypeExpression == defaultBodyContentTypeExpression`, a constant that exists only to be compared |
+
+The largest instance is not in the expression layer at all:
+`lib/src/render/schema_renderer.dart` re-tokenizes fully rendered file bodies
+with `RegExp(r'[a-zA-Z_$][\w$]*')` (`referencedIdentifiers`,
+`_referencedModelHelpers`, `SchemaUsage.fromBody`) so that
+`file_renderer.dart` can decide imports (`importsForApi:677`,
+`importsForModel:776`). `SchemaUsage._validationCallPattern` is a regex
+matching the exact method names `validationCalls` generates — a producer and a
+consumer coupled through nothing but text. That is #250's import pruning: the
+generator asking "what did I just write?" by grepping its own output.
+
+## Decision
+
+Build a small **home-grown sealed expression IR**
+(`lib/src/render/dart_expression.dart`), reusing `DartType` for all type
+references. `isConst` becomes an exhaustive `switch` over the hierarchy —
+derived, never stored. Grow node types as consumers migrate, so the IR never
+exists without a production user.
+
+## Alternatives considered
+
+### `package:code_builder` — rejected
+
+The obvious candidate: Dart-team owned (`tools.dart.dev`), actively maintained
+(4.11.1, June 2026), and its `Expression` API covers every form we emit —
+literals, collection literals, `newInstance` / `constInstance`, `.property()`,
+`.call()`, `.asA()`, `.conditional()`, `.ifNullThen()`.
+
+It was rejected on the one requirement that matters: **it cannot tell you
+whether an expression is constant.** `Expression.isConst` is an authoring flag
+recorded at construction, not a derived property. Probed against `dart analyze`:
+
+```
+literalNum(5)                  isConst=false   // 5 is a constant
+literalString('hi')            isConst=false
+refer('Foo').constInstance([   isConst=true    // emits const Foo(Bar()),
+  refer('Bar').newInstance([])                 // which dart analyze rejects
+])                                             // (const_with_non_const)
+```
+
+It answers "did the caller type `const` here" — which we already know — and
+propagates nothing from children.
+
+Nor can const-ness be recomputed from the tree, because the tree is lossy:
+
+- `literalNum(5)` stores the *string* `'5'` in `LiteralExpression`, which is
+  also the raw-source escape hatch holding `'return'`, `'final'`, `'...'`.
+  The runtime value is gone; you cannot distinguish the constant `5` from the
+  keyword `return` without string-inspecting `.literal`.
+- Property access, casts, `??`, ternaries, spreads and `await` are all
+  `BinaryExpression(left, right, String operator)`, discriminated by an
+  **operator string**. Walking means switching on strings — the same string
+  typing we are trying to leave.
+- `LiteralListExpression.values` is `List<Object?>`, mixing raw Dart values and
+  `Expression`s; `CodeExpression` wraps arbitrary opaque source.
+- `ExpressionVisitor` is documented "INTERNAL ONLY" with no recursive base
+  class — ~29 stubs to implement one traversal.
+
+Secondary costs, each individually survivable: 13 transitive packages,
+including `matcher` → `test_api` in the production graph; and `asA`
+unconditionally parenthesizes with no alternative, which would regress #255
+(don't parenthesize a bare numeric cast in `fromJson`).
+
+**Reconsider if** scope ever widens from expressions to whole-library
+construction — classes, constructors, imports with allocators. That is where
+code_builder's value actually is, and it is a separate decision.
+
+### `package:analyzer`'s AST — rejected
+
+A *parsing* representation built around tokens, offsets and resolution state.
+Constructing nodes synthetically is painful, there is no way to render nodes
+back to source, and it is a heavyweight dependency for a code *generator*.
+
+### Other packages — none credible
+
+`dart_code` is a hobby package (4 likes, unverified uploader) and strictly
+weaker. `source_gen` / `build_runner` are build orchestration, not expression
+models, and delegate to code_builder anyway.
+
+### Hybrid: home-grown IR emitting via code_builder — rejected
+
+Buys nothing. Emission from a sealed IR is a `switch` returning strings — the
+easy half — while paying the full dependency cost and inheriting
+code_builder's emission quirks (`[1, 2, ]`, forced parens on casts).
+
+## Consequences
+
+**Good.** `isConst` stops being a stored field. The text-comparison sites above
+become structural questions or disappear. Eventually referenced identifiers are
+accumulated while building rather than grepped out of rendered output, retiring
+the `schema_renderer.dart` regex layer. Adding a node type becomes a compile
+error at every decision point, per the project's sealed-type convention.
+
+**Costs.** We own the model, including its emission correctness — the same
+deal already taken with `DartType`. It is a long arc (~30 builders), and the
+biggest payoff (import derivation) is at the end, like the `dart fix` arc
+(#249–#257). Mitigation: each step improves correctness locally, and stopping
+at any point leaves the codebase strictly better.
+
+**Relationship to `DartType`.** These are the two halves of the same kernel.
+`doc/dart_type.md` frames `DartType` as the `z.infer` analogue in a Dart-Zod
+mapping, with schema structure on `RenderSchema`. The expression IR is the
+missing piece next to it: `DartType` says what type a thing is, `DartExpression`
+says what code produces a value of that type.

--- a/lib/src/render/example_value.dart
+++ b/lib/src/render/example_value.dart
@@ -55,15 +55,14 @@ import 'package:meta/meta.dart';
 // and #256 (drop redundant argument values) were string-level fixes to
 // what are structural questions.
 //
-// Evaluate `package:code_builder` first — it is the Dart team's
-// answer for building Dart source programmatically and has an
-// `Expression` type with `.property()` / `.call()` / `.constInstance()`.
-// If its `Expression` won't answer "is this const?", a small
-// home-grown IR (literals, identifiers, property access, invocation,
-// collection literals) is a few hundred lines and mirrors how
-// `DartType` earned its place. Not `package:analyzer`'s AST: that is a
-// parsing representation built around tokens, offsets and resolution,
-// and is painful to construct synthetically.
+// The approach is settled: a small home-grown sealed IR, reusing
+// `DartType` for type references, with `isConst` as an exhaustive
+// switch rather than a stored field. `package:code_builder` was
+// evaluated and rejected — its `Expression.isConst` is an authoring
+// flag recorded at construction, not derived (it reports `false` for
+// the literal `5` and `true` for the invalid `const Foo(Bar())`), and
+// its tree is too lossy to recompute it. See `doc/dart_expression.md`
+// for the full decision record; don't re-litigate it here.
 @immutable
 class ExampleValue extends Equatable {
   /// For expressions whose const-ness is *computed* — a composite


### PR DESCRIPTION

## Summary

Adds `doc/dart_expression.md`, a decision record for replacing
string-composed Dart expressions with a small home-grown sealed
expression IR, and why `package:code_builder` was evaluated and
rejected for it.

The deciding factor is that code_builder's `Expression.isConst` is an
authoring flag recorded at construction rather than a derived property:
it reports `false` for the literal `5` and `true` for the invalid
`const Foo(Bar())`, and propagates nothing from children. Its tree is
also too lossy to recompute const-ness — numeric and string literals
are stored as pre-rendered strings in the same class used as the
raw-keyword escape hatch, and property access, casts, `??` and
ternaries are all one `BinaryExpression` discriminated by an operator
string. Secondary costs: 13 transitive packages including `matcher` in
the production graph, and `asA` unconditionally parenthesizes, which
would regress #255.

Also replaces the now-stale "evaluate code_builder first" note in
`ExampleValue`'s TODO with the conclusion and a pointer to the record,
and links the record from `ARCHITECTURE.md` next to the `DartType`
section.

No behavior change.

