### PR TITLE
refactor: emit whole-valued number literals as int literals

### DIFF
--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -3283,11 +3283,11 @@ abstract class RenderNumeric<T extends num> extends RenderSchema {
       // wrong; asking the constructor directly is that comment's fix.
       return DartInvocation(
         type: dartType,
-        arguments: [DartLiteral(value)],
+        arguments: [_numericLiteral(value)],
         isConstConstructor: validationCalls.isEmpty,
       );
     }
-    return DartLiteral(value);
+    return _numericLiteral(value);
   }
 
   @override
@@ -3447,7 +3447,7 @@ class RenderNumber extends RenderNumeric<double> {
 
   @override
   DartExpression? exampleValue(SchemaRenderer context) =>
-      newtypeWrappedExample(DartLiteral(_validNumberExample(common, this)));
+      newtypeWrappedExample(_numericLiteral(_validNumberExample(common, this)));
 }
 
 class RenderInteger extends RenderNumeric<int> {
@@ -3490,6 +3490,33 @@ class RenderInteger extends RenderNumeric<int> {
     DartLiteral(_validNumberExample(common, this).toInt()),
   );
 }
+
+/// A numeric literal for a destination whose static type is the schema's
+/// own — `double` for `number`, `int` for `integer`, or a newtype over
+/// one of those.
+///
+/// A whole-valued `double` renders as an int literal (`0`, not `0.0`).
+/// Dart converts an int literal in a `double` context, so the two forms
+/// denote the same value, and `prefer_int_literals` wants the shorter
+/// one — which `dart fix` was already rewriting it to.
+///
+/// Only sound because the destination is statically `double`. In a
+/// `dynamic` or `num` context (a JSON map literal, say) the two forms
+/// differ at runtime, so this must not be used to build one.
+DartLiteral _numericLiteral(num value) =>
+    DartLiteral(_isExactWholeDouble(value) ? value.toInt() : value);
+
+/// Whether [value] is a `double` holding a whole number that an `int`
+/// can represent exactly.
+///
+/// Non-finite values have no `int` form (`toInt()` throws), and past
+/// 2^53 a `double` no longer represents every integer, so converting
+/// would round to a different number than the spec wrote.
+bool _isExactWholeDouble(num value) =>
+    value is double &&
+    value.isFinite &&
+    value == value.truncateToDouble() &&
+    value.abs() <= 9007199254740992; // 2^53
 
 /// Pick a numeric value satisfying [schema]'s declared bounds. Prefers
 /// the spec's own `example` / `examples` (assumed valid by the

--- a/test/render/render_tree_test.dart
+++ b/test/render/render_tree_test.dart
@@ -1171,6 +1171,41 @@ void main() {
       expect(schema.exampleValue(context)?.source, 'Date(2024, 1, 1)');
     });
 
+    // `number` examples land in a statically-`double` destination, where an
+    // int literal converts and reads better (`prefer_int_literals`). A
+    // fractional value has no int form and must keep the double literal.
+    RenderNumber numberWithExample(num example) => RenderNumber(
+      common: CommonProperties.test(
+        snakeName: 'foo',
+        pointer: const JsonPointer.empty(),
+        example: example,
+      ),
+      defaultValue: null,
+      maximum: null,
+      minimum: null,
+      exclusiveMaximum: null,
+      exclusiveMinimum: null,
+      multipleOf: null,
+      createsNewType: false,
+    );
+
+    test('whole-valued number example renders as an int literal', () {
+      expect(numberWithExample(0.0).exampleValue(context)?.source, '0');
+      expect(numberWithExample(7.0).exampleValue(context)?.source, '7');
+      expect(numberWithExample(-3.0).exampleValue(context)?.source, '-3');
+    });
+
+    test('fractional number example keeps the double literal', () {
+      expect(numberWithExample(1.5).exampleValue(context)?.source, '1.5');
+      expect(numberWithExample(0.25).exampleValue(context)?.source, '0.25');
+    });
+
+    test('number example beyond 2^53 keeps the double literal', () {
+      // Past 2^53 a double no longer represents every integer, so the int
+      // form could denote a different number than the spec wrote.
+      expect(numberWithExample(1e300).exampleValue(context)?.source, '1e+300');
+    });
+
     test('uri format produces a Uri.parse literal', () {
       const schema = RenderPod(
         common: common,


### PR DESCRIPTION
## Summary

Emit `0` rather than `0.0` for whole-valued `number` examples and defaults, closing `prefer_int_literals` (77 of the 199 remaining raw `dart fix` lints).

(#267, which this builds on, is already merged.)

## Details

A `number` schema whose example or default is a whole value emitted a double literal, and `dart fix` rewrote it to the int form:

```dart
condition: ShipComponentCondition(0.0),   // emitted
condition: ShipComponentCondition(0),     // after dart fix
```

`RenderNumber.dartType` is always `double` or a newtype over one, so the destination is statically `double` and Dart's int-literal-in-a-double-context conversion makes the two forms denote the same value. Both the example path and the default-value path now go through one `_numericLiteral` helper.

**Why this is guarded rather than blanket.** The conversion is only sound because the destination is statically `double`; in a `dynamic` or `num` context the two forms differ at runtime, which is why the helper's doc says not to use it to build one. And the value itself has to survive the trip: non-finite values have no `int` form (`toInt()` throws), and past 2^53 a double no longer represents every integer, so converting could denote a different number than the spec wrote. Both keep the double literal, with tests for each.

## Measured effect

Raw lints with the `dart fix` call disabled, across all six specs in the tracker repo (baseline is post-#267):

| category | before | after |
|---|---|---|
| `prefer_int_literals` | 77 | 0 |
| *(all other categories)* | 122 | 122 |
| **total** | **199** | **122** |

spacetraders drops from 84 to 16; petstore and spacetraders are now down to `unused_import` or nothing.

## Testing

- `dart test` green (669); `dart analyze` clean; `dart format` clean.
- Three new unit tests in `test/render/render_tree_test.dart` covering whole-valued, fractional, and beyond-2^53 examples. Direct coverage matters here because the change is **invisible in post-fix output** — `dart fix` was already applying it, so no golden test would move.
- A/B regenerated old-vs-new under the same package name on all six specs: five byte-identical, github differs in **2 files by `dart_style` reflow only** (a shorter expression now fits on one line, so a trailing-comma-wrapped block collapses). Confirmed semantically identical by the documented normalization check (strip whitespace, `,)`→`)`): 0 real differences.

## Timing note

Not a goal of this PR, but recording it since we want to track it: github's `dart fix` is currently **~15.6s** (three consecutive runs: 15678 / 15748 / 15521 ms), against the ~47s in the arc's original notes. One earlier run measured 29.5s immediately after the test suite, so the figure is load-sensitive — take single measurements with suspicion.
