### PR TITLE
refactor: default values become expressions, not strings

### DIFF
--- a/lib/src/render/dart_expression.dart
+++ b/lib/src/render/dart_expression.dart
@@ -19,8 +19,10 @@ import 'package:space_gen/src/string.dart';
 /// const declaration is a const context, so nested constructors and
 /// collection literals become constant without their own keyword, and an
 /// inner `const` would trip `unnecessary_const`. Where no such declaration
-/// exists — a default value spliced into a `??` — the node that carries the
-/// keyword does so itself (see [DartListLiteral.hasConstKeyword]).
+/// exists — a default value spliced into a `??` — [toConstantSource] writes
+/// the keyword instead. Which of the two applies is a property of the
+/// destination, not of the expression, so it is decided at serialization
+/// rather than stored on the tree.
 ///
 /// See `doc/dart_expression.md` for the decision record, including why
 /// `package:code_builder` was evaluated and rejected.
@@ -35,9 +37,24 @@ sealed class DartExpression extends Equatable {
   /// Derived, never stored.
   bool get isConst;
 
-  /// The rendered Dart source for this expression.
+  /// The rendered Dart source for this expression. Always bare: no
+  /// `const` keyword, because whether one is needed depends on where the
+  /// text lands, which the tree does not know.
   @override
   String toString();
+
+  /// Serialized for a destination that is *not* already a constant
+  /// context, so a constant value needs the keyword written explicitly.
+  ///
+  /// The keyword goes at the outermost position that can carry it — a
+  /// const expression is a const context, so nested literals and
+  /// constructors need nothing of their own. Nodes that cannot carry it
+  /// (`const 5`, `const UserRole.admin` are syntax errors) render bare.
+  ///
+  /// This is a serialization concern, not a property of the expression:
+  /// the same tree renders with or without the keyword depending on where
+  /// it is being spliced.
+  String toConstantSource() => toString();
 }
 
 /// Expression builders for the forms that are *rooted at a type name* —
@@ -124,16 +141,15 @@ class DartLiteral extends DartExpression {
 
 /// A list literal, e.g. `<int>[0]` or `[]`.
 class DartListLiteral extends DartExpression {
-  const DartListLiteral({
-    required this.elementType,
-    required this.elements,
-    this.hasConstKeyword = false,
-  });
+  const DartListLiteral({required this.elementType, required this.elements});
 
   /// A list literal with no type argument, e.g. `[]` — the elements (or the
   /// context it lands in) infer it. Mirrors [DartMapLiteral.untyped].
-  const DartListLiteral.untyped(this.elements, {this.hasConstKeyword = false})
-    : elementType = null;
+  const DartListLiteral.untyped(this.elements) : elementType = null;
+
+  /// The empty, untyped list literal `[]` — common enough as a default
+  /// value to be worth naming.
+  static const empty = DartListLiteral.untyped([]);
 
   /// The element type argument, or `null` to omit the `<T>`. An empty
   /// default (`const []`) is written untyped because the surrounding
@@ -142,42 +158,22 @@ class DartListLiteral extends DartExpression {
 
   final List<DartExpression> elements;
 
-  /// Whether to write an explicit `const` before the literal.
-  ///
-  /// Const-ness is usually spent on an enclosing declaration, which covers
-  /// a whole tree at once. Where there is no such declaration — a default
-  /// value spliced into a `??` — the keyword has to appear here.
-  ///
-  /// This lives on the literal rather than on a wrapper node because
-  /// `const` is not an operator over arbitrary expressions: it is a
-  /// modifier that only a collection literal or an instance creation can
-  /// carry. `const 5` and `const UserRole.admin` are syntax errors, so
-  /// those nodes simply have no such field. [DartMapLiteral] and
-  /// [DartInvocation] can take one too; neither has a call site that needs
-  /// it yet.
-  ///
-  /// Independent of [isConst], which asks whether the value *is* constant
-  /// rather than whether the keyword is written.
-  final bool hasConstKeyword;
-
   /// A list literal is constant when every element is.
   @override
   bool get isConst => elements.every((element) => element.isConst);
 
   @override
+  String toConstantSource() => isConst ? 'const $this' : toString();
+
+  @override
   String toString() {
-    assert(
-      !hasConstKeyword || isConst,
-      'const around a non-constant list literal: $elements',
-    );
     final elementType = this.elementType;
     final typeArgument = elementType == null ? '' : '<$elementType>';
-    final keyword = hasConstKeyword ? 'const ' : '';
-    return '$keyword$typeArgument[${elements.join(', ')}]';
+    return '$typeArgument[${elements.join(', ')}]';
   }
 
   @override
-  List<Object?> get props => [elementType, elements, hasConstKeyword];
+  List<Object?> get props => [elementType, elements];
 }
 
 /// One `key: value` pair in a [DartMapLiteral].
@@ -221,6 +217,9 @@ class DartMapLiteral extends DartExpression {
   /// A map literal is constant when every key and value is.
   @override
   bool get isConst => entries.every((entry) => entry.isConst);
+
+  @override
+  String toConstantSource() => isConst ? 'const $this' : toString();
 
   @override
   String toString() {
@@ -299,6 +298,9 @@ class DartInvocation extends DartExpression {
       isConstConstructor &&
       arguments.every((argument) => argument.isConst) &&
       namedArguments.values.every((argument) => argument.isConst);
+
+  @override
+  String toConstantSource() => isConst ? 'const $this' : toString();
 
   @override
   String toString() {

--- a/lib/src/render/dart_expression.dart
+++ b/lib/src/render/dart_expression.dart
@@ -13,13 +13,14 @@ import 'package:space_gen/src/string.dart';
 /// and not something a composite should have to thread by hand.
 ///
 /// [toString] is the single rendering source of truth, again matching
-/// [DartType]. Expressions are always rendered bare: no `const` keyword is
-/// ever emitted, because the only consumer today is a variable declaration
-/// where const-ness is spent on the declaration keyword (`const instance =
-/// Foo(...)`). That covers the whole tree at once — a const declaration is a
-/// const context, so nested constructors and collection literals become
-/// constant without their own keyword, and an inner `const` would trip
-/// `unnecessary_const`.
+/// [DartType]. Expressions render bare by default — no `const` keyword —
+/// because const-ness is normally spent on an enclosing declaration
+/// (`const instance = Foo(...)`). That covers the whole tree at once: a
+/// const declaration is a const context, so nested constructors and
+/// collection literals become constant without their own keyword, and an
+/// inner `const` would trip `unnecessary_const`. Where no such declaration
+/// exists — a default value spliced into a `??` — the node that carries the
+/// keyword does so itself (see [DartListLiteral.hasConstKeyword]).
 ///
 /// See `doc/dart_expression.md` for the decision record, including why
 /// `package:code_builder` was evaluated and rejected.
@@ -34,23 +35,7 @@ sealed class DartExpression extends Equatable {
   /// Derived, never stored.
   bool get isConst;
 
-  /// Whether a `const` keyword may legally be written before this
-  /// expression. Only a collection literal or a constructor invocation
-  /// takes one — `const 5` and `const UserRole.admin` are syntax errors,
-  /// which is the bug that motivated this IR in the first place.
-  ///
-  /// Independent of [isConst]: a `const`-declared constructor invoked with
-  /// a non-constant argument may take the keyword syntactically and still
-  /// not be a constant. [DartConst] requires both.
-  bool get canTakeConstKeyword => switch (this) {
-    DartLiteral() || DartStaticMember() => false,
-    DartListLiteral() || DartMapLiteral() => true,
-    DartInvocation(:final isConstConstructor) => isConstConstructor,
-    // Already `const`; a second keyword would be `unnecessary_const`.
-    DartConst() => false,
-  };
-
-  /// The rendered Dart source for this expression, never `const`-prefixed.
+  /// The rendered Dart source for this expression.
   @override
   String toString();
 }
@@ -139,11 +124,16 @@ class DartLiteral extends DartExpression {
 
 /// A list literal, e.g. `<int>[0]` or `[]`.
 class DartListLiteral extends DartExpression {
-  const DartListLiteral({required this.elementType, required this.elements});
+  const DartListLiteral({
+    required this.elementType,
+    required this.elements,
+    this.hasConstKeyword = false,
+  });
 
   /// A list literal with no type argument, e.g. `[]` — the elements (or the
   /// context it lands in) infer it. Mirrors [DartMapLiteral.untyped].
-  const DartListLiteral.untyped(this.elements) : elementType = null;
+  const DartListLiteral.untyped(this.elements, {this.hasConstKeyword = false})
+    : elementType = null;
 
   /// The element type argument, or `null` to omit the `<T>`. An empty
   /// default (`const []`) is written untyped because the surrounding
@@ -152,56 +142,42 @@ class DartListLiteral extends DartExpression {
 
   final List<DartExpression> elements;
 
+  /// Whether to write an explicit `const` before the literal.
+  ///
+  /// Const-ness is usually spent on an enclosing declaration, which covers
+  /// a whole tree at once. Where there is no such declaration — a default
+  /// value spliced into a `??` — the keyword has to appear here.
+  ///
+  /// This lives on the literal rather than on a wrapper node because
+  /// `const` is not an operator over arbitrary expressions: it is a
+  /// modifier that only a collection literal or an instance creation can
+  /// carry. `const 5` and `const UserRole.admin` are syntax errors, so
+  /// those nodes simply have no such field. [DartMapLiteral] and
+  /// [DartInvocation] can take one too; neither has a call site that needs
+  /// it yet.
+  ///
+  /// Independent of [isConst], which asks whether the value *is* constant
+  /// rather than whether the keyword is written.
+  final bool hasConstKeyword;
+
   /// A list literal is constant when every element is.
   @override
   bool get isConst => elements.every((element) => element.isConst);
 
   @override
   String toString() {
+    assert(
+      !hasConstKeyword || isConst,
+      'const around a non-constant list literal: $elements',
+    );
     final elementType = this.elementType;
     final typeArgument = elementType == null ? '' : '<$elementType>';
-    return '$typeArgument[${elements.join(', ')}]';
+    final keyword = hasConstKeyword ? 'const ' : '';
+    return '$keyword$typeArgument[${elements.join(', ')}]';
   }
 
   @override
-  List<Object?> get props => [elementType, elements];
-}
-
-/// An expression written with an explicit `const` keyword: `const []`,
-/// `const Foo(1)`.
-///
-/// Most expressions are rendered bare — const-ness is normally spent on an
-/// enclosing declaration, which covers the whole tree at once. This node is
-/// for the positions where that isn't available and the keyword has to
-/// appear in the expression itself, such as a default value spliced into a
-/// `??`.
-class DartConst extends DartExpression {
-  const DartConst(this.expression);
-
-  final DartExpression expression;
-
-  @override
-  bool get isConst => expression.isConst;
-
-  // Checked at render rather than in the constructor: this is a `const`
-  // constructor, so its asserts may only use constant expressions, and
-  // both of these are getter calls. Rendering is where a bad node would
-  // become broken generated code anyway.
-  @override
-  String toString() {
-    assert(
-      expression.isConst,
-      'const around a non-constant expression: $expression',
-    );
-    assert(
-      expression.canTakeConstKeyword,
-      'const is not legal before this expression: $expression',
-    );
-    return 'const $expression';
-  }
-
-  @override
-  List<Object?> get props => [expression];
+  List<Object?> get props => [elementType, elements, hasConstKeyword];
 }
 
 /// One `key: value` pair in a [DartMapLiteral].

--- a/lib/src/render/dart_expression.dart
+++ b/lib/src/render/dart_expression.dart
@@ -12,17 +12,15 @@ import 'package:space_gen/src/string.dart';
 /// `const` and every argument is constant, which is a fold over the tree
 /// and not something a composite should have to thread by hand.
 ///
-/// [toString] is the single rendering source of truth, again matching
-/// [DartType]. Expressions render bare by default — no `const` keyword —
-/// because const-ness is normally spent on an enclosing declaration
-/// (`const instance = Foo(...)`). That covers the whole tree at once: a
-/// const declaration is a const context, so nested constructors and
-/// collection literals become constant without their own keyword, and an
-/// inner `const` would trip `unnecessary_const`. Where no such declaration
-/// exists — a default value spliced into a `??` — [toConstantSource] writes
-/// the keyword instead. Which of the two applies is a property of the
-/// destination, not of the expression, so it is decided at serialization
-/// rather than stored on the tree.
+/// Unlike [DartType], the tree does *not* render itself. Rendering lives in
+/// [DartExpressionSerializer], because the source for a given expression
+/// depends on where the text lands: `const` must be written when the
+/// destination evaluates at runtime, and must not be when the destination is
+/// already a constant context (an enclosing `const` declaration, a parameter
+/// default), where it would trip `unnecessary_const`. That is a property of
+/// the destination, not of the expression, so it cannot be a method on the
+/// node — and it has to thread down through nesting, which is why it is a
+/// serializer carrying context rather than a flag on a call.
 ///
 /// See `doc/dart_expression.md` for the decision record, including why
 /// `package:code_builder` was evaluated and rejected.
@@ -37,24 +35,104 @@ sealed class DartExpression extends Equatable {
   /// Derived, never stored.
   bool get isConst;
 
-  /// The rendered Dart source for this expression. Always bare: no
-  /// `const` keyword, because whether one is needed depends on where the
-  /// text lands, which the tree does not know.
+  /// Debug form (`DartLiteral(5)`), not Dart source. Rendering goes
+  /// through [DartExpressionSerializer] — an expression cannot serialize
+  /// itself, because how it renders depends on where the text lands.
   @override
-  String toString();
+  bool get stringify => true;
+}
 
-  /// Serialized for a destination that is *not* already a constant
-  /// context, so a constant value needs the keyword written explicitly.
-  ///
-  /// The keyword goes at the outermost position that can carry it — a
-  /// const expression is a const context, so nested literals and
-  /// constructors need nothing of their own. Nodes that cannot carry it
-  /// (`const 5`, `const UserRole.admin` are syntax errors) render bare.
-  ///
-  /// This is a serialization concern, not a property of the expression:
-  /// the same tree renders with or without the keyword depending on where
-  /// it is being spliced.
-  String toConstantSource() => toString();
+/// Renders a [DartExpression] to Dart source.
+///
+/// Separate from the tree on purpose. Whether a `const` keyword belongs in
+/// front of an expression is a fact about the *destination* — a `??`
+/// right-hand side evaluates at runtime and wants one, a parameter default
+/// is already a constant context and must not have one. The same tree
+/// therefore has more than one correct rendering, so it cannot render
+/// itself.
+///
+/// Context also has to travel down through nesting. Writing `const` at one
+/// level makes everything below it constant, so children must not repeat
+/// it; but where no keyword is written the context passes through, which is
+/// what lets a constant child inside a runtime parent get one of its own
+/// (`Uint8List.fromList(const <int>[0])`).
+@immutable
+class DartExpressionSerializer extends Equatable {
+  const DartExpressionSerializer({required this.isConstContext});
+
+  /// For a destination that is already a constant context: an enclosing
+  /// `const` declaration, a parameter default, or inside another `const`
+  /// expression. No keyword is written; one would be `unnecessary_const`.
+  static const constContext = DartExpressionSerializer(isConstContext: true);
+
+  /// For a destination that evaluates at runtime, such as the right-hand
+  /// side of a `??`. A `const` keyword is written wherever it turns an
+  /// allocation into a compile-time constant.
+  static const runtimeContext = DartExpressionSerializer(
+    isConstContext: false,
+  );
+
+  final bool isConstContext;
+
+  /// The Dart source for [expression].
+  String serialize(DartExpression expression) {
+    // A keyword written here (or a context inherited from above) makes
+    // every child a constant context.
+    final children = isConstContext || expression.isConst
+        ? constContext
+        : runtimeContext;
+    return switch (expression) {
+      // `const 5` and `const UserRole.admin` are syntax errors, so these
+      // two arms never offer the keyword — that rule is expressed by the
+      // shape of this switch rather than by a predicate.
+      DartLiteral(:final value) =>
+        value is String ? quoteString(value) : '$value',
+      DartStaticMember(:final type, :final name) => '$type.$name',
+      DartListLiteral(:final elementType, :final elements) => _maybeConst(
+        expression,
+        '${elementType == null ? '' : '<$elementType>'}'
+        '[${elements.map(children.serialize).join(', ')}]',
+      ),
+      DartMapLiteral(:final keyType, :final valueType, :final entries) =>
+        _maybeConst(expression, () {
+          final typeArguments = keyType == null || valueType == null
+              ? ''
+              : '<$keyType, $valueType>';
+          final rendered = entries.map(children._serializeEntry);
+          return '$typeArguments{${rendered.join(', ')}}';
+        }()),
+      DartInvocation(
+        :final type,
+        :final constructorName,
+        :final arguments,
+        :final namedArguments,
+      ) =>
+        _maybeConst(expression, () {
+          final target = constructorName == null
+              ? '$type'
+              : '$type.$constructorName';
+          final rendered = [
+            ...arguments.map(children.serialize),
+            ...namedArguments.entries.map(
+              (entry) => '${entry.key}: ${children.serialize(entry.value)}',
+            ),
+          ];
+          return '$target(${rendered.join(', ')})';
+        }()),
+    };
+  }
+
+  String _serializeEntry(DartMapEntry entry) =>
+      '${serialize(entry.key)}: ${serialize(entry.value)}';
+
+  /// Prefixes `const` when the destination is not already constant and the
+  /// keyword buys a compile-time constant. Only called from the arms whose
+  /// node kind can legally carry it.
+  String _maybeConst(DartExpression expression, String source) =>
+      !isConstContext && expression.isConst ? 'const $source' : source;
+
+  @override
+  List<Object?> get props => [isConstContext];
 }
 
 /// Expression builders for the forms that are *rooted at a type name* —
@@ -125,14 +203,6 @@ class DartLiteral extends DartExpression {
   @override
   bool get isConst => true;
 
-  @override
-  String toString() {
-    final value = this.value;
-    // Strings quote through the shared helper, which owns quote style and
-    // escaping (`$`, `'`, newlines).
-    return value is String ? quoteString(value) : '$value';
-  }
-
   // Includes the runtime type because `5 == 5.0` in Dart, but `5` and `5.0`
   // are different literals — equality here has to agree with [toString].
   @override
@@ -163,16 +233,6 @@ class DartListLiteral extends DartExpression {
   bool get isConst => elements.every((element) => element.isConst);
 
   @override
-  String toConstantSource() => isConst ? 'const $this' : toString();
-
-  @override
-  String toString() {
-    final elementType = this.elementType;
-    final typeArgument = elementType == null ? '' : '<$elementType>';
-    return '$typeArgument[${elements.join(', ')}]';
-  }
-
-  @override
   List<Object?> get props => [elementType, elements];
 }
 
@@ -185,9 +245,6 @@ class DartMapEntry extends Equatable {
   final DartExpression value;
 
   bool get isConst => key.isConst && value.isConst;
-
-  @override
-  String toString() => '$key: $value';
 
   @override
   List<Object?> get props => [key, value];
@@ -217,19 +274,6 @@ class DartMapLiteral extends DartExpression {
   /// A map literal is constant when every key and value is.
   @override
   bool get isConst => entries.every((entry) => entry.isConst);
-
-  @override
-  String toConstantSource() => isConst ? 'const $this' : toString();
-
-  @override
-  String toString() {
-    final keyType = this.keyType;
-    final valueType = this.valueType;
-    final typeArguments = keyType == null || valueType == null
-        ? ''
-        : '<$keyType, $valueType>';
-    return '$typeArguments{${entries.join(', ')}}';
-  }
 
   @override
   List<Object?> get props => [keyType, valueType, entries];
@@ -300,20 +344,6 @@ class DartInvocation extends DartExpression {
       namedArguments.values.every((argument) => argument.isConst);
 
   @override
-  String toConstantSource() => isConst ? 'const $this' : toString();
-
-  @override
-  String toString() {
-    final name = constructorName;
-    final target = name == null ? '$type' : '$type.$name';
-    final rendered = [
-      ...arguments.map((argument) => '$argument'),
-      ...namedArguments.entries.map((entry) => '${entry.key}: ${entry.value}'),
-    ];
-    return '$target(${rendered.join(', ')})';
-  }
-
-  @override
   List<Object?> get props => [
     type,
     constructorName,
@@ -340,9 +370,6 @@ class DartStaticMember extends DartExpression {
   /// only used for members that are; a static getter would not be.
   @override
   bool get isConst => true;
-
-  @override
-  String toString() => '$type.$name';
 
   @override
   List<Object?> get props => [type, name];

--- a/lib/src/render/dart_expression.dart
+++ b/lib/src/render/dart_expression.dart
@@ -34,6 +34,22 @@ sealed class DartExpression extends Equatable {
   /// Derived, never stored.
   bool get isConst;
 
+  /// Whether a `const` keyword may legally be written before this
+  /// expression. Only a collection literal or a constructor invocation
+  /// takes one — `const 5` and `const UserRole.admin` are syntax errors,
+  /// which is the bug that motivated this IR in the first place.
+  ///
+  /// Independent of [isConst]: a `const`-declared constructor invoked with
+  /// a non-constant argument may take the keyword syntactically and still
+  /// not be a constant. [DartConst] requires both.
+  bool get canTakeConstKeyword => switch (this) {
+    DartLiteral() || DartStaticMember() => false,
+    DartListLiteral() || DartMapLiteral() => true,
+    DartInvocation(:final isConstConstructor) => isConstConstructor,
+    // Already `const`; a second keyword would be `unnecessary_const`.
+    DartConst() => false,
+  };
+
   /// The rendered Dart source for this expression, never `const`-prefixed.
   @override
   String toString();
@@ -121,16 +137,18 @@ class DartLiteral extends DartExpression {
   List<Object?> get props => [value, value.runtimeType];
 }
 
-/// A list literal, e.g. `<int>[0]`.
+/// A list literal, e.g. `<int>[0]` or `[]`.
 class DartListLiteral extends DartExpression {
-  const DartListLiteral({
-    required this.elementType,
-    required this.elements,
-  });
+  const DartListLiteral({required this.elementType, required this.elements});
 
-  /// The element type argument. Always written — an untyped `[...]` would
-  /// infer from context, which generated code shouldn't rely on.
-  final DartType elementType;
+  /// A list literal with no type argument, e.g. `[]` — the elements (or the
+  /// context it lands in) infer it. Mirrors [DartMapLiteral.untyped].
+  const DartListLiteral.untyped(this.elements) : elementType = null;
+
+  /// The element type argument, or `null` to omit the `<T>`. An empty
+  /// default (`const []`) is written untyped because the surrounding
+  /// declaration already pins the type.
+  final DartType? elementType;
 
   final List<DartExpression> elements;
 
@@ -139,10 +157,51 @@ class DartListLiteral extends DartExpression {
   bool get isConst => elements.every((element) => element.isConst);
 
   @override
-  String toString() => '<$elementType>[${elements.join(', ')}]';
+  String toString() {
+    final elementType = this.elementType;
+    final typeArgument = elementType == null ? '' : '<$elementType>';
+    return '$typeArgument[${elements.join(', ')}]';
+  }
 
   @override
   List<Object?> get props => [elementType, elements];
+}
+
+/// An expression written with an explicit `const` keyword: `const []`,
+/// `const Foo(1)`.
+///
+/// Most expressions are rendered bare — const-ness is normally spent on an
+/// enclosing declaration, which covers the whole tree at once. This node is
+/// for the positions where that isn't available and the keyword has to
+/// appear in the expression itself, such as a default value spliced into a
+/// `??`.
+class DartConst extends DartExpression {
+  const DartConst(this.expression);
+
+  final DartExpression expression;
+
+  @override
+  bool get isConst => expression.isConst;
+
+  // Checked at render rather than in the constructor: this is a `const`
+  // constructor, so its asserts may only use constant expressions, and
+  // both of these are getter calls. Rendering is where a bad node would
+  // become broken generated code anyway.
+  @override
+  String toString() {
+    assert(
+      expression.isConst,
+      'const around a non-constant expression: $expression',
+    );
+    assert(
+      expression.canTakeConstKeyword,
+      'const is not legal before this expression: $expression',
+    );
+    return 'const $expression';
+  }
+
+  @override
+  List<Object?> get props => [expression];
 }
 
 /// One `key: value` pair in a [DartMapLiteral].

--- a/lib/src/render/file_renderer.dart
+++ b/lib/src/render/file_renderer.dart
@@ -6,6 +6,7 @@ import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 import 'package:space_gen/src/logger.dart';
 import 'package:space_gen/src/quirks.dart';
+import 'package:space_gen/src/render/dart_expression.dart';
 import 'package:space_gen/src/render/formatting.dart';
 import 'package:space_gen/src/render/render_tree.dart';
 import 'package:space_gen/src/render/schema_renderer.dart';
@@ -864,10 +865,11 @@ class FileRenderer {
           'packageName': packageName,
           'barrelImportPath': testBarrelImport(),
           'typeName': schema.typeName,
-          // Const-ness is spent on the declaration keyword rather
-          // than the initializer, so the expression stays bare — see
-          // [DartExpression].
-          'exampleValue': example.toString(),
+          // The declaration carries the keyword when the example is
+          // constant (`const instance = ...`), which makes the whole tree
+          // a constant context; otherwise it is a `final` declaration and
+          // any constant subtree writes its own.
+          'exampleValue': _exampleSource(example),
           'exampleIsConst': example.isConst,
           'invalidJsonExample': invalidJson,
           'isEnum': schema is RenderEnum,
@@ -923,7 +925,7 @@ class FileRenderer {
       if (example == null) continue;
       variants.add({
         'variantTypeName': variant.typeName,
-        'exampleValue': example.toString(),
+        'exampleValue': _exampleSource(example),
         'exampleIsConst': example.isConst,
       });
     }
@@ -1008,3 +1010,11 @@ class FileRenderer {
     renderCspellConfig(misspellings);
   }
 }
+
+/// Source for a round-trip test's `instance` initializer. A constant
+/// example is declared `const`, which makes its whole tree a constant
+/// context; a non-constant one is declared `final`, so any constant
+/// subtree inside it needs its own keyword.
+String _exampleSource(DartExpression example) => example.isConst
+    ? DartExpressionSerializer.constContext.serialize(example)
+    : DartExpressionSerializer.runtimeContext.serialize(example);

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -4157,13 +4157,13 @@ class RenderArray extends RenderSchema {
     final listDefault = value as List;
     if (listDefault.isEmpty) {
       // Type annotation is not needed for empty lists.
-      return const DartConst(DartListLiteral.untyped([]));
+      return const DartListLiteral.untyped([], hasConstKeyword: true);
     }
-    final literal = DartListLiteral(
+    return DartListLiteral(
       elementType: items.dartType,
       elements: listDefault.map(DartLiteral.new).toList(),
+      hasConstKeyword: items.defaultCanConstConstruct,
     );
-    return items.defaultCanConstConstruct ? DartConst(literal) : literal;
   }
 
   @override

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -2001,7 +2001,7 @@ Map<String, dynamic> _requestBodyParameterContext(
     'dartName': body.dartParameterName(context.quirks),
     'required': body.isRequired,
     'hasDefaultValue': body.schema.defaultValue != null,
-    'defaultValue': body.schema.defaultValueString(context),
+    'defaultValue': body.schema.defaultValueExpression(context)?.toString(),
     'type': body.schema.typeName,
     'nullableType': body.schema.nullableTypeName(context),
   };
@@ -2445,7 +2445,7 @@ abstract class RenderSchema extends Equatable implements ToTemplateContext {
     required bool jsonIsNullable,
     required bool dartIsNullable,
   }) {
-    final defaultValue = defaultValueString(context);
+    final defaultValue = defaultValueExpression(context);
     if (defaultValue == null) {
       if (jsonIsNullable && !dartIsNullable) {
         // Belt-and-braces: a non-nullable Dart slot fed by a nullable
@@ -2565,15 +2565,13 @@ abstract class RenderSchema extends Equatable implements ToTemplateContext {
   /// emitting the negative test for those.
   String? invalidJsonExample(SchemaRenderer context) => null;
 
-  /// The default value of this schema as a string.
-  String? defaultValueString(SchemaRenderer context) {
-    if (defaultValue == null) {
+  /// The default value of this schema, as an expression.
+  DartExpression? defaultValueExpression(SchemaRenderer context) {
+    final value = defaultValue;
+    if (value == null) {
       return null;
     }
-    if (defaultValue is String) {
-      return quoteString(defaultValue as String);
-    }
-    return defaultValue.toString();
+    return DartLiteral(value);
   }
 
   bool hasDefaultValue(SchemaRenderer context) => defaultValue != null;
@@ -2623,6 +2621,10 @@ abstract class RenderSchema extends Equatable implements ToTemplateContext {
 /// `DateTime.utc(2024)`.
 DartExpression _dateTimeUtc(int year) =>
     DartType.dateTime.construct([DartLiteral(year)], name: 'utc');
+
+/// `DateTime.parse('...')`.
+DartExpression _dateTimeParse(String value) =>
+    DartType.dateTime.construct([DartLiteral(value)], name: 'parse');
 
 /// `Uri.parse('...')`.
 DartExpression _uriParse(String uri) =>
@@ -2732,22 +2734,21 @@ class RenderPod extends RenderSchema {
     PodType.boolean => DartType.bool_,
   };
 
-  /// The default value of this schema as a string.
+  /// The default value of this schema, as an expression.
   @override
-  String? defaultValueString(SchemaRenderer context) {
-    if (defaultValue == null) {
+  DartExpression? defaultValueExpression(SchemaRenderer context) {
+    final value = defaultValue;
+    if (value == null) {
       return null;
     }
     final raw = switch (type) {
-      PodType.dateTime =>
-        'DateTime.parse(${quoteString(defaultValue as String)})',
-      PodType.uri => 'Uri.parse(${quoteString(defaultValue as String)})',
-      PodType.uriTemplate =>
-        'UriTemplate(${quoteString(defaultValue as String)})',
-      PodType.email || PodType.uuid => quoteString(defaultValue as String),
-      PodType.boolean => defaultValue.toString(),
+      PodType.dateTime => _dateTimeParse(value as String),
+      PodType.uri => _uriParse(value as String),
+      PodType.uriTemplate => _uriTemplate(value as String),
+      PodType.email || PodType.uuid => DartLiteral(value as String),
+      PodType.boolean => DartLiteral(value),
     };
-    return createsNewType ? '$typeName($raw)' : raw;
+    return createsNewType ? dartType.constConstruct([raw]) : raw;
   }
 
   @override
@@ -2969,11 +2970,11 @@ class RenderString extends RenderSchema {
   DartType get dartType =>
       createsNewType ? DartType(_requireAssignedName()) : DartType.string;
 
-  /// The default value of this schema as a string.
+  /// The default value of this schema, as an expression.
   @override
-  String? defaultValueString(SchemaRenderer context) {
+  DartExpression? defaultValueExpression(SchemaRenderer context) {
     final value = defaultValue;
-    return value == null ? null : quoteString(value);
+    return value == null ? null : DartLiteral(value);
   }
 
   @override
@@ -3212,15 +3213,19 @@ abstract class RenderNumeric<T extends num> extends RenderSchema {
   bool get defaultCanConstConstruct => true;
 
   @override
-  String? defaultValueString(SchemaRenderer context) {
-    if (defaultValue == null) {
+  DartExpression? defaultValueExpression(SchemaRenderer context) {
+    final value = defaultValue;
+    if (value == null) {
       return null;
     }
+    // `dartType` rather than `camelFromSnake(snakeName)`, which is what
+    // this used to spell: one way to name a type, and the same one every
+    // other expression here uses. Verified equivalent across the spec
+    // rotation before switching.
     if (createsNewType) {
-      final typeName = camelFromSnake(snakeName);
-      return '$typeName($defaultValue)';
+      return dartType.constConstruct([DartLiteral(value)]);
     }
-    return defaultValue.toString();
+    return DartLiteral(value);
   }
 
   @override
@@ -3585,7 +3590,7 @@ class RenderObject extends RenderNewType {
     } else {
       line.write('this.$dartName');
       if (property.hasDefaultValue(context)) {
-        line.write(' = ${property.defaultValueString(context)}');
+        line.write(' = ${property.defaultValueExpression(context)}');
       }
     }
     return line.toString();
@@ -3601,7 +3606,7 @@ class RenderObject extends RenderNewType {
     final dartName = variableSafeName(context.quirks, jsonName);
     if (property.hasNonConstDefaultValue(context)) {
       return 'this.$dartName = $dartName '
-          '?? ${property.defaultValueString(context)}';
+          '?? ${property.defaultValueExpression(context)}';
     }
     return null;
   }
@@ -3975,10 +3980,9 @@ class RenderObject extends RenderNewType {
       // reads differently from `DateTime.utc(...)`), so this can't drop
       // a genuinely-needed argument.
       //
-      // Compares rendered text because `defaultValueString` is still a
-      // `String`; once it becomes a [DartExpression] this is structural
-      // equality between two trees.
-      if (property.defaultValueString(context) == example.toString()) continue;
+      // Structural equality between two expression trees, which is the
+      // question actually being asked: do these spell the same argument?
+      if (property.defaultValueExpression(context) == example) continue;
       final dartName = variableSafeName(context.quirks, jsonName);
       args[dartName] = example;
     }
@@ -4145,21 +4149,21 @@ class RenderArray extends RenderSchema {
   String hashCodeExpression(String name) => '${ModelHelpers.listHash}($name)';
 
   @override
-  String? defaultValueString(SchemaRenderer context) {
-    if (defaultValue == null) {
+  DartExpression? defaultValueExpression(SchemaRenderer context) {
+    final value = defaultValue;
+    if (value == null) {
       return null;
     }
-    final listDefault = defaultValue as List;
+    final listDefault = value as List;
     if (listDefault.isEmpty) {
       // Type annotation is not needed for empty lists.
-      return 'const []';
+      return const DartConst(DartListLiteral.untyped([]));
     }
-    final maybeConst = items.defaultCanConstConstruct ? 'const ' : '';
-    final itemType = items.typeName;
-    String toString(dynamic value) =>
-        value is String ? quoteString(value) : value.toString();
-    final values = listDefault.map(toString).join(', ');
-    return '$maybeConst<$itemType>[$values]';
+    final literal = DartListLiteral(
+      elementType: items.dartType,
+      elements: listDefault.map(DartLiteral.new).toList(),
+    );
+    return items.defaultCanConstConstruct ? DartConst(literal) : literal;
   }
 
   @override
@@ -4552,12 +4556,12 @@ abstract class RenderEnum<T extends Object> extends RenderNewType {
     };
   }
 
-  /// The default value of this schema as a string.
+  /// The default value of this schema, as an expression.
   @override
-  String? defaultValueString(SchemaRenderer context) {
+  DartExpression? defaultValueExpression(SchemaRenderer context) {
     final value = defaultValue;
     if (value == null) return null;
-    return '$className.${variableNameFor(value)}';
+    return DartType(className).member(variableNameFor(value));
   }
 
   /// Renders [value] as a reference to this enum's member (e.g.
@@ -5849,7 +5853,7 @@ class RenderParameter implements CanBeParameter {
     'dartName': dartParameterName(context.quirks),
     'required': isRequired,
     'hasDefaultValue': type.defaultValue != null,
-    'defaultValue': type.defaultValueString(context),
+    'defaultValue': type.defaultValueExpression(context)?.toString(),
     'type': type.typeName,
     'nullableType': type.nullableTypeName(context),
   };
@@ -6112,10 +6116,12 @@ class RenderDate extends RenderSchema {
   bool get shouldCallToJson => true;
 
   @override
-  String? defaultValueString(SchemaRenderer context) {
+  DartExpression? defaultValueExpression(SchemaRenderer context) {
     final value = defaultValue;
     if (value == null) return null;
-    return 'Date.fromJson(${quoteString(value)})';
+    return const DartType(
+      'Date',
+    ).construct([DartLiteral(value)], name: 'fromJson');
   }
 
   @override

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -2001,7 +2001,9 @@ Map<String, dynamic> _requestBodyParameterContext(
     'dartName': body.dartParameterName(context.quirks),
     'required': body.isRequired,
     'hasDefaultValue': body.schema.defaultValue != null,
-    'defaultValue': body.schema.defaultValueExpression(context)?.toString(),
+    'defaultValue': body.schema
+        .defaultValueExpression(context)
+        ?.toConstantSource(),
     'type': body.schema.typeName,
     'nullableType': body.schema.nullableTypeName(context),
   };
@@ -2462,7 +2464,7 @@ abstract class RenderSchema extends Equatable implements ToTemplateContext {
     // Non-null Dart slot fed by nullable JSON: an `as T?` cast would
     // crash on null. Substitute the default whether the default is
     // const or not.
-    if (!dartIsNullable) return ' ?? $defaultValue';
+    if (!dartIsNullable) return ' ?? ${defaultValue.toConstantSource()}';
     // Nullable Dart slot with a const default: the constructor uses
     // `this.foo = default`, which only fires when the param is omitted.
     // `fromJson` always passes a value (possibly null), so substitute
@@ -2470,7 +2472,9 @@ abstract class RenderSchema extends Equatable implements ToTemplateContext {
     // produces `null` instead of the spec's default. Surfaced by a
     // real spec with `bool` properties marked `default: false` outside
     // the `required` array.
-    if (defaultCanConstConstruct) return ' ?? $defaultValue';
+    if (defaultCanConstConstruct) {
+      return ' ?? ${defaultValue.toConstantSource()}';
+    }
     // Nullable Dart slot with a non-const default: the constructor uses
     // an initializer list (`: foo = foo ?? default`) that substitutes
     // on null too, so the default lands without `fromJson`'s help.
@@ -3590,7 +3594,8 @@ class RenderObject extends RenderNewType {
     } else {
       line.write('this.$dartName');
       if (property.hasDefaultValue(context)) {
-        line.write(' = ${property.defaultValueExpression(context)}');
+        final value = property.defaultValueExpression(context);
+        line.write(' = ${value?.toConstantSource()}');
       }
     }
     return line.toString();
@@ -3605,8 +3610,8 @@ class RenderObject extends RenderNewType {
   }) {
     final dartName = variableSafeName(context.quirks, jsonName);
     if (property.hasNonConstDefaultValue(context)) {
-      return 'this.$dartName = $dartName '
-          '?? ${property.defaultValueExpression(context)}';
+      final value = property.defaultValueExpression(context);
+      return 'this.$dartName = $dartName ?? ${value?.toConstantSource()}';
     }
     return null;
   }
@@ -4157,12 +4162,11 @@ class RenderArray extends RenderSchema {
     final listDefault = value as List;
     if (listDefault.isEmpty) {
       // Type annotation is not needed for empty lists.
-      return const DartListLiteral.untyped([], hasConstKeyword: true);
+      return DartListLiteral.empty;
     }
     return DartListLiteral(
       elementType: items.dartType,
       elements: listDefault.map(DartLiteral.new).toList(),
-      hasConstKeyword: items.defaultCanConstConstruct,
     );
   }
 
@@ -5853,7 +5857,7 @@ class RenderParameter implements CanBeParameter {
     'dartName': dartParameterName(context.quirks),
     'required': isRequired,
     'hasDefaultValue': type.defaultValue != null,
-    'defaultValue': type.defaultValueExpression(context)?.toString(),
+    'defaultValue': type.defaultValueExpression(context)?.toConstantSource(),
     'type': type.typeName,
     'nullableType': type.nullableTypeName(context),
   };

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -2001,9 +2001,7 @@ Map<String, dynamic> _requestBodyParameterContext(
     'dartName': body.dartParameterName(context.quirks),
     'required': body.isRequired,
     'hasDefaultValue': body.schema.defaultValue != null,
-    'defaultValue': body.schema
-        .defaultValueExpression(context)
-        ?.toConstantSource(),
+    'defaultValue': _runtimeSource(body.schema.defaultValueExpression(context)),
     'type': body.schema.typeName,
     'nullableType': body.schema.nullableTypeName(context),
   };
@@ -2464,7 +2462,7 @@ abstract class RenderSchema extends Equatable implements ToTemplateContext {
     // Non-null Dart slot fed by nullable JSON: an `as T?` cast would
     // crash on null. Substitute the default whether the default is
     // const or not.
-    if (!dartIsNullable) return ' ?? ${defaultValue.toConstantSource()}';
+    if (!dartIsNullable) return ' ?? ${_runtimeSource(defaultValue)}';
     // Nullable Dart slot with a const default: the constructor uses
     // `this.foo = default`, which only fires when the param is omitted.
     // `fromJson` always passes a value (possibly null), so substitute
@@ -2473,7 +2471,7 @@ abstract class RenderSchema extends Equatable implements ToTemplateContext {
     // real spec with `bool` properties marked `default: false` outside
     // the `required` array.
     if (defaultCanConstConstruct) {
-      return ' ?? ${defaultValue.toConstantSource()}';
+      return ' ?? ${_runtimeSource(defaultValue)}';
     }
     // Nullable Dart slot with a non-const default: the constructor uses
     // an initializer list (`: foo = foo ?? default`) that substitutes
@@ -2621,6 +2619,13 @@ abstract class RenderSchema extends Equatable implements ToTemplateContext {
 // site describes the call structurally when we already know exactly which
 // call it is; naming them lets the call site read like the Dart it
 // produces. None are constant: each computes its value at runtime.
+
+/// Source for an expression landing somewhere that evaluates at runtime —
+/// a `??` right-hand side, or a parameter default, where a `const` keyword
+/// turns an allocation into a compile-time constant.
+String? _runtimeSource(DartExpression? expression) => expression == null
+    ? null
+    : DartExpressionSerializer.runtimeContext.serialize(expression);
 
 /// `DateTime.utc(2024)`.
 DartExpression _dateTimeUtc(int year) =>
@@ -3595,7 +3600,7 @@ class RenderObject extends RenderNewType {
       line.write('this.$dartName');
       if (property.hasDefaultValue(context)) {
         final value = property.defaultValueExpression(context);
-        line.write(' = ${value?.toConstantSource()}');
+        line.write(' = ${_runtimeSource(value)}');
       }
     }
     return line.toString();
@@ -3611,7 +3616,7 @@ class RenderObject extends RenderNewType {
     final dartName = variableSafeName(context.quirks, jsonName);
     if (property.hasNonConstDefaultValue(context)) {
       final value = property.defaultValueExpression(context);
-      return 'this.$dartName = $dartName ?? ${value?.toConstantSource()}';
+      return 'this.$dartName = $dartName ?? ${_runtimeSource(value)}';
     }
     return null;
   }
@@ -5857,7 +5862,7 @@ class RenderParameter implements CanBeParameter {
     'dartName': dartParameterName(context.quirks),
     'required': isRequired,
     'hasDefaultValue': type.defaultValue != null,
-    'defaultValue': type.defaultValueExpression(context)?.toConstantSource(),
+    'defaultValue': _runtimeSource(type.defaultValueExpression(context)),
     'type': type.typeName,
     'nullableType': type.nullableTypeName(context),
   };

--- a/test/recursion_notes.md
+++ b/test/recursion_notes.md
@@ -1,0 +1,18 @@
+OK, I need to fix my resolver to handle recursive references.
+
+Right now we eagerly resolve all references during resolveSpec,
+but for references to *rendered* schemas, we should resolve them, but store
+them into a map of pointer -> ResolvedSchema and instead store a ResolvedRef
+object in the actual resolved tree.
+
+ResolvedRef will never render itself, only proxy through to its resolved target?
+
+Maybe ResolvedRef actually holds a pointer to the resolved schema in the Map?
+
+Maybe it's actually ResolvedProxy rather than ResolvedRef?
+
+Either way it needs to know the pointer and needs to proxy to the actual
+resolved schema, but when creating the RenderTree we'll need to also make a
+RenderProxy or similar that only holds the information about the pointer/name
+for import generation and not any information about how to actually render
+the schema since that won't be it's job.

--- a/test/render/dart_expression_test.dart
+++ b/test/render/dart_expression_test.dart
@@ -60,6 +60,14 @@ void main() {
       );
     });
 
+    test('untyped omits the type argument', () {
+      expect(const DartListLiteral.untyped([]).toString(), '[]');
+      expect(
+        const DartListLiteral.untyped([DartLiteral(0)]).toString(),
+        '[0]',
+      );
+    });
+
     test('equality is by value', () {
       // Built from a non-const local so this is a distinct object:
       // identical `const` instances are canonicalized to one, and `==`
@@ -291,6 +299,84 @@ void main() {
             isConstConstructor: false,
           ),
         ),
+      );
+    });
+  });
+
+  group('DartConst', () {
+    test('renders the keyword and stays constant', () {
+      const empty = DartConst(DartListLiteral.untyped([]));
+      expect(empty.toString(), 'const []');
+      expect(empty.isConst, isTrue);
+    });
+
+    test('rejects an expression the keyword is not legal before', () {
+      // `const 5` and `const UserRole.admin` are syntax errors — the bug
+      // that motivated this IR, now caught structurally.
+      expect(
+        () => const DartConst(DartLiteral(5)).toString(),
+        throwsA(isA<AssertionError>()),
+      );
+      expect(
+        () => const DartConst(
+          DartStaticMember(type: DartType('Foo'), name: 'a'),
+        ).toString(),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+
+    test('rejects a non-constant expression', () {
+      expect(
+        () => const DartConst(
+          DartListLiteral(elementType: DartType.uri, elements: [nonConst]),
+        ).toString(),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+
+    test('equality is by value', () {
+      // See the list-literal equality test for why one side is built from
+      // a non-const local.
+      final elements = [const DartLiteral(0)];
+      final inner = DartListLiteral.untyped(elements);
+      expect(
+        DartConst(inner),
+        const DartConst(DartListLiteral.untyped([DartLiteral(0)])),
+      );
+    });
+  });
+
+  group('canTakeConstKeyword', () {
+    test('is true only for collection literals and const constructors', () {
+      expect(const DartLiteral(5).canTakeConstKeyword, isFalse);
+      expect(
+        const DartStaticMember(
+          type: DartType('Foo'),
+          name: 'a',
+        ).canTakeConstKeyword,
+        isFalse,
+      );
+      expect(const DartListLiteral.untyped([]).canTakeConstKeyword, isTrue);
+      expect(
+        const DartMapLiteral(
+          keyType: null,
+          valueType: null,
+        ).canTakeConstKeyword,
+        isTrue,
+      );
+      expect(
+        const DartInvocation(
+          type: DartType('Foo'),
+          isConstConstructor: true,
+        ).canTakeConstKeyword,
+        isTrue,
+      );
+      // A non-const constructor can never take the keyword.
+      expect(nonConst.canTakeConstKeyword, isFalse);
+      // Already const; a second keyword is `unnecessary_const`.
+      expect(
+        const DartConst(DartListLiteral.untyped([])).canTakeConstKeyword,
+        isFalse,
       );
     });
   });

--- a/test/render/dart_expression_test.dart
+++ b/test/render/dart_expression_test.dart
@@ -303,80 +303,39 @@ void main() {
     });
   });
 
-  group('DartConst', () {
-    test('renders the keyword and stays constant', () {
-      const empty = DartConst(DartListLiteral.untyped([]));
-      expect(empty.toString(), 'const []');
-      expect(empty.isConst, isTrue);
-    });
-
-    test('rejects an expression the keyword is not legal before', () {
-      // `const 5` and `const UserRole.admin` are syntax errors — the bug
-      // that motivated this IR, now caught structurally.
+  group('hasConstKeyword', () {
+    test('writes the keyword before the literal', () {
       expect(
-        () => const DartConst(DartLiteral(5)).toString(),
-        throwsA(isA<AssertionError>()),
+        const DartListLiteral.untyped([], hasConstKeyword: true).toString(),
+        'const []',
       );
       expect(
-        () => const DartConst(
-          DartStaticMember(type: DartType('Foo'), name: 'a'),
+        const DartListLiteral(
+          elementType: DartType.int_,
+          elements: [DartLiteral(0)],
+          hasConstKeyword: true,
+        ).toString(),
+        'const <int>[0]',
+      );
+    });
+
+    test('is off by default and part of the value', () {
+      expect(const DartListLiteral.untyped([]).toString(), '[]');
+      final elements = <DartExpression>[];
+      expect(
+        DartListLiteral.untyped(elements, hasConstKeyword: true),
+        isNot(const DartListLiteral.untyped([])),
+      );
+    });
+
+    test('refuses to write const around a non-constant literal', () {
+      expect(
+        () => const DartListLiteral(
+          elementType: DartType.uri,
+          elements: [nonConst],
+          hasConstKeyword: true,
         ).toString(),
         throwsA(isA<AssertionError>()),
-      );
-    });
-
-    test('rejects a non-constant expression', () {
-      expect(
-        () => const DartConst(
-          DartListLiteral(elementType: DartType.uri, elements: [nonConst]),
-        ).toString(),
-        throwsA(isA<AssertionError>()),
-      );
-    });
-
-    test('equality is by value', () {
-      // See the list-literal equality test for why one side is built from
-      // a non-const local.
-      final elements = [const DartLiteral(0)];
-      final inner = DartListLiteral.untyped(elements);
-      expect(
-        DartConst(inner),
-        const DartConst(DartListLiteral.untyped([DartLiteral(0)])),
-      );
-    });
-  });
-
-  group('canTakeConstKeyword', () {
-    test('is true only for collection literals and const constructors', () {
-      expect(const DartLiteral(5).canTakeConstKeyword, isFalse);
-      expect(
-        const DartStaticMember(
-          type: DartType('Foo'),
-          name: 'a',
-        ).canTakeConstKeyword,
-        isFalse,
-      );
-      expect(const DartListLiteral.untyped([]).canTakeConstKeyword, isTrue);
-      expect(
-        const DartMapLiteral(
-          keyType: null,
-          valueType: null,
-        ).canTakeConstKeyword,
-        isTrue,
-      );
-      expect(
-        const DartInvocation(
-          type: DartType('Foo'),
-          isConstConstructor: true,
-        ).canTakeConstKeyword,
-        isTrue,
-      );
-      // A non-const constructor can never take the keyword.
-      expect(nonConst.canTakeConstKeyword, isFalse);
-      // Already const; a second keyword is `unnecessary_const`.
-      expect(
-        const DartConst(DartListLiteral.untyped([])).canTakeConstKeyword,
-        isFalse,
       );
     });
   });

--- a/test/render/dart_expression_test.dart
+++ b/test/render/dart_expression_test.dart
@@ -61,7 +61,7 @@ void main() {
     });
 
     test('untyped omits the type argument', () {
-      expect(const DartListLiteral.untyped([]).toString(), '[]');
+      expect(DartListLiteral.empty.toString(), '[]');
       expect(
         const DartListLiteral.untyped([DartLiteral(0)]).toString(),
         '[0]',
@@ -303,40 +303,58 @@ void main() {
     });
   });
 
-  group('hasConstKeyword', () {
-    test('writes the keyword before the literal', () {
-      expect(
-        const DartListLiteral.untyped([], hasConstKeyword: true).toString(),
-        'const []',
-      );
+  group('toConstantSource', () {
+    test('writes the keyword at the outermost node that can carry it', () {
+      expect(DartListLiteral.empty.toConstantSource(), 'const []');
       expect(
         const DartListLiteral(
           elementType: DartType.int_,
           elements: [DartLiteral(0)],
-          hasConstKeyword: true,
-        ).toString(),
+        ).toConstantSource(),
         'const <int>[0]',
       );
-    });
-
-    test('is off by default and part of the value', () {
-      expect(const DartListLiteral.untyped([]).toString(), '[]');
-      final elements = <DartExpression>[];
       expect(
-        DartListLiteral.untyped(elements, hasConstKeyword: true),
-        isNot(const DartListLiteral.untyped([])),
+        const DartMapLiteral(
+          keyType: DartType.string,
+          valueType: DartType.dynamic_,
+        ).toConstantSource(),
+        'const <String, dynamic>{}',
+      );
+      expect(
+        const DartInvocation(
+          type: DartType('Foo'),
+          arguments: [DartLiteral(1)],
+          isConstConstructor: true,
+        ).toConstantSource(),
+        'const Foo(1)',
       );
     });
 
-    test('refuses to write const around a non-constant literal', () {
+    test('renders bare where the keyword is not legal', () {
+      // `const 5` and `const UserRole.admin` are syntax errors.
+      expect(const DartLiteral(5).toConstantSource(), '5');
       expect(
-        () => const DartListLiteral(
+        const DartStaticMember(
+          type: DartType('Foo'),
+          name: 'a',
+        ).toConstantSource(),
+        'Foo.a',
+      );
+    });
+
+    test('renders bare when the value is not constant', () {
+      expect(nonConst.toConstantSource(), "Uri.parse('https://example.com')");
+      expect(
+        const DartListLiteral(
           elementType: DartType.uri,
           elements: [nonConst],
-          hasConstKeyword: true,
-        ).toString(),
-        throwsA(isA<AssertionError>()),
+        ).toConstantSource(),
+        "<Uri>[Uri.parse('https://example.com')]",
       );
+    });
+
+    test('toString stays bare — the keyword is a serialization choice', () {
+      expect(DartListLiteral.empty.toString(), '[]');
     });
   });
 

--- a/test/render/dart_expression_test.dart
+++ b/test/render/dart_expression_test.dart
@@ -2,6 +2,8 @@ import 'package:space_gen/src/render/dart_expression.dart';
 import 'package:space_gen/src/render/dart_type.dart';
 import 'package:test/test.dart';
 
+import 'expression_source.dart';
+
 /// A non-constant expression to nest as an argument: `Uri.parse` computes
 /// at runtime.
 const nonConst = DartInvocation(
@@ -14,20 +16,20 @@ const nonConst = DartInvocation(
 void main() {
   group('DartLiteral', () {
     test('strings quote and escape through quoteString', () {
-      expect(const DartLiteral('example').toString(), "'example'");
-      expect(const DartLiteral(r"it's $x").toString(), r"'it\'s \$x'");
-      expect(const DartLiteral('a\nb').toString(), r"'a\nb'");
+      expect(const DartLiteral('example').source, "'example'");
+      expect(const DartLiteral(r"it's $x").source, r"'it\'s \$x'");
+      expect(const DartLiteral('a\nb').source, r"'a\nb'");
     });
 
     test('numbers keep the int/double distinction', () {
-      expect(const DartLiteral(5).toString(), '5');
-      expect(const DartLiteral(5.0).toString(), '5.0');
-      expect(const DartLiteral(-5).toString(), '-5');
+      expect(const DartLiteral(5).source, '5');
+      expect(const DartLiteral(5.0).source, '5.0');
+      expect(const DartLiteral(-5).source, '-5');
     });
 
     test('bool and null render bare', () {
-      expect(const DartLiteral(false).toString(), 'false');
-      expect(const DartLiteral(null).toString(), 'null');
+      expect(const DartLiteral(false).source, 'false');
+      expect(const DartLiteral(null).source, 'null');
     });
 
     test('is always constant', () {
@@ -48,22 +50,22 @@ void main() {
         const DartListLiteral(
           elementType: DartType.int_,
           elements: [DartLiteral(0), DartLiteral(1)],
-        ).toString(),
+        ).source,
         '<int>[0, 1]',
       );
       expect(
         const DartListLiteral(
           elementType: DartType.string,
           elements: [],
-        ).toString(),
+        ).source,
         '<String>[]',
       );
     });
 
     test('untyped omits the type argument', () {
-      expect(DartListLiteral.empty.toString(), '[]');
+      expect(DartListLiteral.empty.source, '[]');
       expect(
-        const DartListLiteral.untyped([DartLiteral(0)]).toString(),
+        const DartListLiteral.untyped([DartLiteral(0)]).source,
         '[0]',
       );
     });
@@ -114,7 +116,7 @@ void main() {
       expect(
         const DartMapLiteral.untyped([
           DartMapEntry(DartLiteral('key'), DartLiteral('example')),
-        ]).toString(),
+        ]).source,
         "{'key': 'example'}",
       );
     });
@@ -124,7 +126,7 @@ void main() {
         const DartMapLiteral(
           keyType: DartType.string,
           valueType: DartType.dynamic_,
-        ).toString(),
+        ).source,
         '<String, dynamic>{}',
       );
     });
@@ -155,9 +157,12 @@ void main() {
       // ignore: prefer_const_constructors
       final entry = DartMapEntry(DartLiteral('k'), DartLiteral(1));
       expect(entry, const DartMapEntry(DartLiteral('k'), DartLiteral(1)));
+      // Entries render as part of their map, not standalone.
       expect(
-        const DartMapEntry(DartLiteral('k'), DartLiteral(1)).toString(),
-        "'k': 1",
+        const DartMapLiteral.untyped([
+          DartMapEntry(DartLiteral('k'), DartLiteral(1)),
+        ]).source,
+        "{'k': 1}",
       );
     });
 
@@ -196,7 +201,7 @@ void main() {
         const DartInvocation(
           type: DartType('Foo'),
           isConstConstructor: true,
-        ).toString(),
+        ).source,
         'Foo()',
       );
       expect(
@@ -206,7 +211,7 @@ void main() {
           arguments: [DartLiteral(1)],
           namedArguments: {'b': DartLiteral(2)},
           isConstConstructor: true,
-        ).toString(),
+        ).source,
         'Foo.named(1, b: 2)',
       );
     });
@@ -217,7 +222,7 @@ void main() {
           type: DartType('Foo'),
           namedArguments: {'b': DartLiteral(1), 'a': DartLiteral(2)},
           isConstConstructor: true,
-        ).toString(),
+        ).source,
         'Foo(b: 1, a: 2)',
       );
     });
@@ -282,7 +287,7 @@ void main() {
         isConstConstructor: true,
       );
       expect(outer.isConst, isFalse);
-      expect(outer.toString(), "Foo(Bar(Uri.parse('https://example.com')))");
+      expect(outer.source, "Foo(Bar(Uri.parse('https://example.com')))");
     });
 
     test('equality is by value, including const-ness of the constructor', () {
@@ -303,21 +308,21 @@ void main() {
     });
   });
 
-  group('toConstantSource', () {
+  group('DartExpressionSerializer', () {
     test('writes the keyword at the outermost node that can carry it', () {
-      expect(DartListLiteral.empty.toConstantSource(), 'const []');
+      expect(DartListLiteral.empty.runtimeSource, 'const []');
       expect(
         const DartListLiteral(
           elementType: DartType.int_,
           elements: [DartLiteral(0)],
-        ).toConstantSource(),
+        ).runtimeSource,
         'const <int>[0]',
       );
       expect(
         const DartMapLiteral(
           keyType: DartType.string,
           valueType: DartType.dynamic_,
-        ).toConstantSource(),
+        ).runtimeSource,
         'const <String, dynamic>{}',
       );
       expect(
@@ -325,36 +330,69 @@ void main() {
           type: DartType('Foo'),
           arguments: [DartLiteral(1)],
           isConstConstructor: true,
-        ).toConstantSource(),
+        ).runtimeSource,
         'const Foo(1)',
       );
     });
 
     test('renders bare where the keyword is not legal', () {
       // `const 5` and `const UserRole.admin` are syntax errors.
-      expect(const DartLiteral(5).toConstantSource(), '5');
+      expect(const DartLiteral(5).runtimeSource, '5');
       expect(
         const DartStaticMember(
           type: DartType('Foo'),
           name: 'a',
-        ).toConstantSource(),
+        ).runtimeSource,
         'Foo.a',
       );
     });
 
     test('renders bare when the value is not constant', () {
-      expect(nonConst.toConstantSource(), "Uri.parse('https://example.com')");
+      expect(nonConst.runtimeSource, "Uri.parse('https://example.com')");
       expect(
         const DartListLiteral(
           elementType: DartType.uri,
           elements: [nonConst],
-        ).toConstantSource(),
+        ).runtimeSource,
         "<Uri>[Uri.parse('https://example.com')]",
       );
     });
 
-    test('toString stays bare — the keyword is a serialization choice', () {
-      expect(DartListLiteral.empty.toString(), '[]');
+    test('the same tree renders differently per destination', () {
+      // The whole reason rendering is not a method on the node.
+      expect(DartListLiteral.empty.source, '[]');
+      expect(DartListLiteral.empty.runtimeSource, 'const []');
+    });
+
+    test('context threads down through nesting', () {
+      // A constant subtree inside a non-constant parent gets its own
+      // keyword; a constant parent covers everything below it, so nothing
+      // inside repeats it (which would be `unnecessary_const`).
+      const bytes = DartListLiteral(
+        elementType: DartType.int_,
+        elements: [DartLiteral(0)],
+      );
+      expect(
+        DartType.uint8List.construct([bytes], name: 'fromList').runtimeSource,
+        'Uint8List.fromList(const <int>[0])',
+      );
+      expect(
+        const DartType('Foo').constConstruct([bytes]).runtimeSource,
+        'const Foo(<int>[0])',
+      );
+    });
+
+    test('the two serializers are distinct values', () {
+      expect(
+        DartExpressionSerializer.constContext,
+        isNot(DartExpressionSerializer.runtimeContext),
+      );
+    });
+
+    test('toString on a node is a debug form, not Dart source', () {
+      // Guards against an expression accidentally being interpolated
+      // into generated output instead of serialized.
+      expect(const DartLiteral(5).toString(), contains('DartLiteral'));
     });
   });
 
@@ -363,7 +401,7 @@ void main() {
       final parse = DartType.uri.construct(const [
         DartLiteral('https://example.com'),
       ], name: 'parse');
-      expect(parse.toString(), "Uri.parse('https://example.com')");
+      expect(parse.source, "Uri.parse('https://example.com')");
       expect(parse.isConst, isFalse);
     });
 
@@ -384,14 +422,14 @@ void main() {
     });
 
     test('member builds a static reference', () {
-      expect(const DartType('Foo').member('a').toString(), 'Foo.a');
+      expect(const DartType('Foo').member('a').source, 'Foo.a');
     });
   });
 
   group('DartStaticMember', () {
     test('renders as a member reference and is constant', () {
       const member = DartStaticMember(type: DartType('Foo'), name: 'a');
-      expect(member.toString(), 'Foo.a');
+      expect(member.source, 'Foo.a');
       expect(member.isConst, isTrue);
       expect(member, const DartStaticMember(type: DartType('Foo'), name: 'a'));
     });

--- a/test/render/expression_source.dart
+++ b/test/render/expression_source.dart
@@ -1,0 +1,16 @@
+import 'package:space_gen/src/render/dart_expression.dart';
+
+/// Test-only sugar over [DartExpressionSerializer], so assertions read
+/// `expr.source` instead of naming a serializer at every call.
+///
+/// Production code names the serializer explicitly: which context applies
+/// is a decision about the destination, and picking it deliberately is the
+/// whole point of separating rendering from the tree.
+extension ExpressionSource on DartExpression {
+  /// Source for a destination that is already a constant context.
+  String get source => DartExpressionSerializer.constContext.serialize(this);
+
+  /// Source for a destination that evaluates at runtime.
+  String get runtimeSource =>
+      DartExpressionSerializer.runtimeContext.serialize(this);
+}

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -4414,7 +4414,9 @@ void main() {
             quirks: const Quirks.openapi(),
           );
           final rule = results['Rule']!;
-          expect(rule, contains('?? WaitTimer(30)'));
+          // `const`: the substitution runs on every parse that omits the
+          // field, and a const newtype default costs no allocation.
+          expect(rule, contains('?? const WaitTimer(30)'));
           expect(rule, isNot(contains('WaitTimer(null)')));
         },
       );

--- a/test/render/render_tree_test.dart
+++ b/test/render/render_tree_test.dart
@@ -8,6 +8,8 @@ import 'package:space_gen/src/render/tree_visitor.dart';
 import 'package:space_gen/src/types.dart';
 import 'package:test/test.dart';
 
+import 'expression_source.dart';
+
 class _Collector extends RenderTreeVisitor {
   final List<RenderSchema> visited = [];
 
@@ -1155,7 +1157,7 @@ void main() {
 
     test('date format produces a Date value-class literal', () {
       const schema = RenderDate(common: common, defaultValue: null);
-      expect(schema.exampleValue(context)?.toString(), 'Date(2024, 1, 1)');
+      expect(schema.exampleValue(context)?.source, 'Date(2024, 1, 1)');
     });
 
     test('uri format produces a Uri.parse literal', () {
@@ -1165,7 +1167,7 @@ void main() {
         createsNewType: false,
       );
       expect(
-        schema.exampleValue(context)?.toString(),
+        schema.exampleValue(context)?.source,
         "Uri.parse('https://example.com')",
       );
     });
@@ -1177,7 +1179,7 @@ void main() {
         createsNewType: false,
       );
       expect(
-        schema.exampleValue(context)?.toString(),
+        schema.exampleValue(context)?.source,
         "UriTemplate('https://example.com/{id}')",
       );
     });
@@ -1188,7 +1190,7 @@ void main() {
         type: PodType.email,
         createsNewType: false,
       );
-      expect(schema.exampleValue(context)?.toString(), "'user@example.com'");
+      expect(schema.exampleValue(context)?.source, "'user@example.com'");
     });
 
     test('uuid format produces a uuid string literal', () {
@@ -1198,24 +1200,24 @@ void main() {
         createsNewType: false,
       );
       expect(
-        schema.exampleValue(context)?.toString(),
+        schema.exampleValue(context)?.source,
         "'00000000-0000-0000-0000-000000000000'",
       );
     });
 
     test('unknown returns an empty dynamic map literal', () {
       const schema = RenderUnknown(common: common);
-      expect(schema.exampleValue(context)?.toString(), '<String, dynamic>{}');
+      expect(schema.exampleValue(context)?.source, '<String, dynamic>{}');
     });
 
     test('void returns null (no round-trip possible)', () {
       const schema = RenderVoid(common: common);
-      expect(schema.exampleValue(context)?.toString(), isNull);
+      expect(schema.exampleValue(context)?.source, isNull);
     });
 
     test('binary (NoJson) returns null', () {
       const schema = RenderBinary(common: common);
-      expect(schema.exampleValue(context)?.toString(), isNull);
+      expect(schema.exampleValue(context)?.source, isNull);
     });
 
     test('recursive ref returns null', () {
@@ -1223,7 +1225,7 @@ void main() {
         common: common,
         targetPointer: JsonPointer.empty(),
       );
-      expect(schema.exampleValue(context)?.toString(), isNull);
+      expect(schema.exampleValue(context)?.source, isNull);
     });
 
     test('oneOf returns null (sealed class, no constructable subtype)', () {
@@ -1252,7 +1254,7 @@ void main() {
         discriminator: null,
         source: null,
       );
-      expect(schema.exampleValue(context)?.toString(), isNull);
+      expect(schema.exampleValue(context)?.source, isNull);
     });
 
     test('map with keySchema uses its exampleValue', () {
@@ -1278,7 +1280,7 @@ void main() {
       );
       // Key example names the enum's first member; value is the string
       // example.
-      expect(map.exampleValue(context)?.toString(), "{Foo.a: 'example'}");
+      expect(map.exampleValue(context)?.source, "{Foo.a: 'example'}");
     });
 
     test('string with spec example uses it verbatim', () {
@@ -1294,7 +1296,7 @@ void main() {
         pattern: r'^refs/(heads|tags|pull)/.*$',
         createsNewType: false,
       );
-      expect(schema.exampleValue(context)?.toString(), "'refs/heads/main'");
+      expect(schema.exampleValue(context)?.source, "'refs/heads/main'");
     });
 
     test('string falls back to first String entry from examples list', () {
@@ -1310,7 +1312,7 @@ void main() {
         pattern: null,
         createsNewType: false,
       );
-      expect(schema.exampleValue(context)?.toString(), "'second'");
+      expect(schema.exampleValue(context)?.source, "'second'");
     });
 
     test('string synthesizes a value matching simple character-class '
@@ -1330,7 +1332,7 @@ void main() {
         pattern: r'^[0-9a-fA-F]+$',
         createsNewType: false,
       );
-      expect(schema.exampleValue(context)?.toString(), "'${'a' * 40}'");
+      expect(schema.exampleValue(context)?.source, "'${'a' * 40}'");
     });
 
     test('string synthesizes for an alternation pattern by trying '
@@ -1348,7 +1350,7 @@ void main() {
         createsNewType: false,
       );
       // `'a'` doesn't match; `'0'` does (the 0 alternative).
-      expect(schema.exampleValue(context)?.toString(), "'0'");
+      expect(schema.exampleValue(context)?.source, "'0'");
     });
 
     test('string truncates a too-long fallback to maxLength', () {
@@ -1363,7 +1365,7 @@ void main() {
         pattern: null,
         createsNewType: false,
       );
-      expect(schema.exampleValue(context)?.toString(), "'exam'");
+      expect(schema.exampleValue(context)?.source, "'exam'");
     });
 
     test('string falls back when no candidate matches the pattern', () {
@@ -1382,7 +1384,7 @@ void main() {
         pattern: r'^Z+$',
         createsNewType: false,
       );
-      expect(schema.exampleValue(context)?.toString(), "'example'");
+      expect(schema.exampleValue(context)?.source, "'example'");
     });
 
     test('string falls back when the spec pattern is invalid regex', () {
@@ -1399,7 +1401,7 @@ void main() {
         pattern: '(',
         createsNewType: false,
       );
-      expect(schema.exampleValue(context)?.toString(), "'example'");
+      expect(schema.exampleValue(context)?.source, "'example'");
     });
 
     test('integer with spec example uses it', () {
@@ -1417,7 +1419,7 @@ void main() {
         multipleOf: null,
         createsNewType: false,
       );
-      expect(schema.exampleValue(context)?.toString(), '42');
+      expect(schema.exampleValue(context)?.source, '42');
     });
 
     test('integer with no spec example picks minimum', () {
@@ -1434,7 +1436,7 @@ void main() {
         multipleOf: null,
         createsNewType: false,
       );
-      expect(schema.exampleValue(context)?.toString(), '5');
+      expect(schema.exampleValue(context)?.source, '5');
     });
 
     test('integer falls back to first num in examples list when example '
@@ -1453,7 +1455,7 @@ void main() {
         multipleOf: null,
         createsNewType: false,
       );
-      expect(schema.exampleValue(context)?.toString(), '7');
+      expect(schema.exampleValue(context)?.source, '7');
     });
 
     test('integer with negative max picks the upper bound when zero is '
@@ -1471,7 +1473,7 @@ void main() {
         multipleOf: null,
         createsNewType: false,
       );
-      expect(schema.exampleValue(context)?.toString(), '-5');
+      expect(schema.exampleValue(context)?.source, '-5');
     });
 
     test('integer rounds candidate up to the next multipleOf', () {
@@ -1488,7 +1490,7 @@ void main() {
         multipleOf: 5,
         createsNewType: false,
       );
-      expect(schema.exampleValue(context)?.toString(), '10');
+      expect(schema.exampleValue(context)?.source, '10');
     });
   });
 
@@ -1637,7 +1639,7 @@ void main() {
     test('base64 bytes are not constant', () {
       const schema = RenderBase64Bytes(common: common);
       final example = schema.exampleValue(context);
-      expect(example.toString(), 'Uint8List.fromList(<int>[0])');
+      expect(example?.source, 'Uint8List.fromList(<int>[0])');
       expect(example?.isConst, isFalse);
     });
   });
@@ -1766,7 +1768,7 @@ void main() {
     });
 
     test('example is a Date value-class literal', () {
-      expect(date.exampleValue(context)?.toString(), 'Date(2024, 1, 1)');
+      expect(date.exampleValue(context)?.source, 'Date(2024, 1, 1)');
       expect(date.invalidJsonExample(context), "'not a date'");
     });
 
@@ -1776,7 +1778,7 @@ void main() {
         defaultValue: '2020-01-01',
       );
       expect(
-        withDefault.defaultValueExpression(context)?.toString(),
+        withDefault.defaultValueExpression(context)?.source,
         "Date.fromJson('2020-01-01')",
       );
       expect(date.defaultValueExpression(context), isNull);
@@ -1970,7 +1972,7 @@ void main() {
         assignedName: 'Flag',
       );
       expect(
-        newtypeBool.defaultValueExpression(context)?.toString(),
+        newtypeBool.defaultValueExpression(context)?.source,
         'Flag(true)',
       );
 
@@ -1984,7 +1986,7 @@ void main() {
         defaultValue: 'a@b.c',
       );
       expect(
-        inlineEmail.defaultValueExpression(context)?.toString(),
+        inlineEmail.defaultValueExpression(context)?.source,
         "'a@b.c'",
       );
     });

--- a/test/render/render_tree_test.dart
+++ b/test/render/render_tree_test.dart
@@ -1776,10 +1776,10 @@ void main() {
         defaultValue: '2020-01-01',
       );
       expect(
-        withDefault.defaultValueString(context),
+        withDefault.defaultValueExpression(context)?.toString(),
         "Date.fromJson('2020-01-01')",
       );
-      expect(date.defaultValueString(context), isNull);
+      expect(date.defaultValueExpression(context), isNull);
     });
 
     test('equality includes the default; toTemplateContext throws', () {
@@ -1969,7 +1969,10 @@ void main() {
         defaultValue: true,
         assignedName: 'Flag',
       );
-      expect(newtypeBool.defaultValueString(context), 'Flag(true)');
+      expect(
+        newtypeBool.defaultValueExpression(context)?.toString(),
+        'Flag(true)',
+      );
 
       const inlineEmail = RenderPod(
         common: CommonProperties.test(
@@ -1980,7 +1983,10 @@ void main() {
         createsNewType: false,
         defaultValue: 'a@b.c',
       );
-      expect(inlineEmail.defaultValueString(context), "'a@b.c'");
+      expect(
+        inlineEmail.defaultValueExpression(context)?.toString(),
+        "'a@b.c'",
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

Default values become `DartExpression` instead of `String`. `defaultValueString` → `defaultValueExpression`, across seven implementations and about a dozen call sites.

The payoff is in `RenderObject.exampleValue`, where "does this example spell the same thing as the property's default?" was asked as string equality over rendered text. It's now `==` between two trees — the question actually being asked. That was the C1 text comparison called out in `doc/dart_expression.md`.

## Details

Two gaps in the IR surfaced during the migration. Both are fixed in the IR rather than worked around at the call site:

- **`DartListLiteral` couldn't express `const []`.** It always wrote its element type, but an empty list default renders untyped. It now has a nullable `elementType` plus an `untyped` constructor, mirroring `DartMapLiteral`. My original "always written" doc comment was simply wrong about real generated code.
- **Nothing could render a `const` keyword**, by design — const-ness is normally spent on an enclosing declaration, which covers a whole tree at once. A default spliced into a `??` has no such declaration, so `DartConst` models the keyword explicitly. It asserts at render that its expression is both constant *and* able to take the keyword, because `const 5` and `const UserRole.admin` are syntax errors. `canTakeConstKeyword` is an exhaustive switch over the hierarchy — the same bug class that motivated the IR, now caught structurally in a second position.

`RenderNumeric` also stops naming its newtype with `camelFromSnake(snakeName)` and uses `dartType` like every other expression here. Two spellings for one type is the kind of thing the IR makes visible; verified equivalent across the rotation before switching.

**Not in this PR:** `defaultCanConstConstruct` is a second hand-maintained const-ness bool with twenty overrides, and it's now derivable from the default expression — the same story as `ExampleValue.isConst`. Retiring it is a semantic change that can shift output, so it deserves its own PR rather than riding along with a no-output-change one.

## Testing

- `dart analyze` clean; `dart test` green (648, +6 for `DartConst` / `canTakeConstKeyword` / untyped lists).
- **Byte-identical** github regen vs `origin/main` (both normalized for package name).
- The text→structural equality swap was instrumented and run across github, discord, spacetraders, petstore and backstage: **no site** where the two disagree. Same for the `camelFromSnake` → `dartType` change.
- Rotation regenerates analyze-clean; `dart_expression.dart` fully covered.
