### PR TITLE
refactor: toJsonExpression returns a DartExpression

### DIFF
--- a/lib/src/render/dart_expression.dart
+++ b/lib/src/render/dart_expression.dart
@@ -88,6 +88,22 @@ class DartExpressionSerializer extends Equatable {
       DartLiteral(:final value) =>
         value is String ? quoteString(value) : '$value',
       DartStaticMember(:final type, :final name) => '$type.$name',
+      DartIdentifier(:final name) => name,
+      // A call and a closure both evaluate at runtime, so neither can
+      // carry the keyword; their children serialize in whatever context
+      // reaches them.
+      DartMethodCall(
+        :final target,
+        :final name,
+        :final arguments,
+        :final isNullAware,
+      ) =>
+        '${children.serialize(target)}${isNullAware ? '?.' : '.'}$name'
+            '(${arguments.map(children.serialize).join(', ')})',
+      DartPropertyAccess(:final target, :final name, :final isNullAware) =>
+        '${children.serialize(target)}${isNullAware ? '?.' : '.'}$name',
+      DartLambda(:final parameters, :final body) =>
+        '(${parameters.join(', ')}) => ${children.serialize(body)}',
       DartListLiteral(:final elementType, :final elements) => _maybeConst(
         expression,
         '${elementType == null ? '' : '<$elementType>'}'
@@ -277,6 +293,104 @@ class DartMapLiteral extends DartExpression {
 
   @override
   List<Object?> get props => [keyType, valueType, entries];
+}
+
+/// A bare identifier: a parameter, local, or field name (`json`, `e`,
+/// `value`).
+///
+/// Modeled rather than spliced as text so consumers can ask what an
+/// expression *is* instead of matching `^[a-zA-Z_$][\w$]*$` against
+/// rendered source.
+class DartIdentifier extends DartExpression {
+  const DartIdentifier(this.name);
+
+  final String name;
+
+  /// A reference to a variable is not a constant expression, even when the
+  /// variable happens to hold one.
+  @override
+  bool get isConst => false;
+
+  @override
+  List<Object?> get props => [name];
+}
+
+/// A method call on a target: `value.toJson()`, `items?.map(f).toList()`.
+///
+/// Chains by nesting — the target of one call is another call — so
+/// `x.map(f).toList()` needs no special support.
+class DartMethodCall extends DartExpression {
+  const DartMethodCall({
+    required this.target,
+    required this.name,
+    this.arguments = const [],
+    this.isNullAware = false,
+  });
+
+  /// The receiver the method is called on.
+  final DartExpression target;
+
+  final String name;
+
+  final List<DartExpression> arguments;
+
+  /// Whether to call through `?.` rather than `.`, so a null target short
+  /// circuits to null instead of throwing.
+  final bool isNullAware;
+
+  /// A method call runs at runtime; no invocation of one is constant.
+  @override
+  bool get isConst => false;
+
+  @override
+  List<Object?> get props => [target, name, arguments, isNullAware];
+}
+
+/// A property access: `entry.value`, `response.body`.
+///
+/// Distinct from [DartMethodCall] because it emits no parentheses, and
+/// from [DartStaticMember] because the target is an expression rather than
+/// a type.
+class DartPropertyAccess extends DartExpression {
+  const DartPropertyAccess({
+    required this.target,
+    required this.name,
+    this.isNullAware = false,
+  });
+
+  final DartExpression target;
+
+  final String name;
+
+  /// Whether to read through `?.` rather than `.`.
+  final bool isNullAware;
+
+  /// Reading a property runs at runtime; the result is not a constant.
+  @override
+  bool get isConst => false;
+
+  @override
+  List<Object?> get props => [target, name, isNullAware];
+}
+
+/// An expression-bodied lambda: `(e) => e.toJson()`.
+///
+/// Only the arrow form is modeled, which is all the generator emits.
+class DartLambda extends DartExpression {
+  const DartLambda({required this.parameters, required this.body});
+
+  /// Parameter names, in order. Untyped — the generator relies on
+  /// inference at every site that emits one.
+  final List<String> parameters;
+
+  final DartExpression body;
+
+  /// A closure is never a constant expression.
+  @override
+  bool get isConst => false;
+
+  @override
+  List<Object?> get props => [parameters, body];
 }
 
 /// A constructor invocation or static method call: `Foo(1)`,

--- a/lib/src/render/dart_expression.dart
+++ b/lib/src/render/dart_expression.dart
@@ -7,10 +7,10 @@ import 'package:space_gen/src/string.dart';
 ///
 /// The expression-level counterpart to [DartType], and for the same reason:
 /// facts about an expression should be *derived* from what it is, not
-/// recovered by inspecting rendered source. [isConst] is the motivating
-/// case — a constructor invocation is constant iff its constructor is
-/// `const` and every argument is constant, which is a fold over the tree
-/// and not something a composite should have to thread by hand.
+/// recovered by inspecting rendered source. [canBeConst] is the motivating
+/// case — a constructor invocation can be const iff its constructor is
+/// declared `const` and every argument can be, which is a fold over the
+/// tree and not something a composite should have to thread by hand.
 ///
 /// Unlike [DartType], the tree does *not* render itself. Rendering lives in
 /// [DartExpressionSerializer], because the source for a given expression
@@ -28,12 +28,28 @@ import 'package:space_gen/src/string.dart';
 sealed class DartExpression extends Equatable {
   const DartExpression();
 
-  /// Whether this is a compile-time constant expression, and so whether it
-  /// can be assigned to a `const` variable and used inside an enclosing
-  /// constant expression.
+  /// Whether this expression *could* be evaluated at compile time — with
+  /// the keyword written, or by sitting in a context that is already
+  /// constant.
   ///
-  /// Derived, never stored.
-  bool get isConst;
+  /// Deliberately not `isConst`. Three different things get called that,
+  /// and only this one is a property of the tree:
+  ///
+  /// - **is a constant** — actually evaluated at compile time. `5` always
+  ///   is; `Foo(1)` only if it is written `const Foo(1)` or lands in a
+  ///   constant context. That depends on the destination, so the tree
+  ///   cannot answer it.
+  /// - **can be const** — this getter. A constructor invocation qualifies
+  ///   when its constructor is declared `const` *and* every argument
+  ///   qualifies. `[1, 2]` qualifies even though, written bare in a
+  ///   runtime context, it allocates a fresh list each time.
+  /// - **is written `const`** — the keyword, pure syntax. That is
+  ///   [DartExpressionSerializer.isConstContext]'s business, not the
+  ///   tree's.
+  ///
+  /// Derived, never stored. That derivation is the reason this IR exists:
+  /// see `doc/dart_expression.md`.
+  bool get canBeConst;
 
   /// Debug form (`DartLiteral(5)`), not Dart source. Rendering goes
   /// through [DartExpressionSerializer] — an expression cannot serialize
@@ -78,7 +94,7 @@ class DartExpressionSerializer extends Equatable {
   String serialize(DartExpression expression) {
     // A keyword written here (or a context inherited from above) makes
     // every child a constant context.
-    final children = isConstContext || expression.isConst
+    final children = isConstContext || expression.canBeConst
         ? constContext
         : runtimeContext;
     return switch (expression) {
@@ -145,7 +161,7 @@ class DartExpressionSerializer extends Equatable {
   /// keyword buys a compile-time constant. Only called from the arms whose
   /// node kind can legally carry it.
   String _maybeConst(DartExpression expression, String source) =>
-      !isConstContext && expression.isConst ? 'const $source' : source;
+      !isConstContext && expression.canBeConst ? 'const $source' : source;
 
   @override
   List<Object?> get props => [isConstContext];
@@ -217,7 +233,7 @@ class DartLiteral extends DartExpression {
 
   /// Literals are always constant.
   @override
-  bool get isConst => true;
+  bool get canBeConst => true;
 
   // Includes the runtime type because `5 == 5.0` in Dart, but `5` and `5.0`
   // are different literals — equality here has to agree with [toString].
@@ -246,7 +262,7 @@ class DartListLiteral extends DartExpression {
 
   /// A list literal is constant when every element is.
   @override
-  bool get isConst => elements.every((element) => element.isConst);
+  bool get canBeConst => elements.every((element) => element.canBeConst);
 
   @override
   List<Object?> get props => [elementType, elements];
@@ -260,7 +276,7 @@ class DartMapEntry extends Equatable {
   final DartExpression key;
   final DartExpression value;
 
-  bool get isConst => key.isConst && value.isConst;
+  bool get canBeConst => key.canBeConst && value.canBeConst;
 
   @override
   List<Object?> get props => [key, value];
@@ -289,7 +305,7 @@ class DartMapLiteral extends DartExpression {
 
   /// A map literal is constant when every key and value is.
   @override
-  bool get isConst => entries.every((entry) => entry.isConst);
+  bool get canBeConst => entries.every((entry) => entry.canBeConst);
 
   @override
   List<Object?> get props => [keyType, valueType, entries];
@@ -309,7 +325,7 @@ class DartIdentifier extends DartExpression {
   /// A reference to a variable is not a constant expression, even when the
   /// variable happens to hold one.
   @override
-  bool get isConst => false;
+  bool get canBeConst => false;
 
   @override
   List<Object?> get props => [name];
@@ -340,7 +356,7 @@ class DartMethodCall extends DartExpression {
 
   /// A method call runs at runtime; no invocation of one is constant.
   @override
-  bool get isConst => false;
+  bool get canBeConst => false;
 
   @override
   List<Object?> get props => [target, name, arguments, isNullAware];
@@ -367,7 +383,7 @@ class DartPropertyAccess extends DartExpression {
 
   /// Reading a property runs at runtime; the result is not a constant.
   @override
-  bool get isConst => false;
+  bool get canBeConst => false;
 
   @override
   List<Object?> get props => [target, name, isNullAware];
@@ -387,7 +403,7 @@ class DartLambda extends DartExpression {
 
   /// A closure is never a constant expression.
   @override
-  bool get isConst => false;
+  bool get canBeConst => false;
 
   @override
   List<Object?> get props => [parameters, body];
@@ -426,13 +442,14 @@ class DartInvocation extends DartExpression {
   final Map<String, DartExpression> namedArguments;
 
   /// Whether the invoked constructor is *declared* `const` — a fact only the
-  /// caller knows. False for factories and anything that computes at runtime
+  /// caller knows, and the input to [canBeConst] rather than a synonym for
+  /// it. False for factories and anything that computes at runtime
   /// (`Uri.parse`, `DateTime.utc`, `Uint8List.fromList`), and for a
   /// generated constructor with a validating body.
   ///
-  /// This is the input to [isConst], not a synonym for it: a const
-  /// constructor invoked with a non-constant argument is not a constant
-  /// expression.
+  /// A const constructor invoked with an argument that cannot be const
+  /// does not itself qualify, which is what the fold in [canBeConst]
+  /// works out.
   //
   // TODO(eseidel): Model the constructor itself, not a bool about it.
   //
@@ -452,10 +469,10 @@ class DartInvocation extends DartExpression {
   final bool isConstConstructor;
 
   @override
-  bool get isConst =>
+  bool get canBeConst =>
       isConstConstructor &&
-      arguments.every((argument) => argument.isConst) &&
-      namedArguments.values.every((argument) => argument.isConst);
+      arguments.every((argument) => argument.canBeConst) &&
+      namedArguments.values.every((argument) => argument.canBeConst);
 
   @override
   List<Object?> get props => [
@@ -483,7 +500,7 @@ class DartStaticMember extends DartExpression {
   /// Enum members and other static const members are constant. This node is
   /// only used for members that are; a static getter would not be.
   @override
-  bool get isConst => true;
+  bool get canBeConst => true;
 
   @override
   List<Object?> get props => [type, name];

--- a/lib/src/render/file_renderer.dart
+++ b/lib/src/render/file_renderer.dart
@@ -870,7 +870,7 @@ class FileRenderer {
           // a constant context; otherwise it is a `final` declaration and
           // any constant subtree writes its own.
           'exampleValue': _exampleSource(example),
-          'exampleIsConst': example.isConst,
+          'exampleIsConst': example.canBeConst,
           'invalidJsonExample': invalidJson,
           'isEnum': schema is RenderEnum,
           // `toString()` returns a String for every enum, but `toJson()`
@@ -926,7 +926,7 @@ class FileRenderer {
       variants.add({
         'variantTypeName': variant.typeName,
         'exampleValue': _exampleSource(example),
-        'exampleIsConst': example.isConst,
+        'exampleIsConst': example.canBeConst,
       });
     }
     if (variants.isEmpty) return;
@@ -1015,6 +1015,6 @@ class FileRenderer {
 /// example is declared `const`, which makes its whole tree a constant
 /// context; a non-constant one is declared `final`, so any constant
 /// subtree inside it needs its own keyword.
-String _exampleSource(DartExpression example) => example.isConst
+String _exampleSource(DartExpression example) => example.canBeConst
     ? DartExpressionSerializer.constContext.serialize(example)
     : DartExpressionSerializer.runtimeContext.serialize(example);

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -19,16 +19,16 @@ import 'package:space_gen/src/types.dart';
 /// A Dart expression that is a single bare identifier — no member
 /// access, call, or operator — so it can be interpolated without braces
 /// (`'$x'` rather than `'${x}'`).
-final _bareIdentifier = RegExp(r'^[a-zA-Z_$][\w$]*$');
-
 /// Coerces [expr] — the wire value of [schema] — to a `String`, adding
 /// `.toString()` only when the value isn't already one. Query/header
 /// params must hand `String`s to the client; calling `.toString()` on a
 /// value that is already a `String` (raw strings, dateTime/date/uri
 /// pods that serialize to `String`, string enums) is a
 /// `noop_primitive_operations` lint.
-String _stringifyWireValue(RenderSchema schema, String expr) =>
-    schema.jsonStorageDartType == DartType.string ? expr : '$expr.toString()';
+DartExpression _stringifyWireValue(RenderSchema schema, DartExpression expr) =>
+    schema.jsonStorageDartType == DartType.string
+    ? expr
+    : DartMethodCall(target: expr, name: 'toString');
 
 String avoidReservedWord(String value) {
   if (isReservedWord(value)) {
@@ -1245,8 +1245,13 @@ class Endpoint implements ToTemplateContext {
   /// (`unnecessary_brace_in_string_interps`).
   String _pathReplacement(RenderParameter p, SchemaRenderer context) {
     final expr = p.toJsonExpression(context);
-    if (p.type.jsonStorageDartType == DartType.string) return expr;
-    return _bareIdentifier.hasMatch(expr) ? "'\$$expr'" : "'\${$expr}'";
+    final source = _runtimeSource(expr);
+    if (p.type.jsonStorageDartType == DartType.string) return source;
+    // Braces are only needed when the expression is more than a bare
+    // identifier (`unnecessary_brace_in_string_interps`). That is a
+    // question about the expression's shape, which the tree answers
+    // directly — it used to be a regex over the rendered text.
+    return expr is DartIdentifier ? "'\$$source'" : "'\${$source}'";
   }
 
   List<String> _queryParamsLines(
@@ -1283,12 +1288,12 @@ class Endpoint implements ToTemplateContext {
     final String value;
     if (paramType is RenderArray) {
       final itemsToJson = paramType.items.toJsonExpression(
-        'e',
+        const DartIdentifier('e'),
         context,
         dartIsNullable: false,
       );
       final item = _stringifyWireValue(paramType.items, itemsToJson);
-      final items = '$dartName.map((e) => $item)';
+      final items = '$dartName.map((e) => ${_runtimeSource(item)})';
       // `explode: false` (style=form) comma-joins the array into a single
       // value (`?k=a,b,c`) rather than repeating the key. Wrap the joined
       // string in a 1-element list so it flows through the same
@@ -1296,11 +1301,12 @@ class Endpoint implements ToTemplateContext {
       value = p.explode ? '$items.toList()' : "[$items.join(',')]";
     } else {
       final scalarToJson = paramType.toJsonExpression(
-        dartName,
+        DartIdentifier(dartName),
         context,
         dartIsNullable: false,
       );
-      value = '[${_stringifyWireValue(paramType, scalarToJson)}]';
+      final stringified = _stringifyWireValue(paramType, scalarToJson);
+      value = '[${_runtimeSource(stringified)}]';
     }
     if (p.isNullable) {
       return "${innerIndent}if ($dartName != null) '${p.name}': $value,";
@@ -1352,17 +1358,18 @@ class Endpoint implements ToTemplateContext {
     if (paramType is RenderArray) {
       final dartName = p.dartParameterName(context.quirks);
       final itemsToJson = paramType.items.toJsonExpression(
-        'e',
+        const DartIdentifier('e'),
         context,
         dartIsNullable: false,
       );
       final item = _stringifyWireValue(paramType.items, itemsToJson);
-      final mapCall = ".map((e) => $item).join(',')";
+      final mapCall = ".map((e) => ${_runtimeSource(item)}).join(',')";
       final value = p.isNullable ? '?$dartName?$mapCall' : '$dartName$mapCall';
       return "$innerIndent'${p.name}': $value,";
     }
     final prefix = p.isNullable ? '?' : '';
-    return "$innerIndent'${p.name}': $prefix${p.toJsonExpression(context)},";
+    final scalar = _runtimeSource(p.toJsonExpression(context));
+    return "$innerIndent'${p.name}': $prefix$scalar,";
   }
 
   List<String> _authRequestLines(String indent) {
@@ -2001,7 +2008,9 @@ Map<String, dynamic> _requestBodyParameterContext(
     'dartName': body.dartParameterName(context.quirks),
     'required': body.isRequired,
     'hasDefaultValue': body.schema.defaultValue != null,
-    'defaultValue': _runtimeSource(body.schema.defaultValueExpression(context)),
+    'defaultValue': _maybeRuntimeSource(
+      body.schema.defaultValueExpression(context),
+    ),
     'type': body.schema.typeName,
     'nullableType': body.schema.nullableTypeName(context),
   };
@@ -2018,10 +2027,12 @@ class RenderRequestBodyJson extends RenderRequestBodySimple {
   String get bodyContentTypeExpression => 'BodyContentType.json';
 
   @override
-  String bodyExpression(SchemaRenderer context) => schema.toJsonExpression(
-    dartParameterName(context.quirks),
-    context,
-    dartIsNullable: !isRequired,
+  String bodyExpression(SchemaRenderer context) => _runtimeSource(
+    schema.toJsonExpression(
+      DartIdentifier(dartParameterName(context.quirks)),
+      context,
+      dartIsNullable: !isRequired,
+    ),
   );
 
   @override
@@ -2184,12 +2195,20 @@ class RenderRequestBodyMultipart extends RenderRequestBody {
             // Dart types → identity). `.toString()` coerces non-String
             // json types (int, bool, enum with int values) to satisfy
             // Map<String, String>.
-            requiredValueExpr: _multipartValueExpr(
-              property,
-              dartAccess,
-              context,
+            requiredValueExpr: _runtimeSource(
+              _multipartValueExpr(
+                property,
+                DartIdentifier(dartAccess),
+                context,
+              ),
             ),
-            nullableValueExpr: _multipartValueExpr(property, 'v', context),
+            nullableValueExpr: _runtimeSource(
+              _multipartValueExpr(
+                property,
+                const DartIdentifier('v'),
+                context,
+              ),
+            ),
           ),
         );
       } else {
@@ -2208,9 +2227,9 @@ class RenderRequestBodyMultipart extends RenderRequestBody {
       _requestBodyParameterContext(this, context);
 }
 
-String _multipartValueExpr(
+DartExpression _multipartValueExpr(
   RenderSchema property,
-  String base,
+  DartExpression base,
   SchemaRenderer context,
 ) {
   final jsonExpr = property.toJsonExpression(
@@ -2218,8 +2237,10 @@ String _multipartValueExpr(
     context,
     dartIsNullable: false,
   );
-  final jsonType = property.jsonStorageType(isNullable: false);
-  return jsonType == 'String' ? jsonExpr : '$jsonExpr.toString()';
+  // Was `jsonStorageType(isNullable: false) == 'String'` — the same
+  // question [_stringifyWireValue] already answers from [DartType],
+  // spelled as a comparison against rendered text.
+  return _stringifyWireValue(property, jsonExpr);
 }
 
 bool _isMultipartScalar(RenderSchema schema) {
@@ -2518,8 +2539,10 @@ abstract class RenderSchema extends Equatable implements ToTemplateContext {
       (isNullable ? jsonStorageDartType.asNullable() : jsonStorageDartType)
           .toString();
 
-  String toJsonExpression(
-    String dartName,
+  /// The expression that converts [dartName] (a value of this schema's
+  /// Dart type) into its JSON wire form.
+  DartExpression toJsonExpression(
+    DartExpression dartName,
     SchemaRenderer context, {
     required bool dartIsNullable,
   });
@@ -2625,9 +2648,12 @@ abstract class RenderSchema extends Equatable implements ToTemplateContext {
 /// Source for an expression landing somewhere that evaluates at runtime —
 /// a `??` right-hand side, or a parameter default, where a `const` keyword
 /// turns an allocation into a compile-time constant.
-String? _runtimeSource(DartExpression? expression) => expression == null
-    ? null
-    : DartExpressionSerializer.runtimeContext.serialize(expression);
+String _runtimeSource(DartExpression expression) =>
+    DartExpressionSerializer.runtimeContext.serialize(expression);
+
+/// [_runtimeSource] for an expression that may be absent.
+String? _maybeRuntimeSource(DartExpression? expression) =>
+    expression == null ? null : _runtimeSource(expression);
 
 /// `DateTime.utc(2024)`.
 DartExpression _dateTimeUtc(int year) =>
@@ -2761,12 +2787,15 @@ class RenderPod extends RenderSchema {
 
   /// Converts `value` (of type [dartTypeName]) to its JSON representation.
   /// Used both at the inline use site and inside the newtype's toJson.
-  String _valueToJsonBody(String name, {required bool nameIsNullable}) {
-    final nameCall = nameIsNullable ? '$name?' : name;
+  DartExpression _valueToJsonBody(
+    DartExpression name, {
+    required bool nameIsNullable,
+  }) {
+    DartExpression call(String method) =>
+        DartMethodCall(target: name, name: method, isNullAware: nameIsNullable);
     return switch (type) {
-      PodType.dateTime => '$nameCall.toIso8601String()',
-      PodType.uri => '$nameCall.toString()',
-      PodType.uriTemplate => '$nameCall.toString()',
+      PodType.dateTime => call('toIso8601String'),
+      PodType.uri || PodType.uriTemplate => call('toString'),
       // String- and bool-backed types: no conversion; `name` already
       // has the correct nullable/non-nullable type.
       PodType.email || PodType.uuid || PodType.boolean => name,
@@ -2784,13 +2813,17 @@ class RenderPod extends RenderSchema {
   };
 
   @override
-  String toJsonExpression(
-    String dartName,
+  DartExpression toJsonExpression(
+    DartExpression dartName,
     SchemaRenderer context, {
     required bool dartIsNullable,
   }) {
     if (createsNewType) {
-      return dartIsNullable ? '$dartName?.toJson()' : '$dartName.toJson()';
+      return DartMethodCall(
+        target: dartName,
+        name: 'toJson',
+        isNullAware: dartIsNullable,
+      );
     }
     return _valueToJsonBody(dartName, nameIsNullable: dartIsNullable);
   }
@@ -2855,7 +2888,9 @@ class RenderPod extends RenderSchema {
       'dartType': dartTypeName,
       'jsonType': jsonStorageType(isNullable: false),
       'fromJsonBody': _jsonToValueBody('json'),
-      'toJsonBody': _valueToJsonBody('value', nameIsNullable: false),
+      'toJsonBody': _runtimeSource(
+        _valueToJsonBody(const DartIdentifier('value'), nameIsNullable: false),
+      ),
       // Bool newtypes wrap a single positional `bool` in three places
       // (the extension-type representation, `fromJson`, `maybeFromJson`)
       // that all trip `avoid_positional_boolean_parameters`. The lint
@@ -2927,13 +2962,16 @@ abstract class RenderNewType extends RenderSchema {
   DartType get dartType => DartType(className);
 
   @override
-  String toJsonExpression(
-    String dartName,
+  DartExpression toJsonExpression(
+    DartExpression dartName,
     SchemaRenderer context, {
     required bool dartIsNullable,
   }) {
-    final nameCall = dartIsNullable ? '$dartName?' : dartName;
-    return '$nameCall.toJson()';
+    return DartMethodCall(
+      target: dartName,
+      name: 'toJson',
+      isNullAware: dartIsNullable,
+    );
   }
 }
 
@@ -3053,13 +3091,17 @@ class RenderString extends RenderSchema {
   }
 
   @override
-  String toJsonExpression(
-    String dartName,
+  DartExpression toJsonExpression(
+    DartExpression dartName,
     SchemaRenderer context, {
     required bool dartIsNullable,
   }) {
     if (createsNewType) {
-      return dartIsNullable ? '$dartName?.toJson()' : '$dartName.toJson()';
+      return DartMethodCall(
+        target: dartName,
+        name: 'toJson',
+        isNullAware: dartIsNullable,
+      );
     }
     return dartName;
   }
@@ -3317,13 +3359,17 @@ abstract class RenderNumeric<T extends num> extends RenderSchema {
   }
 
   @override
-  String toJsonExpression(
-    String dartName,
+  DartExpression toJsonExpression(
+    DartExpression dartName,
     SchemaRenderer context, {
     required bool dartIsNullable,
   }) {
     if (createsNewType) {
-      return dartIsNullable ? '$dartName?.toJson()' : '$dartName.toJson()';
+      return DartMethodCall(
+        target: dartName,
+        name: 'toJson',
+        isNullAware: dartIsNullable,
+      );
     }
     return dartName;
   }
@@ -3589,7 +3635,7 @@ class RenderObject extends RenderNewType {
       line.write('this.$dartName');
       if (property.hasDefaultValue(context)) {
         final value = property.defaultValueExpression(context);
-        line.write(' = ${_runtimeSource(value)}');
+        line.write(' = ${_maybeRuntimeSource(value)}');
       }
     }
     return line.toString();
@@ -3605,7 +3651,8 @@ class RenderObject extends RenderNewType {
     final dartName = variableSafeName(context.quirks, jsonName);
     if (property.hasNonConstDefaultValue(context)) {
       final value = property.defaultValueExpression(context);
-      return 'this.$dartName = $dartName ?? ${_runtimeSource(value)}';
+      final source = _maybeRuntimeSource(value);
+      return 'this.$dartName = $dartName ?? $source';
     }
     return null;
   }
@@ -3714,10 +3761,12 @@ class RenderObject extends RenderNewType {
       ),
       'equals': property.equalsExpression(dartName, context),
       'hashCode': property.hashCodeExpression(dartName),
-      'toJson': property.toJsonExpression(
-        dartName,
-        context,
-        dartIsNullable: dartIsNullable,
+      'toJson': _runtimeSource(
+        property.toJsonExpression(
+          DartIdentifier(dartName),
+          context,
+          dartIsNullable: dartIsNullable,
+        ),
       ),
       'fromJson': property.fromJsonExpression(
         jsonRead,
@@ -3851,10 +3900,15 @@ class RenderObject extends RenderNewType {
       // `entry.value`). The for-loop filters out keys that belong to
       // the named properties so a round-trip doesn't accidentally
       // sweep them into `entries`.
-      'entryValueToJson': valueSchema?.toJsonExpression(
-        'entry.value',
-        context,
-        dartIsNullable: isNullable,
+      'entryValueToJson': _maybeRuntimeSource(
+        valueSchema?.toJsonExpression(
+          const DartPropertyAccess(
+            target: DartIdentifier('entry'),
+            name: 'value',
+          ),
+          context,
+          dartIsNullable: isNullable,
+        ),
       ),
       'entryValueFromJson': valueSchema?.fromJsonExpression(
         'entry.value',
@@ -4110,11 +4164,11 @@ class RenderArray extends RenderSchema {
     final String toJson;
     if (items.shouldCallToJson) {
       final itemTo = items.toJsonExpression(
-        'e',
+        const DartIdentifier('e'),
         context,
         dartIsNullable: false,
       );
-      toJson = 'value.map((e) => $itemTo).toList()';
+      toJson = 'value.map((e) => ${_runtimeSource(itemTo)}).toList()';
     } else {
       toJson = 'value';
     }
@@ -4157,8 +4211,8 @@ class RenderArray extends RenderSchema {
   DartType get jsonStorageDartType => DartType.list();
 
   @override
-  String toJsonExpression(
-    String dartName,
+  DartExpression toJsonExpression(
+    DartExpression dartName,
     SchemaRenderer context, {
     required bool dartIsNullable,
   }) {
@@ -4166,13 +4220,22 @@ class RenderArray extends RenderSchema {
     if (!items.shouldCallToJson) {
       return dartName;
     }
-    final nameCall = dartIsNullable ? '$dartName?' : dartName;
     final itemsToJson = items.toJsonExpression(
-      'e',
+      const DartIdentifier('e'),
       context,
       dartIsNullable: false,
     );
-    return '$nameCall.map((e) => $itemsToJson).toList()';
+    return DartMethodCall(
+      target: DartMethodCall(
+        target: dartName,
+        name: 'map',
+        arguments: [
+          DartLambda(parameters: const ['e'], body: itemsToJson),
+        ],
+        isNullAware: dartIsNullable,
+      ),
+      name: 'toList',
+    );
   }
 
   @override
@@ -4301,7 +4364,7 @@ class RenderMap extends RenderSchema {
     );
     final keyToJson = keyEnum == null ? 'k' : 'k.toJson()';
     final valueToJson = value.toJsonExpression(
-      'val',
+      const DartIdentifier('val'),
       context,
       dartIsNullable: false,
     );
@@ -4333,8 +4396,8 @@ class RenderMap extends RenderSchema {
   DartType get jsonStorageDartType => _jsonWireMap;
 
   @override
-  String toJsonExpression(
-    String dartName,
+  DartExpression toJsonExpression(
+    DartExpression dartName,
     SchemaRenderer context, {
     required bool dartIsNullable,
   }) {
@@ -4342,15 +4405,26 @@ class RenderMap extends RenderSchema {
     if (keySchema == null && !valueSchema.shouldCallToJson) {
       return dartName;
     }
-    final keyToJson = keySchema == null ? 'key' : 'key.toJson()';
+    const key = DartIdentifier('key');
+    final keyToJson = keySchema == null
+        ? key
+        : const DartMethodCall(target: key, name: 'toJson');
     final valueToJson = valueSchema.toJsonExpression(
-      'value',
+      const DartIdentifier('value'),
       context,
       dartIsNullable: false,
     );
-    final callMap = dartIsNullable ? '?.map' : '.map';
-    return '$dartName$callMap((key, value) => '
-        'MapEntry($keyToJson, $valueToJson))';
+    return DartMethodCall(
+      target: dartName,
+      name: 'map',
+      arguments: [
+        DartLambda(
+          parameters: const ['key', 'value'],
+          body: const DartType('MapEntry').construct([keyToJson, valueToJson]),
+        ),
+      ],
+      isNullAware: dartIsNullable,
+    );
   }
 
   @override
@@ -5800,9 +5874,9 @@ class RenderParameter implements CanBeParameter {
   /// The Dart expression that serializes this parameter's value. Wraps
   /// [RenderSchema.toJsonExpression] with the right [dartParameterName]
   /// and nullability for this parameter.
-  String toJsonExpression(SchemaRenderer context) {
+  DartExpression toJsonExpression(SchemaRenderer context) {
     return type.toJsonExpression(
-      dartParameterName(context.quirks),
+      DartIdentifier(dartParameterName(context.quirks)),
       context,
       dartIsNullable: isNullable,
     );
@@ -5821,7 +5895,7 @@ class RenderParameter implements CanBeParameter {
     'dartName': dartParameterName(context.quirks),
     'required': isRequired,
     'hasDefaultValue': type.defaultValue != null,
-    'defaultValue': _runtimeSource(type.defaultValueExpression(context)),
+    'defaultValue': _maybeRuntimeSource(type.defaultValueExpression(context)),
     'type': type.typeName,
     'nullableType': type.nullableTypeName(context),
   };
@@ -5846,8 +5920,8 @@ class RenderUnknown extends RenderSchema {
   // We might need to jsonDecode(jsonEncode(dartName)) to get everything into
   // json types.
   @override
-  String toJsonExpression(
-    String dartName,
+  DartExpression toJsonExpression(
+    DartExpression dartName,
     SchemaRenderer context, {
     required bool dartIsNullable,
   }) => dartName;
@@ -5917,11 +5991,11 @@ abstract class RenderNoJson extends RenderSchema {
       'throw UnimplementedError("$runtimeType.jsonStorageType")';
 
   @override
-  String toJsonExpression(
-    String dartName,
+  DartExpression toJsonExpression(
+    DartExpression dartName,
     SchemaRenderer context, {
     required bool dartIsNullable,
-  }) => 'throw UnimplementedError("$runtimeType.toJson")';
+  }) => DartIdentifier('throw UnimplementedError("$runtimeType.toJson")');
 
   @override
   String fromJsonExpression(
@@ -6020,17 +6094,25 @@ class RenderBase64Bytes extends RenderSchema {
   }
 
   @override
-  String toJsonExpression(
-    String dartName,
+  DartExpression toJsonExpression(
+    DartExpression dartName,
     SchemaRenderer context, {
     required bool dartIsNullable,
   }) {
     if (dartIsNullable) {
       // Same reasoning as `fromJsonExpression`: nullable `Uint8List`
       // doesn't promote in a ternary at a property access site.
-      return '${ModelHelpers.maybeBase64Encode}($dartName)';
+      return DartInvocation(
+        type: const DartType(ModelHelpers.maybeBase64Encode),
+        arguments: [dartName],
+        isConstConstructor: false,
+      );
     }
-    return 'base64.encode($dartName)';
+    return DartMethodCall(
+      target: const DartIdentifier('base64'),
+      name: 'encode',
+      arguments: [dartName],
+    );
   }
 
   @override
@@ -6098,11 +6180,15 @@ class RenderDate extends RenderSchema {
   }
 
   @override
-  String toJsonExpression(
-    String dartName,
+  DartExpression toJsonExpression(
+    DartExpression dartName,
     SchemaRenderer context, {
     required bool dartIsNullable,
-  }) => dartIsNullable ? '$dartName?.toJson()' : '$dartName.toJson()';
+  }) => DartMethodCall(
+    target: dartName,
+    name: 'toJson',
+    isNullAware: dartIsNullable,
+  );
 
   @override
   DartExpression? exampleValue(SchemaRenderer context) =>
@@ -6155,11 +6241,15 @@ class RenderEmptyObject extends RenderNewType {
   DartType get jsonStorageDartType => _jsonWireMap;
 
   @override
-  String toJsonExpression(
-    String dartName,
+  DartExpression toJsonExpression(
+    DartExpression dartName,
     SchemaRenderer context, {
     required bool dartIsNullable,
-  }) => dartIsNullable ? '$dartName?.toJson()' : '$dartName.toJson()';
+  }) => DartMethodCall(
+    target: dartName,
+    name: 'toJson',
+    isNullAware: dartIsNullable,
+  );
 
   @override
   String fromJsonExpression(
@@ -6227,13 +6317,16 @@ class RenderRecursiveRef extends RenderSchema {
   DartType get jsonStorageDartType => _jsonWireMap;
 
   @override
-  String toJsonExpression(
-    String dartName,
+  DartExpression toJsonExpression(
+    DartExpression dartName,
     SchemaRenderer context, {
     required bool dartIsNullable,
   }) {
-    final nameCall = dartIsNullable ? '$dartName?' : dartName;
-    return '$nameCall.toJson()';
+    return DartMethodCall(
+      target: dartName,
+      name: 'toJson',
+      isNullAware: dartIsNullable,
+    );
   }
 
   @override

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -2417,7 +2417,7 @@ abstract class RenderSchema extends Equatable implements ToTemplateContext {
   /// list rather than as a constructor parameter default.
   bool hasNonConstDefaultValue(SchemaRenderer context) {
     final expression = defaultValueExpression(context);
-    return expression != null && !expression.isConst;
+    return expression != null && !expression.canBeConst;
   }
 
   Iterable<Import> get additionalImports => const [];
@@ -2493,7 +2493,7 @@ abstract class RenderSchema extends Equatable implements ToTemplateContext {
     // produces `null` instead of the spec's default. Surfaced by a
     // real spec with `bool` properties marked `default: false` outside
     // the `required` array.
-    if (defaultValue.isConst) {
+    if (defaultValue.canBeConst) {
       return ' ?? ${_runtimeSource(defaultValue)}';
     }
     // Nullable Dart slot with a non-const default: the constructor uses
@@ -2561,7 +2561,7 @@ abstract class RenderSchema extends Equatable implements ToTemplateContext {
   /// Callers treat `null` as a signal to skip emitting a round-trip
   /// test for the enclosing type.
   ///
-  /// Whether the result is const-able is [DartExpression.isConst], derived
+  /// Whether the result is const-able is [DartExpression.canBeConst], derived
   /// from the returned tree rather than tracked alongside it.
   DartExpression? exampleValue(SchemaRenderer context);
 
@@ -4058,7 +4058,7 @@ class RenderObject extends RenderNewType {
       );
     }
     // Any non-const argument makes the whole construction non-const even
-    // when the constructor itself is `const` — [DartInvocation.isConst]
+    // when the constructor itself is `const` — [DartInvocation.canBeConst]
     // folds that over the arguments.
     return DartInvocation(
       type: dartType,

--- a/test/render/dart_expression_test.dart
+++ b/test/render/dart_expression_test.dart
@@ -308,6 +308,122 @@ void main() {
     });
   });
 
+  group('call and reference nodes', () {
+    const value = DartIdentifier('value');
+
+    test('an identifier renders bare and is never constant', () {
+      expect(value.source, 'value');
+      // A reference to a variable is not a constant expression even when
+      // the variable holds one.
+      expect(value.isConst, isFalse);
+    });
+
+    test('a method call renders with and without null-aware access', () {
+      expect(
+        const DartMethodCall(target: value, name: 'toJson').source,
+        'value.toJson()',
+      );
+      expect(
+        const DartMethodCall(
+          target: value,
+          name: 'toJson',
+          isNullAware: true,
+        ).source,
+        'value?.toJson()',
+      );
+    });
+
+    test('calls chain by nesting rather than by special support', () {
+      // `x.map(f).toList()` is a call whose target is a call.
+      const chained = DartMethodCall(
+        target: DartMethodCall(
+          target: value,
+          name: 'map',
+          arguments: [
+            DartLambda(
+              parameters: ['e'],
+              body: DartMethodCall(
+                target: DartIdentifier('e'),
+                name: 'toJson',
+              ),
+            ),
+          ],
+          isNullAware: true,
+        ),
+        name: 'toList',
+      );
+      expect(chained.source, 'value?.map((e) => e.toJson()).toList()');
+      expect(chained.isConst, isFalse);
+    });
+
+    test('a property access emits no parentheses', () {
+      expect(
+        const DartPropertyAccess(
+          target: DartIdentifier('entry'),
+          name: 'value',
+        ).source,
+        'entry.value',
+      );
+      expect(
+        const DartPropertyAccess(
+          target: value,
+          name: 'length',
+          isNullAware: true,
+        ).source,
+        'value?.length',
+      );
+    });
+
+    test('a lambda takes multiple parameters', () {
+      expect(
+        DartLambda(
+          parameters: const ['key', 'value'],
+          body: const DartType('MapEntry').construct(const [
+            DartIdentifier('key'),
+            DartIdentifier('value'),
+          ]),
+        ).source,
+        '(key, value) => MapEntry(key, value)',
+      );
+    });
+
+    test('a runtime destination adds no keyword to a call', () {
+      // Nothing here is constant, so nothing gains `const` even in a
+      // runtime context.
+      expect(
+        const DartMethodCall(target: value, name: 'toJson').runtimeSource,
+        'value.toJson()',
+      );
+    });
+
+    test('equality is by value', () {
+      // See the list-literal equality test for why one side is non-const.
+      final names = ['entry'];
+      final target = DartIdentifier(names.first);
+      expect(
+        DartPropertyAccess(target: target, name: 'value'),
+        const DartPropertyAccess(
+          target: DartIdentifier('entry'),
+          name: 'value',
+        ),
+      );
+      expect(
+        DartLambda(parameters: const ['e'], body: target),
+        const DartLambda(parameters: ['e'], body: DartIdentifier('entry')),
+      );
+      expect(
+        const DartMethodCall(target: value, name: 'toJson'),
+        isNot(
+          const DartMethodCall(
+            target: value,
+            name: 'toJson',
+            isNullAware: true,
+          ),
+        ),
+      );
+    });
+  });
+
   group('DartExpressionSerializer', () {
     test('writes the keyword at the outermost node that can carry it', () {
       expect(DartListLiteral.empty.runtimeSource, 'const []');

--- a/test/render/dart_expression_test.dart
+++ b/test/render/dart_expression_test.dart
@@ -33,8 +33,8 @@ void main() {
     });
 
     test('is always constant', () {
-      expect(const DartLiteral(5).isConst, isTrue);
-      expect(const DartLiteral(null).isConst, isTrue);
+      expect(const DartLiteral(5).canBeConst, isTrue);
+      expect(const DartLiteral(null).canBeConst, isTrue);
     });
 
     test('equality is by value', () {
@@ -98,14 +98,14 @@ void main() {
         const DartListLiteral(
           elementType: DartType.int_,
           elements: [DartLiteral(0)],
-        ).isConst,
+        ).canBeConst,
         isTrue,
       );
       expect(
         const DartListLiteral(
           elementType: DartType.uri,
           elements: [nonConst],
-        ).isConst,
+        ).canBeConst,
         isFalse,
       );
     });
@@ -137,7 +137,7 @@ void main() {
           keyType: null,
           valueType: null,
           entries: [DartMapEntry(DartLiteral('key'), DartLiteral(1))],
-        ).isConst,
+        ).canBeConst,
         isTrue,
       );
       expect(
@@ -145,7 +145,7 @@ void main() {
           keyType: null,
           valueType: null,
           entries: [DartMapEntry(DartLiteral('key'), nonConst)],
-        ).isConst,
+        ).canBeConst,
         isFalse,
       );
     });
@@ -235,7 +235,7 @@ void main() {
           type: DartType('Foo'),
           arguments: [DartLiteral(1)],
           isConstConstructor: false,
-        ).isConst,
+        ).canBeConst,
         isFalse,
       );
     });
@@ -246,7 +246,7 @@ void main() {
           type: DartType('Foo'),
           arguments: [nonConst],
           isConstConstructor: true,
-        ).isConst,
+        ).canBeConst,
         isFalse,
       );
       expect(
@@ -254,7 +254,7 @@ void main() {
           type: DartType('Foo'),
           namedArguments: {'a': nonConst},
           isConstConstructor: true,
-        ).isConst,
+        ).canBeConst,
         isFalse,
       );
     });
@@ -266,7 +266,7 @@ void main() {
           arguments: [DartLiteral(1)],
           namedArguments: {'b': DartLiteral('x')},
           isConstConstructor: true,
-        ).isConst,
+        ).canBeConst,
         isTrue,
       );
     });
@@ -286,7 +286,7 @@ void main() {
         arguments: [inner],
         isConstConstructor: true,
       );
-      expect(outer.isConst, isFalse);
+      expect(outer.canBeConst, isFalse);
       expect(outer.source, "Foo(Bar(Uri.parse('https://example.com')))");
     });
 
@@ -315,7 +315,7 @@ void main() {
       expect(value.source, 'value');
       // A reference to a variable is not a constant expression even when
       // the variable holds one.
-      expect(value.isConst, isFalse);
+      expect(value.canBeConst, isFalse);
     });
 
     test('a method call renders with and without null-aware access', () {
@@ -353,7 +353,7 @@ void main() {
         name: 'toList',
       );
       expect(chained.source, 'value?.map((e) => e.toJson()).toList()');
-      expect(chained.isConst, isFalse);
+      expect(chained.canBeConst, isFalse);
     });
 
     test('a property access emits no parentheses', () {
@@ -518,7 +518,7 @@ void main() {
         DartLiteral('https://example.com'),
       ], name: 'parse');
       expect(parse.source, "Uri.parse('https://example.com')");
-      expect(parse.isConst, isFalse);
+      expect(parse.canBeConst, isFalse);
     });
 
     test('constConstruct is constant when its arguments are', () {
@@ -527,12 +527,12 @@ void main() {
         const DartInvocation(type: DartType('Foo'), isConstConstructor: true),
       );
       expect(
-        const DartType('Foo').constConstruct(const [DartLiteral(1)]).isConst,
+        const DartType('Foo').constConstruct(const [DartLiteral(1)]).canBeConst,
         isTrue,
       );
       // ...and not when they aren't: the whole point of the derivation.
       expect(
-        const DartType('Foo').constConstruct(const [nonConst]).isConst,
+        const DartType('Foo').constConstruct(const [nonConst]).canBeConst,
         isFalse,
       );
     });
@@ -546,7 +546,7 @@ void main() {
     test('renders as a member reference and is constant', () {
       const member = DartStaticMember(type: DartType('Foo'), name: 'a');
       expect(member.source, 'Foo.a');
-      expect(member.isConst, isTrue);
+      expect(member.canBeConst, isTrue);
       expect(member, const DartStaticMember(type: DartType('Foo'), name: 'a'));
     });
   });

--- a/test/render/render_tree_test.dart
+++ b/test/render/render_tree_test.dart
@@ -1575,7 +1575,7 @@ void main() {
         assignedName: 'WaitTimer',
       );
       expect(schema.defaultValueExpression(context)?.source, 'WaitTimer(30)');
-      expect(schema.defaultValueExpression(context)?.isConst, isTrue);
+      expect(schema.defaultValueExpression(context)?.canBeConst, isTrue);
       expect(schema.hasNonConstDefaultValue(context), isFalse);
     });
 
@@ -1615,7 +1615,7 @@ void main() {
       );
       expect(schema.validationCalls, isNotEmpty);
       expect(schema.defaultValueExpression(context)?.source, 'WaitTimer(30)');
-      expect(schema.defaultValueExpression(context)?.isConst, isFalse);
+      expect(schema.defaultValueExpression(context)?.canBeConst, isFalse);
       expect(schema.hasNonConstDefaultValue(context), isTrue);
     });
 
@@ -1647,7 +1647,7 @@ void main() {
         ),
         defaultValue: ['push'],
       );
-      expect(schema.defaultValueExpression(context)?.isConst, isTrue);
+      expect(schema.defaultValueExpression(context)?.canBeConst, isTrue);
       expect(schema.hasNonConstDefaultValue(context), isFalse);
       // The `??` destination evaluates at runtime, so the keyword is
       // written there and not in a parameter default.
@@ -1690,7 +1690,7 @@ void main() {
         minLength: null,
         pattern: null,
       );
-      expect(schema.exampleValue(context)?.isConst, isTrue);
+      expect(schema.exampleValue(context)?.canBeConst, isTrue);
     });
 
     test('a newtype with no validations is constant', () {
@@ -1725,7 +1725,7 @@ void main() {
         pattern: null,
         assignedName: 'Foo',
       );
-      expect(schema.exampleValue(context)?.isConst, isFalse);
+      expect(schema.exampleValue(context)?.canBeConst, isFalse);
     });
 
     test('DateTime and Uri pods are not constant', () {
@@ -1736,7 +1736,7 @@ void main() {
           createsNewType: false,
         );
         expect(
-          schema.exampleValue(context)?.isConst,
+          schema.exampleValue(context)?.canBeConst,
           isFalse,
           reason: '$type has no const constructor',
         );
@@ -1749,7 +1749,7 @@ void main() {
         type: PodType.boolean,
         createsNewType: false,
       );
-      expect(schema.exampleValue(context)?.isConst, isTrue);
+      expect(schema.exampleValue(context)?.canBeConst, isTrue);
     });
 
     test('an enum names its first member rather than values.first', () {
@@ -1786,14 +1786,14 @@ void main() {
         const RenderArray(
           common: common,
           items: constElement,
-        ).exampleValue(context)?.isConst,
+        ).exampleValue(context)?.canBeConst,
         isTrue,
       );
       expect(
         const RenderArray(
           common: common,
           items: nonConstElement,
-        ).exampleValue(context)?.isConst,
+        ).exampleValue(context)?.canBeConst,
         isFalse,
       );
     });
@@ -1809,7 +1809,7 @@ void main() {
           common: common,
           valueSchema: nonConstValue,
           keySchema: null,
-        ).exampleValue(context)?.isConst,
+        ).exampleValue(context)?.canBeConst,
         isFalse,
       );
     });
@@ -1818,7 +1818,7 @@ void main() {
       const schema = RenderBase64Bytes(common: common);
       final example = schema.exampleValue(context);
       expect(example?.source, 'Uint8List.fromList(<int>[0])');
-      expect(example?.isConst, isFalse);
+      expect(example?.canBeConst, isFalse);
     });
   });
 

--- a/test/render/render_tree_test.dart
+++ b/test/render/render_tree_test.dart
@@ -973,11 +973,23 @@ void main() {
       final templates = TemplateProvider.defaultLocation();
       final context = SchemaRenderer(templates: templates);
       expect(
-        ref.toJsonExpression('foo', context, dartIsNullable: false),
+        ref
+            .toJsonExpression(
+              const DartIdentifier('foo'),
+              context,
+              dartIsNullable: false,
+            )
+            .source,
         'foo.toJson()',
       );
       expect(
-        ref.toJsonExpression('foo', context, dartIsNullable: true),
+        ref
+            .toJsonExpression(
+              const DartIdentifier('foo'),
+              context,
+              dartIsNullable: true,
+            )
+            .source,
         'foo?.toJson()',
       );
     });
@@ -1924,11 +1936,23 @@ void main() {
 
     test('toJson delegates to Date.toJson', () {
       expect(
-        date.toJsonExpression('d', context, dartIsNullable: false),
+        date
+            .toJsonExpression(
+              const DartIdentifier('d'),
+              context,
+              dartIsNullable: false,
+            )
+            .source,
         'd.toJson()',
       );
       expect(
-        date.toJsonExpression('d', context, dartIsNullable: true),
+        date
+            .toJsonExpression(
+              const DartIdentifier('d'),
+              context,
+              dartIsNullable: true,
+            )
+            .source,
         'd?.toJson()',
       );
     });
@@ -2003,39 +2027,57 @@ void main() {
     test('toJsonExpression delegates to .toJson() when a newtype', () {
       final schema = pod(PodType.dateTime, createsNewType: true);
       expect(
-        schema.toJsonExpression('x', context, dartIsNullable: false),
+        schema
+            .toJsonExpression(
+              const DartIdentifier('x'),
+              context,
+              dartIsNullable: false,
+            )
+            .source,
         'x.toJson()',
       );
       expect(
-        schema.toJsonExpression('x', context, dartIsNullable: true),
+        schema
+            .toJsonExpression(
+              const DartIdentifier('x'),
+              context,
+              dartIsNullable: true,
+            )
+            .source,
         'x?.toJson()',
       );
     });
 
     test('toJsonExpression is inline for pod types when not a newtype', () {
       expect(
-        pod(PodType.dateTime).toJsonExpression(
-          'x',
-          context,
-          dartIsNullable: false,
-        ),
+        pod(PodType.dateTime)
+            .toJsonExpression(
+              const DartIdentifier('x'),
+              context,
+              dartIsNullable: false,
+            )
+            .source,
         'x.toIso8601String()',
       );
       // email and uuid are Strings; no conversion, just pass dartName.
       expect(
-        pod(PodType.email).toJsonExpression(
-          'x',
-          context,
-          dartIsNullable: true,
-        ),
+        pod(PodType.email)
+            .toJsonExpression(
+              const DartIdentifier('x'),
+              context,
+              dartIsNullable: true,
+            )
+            .source,
         'x',
       );
       expect(
-        pod(PodType.uuid).toJsonExpression(
-          'x',
-          context,
-          dartIsNullable: true,
-        ),
+        pod(PodType.uuid)
+            .toJsonExpression(
+              const DartIdentifier('x'),
+              context,
+              dartIsNullable: true,
+            )
+            .source,
         'x',
       );
     });


### PR DESCRIPTION
## Summary

`toJsonExpression` takes and returns a `DartExpression` instead of a `String`, across fourteen implementations and their call sites, deleting two of the text-inspection sites named in `doc/dart_expression.md`. Also renames `DartExpression.isConst` to `canBeConst`, which is what it has always computed.

## toJsonExpression

Four new node types cover everything `toJson` emits:

| node | example |
|---|---|
| `DartIdentifier` | `value`, `e`, `key` |
| `DartMethodCall` | `value.toJson()`, `items?.map(f)` |
| `DartPropertyAccess` | `entry.value` |
| `DartLambda` | `(key, value) => MapEntry(k, v)` |

`DartMethodCall` chains by nesting — `x.map(f).toList()` is a call whose target is a call — so chains need no special support. `MapEntry(k, v)` was already a `DartInvocation`.

**Two ADR sites deleted**, because the tree answers what the text was being asked:

- **`_bareIdentifier`** — a `RegExp(r'^[a-zA-Z_$][\w$]*$')` matched against rendered source to decide whether a path parameter needed `'$x'` or `'${x}'` (`unnecessary_brace_in_string_interps`). Now `expr is DartIdentifier`; the regex is gone from the file.
- **`_multipartValueExpr`'s `jsonStorageType(isNullable: false) == 'String'`** — the same question `_stringifyWireValue` already answered structurally from `DartType`. The ADR called this one out explicitly as "the same question answered two ways". The duplicate is gone; both callers share the structural one.

**The debug `toString` from #262 earned itself.** One site interpolated a `toJsonExpression` result instead of serializing it, and the generated output contained `DartMethodCall(DartIdentifier(e), toJson, [], false)` — caught immediately by a test. Had `toString` still returned Dart source, that site would have silently emitted plausible-looking text serialized in the wrong context.

## isConst → canBeConst

`isConst` named the wrong one of three things Dart calls const:

- **is a constant** — actually evaluated at compile time. `5` always is; `Foo(1)` only when written `const Foo(1)` or placed in a constant context. That depends on the destination, so the tree cannot answer it.
- **can be const** — what the getter has always computed, and what every consumer uses: the `const` declaration for an example, the keyword decision in the serializer, and whether a default may be a parameter default.
- **is written `const`** — the keyword, which is `DartExpressionSerializer.isConstContext`'s business and was separated out in #262.

The old name read as the first while meaning the second, which misleads exactly where it matters: `DartListLiteral([1, 2]).isConst` being true sounds like a claim the list *is* constant, when written bare in a runtime context it allocates a fresh list every time.

`isConstConstructor` and `isConstContext` keep their names — the first is a fact about a declaration and the input to the fold, the second is about a destination.

## What's next

`fromJsonExpression` is the remaining half (16 overrides) and needs cast and `??` nodes, where #255's don't-parenthesize-a-bare-cast rule has to become structural.

## Testing

- `dart analyze` clean; `dart test` green (666, +7 covering the four new node types: rendering, null-aware access, chaining, value equality).
- **Byte-identical** across github, discord, spacetraders, petstore and backstage, and again after the rename (all generated under the same package name, so `directives_ordering` cannot produce phantom diffs).
- `dart_expression.dart` fully covered.
