### PR TITLE
refactor: emit tearoffs where the generator wrote identity closures

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -5,6 +5,9 @@ ignorePaths:
   - "*.txt" # ignore text files at the root of the project
 words:
   - subtyping
+  - tearoff
+  - tearoffs
+  - parenthesization
   - interps
   - goldens
   - impls

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -4506,11 +4506,13 @@ class RenderMap extends RenderSchema {
     // We could probably do a smaller cast if the value schema is only json
     // types.
     final jsonType = jsonStorageType(isNullable: jsonIsNullable);
+    const keyName = 'key';
+    const valueName = 'value';
     final keyFromJson = keySchema == null
-        ? 'key'
-        : '${keySchema!.typeName}.fromJson(key)';
+        ? keyName
+        : '${keySchema!.typeName}.fromJson($keyName)';
     final valueFromJson = valueSchema.fromJsonExpression(
-      'value',
+      valueName,
       context,
       jsonIsNullable: false,
       dartIsNullable: false,
@@ -4518,8 +4520,22 @@ class RenderMap extends RenderSchema {
     // TODO(eseidel): Support orDefault?
     // Should this have a leading ? to skip the key on null?
     final callMap = jsonIsNullable ? '?.map' : '.map';
-    return '($jsonValue as $jsonType)$callMap((key, value) => '
-        'MapEntry($keyFromJson, $valueFromJson))';
+    // When neither key nor value transforms, the closure is
+    // `(key, value) => MapEntry(key, value)` — a tearoff written the long
+    // way (`unnecessary_lambdas`). Asking whether each side returned the
+    // name it was handed is a stopgap: once `fromJsonExpression` returns a
+    // `DartExpression` (see doc/dart_expression.md), identity becomes
+    // `expr == DartIdentifier(valueName)` structurally.
+    //
+    // The better output drops the `.map(...)` altogether, since an
+    // identity map only copies. That needs the same migration, because
+    // the result is then a bare cast whose parenthesization is a
+    // structural question (#255) rather than one this string can answer.
+    final isIdentity = keyFromJson == keyName && valueFromJson == valueName;
+    final transform = isIdentity
+        ? 'MapEntry.new'
+        : '(key, value) => MapEntry($keyFromJson, $valueFromJson)';
+    return '($jsonValue as $jsonType)$callMap($transform)';
   }
 
   @override

--- a/lib/templates/schema_object.mustache
+++ b/lib/templates/schema_object.mustache
@@ -31,6 +31,7 @@
     {{/hasNoJsonProperty}}
     {{/castFromJsonArg}}
     {{^hasNoJsonProperty}}
+        {{#hasProperties}}
         return parseFromJson('{{ typeName }}', json, () => {{ typeName }}(
             {{#properties}}
             {{^isConstGetter}}{{ dartName }}: {{{ fromJson }}},{{/isConstGetter}}
@@ -43,6 +44,12 @@
             },
             {{/hasAdditionalProperties}}
         ));
+        {{/hasProperties}}
+        {{! Every property is a const getter, so the constructor takes no }}
+        {{! arguments and the closure is a tearoff written the long way. }}
+        {{^hasProperties}}
+        return parseFromJson('{{ typeName }}', json, {{ typeName }}.new);
+        {{/hasProperties}}
     {{/hasNoJsonProperty}}
     }
 

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -1095,6 +1095,39 @@ void main() {
       expect(result, isNot(contains('throw UnimplementedError')));
     });
 
+    // An object whose only property is pinned to a single enum value
+    // renders that property as a const getter, so the constructor takes
+    // no arguments. The fromJson closure is then a tearoff written the
+    // long way (`unnecessary_lambdas`) and is emitted as `Type.new`.
+    test('object with only const-getter properties uses a tearoff', () {
+      final results = renderTestSchemas(
+        {
+          'Pong': {
+            'type': 'object',
+            'properties': {
+              'type': {
+                'type': 'integer',
+                'enum': [1],
+                'allOf': [
+                  {r'$ref': '#/components/schemas/CallbackType'},
+                ],
+              },
+            },
+            'required': ['type'],
+          },
+          'CallbackType': {
+            'type': 'integer',
+            'enum': [1, 4],
+          },
+        },
+        specUrl: Uri.parse('file:///spec.yaml'),
+      );
+      final pong = results['Pong'];
+      expect(pong, isNotNull);
+      expect(pong, contains("parseFromJson('Pong', json, Pong.new)"));
+      expect(pong, isNot(contains('() => Pong(')));
+    });
+
     test('typed map variant walks each entry through fromJson/toJson', () {
       // Map with a non-trivial value schema. The wrapper must convert
       // each entry on fromJson and reverse on toJson.
@@ -3439,7 +3472,9 @@ void main() {
         "            mUri: (json['m_uri'] as Map<String, dynamic>?)?.map((key, value) => MapEntry(key, Uri.parse(value as String))),\n"
         "            mMapOfString: (json['m_map_of_string'] as Map<String, dynamic>?)?.map((key, value) => MapEntry(key, (value as Map<String, dynamic>).map((key, value) => MapEntry(key, value as String)))),\n"
         "            mEnum: (json['m_enum'] as Map<String, dynamic>?)?.map((key, value) => MapEntry(key, TestMEnum.fromJson(value as String))),\n"
-        "            mUnknown: (json['m_unknown'] as Map<String, dynamic>?)?.map((key, value) => MapEntry(key, value)),\n"
+        // Neither key nor value transforms, so the identity closure is
+        // emitted as the tearoff it is.
+        "            mUnknown: (json['m_unknown'] as Map<String, dynamic>?)?.map(MapEntry.new),\n"
         '        ));\n'
         '    }\n'
         '\n'


### PR DESCRIPTION
## Summary

Emit tearoffs where the generator was writing identity closures, closing `unnecessary_lambdas` (all 29 sites across the six tracked specs) plus 3 `prefer_const_constructors`. Independent of #268 and #269.

## Details

Two sites emitted a closure that only forwards its arguments, which `dart fix` then rewrote as a tearoff.

**1. `RenderMap.fromJsonExpression` — 26 sites.** A `Map<String, dynamic>` property transforms neither key nor value, so it emitted an identity map:

```dart
headers: (checkedKey(json, 'headers') as Map<String, dynamic>?)?.map(
  (key, value) => MapEntry(key, value),
),
```

`toJsonExpression` already short-circuits exactly this case ("Nothing to do if both key and value are json types"); `fromJsonExpression` never did. It now emits `.map(MapEntry.new)`.

**2. `schema_object.mustache` — 3 sites.** An object whose properties are all const getters (a discriminator pinned to one enum value) has a constructor taking no arguments, so the wrapper degenerated to `() => Pong()`. Gated on the existing `hasProperties` flag, it becomes `Pong.new`.

The map change also closed discord's 3 `prefer_const_constructors`, since the closure body was a const-able invocation that is no longer written out.

### What this deliberately does not do

`.map(MapEntry.new)` still only *copies* — handwritten Dart would drop the call and keep the cast. Doing that leaves a bare cast whose parenthesization is the structural question #255 handled by hand for numerics, so it needs `fromJsonExpression` on the expression IR (`doc/dart_expression.md` remaining-work item 1). **Filed as #272.** Relatedly, "identity" is spelled here as *did each side return the name it was handed* — a string comparison, and a stopgap until that migration makes it `expr == DartIdentifier(valueName)`.

## Measured effect

Raw lints with the `dart fix` call disabled, measured on `main`:

| category | before | after |
|---|---|---|
| `unnecessary_lambdas` | 29 | **0** |
| `prefer_const_constructors` | 5 | 2 |
| **total** | **199** | **167** |

With #268 (−77) and #269 (−25) also landed: **65**.

## Testing

- `dart test` green (667); `dart analyze` clean; `dart format` clean.
- New unit test for the tearoff path (an object whose only property is pinned to a single enum value), asserting both `Pong.new` and the absence of `() => Pong(`. The non-identity map path was already covered in `render_schema_test.dart` / `render_operation_test.dart` and still asserts the closure form.
- A/B regenerated old-vs-new under the same package name on all six specs: **four byte-identical**; backstage (8 files) and github (1) differ by `dart_style` reflow only — the generator now emits the shorter form directly, so a trailing-comma-wrapped block collapses to one line. Confirmed by the normalization check (strip whitespace, `,)`→`)`): **0 semantic differences** across all 9.
