### PR TITLE
refactor: build auth requests on the expression IR

### DIFF
--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -1008,28 +1008,34 @@ class RenderSpec {
   }).toList();
 }
 
+/// The `AuthRequest` types from `lib/templates/auth.dart`, all of which
+/// declare `const` constructors — which is what lets an auth argument be a
+/// compile-time constant, since every value in one comes from the spec and
+/// so is a literal or an enum member.
+const _noAuthType = DartType('NoAuth');
+const _allOfAuthType = DartType('AllOfAuth');
+const _oneOfAuthType = DartType('OneOfAuth');
+const _apiKeyAuthType = DartType('ApiKeyAuth');
+const _httpAuthType = DartType('HttpAuth');
+const _apiKeyLocationType = DartType('ApiKeyLocation');
+
 extension on ResolvedSecurityRequirement {
   /// Turn the SecurityRequirements into AuthRequest subclasses to be
   /// resolved at runtime by the ApiClient.  If this requirement has
   /// multiple conditions, wrap them in an AllOfAuth.
-  String toArgumentString({int indent = 0}) {
-    final indentString = ' ' * indent;
+  DartExpression toExpression() {
     if (conditions.isEmpty) {
-      return '${indentString}NoAuth()';
+      return _noAuthType.constConstruct([]);
     }
     // TODO(eseidel): Support scopes/roles in conditions.values.
-    final buffer = StringBuffer();
-    if (conditions.length > 1) {
-      buffer.write('${indentString}AllOfAuth([\n');
-      for (final scheme in conditions.keys) {
-        buffer.write('${scheme.toArgumentString(indent: indent + 2)},\n');
-      }
-      buffer.write('$indentString])');
-    } else {
-      final scheme = conditions.keys.first;
-      buffer.write(scheme.toArgumentString(indent: indent));
+    if (conditions.length == 1) {
+      return conditions.keys.first.toExpression();
     }
-    return buffer.toString();
+    return _allOfAuthType.constConstruct([
+      DartListLiteral.untyped(
+        conditions.keys.map((scheme) => scheme.toExpression()).toList(),
+      ),
+    ]);
   }
 }
 
@@ -1040,20 +1046,32 @@ extension on SecurityScheme {
   /// caller is expected to override `ApiClient.resolveAuth` or set
   /// `defaultHeaders` to inject auth themselves. The parser emits a
   /// warning at generation time so consumers notice.
-  String toArgumentString({int indent = 0}) {
-    final expression = switch (this) {
-      ApiKeySecurityScheme(
-        keyName: final keyName,
-        inLocation: final inLocation,
-      ) =>
-        "ApiKeyAuth(name: '$keyName', secretName: '$name', "
-            'sendIn: $inLocation)',
-      HttpSecurityScheme(scheme: final scheme) =>
-        "HttpAuth(scheme: '$scheme', secretName: '$name')",
-      UnsupportedSecurityScheme() => 'NoAuth()',
-    };
-    return '${' ' * indent}$expression';
-  }
+  DartExpression toExpression() => switch (this) {
+    // Named arguments, so these build [DartInvocation] directly rather than
+    // going through `constConstruct` (positional only).
+    ApiKeySecurityScheme(
+      keyName: final keyName,
+      inLocation: final inLocation,
+    ) =>
+      DartInvocation(
+        type: _apiKeyAuthType,
+        isConstConstructor: true,
+        namedArguments: {
+          'name': DartLiteral(keyName),
+          'secretName': DartLiteral(name),
+          'sendIn': _apiKeyLocationType.member(inLocation.name),
+        },
+      ),
+    HttpSecurityScheme(scheme: final scheme) => DartInvocation(
+      type: _httpAuthType,
+      isConstConstructor: true,
+      namedArguments: {
+        'scheme': DartLiteral(scheme),
+        'secretName': DartLiteral(name),
+      },
+    ),
+    UnsupportedSecurityScheme() => _noAuthType.constConstruct([]),
+  };
 }
 
 /// A convenience class created for each operation within a path item
@@ -1173,23 +1191,18 @@ class Endpoint implements ToTemplateContext {
   ///     ),
   ///     NoAuth(),
   /// ]),
-  String? authArgument({int indent = 0}) {
+  DartExpression? authExpression() {
     if (securityRequirements.isEmpty) {
       return null;
     }
-
-    final indentString = ' ' * indent;
-    final buffer = StringBuffer();
     if (securityRequirements.length == 1) {
-      buffer.write(securityRequirements.first.toArgumentString(indent: indent));
-    } else {
-      buffer.write('${indentString}OneOfAuth([\n');
-      for (final requirement in securityRequirements) {
-        buffer.write('${requirement.toArgumentString(indent: indent + 2)},\n');
-      }
-      buffer.write('$indentString])');
+      return securityRequirements.first.toExpression();
     }
-    return buffer.toString();
+    return _oneOfAuthType.constConstruct([
+      DartListLiteral.untyped(
+        securityRequirements.map((r) => r.toExpression()).toList(),
+      ),
+    ]);
   }
 
   // The two builders below produce strings whose indentation is fixed
@@ -1373,9 +1386,13 @@ class Endpoint implements ToTemplateContext {
   }
 
   List<String> _authRequestLines(String indent) {
-    final authArg = authArgument(indent: indent.length)?.trimLeft();
-    if (authArg == null) return const [];
-    return ['${indent}authRequest: $authArg,'];
+    // Serialized for a runtime destination: `invokeApi`'s argument list is
+    // not a constant context, so the `const` keyword gets written at the
+    // outermost const-able point (and, by [DartExpressionSerializer], only
+    // there). `dart format` owns the wrapping, so no indent is threaded in.
+    final auth = _maybeRuntimeSource(authExpression());
+    if (auth == null) return const [];
+    return ['${indent}authRequest: $auth,'];
   }
 
   /// Render the `multipart/form-data` field/file assembly that precedes

--- a/test/render/render_operation_test.dart
+++ b/test/render/render_operation_test.dart
@@ -1566,7 +1566,7 @@ void main() {
         '        final response = await client.invokeApi(\n'
         '            method: Method.post,\n'
         "            path: '/users',\n"
-        "            authRequest: ApiKeyAuth(name: 'apiKey', secretName: 'apiKey', sendIn: ApiKeyLocation.header),\n"
+        "            authRequest: const ApiKeyAuth(name: 'apiKey', secretName: 'apiKey', sendIn: ApiKeyLocation.header),\n"
         '        );\n'
         '\n'
         '        if (response.statusCode >= HttpStatus.badRequest) {\n'
@@ -1634,14 +1634,11 @@ void main() {
         '        final response = await client.invokeApi(\n'
         '            method: Method.post,\n'
         "            path: '/users',\n"
-        '            authRequest: OneOfAuth([\n'
-        '              AllOfAuth([\n'
-        "                ApiKeyAuth(name: 'apiKey', secretName: 'apiKey', sendIn: ApiKeyLocation.header),\n"
-        "                HttpAuth(scheme: 'Bearer', secretName: 'http'),\n"
-        '              ]),\n'
-        "              ApiKeyAuth(name: 'apiKey', secretName: 'apiKey', sendIn: ApiKeyLocation.header),\n"
-        '              NoAuth(),\n'
-        '            ]),\n'
+        // One `const`, at the outermost const-able point: the nested
+        // AllOfAuth / ApiKeyAuth / NoAuth sit in a constant context already,
+        // so repeating it would be `unnecessary_const`. `dart format` owns
+        // the wrapping, which is why this is emitted on one line.
+        "            authRequest: const OneOfAuth([AllOfAuth([ApiKeyAuth(name: 'apiKey', secretName: 'apiKey', sendIn: ApiKeyLocation.header), HttpAuth(scheme: 'Bearer', secretName: 'http')]), ApiKeyAuth(name: 'apiKey', secretName: 'apiKey', sendIn: ApiKeyLocation.header), NoAuth()]),\n"
         '        );\n'
         '\n'
         '        if (response.statusCode >= HttpStatus.badRequest) {\n'
@@ -1700,7 +1697,7 @@ void main() {
       expect(
         result,
         contains(
-          "authRequest: HttpAuth(scheme: 'bearer', secretName: 'oauth2'),",
+          "authRequest: const HttpAuth(scheme: 'bearer', secretName: 'oauth2'),",
         ),
       );
     });


### PR DESCRIPTION
## Summary

Build the `authRequest:` argument on the expression IR instead of by string concatenation, so it carries `const`. Closes 514 of the 797 raw `dart fix` lints across our six tracked specs — the largest remaining category in the dart-fix reduction arc.

## Details

`ResolvedSecurityRequirement.toArgumentString` assembled `ApiKeyAuth(name: '...', secretName: '...', sendIn: ...)` and its `AllOfAuth` / `OneOfAuth` wrappers as text, threading indentation by hand and emitting no `const`. `dart fix` then added the keyword on every generated endpoint — 339 of them in discord's `default_api.dart` alone.

All five `AuthRequest` types in `lib/templates/auth.dart` declare `const` constructors, and every value in an auth request comes from the spec, so it is a literal or an enum member. That makes this exactly the question the IR exists to answer: `canBeConst` folds to true, and `DartExpressionSerializer` writes `const` at the outermost const-able point — and only there, since a written keyword makes everything below it a constant context:

```dart
authRequest: const OneOfAuth([
  AllOfAuth([                        // no `const` — already constant
    ApiKeyAuth(name: 'apiKey', secretName: 'apiKey', sendIn: ApiKeyLocation.header),
    HttpAuth(scheme: 'Bearer', secretName: 'http'),
  ]),
  NoAuth(),
]),
```

Nesting is what makes the derived answer worth having: hand-written `const` placement here means reasoning about which of five node kinds can carry the keyword and which are already in a constant context. The fold does it.

Hand-threaded indentation goes away with it — the expression is emitted on one line and `dart format` owns the wrapping, which is why the updated test assertions are single-line.

## Measured effect

Raw lints with the `dart fix` call disabled, across all six specs in the tracker repo:

| category | before | after |
|---|---|---|
| `prefer_const_constructors` | 514 | 5 |
| `prefer_const_literals_to_create_immutables` | 89 | 0 |
| *(all other categories)* | 194 | 194 |
| **total** | **797** | **199** |

petstore is now fully `dart analyze`-clean without `dart fix`. The 5 residual `prefer_const_constructors` are unrelated sites (discord 3, github 2).

## Testing

- `dart test` green; `dart analyze` clean; `dart format` clean.
- Three existing assertions in `test/render/render_operation_test.dart` updated — they pin the pre-format string, so they are the direct coverage for this change. The multi-scheme case asserts the one-`const` nesting property specifically.
- **Byte-identical-after-fix on all six specs** (petstore, train-travel, spacetraders, discord, backstage, github), regenerated old-vs-new under the same package name. `dart fix` was already applying exactly this transform, so shipped output does not move.
