### PR TITLE
refactor: separate Library from Import

### DIFF
--- a/lib/src/render/file_renderer.dart
+++ b/lib/src/render/file_renderer.dart
@@ -341,8 +341,8 @@ class FileRenderer {
   /// the order without tripping `directives_ordering` on one spec or the
   /// other. Sorted here for the same reason [renderModels] sorts its own.
   List<Map<String, dynamic>> testImportsContext() => [
-    Import('package:$packageName/${testBarrelImport()}'),
-    Libraries.test,
+    Import.path('package:$packageName/${testBarrelImport()}'),
+    const Import(Libraries.test),
   ].sortedBy((i) => i.path).map((i) => i.toTemplateContext()).toList();
 
   LayoutContext _contextFor(RenderSchema schema) => LayoutContext(
@@ -534,7 +534,7 @@ class FileRenderer {
     // it. The import is only added when the body actually names `Date`.
     usedDate = true;
     return bodyNamesDate
-        ? [Import('package:$packageName/date.dart')]
+        ? [Import.path('package:$packageName/date.dart')]
         : const [];
   }
 
@@ -597,7 +597,7 @@ class FileRenderer {
     // them. Which side it lands on depends on the package name, so
     // appending only happened to look right for the names we generate.
     final allExports = <Import>[
-      for (final path in paths) Import('package:$packageName/$path'),
+      for (final path in paths) Import.path('package:$packageName/$path'),
       ...externalExports,
     ];
     bool isDart(Import e) => e.path.startsWith('dart:');
@@ -639,7 +639,7 @@ class FileRenderer {
   /// names re-exposed explicitly.
   ///
   /// Only imports with an explicit `shown:` list are candidates — an
-  /// unconstrained `Import('package:x/x.dart')` means "the schema
+  /// unconstrained `Import.path('package:x/x.dart')` means "the schema
   /// needs the package internally" (e.g. `package:meta/meta.dart`
   /// for `@immutable` or `dart:convert` for the `base64` codec), not
   /// "expose every symbol in it to consumers of the barrel."
@@ -661,7 +661,7 @@ class FileRenderer {
     }
     return [
       for (final entry in byPath.entries)
-        Import(entry.key, shown: entry.value.toList()),
+        Import.path(entry.key, shown: entry.value.toList()),
     ]..sort((a, b) => a.path.compareTo(b.path));
   }
 
@@ -692,7 +692,7 @@ class FileRenderer {
   /// [Libraries] makes one library one value, so the set these are
   /// gathered in normally dedupes them itself. This is the backstop for
   /// the case it cannot catch: the same library legitimately described
-  /// two ways, e.g. bare versus narrowed by [Import.showing] for the
+  /// two ways, e.g. bare versus narrowed by a `show` clause for the
   /// barrel. `add_imports.mustache` emits only the path and the prefix,
   /// so those two decide identity here — prefix included, because
   /// `import 'x' as a` and `import 'x' as b` are different directives.
@@ -727,14 +727,15 @@ class FileRenderer {
         Libraries.dartConvert,
         Libraries.dartIo,
       ])
-        if (library.isNeededBy(names)) library,
-      if (names('ApiClient')) Import('package:$packageName/api_client.dart'),
+        if (library.isNeededBy(names)) Import(library),
+      if (names('ApiClient'))
+        Import.path('package:$packageName/api_client.dart'),
       if (names('ApiException'))
-        Import('package:$packageName/api_exception.dart'),
+        Import.path('package:$packageName/api_exception.dart'),
       // `as http` is only ever used via the `http.` prefix, so it is
       // gated on that rather than on a bare identifier: a `http` token in
       // a URL doc-comment must not keep it.
-      if (body.contains('http.')) Libraries.http,
+      if (body.contains('http.')) const Import(Libraries.http, asName: 'http'),
       ...usage.importsFor(packageName),
     };
 
@@ -753,14 +754,14 @@ class FileRenderer {
         .where((s) => !s.isSmooshed)
         .where((s) => names(s.typeName));
     final apiImports = importedSchemas
-        .map((s) => Import(modelPackageImport(this, s)))
+        .map((s) => Import.path(modelPackageImport(this, s)))
         .toList();
     imports.addAll({
       // Gated on what each library provides, the same as the fixed
       // imports above — see [Import.provides].
       ...inlineSchemas
           .expand((s) => s.additionalImports)
-          .where((i) => i.isNeededBy(names)),
+          .where((i) => i.library.isNeededBy(names)),
       ..._dateImportFor(inlineSchemas, bodyNamesDate: names('Date')),
       ...apiImports,
     });
@@ -838,14 +839,14 @@ class FileRenderer {
         .where((s) => referenced.contains(s.typeName))
         .toSet();
     final referencedImports = importedSchemas
-        .map((s) => Import(modelPackageImport(this, s)))
+        .map((s) => Import.path(modelPackageImport(this, s)))
         .toList();
 
     // `additionalImports` are collected from the schema *tree*, but the
     // body only emits code for part of it, so each is gated on what its
     // library provides (see [Import.provides]). Same discipline
     // [importsForApi] applies to the api file's fixed imports.
-    bool bodyNeeds(Import i) => i.isNeededBy(referenced.contains);
+    bool bodyNeeds(Import i) => i.library.isNeededBy(referenced.contains);
 
     final imports = {
       ...usage.importsFor(packageName),

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -393,24 +393,34 @@ abstract class CanBeParameter implements ToTemplateContext {
 
 // Could make this comparable to have a nicer sort for our test results.
 @immutable
-class Import extends Equatable {
-  const Import(
-    this.path, {
-    this.asName,
-    this.shown = const [],
-    this.provides = const {},
-  });
+/// A library the generator can emit an import of, and the identifiers it
+/// provides.
+///
+/// The *providing* side of an import: where the library lives and which
+/// of its names the generator is able to emit. Distinct from [Import],
+/// which is one file's directive naming this library — the prefix and
+/// `show` clause there are the consuming file's choices and no business
+/// of the library's.
+@immutable
+class Library extends Equatable {
+  const Library(this.path, {this.provides = const {}});
 
   final String path;
-  final String? asName;
 
   /// The identifiers this library provides that the generator can emit,
-  /// or empty to keep the import unconditionally.
+  /// or empty to import it unconditionally.
   ///
   /// The generator never reads a library to find out what it exports, so
   /// the identifier-to-library mapping has to be written down — see
-  /// [Libraries], which is where it lives. An import is kept when the
-  /// rendered body names any of these.
+  /// [Libraries], which is where it lives.
+  ///
+  /// A set rather than one name because a library can provide several:
+  /// `dart:convert` supplies `jsonDecode` to api files and `base64` to
+  /// models.
+  final Set<String> provides;
+
+  /// Whether a file whose body is tokenized by [bodyNames] needs this
+  /// library.
   ///
   /// Gating matters because schema-contributed imports
   /// (`additionalImports`) are collected from the *schema tree*, but a
@@ -419,37 +429,49 @@ class Import extends Equatable {
   /// a `model_helpers.dart` wrapper (`maybeBase64Decode`) and never
   /// names `base64` itself.
   ///
-  /// A set rather than one name because a library can provide several —
-  /// `dart:convert` supplies `jsonDecode` to api files and `base64` to
-  /// models. Encoding that as one sentinel per call site is what let two
-  /// spellings of `package:meta/meta.dart` disagree and both survive the
-  /// set they were gathered in, emitting a duplicate directive.
-  ///
   /// Conservative in the safe direction, like `referencedIdentifiers`:
-  /// keeping an import requires a token to be present, so a used import
+  /// keeping a library requires a token to be present, so a used import
   /// is never dropped — the effect is only to stop emitting ones the
   /// file never references (which `dart fix` would otherwise strip).
-  final Set<String> provides;
+  bool isNeededBy(bool Function(String) bodyNames) =>
+      provides.isEmpty || provides.any(bodyNames);
+
+  @override
+  List<Object?> get props => [path, provides];
+}
+
+/// One file's import directive naming a [Library].
+///
+/// The *consuming* side: [asName] and [shown] are this file's choices
+/// about how to bring the library into scope, so two files can import
+/// one library differently without disagreeing about the library itself.
+@immutable
+class Import extends Equatable {
+  const Import(this.library, {this.asName, this.shown = const []});
+
+  /// An import of a library that declares no identifiers — the generated
+  /// package's own files, whose paths depend on the package name and so
+  /// cannot be [Libraries] constants.
+  Import.path(String path, {this.asName, this.shown = const []})
+    : library = Library(path);
+
+  final Library library;
+
+  final String? asName;
 
   /// Specific identifiers to narrow the import/export with a `show`
-  /// clause. Empty means "show all". Only meaningful when `asName` is
+  /// clause. Empty means "show all". Only meaningful when [asName] is
   /// null (prefix imports already scope symbols via the prefix). Used
   /// by the public-api barrel to narrow third-party re-exports to the
   /// types the generated API actually references.
   final List<String> shown;
 
-  /// This import narrowed to a `show` clause, for the barrel re-export.
-  Import showing(List<String> types) =>
-      Import(path, asName: asName, shown: types, provides: provides);
-
-  /// Whether the body, tokenized by [bodyNames], needs this import.
-  bool isNeededBy(bool Function(String) bodyNames) =>
-      provides.isEmpty || provides.any(bodyNames);
+  String get path => library.path;
 
   Map<String, dynamic> toTemplateContext() => {'path': path, 'asName': asName};
 
   @override
-  List<Object?> get props => [path, asName, shown, provides];
+  List<Object?> get props => [library, asName, shown];
 }
 
 /// Every library space_gen imports on a consumer's behalf, defined once.
@@ -466,43 +488,44 @@ class Import extends Equatable {
 /// generator itself emits into `model_helpers.dart`.
 abstract final class Libraries {
   /// `@immutable` on generated model and wrapper classes.
-  static const meta = Import(
+  static const meta = Library(
     'package:meta/meta.dart',
     provides: {'immutable'},
   );
 
   /// `Future`, in generated api method signatures.
-  static const dartAsync = Import('dart:async', provides: {'Future'});
+  static const dartAsync = Library('dart:async', provides: {'Future'});
 
   /// `jsonDecode` in api files; `base64` in models with
   /// `contentEncoding: base64` fields.
-  static const dartConvert = Import(
+  static const dartConvert = Library(
     'dart:convert',
     provides: {'jsonDecode', 'jsonEncode', 'base64'},
   );
 
   /// `HttpStatus`, emitted by `api.mustache`.
-  static const dartIo = Import('dart:io', provides: {'HttpStatus'});
+  static const dartIo = Library('dart:io', provides: {'HttpStatus'});
 
   /// `Uint8List`, for `format: binary` and `contentEncoding: base64`.
-  static const dartTypedData = Import(
+  static const dartTypedData = Library(
     'dart:typed_data',
     provides: {'Uint8List'},
   );
 
   /// `UriTemplate`, for `format: uri-template`.
-  static const uri = Import(
+  static const uri = Library(
     'package:uri/uri.dart',
     provides: {'UriTemplate'},
   );
 
-  /// Always used via the `http.` prefix, so it is gated on that rather
-  /// than on a bare identifier — a `http` token in a doc-comment URL
-  /// must not keep it.
-  static const http = Import('package:http/http.dart', asName: 'http');
+  /// Always imported via the `http.` prefix. It declares no `provides`
+  /// because the gate is on the `http.` prefix appearing in the body, not
+  /// on a bare identifier — a `http` token in a doc-comment URL must not
+  /// keep it.
+  static const http = Library('package:http/http.dart');
 
   /// `package:test`, in generated round-trip tests.
-  static const test = Import('package:test/test.dart');
+  static const test = Library('package:test/test.dart');
 }
 
 /// Identifiers emitted by the renderer that are defined in the generated
@@ -2892,7 +2915,7 @@ class RenderPod extends RenderSchema {
   Iterable<Import> get additionalImports => [
     ...super.additionalImports,
     if (type == PodType.uriTemplate)
-      Libraries.uri.showing(const ['UriTemplate']),
+      const Import(Libraries.uri, shown: ['UriTemplate']),
   ];
 
   /// Converts `value` (of type [dartTypeName]) to its JSON representation.
@@ -5023,7 +5046,7 @@ class RenderOneOf extends RenderNewType {
     // variants — dispatch fires, but the emitted body is a bare
     // `switch (json) { _ => throw }` with no annotation — so the import
     // was unused. Asking what was emitted cannot disagree with it.
-    Libraries.meta,
+    const Import(Libraries.meta),
   ];
 
   @override
@@ -6173,7 +6196,7 @@ class RenderBinary extends RenderNoJson {
   @override
   Iterable<Import> get additionalImports => [
     ...super.additionalImports,
-    Libraries.dartTypedData,
+    const Import(Libraries.dartTypedData),
   ];
 
   @override
@@ -6210,8 +6233,8 @@ class RenderBase64Bytes extends RenderSchema {
     // reaches its bytes through `maybeBase64Decode` from
     // `model_helpers.dart`, so the body names neither `base64` nor
     // (if no field is non-nullable) `Uint8List`.
-    Libraries.dartTypedData.showing(const ['Uint8List']),
-    Libraries.dartConvert,
+    const Import(Libraries.dartTypedData, shown: ['Uint8List']),
+    const Import(Libraries.dartConvert),
   ];
 
   @override

--- a/lib/src/render/schema_renderer.dart
+++ b/lib/src/render/schema_renderer.dart
@@ -93,12 +93,12 @@ class SchemaUsage {
   /// Imports required by the body itself. Package-local imports are
   /// resolved against [packageName].
   Iterable<Import> importsFor(String packageName) sync* {
-    if (usesMetaAnnotations) yield Libraries.meta;
+    if (usesMetaAnnotations) yield const Import(Libraries.meta);
     if (usesModelHelpers) {
-      yield Import('package:$packageName/model_helpers.dart');
+      yield Import.path('package:$packageName/model_helpers.dart');
     }
     if (usesValidationExtensions) {
-      yield Import('package:$packageName/api_exception.dart');
+      yield Import.path('package:$packageName/api_exception.dart');
     }
   }
 }
@@ -128,9 +128,9 @@ class ApiUsage {
   bool get usesModelHelpers => modelHelpers.isNotEmpty;
 
   Iterable<Import> importsFor(String packageName) sync* {
-    if (usesMetaAnnotations) yield Libraries.meta;
+    if (usesMetaAnnotations) yield const Import(Libraries.meta);
     if (usesModelHelpers) {
-      yield Import('package:$packageName/model_helpers.dart');
+      yield Import.path('package:$packageName/model_helpers.dart');
     }
   }
 }

--- a/test/render/file_renderer_test.dart
+++ b/test/render/file_renderer_test.dart
@@ -2726,13 +2726,13 @@ void main() {
       // gated on the body naming `Uint8List` — a schema in the tree does
       // not mean the emitted code uses it.
       expect(importsFor('class Foo { Uint8List? bar; }'), {
-        Libraries.meta,
-        const Import('package:spacetraders/model_helpers.dart'),
-        Libraries.dartTypedData,
+        const Import(Libraries.meta),
+        Import.path('package:spacetraders/model_helpers.dart'),
+        const Import(Libraries.dartTypedData),
       });
       expect(importsFor('class Foo {}'), {
-        Libraries.meta,
-        const Import('package:spacetraders/model_helpers.dart'),
+        const Import(Libraries.meta),
+        Import.path('package:spacetraders/model_helpers.dart'),
       });
     });
 
@@ -2791,11 +2791,11 @@ void main() {
       );
       expect(
         imports,
-        contains(const Import('package:spacetraders/models/nested.dart')),
+        contains(Import.path('package:spacetraders/models/nested.dart')),
       );
       expect(
         imports,
-        isNot(contains(const Import('package:spacetraders/models/deep.dart'))),
+        isNot(contains(Import.path('package:spacetraders/models/deep.dart'))),
       );
     });
 
@@ -2811,7 +2811,7 @@ void main() {
       expect(usage.usesValidationExtensions, isTrue);
       expect(
         usage.importsFor('spacetraders'),
-        contains(const Import('package:spacetraders/api_exception.dart')),
+        contains(Import.path('package:spacetraders/api_exception.dart')),
       );
     });
 
@@ -2822,7 +2822,7 @@ void main() {
       expect(
         usage.importsFor('spacetraders'),
         isNot(
-          contains(const Import('package:spacetraders/api_exception.dart')),
+          contains(Import.path('package:spacetraders/api_exception.dart')),
         ),
       );
     });
@@ -2944,14 +2944,14 @@ void main() {
         body: fullBody,
       );
       expect(imports, {
-        Libraries.dartAsync,
-        Libraries.dartConvert,
-        Libraries.dartIo,
-        const Import('package:spacetraders/api_client.dart'),
-        const Import('package:spacetraders/api_exception.dart'),
-        Libraries.http,
+        const Import(Libraries.dartAsync),
+        const Import(Libraries.dartConvert),
+        const Import(Libraries.dartIo),
+        Import.path('package:spacetraders/api_client.dart'),
+        Import.path('package:spacetraders/api_exception.dart'),
+        const Import(Libraries.http, asName: 'http'),
         // Uint8List from RenderBinary.
-        Libraries.dartTypedData,
+        const Import(Libraries.dartTypedData),
       });
     });
 

--- a/test/render/render_tree_test.dart
+++ b/test/render/render_tree_test.dart
@@ -939,8 +939,8 @@ void main() {
           ),
         ).additionalImports,
         equals([
-          Libraries.dartTypedData.showing(const ['Uint8List']),
-          Libraries.dartConvert,
+          const Import(Libraries.dartTypedData, shown: ['Uint8List']),
+          const Import(Libraries.dartConvert),
         ]),
       );
     });
@@ -957,7 +957,7 @@ void main() {
           createsNewType: false,
         ).additionalImports,
         equals([
-          Libraries.uri.showing(const ['UriTemplate']),
+          const Import(Libraries.uri, shown: ['UriTemplate']),
         ]),
       );
     });
@@ -1166,15 +1166,18 @@ void main() {
     // emit a duplicate import line.
 
     test('imports with identical fields compare equal', () {
-      const a = Import('package:meta/meta.dart');
-      const b = Import('package:meta/meta.dart');
+      final a = Import.path('package:meta/meta.dart');
+      final b = Import.path('package:meta/meta.dart');
       expect(a, equals(b));
       expect(a.hashCode, equals(b.hashCode));
     });
 
     test('imports with different shown lists do NOT compare equal', () {
-      const a = Import('package:uri/uri.dart', shown: ['UriTemplate']);
-      const b = Import('package:uri/uri.dart');
+      final a = Import.path(
+        'package:uri/uri.dart',
+        shown: const ['UriTemplate'],
+      );
+      final b = Import.path('package:uri/uri.dart');
       expect(a, isNot(equals(b)));
     });
   });


### PR DESCRIPTION
## Summary

Closes #274. `Import` carried four fields belonging to two different sides of one relationship; this splits them. No output change — byte-identical on all six tracked specs.

> Stacked on #275. Review the second commit only, or land #275 first.

## Details

```dart
// before
class Import {
  final String path;          // the library
  final Set<String> provides; // the library
  final String? asName;       // this file's directive
  final List<String> shown;   // this file's directive
}
```

`path` and `provides` say where a library lives and which of its names the generator can emit. `asName` and `shown` are the choices a *particular file* makes when bringing it into scope. A `Libraries` constant had to carry both, so every library implicitly declared a use-site shape it has no opinion about.

```dart
// after
class Library {
  final String path;
  final Set<String> provides;
  bool isNeededBy(bool Function(String) bodyNames);
}

class Import {
  final Library library;
  final String? asName;
  final List<String> shown;
}
```

Gating is now a `Library` question (`i.library.isNeededBy(names)`) and emission an `Import` one, which is what they always were.

### What falls out

- **`Import.showing` is gone.** It existed only to clone a library constant with a different `shown`, producing a second value for the same library — the thing `_dedupeRenderedImports` then had to collapse. Narrowing for the barrel is now just `Import(Libraries.uri, shown: ['UriTemplate'])`.
- **Equality no longer mixes the two sides.** `provides` divergence can no longer yield two "different" imports of one library. That is exactly the shape that let `package:meta/meta.dart` emit twice (145 duplicate directives, fixed in #275) — this removes the possibility rather than the instance.

`Import.path(...)` covers libraries with no declared identifiers: the generated package's own files, whose paths depend on the package name and so can't be `Libraries` constants.

`_dedupeRenderedImports` stays. It is now genuinely a backstop rather than load-bearing — the only way to reach it is two files legitimately importing one library with different `shown`/`asName`.

## Testing

- `dart test` green (671); `dart analyze` clean; `dart format` clean; cspell clean.
- A/B regenerated old-vs-new under the same package name on all six specs, via a `git worktree` at #275's head: **all six byte-identical**.
- One real bug caught by the suite during the refactor: a mechanical edit turned `'package:$packageName/model_helpers.dart'` into an escaped `'package:\$packageName/...'`, i.e. a literal rather than an interpolation. Two `importsFor` tests failed on it immediately.
