### PR TITLE
refactor: gate schema-contributed imports on what the body names

### DIFF
--- a/lib/src/render/file_renderer.dart
+++ b/lib/src/render/file_renderer.dart
@@ -662,6 +662,14 @@ class FileRenderer {
       // subclasses to live in the same library) — no separate file.
       !schema.isSmooshed;
 
+  /// Whether a schema-contributed import survives its sentinel gate:
+  /// either it declares none, or [bodyNames] confirms the rendered body
+  /// references it. See [Import.neededWhenBodyNames].
+  static bool _bodyNeedsImport(Import i, bool Function(String) bodyNames) {
+    final sentinel = i.neededWhenBodyNames;
+    return sentinel == null || bodyNames(sentinel);
+  }
+
   @visibleForTesting
   Iterable<Import> importsForApi(
     Api api,
@@ -712,7 +720,11 @@ class FileRenderer {
         .map((s) => Import(modelPackageImport(this, s)))
         .toList();
     imports.addAll({
-      ...inlineSchemas.expand((s) => s.additionalImports),
+      // Gated on their declared sentinel, the same as the fixed imports
+      // above — see [Import.neededWhenBodyNames].
+      ...inlineSchemas
+          .expand((s) => s.additionalImports)
+          .where((i) => _bodyNeedsImport(i, names)),
       ..._dateImportFor(inlineSchemas, bodyNamesDate: names('Date')),
       ...apiImports,
     });
@@ -793,10 +805,16 @@ class FileRenderer {
         .map((s) => Import(modelPackageImport(this, s)))
         .toList();
 
+    // `additionalImports` are collected from the schema *tree*, but the
+    // body only emits code for part of it, so each is gated on the
+    // sentinel it declares (see [Import.neededWhenBodyNames]). Same
+    // discipline [importsForApi] applies to the api file's fixed imports.
+    bool bodyNeeds(Import i) => _bodyNeedsImport(i, referenced.contains);
+
     final imports = {
       ...usage.importsFor(packageName),
-      ...schema.additionalImports,
-      ...localSchemas.expand((s) => s.additionalImports),
+      ...schema.additionalImports.where(bodyNeeds),
+      ...localSchemas.expand((s) => s.additionalImports).where(bodyNeeds),
       ..._dateImportFor(
         localSchemas,
         bodyNamesDate: referenced.contains('Date'),

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -394,10 +394,33 @@ abstract class CanBeParameter implements ToTemplateContext {
 // Could make this comparable to have a nicer sort for our test results.
 @immutable
 class Import extends Equatable {
-  const Import(this.path, {this.asName, this.shown = const []});
+  const Import(
+    this.path, {
+    this.asName,
+    this.shown = const [],
+    this.neededWhenBodyNames,
+  });
 
   final String path;
   final String? asName;
+
+  /// An identifier that must appear in the rendered body for this import
+  /// to be needed, or `null` to keep the import unconditionally.
+  ///
+  /// Schema-contributed imports (`additionalImports`) are collected from
+  /// the *schema tree*, but a model file only emits code for part of that
+  /// tree: a nested schema can contribute `dart:convert` while the body
+  /// reaches its bytes through a `model_helpers.dart` wrapper
+  /// (`maybeBase64Decode`) and never names `base64` itself. Gating on a
+  /// sentinel the emitted code must contain closes that gap.
+  ///
+  /// Conservative in the safe direction, like `referencedIdentifiers`:
+  /// keeping an import requires the token to be present, so a used
+  /// import is never dropped — the effect is only to stop emitting ones
+  /// the file never references (which `dart fix` would otherwise strip).
+  /// This mirrors the `names(...)` gating `FileRenderer.importsForApi`
+  /// already applies to the api file's fixed imports.
+  final String? neededWhenBodyNames;
 
   /// Specific identifiers to narrow the import/export with a `show`
   /// clause. Empty means "show all". Only meaningful when `asName` is
@@ -409,7 +432,7 @@ class Import extends Equatable {
   Map<String, dynamic> toTemplateContext() => {'path': path, 'asName': asName};
 
   @override
-  List<Object?> get props => [path, asName, shown];
+  List<Object?> get props => [path, asName, shown, neededWhenBodyNames];
 }
 
 /// Identifiers emitted by the renderer that are defined in the generated
@@ -2799,7 +2822,11 @@ class RenderPod extends RenderSchema {
   Iterable<Import> get additionalImports => [
     ...super.additionalImports,
     if (type == PodType.uriTemplate)
-      const Import('package:uri/uri.dart', shown: ['UriTemplate']),
+      const Import(
+        'package:uri/uri.dart',
+        shown: ['UriTemplate'],
+        neededWhenBodyNames: 'UriTemplate',
+      ),
   ];
 
   /// Converts `value` (of type [dartTypeName]) to its JSON representation.
@@ -3610,12 +3637,10 @@ class RenderObject extends RenderNewType {
   @override
   DartType get jsonStorageDartType => _jsonWireMap;
 
-  @override
-  Iterable<Import> get additionalImports => [
-    ...super.additionalImports,
-    if (properties.values.any((p) => p.isDeprecated))
-      const Import('package:meta/meta.dart'),
-  ];
+  // A deprecated property emits `@deprecated`, which is a `dart:core`
+  // constant — not `package:meta`'s. This class used to add a meta
+  // import for it, which was never needed; the `@immutable` case that
+  // genuinely needs meta comes from `SchemaUsage.usesMetaAnnotations`.
 
   // isNullable means it's optional for the server, use nullable storage.
   bool propertyDartIsNullable({
@@ -4877,21 +4902,19 @@ class RenderOneOf extends RenderNewType {
     );
   }
 
-  /// Whether any dispatch strategy will fire — drives whether the
-  /// `@immutable` wrapper-class import is needed. Calls [decideDispatch]
-  /// on the resolved source; cheap and pure.
-  bool get _hasDispatch {
-    final src = source;
-    if (src == null) return false;
-    return decideDispatch(src) is! NoDispatch;
-  }
-
   @override
   Iterable<Import> get additionalImports => [
     ...super.additionalImports,
-    // The dispatch path emits @immutable wrappers that override == /
-    // hashCode; the legacy UnimplementedError stub doesn't need it.
-    if (_hasDispatch) const Import('package:meta/meta.dart'),
+    // The dispatch path emits `@immutable` wrappers that override == /
+    // hashCode; the legacy UnimplementedError stub doesn't.
+    //
+    // Gated on the body naming `immutable` rather than on a
+    // `decideDispatch(source) is! NoDispatch` prediction, which this
+    // used to ask. The prediction was wrong for a oneOf with no
+    // variants — dispatch fires, but the emitted body is a bare
+    // `switch (json) { _ => throw }` with no annotation — so the import
+    // was unused. Asking what was emitted cannot disagree with it.
+    const Import('package:meta/meta.dart', neededWhenBodyNames: 'immutable'),
   ];
 
   @override
@@ -6041,7 +6064,7 @@ class RenderBinary extends RenderNoJson {
   @override
   Iterable<Import> get additionalImports => [
     ...super.additionalImports,
-    const Import('dart:typed_data'),
+    const Import('dart:typed_data', neededWhenBodyNames: 'Uint8List'),
   ];
 
   @override
@@ -6073,8 +6096,17 @@ class RenderBase64Bytes extends RenderSchema {
     // api.dart barrel. `dart:convert` is imported without a `shown:`
     // list since `base64` is only used internally by the encoded
     // fromJson/toJson and never appears in a public field signature.
-    const Import('dart:typed_data', shown: ['Uint8List']),
-    const Import('dart:convert'),
+    //
+    // Both are gated on the emitted code naming them: a nullable field
+    // reaches its bytes through `maybeBase64Decode` from
+    // `model_helpers.dart`, so the body names neither `base64` nor
+    // (if no field is non-nullable) `Uint8List`.
+    const Import(
+      'dart:typed_data',
+      shown: ['Uint8List'],
+      neededWhenBodyNames: 'Uint8List',
+    ),
+    const Import('dart:convert', neededWhenBodyNames: 'base64'),
   ];
 
   @override

--- a/test/render/file_renderer_test.dart
+++ b/test/render/file_renderer_test.dart
@@ -2715,18 +2715,24 @@ void main() {
           ),
         },
       );
-      final imports = fileRenderer.importsForModel(
-        schema,
-        const SchemaUsage(
-          usesMetaAnnotations: true,
-          modelHelpers: {ModelHelpers.parseFromJson},
-        ),
-        body: 'class Foo {}',
+      const usage = SchemaUsage(
+        usesMetaAnnotations: true,
+        modelHelpers: {ModelHelpers.parseFromJson},
       );
-      expect(imports, {
+      Iterable<Import> importsFor(String body) =>
+          fileRenderer.importsForModel(schema, usage, body: body);
+
+      // `dart:typed_data` comes from the nested RenderBinary, but is
+      // gated on the body naming `Uint8List` — a schema in the tree does
+      // not mean the emitted code uses it.
+      expect(importsFor('class Foo { Uint8List? bar; }'), {
         const Import('package:meta/meta.dart'),
         const Import('package:spacetraders/model_helpers.dart'),
-        const Import('dart:typed_data'), // Uint8List from RenderBinary.
+        const Import('dart:typed_data', neededWhenBodyNames: 'Uint8List'),
+      });
+      expect(importsFor('class Foo {}'), {
+        const Import('package:meta/meta.dart'),
+        const Import('package:spacetraders/model_helpers.dart'),
       });
     });
 
@@ -2928,6 +2934,9 @@ void main() {
           '    }\n'
           '    return jsonDecode(response.body) as Map<String, dynamic>;\n'
           '  }\n'
+          // Names `Uint8List` so the RenderBinary-contributed
+          // `dart:typed_data` clears its sentinel gate too.
+          '  Uint8List? bytes;\n'
           '}\n';
       final imports = fileRenderer.importsForApi(
         api,
@@ -2941,7 +2950,8 @@ void main() {
         const Import('package:spacetraders/api_client.dart'),
         const Import('package:spacetraders/api_exception.dart'),
         const Import('package:http/http.dart', asName: 'http'),
-        const Import('dart:typed_data'), // Uint8List from RenderBinary.
+        // Uint8List from RenderBinary.
+        const Import('dart:typed_data', neededWhenBodyNames: 'Uint8List'),
       });
     });
 

--- a/test/render/render_tree_test.dart
+++ b/test/render/render_tree_test.dart
@@ -926,6 +926,29 @@ void main() {
       );
     });
 
+    // Both are gated: a nullable base64 field decodes through
+    // `maybeBase64Decode` from model_helpers.dart, so the body names
+    // neither `base64` nor necessarily `Uint8List`.
+    test('base64 bytes carries gated typed_data and convert imports', () {
+      expect(
+        const RenderBase64Bytes(
+          common: CommonProperties.test(
+            snakeName: 'a',
+            pointer: JsonPointer.empty(),
+            description: 'Foo',
+          ),
+        ).additionalImports,
+        equals([
+          const Import(
+            'dart:typed_data',
+            shown: ['Uint8List'],
+            neededWhenBodyNames: 'Uint8List',
+          ),
+          const Import('dart:convert', neededWhenBodyNames: 'base64'),
+        ]),
+      );
+    });
+
     test('uriTemplate', () {
       expect(
         const RenderPod(

--- a/test/render/render_tree_test.dart
+++ b/test/render/render_tree_test.dart
@@ -895,7 +895,10 @@ void main() {
       );
     });
 
-    test('deprecated', () {
+    // `@deprecated` is a `dart:core` constant, so a deprecated property
+    // needs no import of its own. Meta is imported only for `@immutable`,
+    // which `SchemaUsage.usesMetaAnnotations` drives from the body.
+    test('deprecated property adds no import', () {
       expect(
         const RenderObject(
           common: CommonProperties.test(
@@ -919,7 +922,7 @@ void main() {
             ),
           },
         ).additionalImports,
-        equals([const Import('package:meta/meta.dart')]),
+        isEmpty,
       );
     });
 
@@ -935,7 +938,11 @@ void main() {
           createsNewType: false,
         ).additionalImports,
         equals([
-          const Import('package:uri/uri.dart', shown: ['UriTemplate']),
+          const Import(
+            'package:uri/uri.dart',
+            shown: ['UriTemplate'],
+            neededWhenBodyNames: 'UriTemplate',
+          ),
         ]),
       );
     });


### PR DESCRIPTION
## Summary

Gate schema-contributed imports on whether the rendered body actually names them, closing 25 of the 48 `unused_import` warnings across the six tracked specs. Independent of #268.

## Details

`additionalImports` is collected by walking the schema **tree**, but a file only emits code for part of that tree. A nested `RenderBase64Bytes` contributed `dart:convert`, yet a nullable field reaches its bytes through `maybeBase64Decode` from `model_helpers.dart` and never names `base64` — so the import was emitted and `dart fix` stripped it again.

Each such import now declares the identifier that must appear for it to be needed:

```dart
const Import('dart:convert', neededWhenBodyNames: 'base64'),
```

and both `importsForModel` and `importsForApi` gate on it. This is the discipline `importsForApi` already applied to its own fixed imports (`if (names('jsonDecode')) const Import('dart:convert')`), generalized to the schema-contributed ones. Conservative in the same direction: keeping an import *requires* the token, so a used import can never be dropped — the effect is only to stop emitting ones the file never references.

### Two predictions become evidence

The interesting part isn't the plumbing, it's that two sites were *predicting* what they were about to emit:

- **`RenderOneOf`** imported `package:meta` when `decideDispatch(source) is! NoDispatch` — a structural guess that an `@immutable` wrapper would be emitted. It's wrong for a oneOf with no variants, whose body is a bare `switch (json) { _ => throw }` with no annotation. Gating on the body naming `immutable` cannot disagree with what was emitted, so `_hasDispatch` is deleted rather than fixed.
- **`RenderObject`** imported `package:meta` for a deprecated property. `@deprecated` is a `dart:core` constant, not meta's — that import was never needed at all.

## Measured effect

`unused_import`, raw (with the `dart fix` call disabled), measured on `main`:

| spec | before | after |
|---|---|---|
| discord | 21 | **0** |
| github | 11 | 7 |
| spacetraders | 16 | 16 |
| **total** | **48** | **23** |

By import: `dart:convert` 15→0, `package:meta` 7→0, `dart:typed_data` 2→0, `package:uri` 1→0.

Every one of the 23 survivors is a **model** import — a separate root cause (the `referencedIdentifiers` token scan keeps an import the analyzer still considers unused, e.g. a name appearing only in a doc comment). Left for a follow-up rather than folded in here.

Total tail on `main`: 199 → 174; stacked with #268's 77, → 97.

## Testing

- `dart test` green (666); `dart analyze` clean; `dart format` clean.
- Updated four existing assertions and extended `importsForModel imports for model` to cover **both** directions of the new gate (body names `Uint8List` → kept; body doesn't → dropped), which is the actual behavior change.
- A/B regenerated old-vs-new under the same package name on all six specs: **five byte-identical**. github differs in 2 files by exactly one blank line — when `dart fix` strips an import it leaves the blank line behind, and not emitting the import avoids it. The new output is the better of the two:

```diff
  // ignore_for_file: lines_longer_than_80_chars
- 
  /// The publisher of the advisory.
```
