### PR TITLE
fix: a const getter's storage is never nullable

### DIFF
--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -3760,27 +3760,6 @@ class RenderObject extends RenderNewType {
     final hasDefaultValue = property.hasDefaultValue(context);
     final jsonKeyIsRequired = requiredProperties.contains(jsonName);
     final jsonIsNullable = !jsonKeyIsRequired || property.common.nullable;
-    final dartIsNullable =
-        propertyDartIsNullable(
-          jsonName: jsonName,
-          context: context,
-          propertyHasDefaultValue: hasDefaultValue,
-        ) ||
-        property.common.nullable;
-    // OpenAPI 3.1 lets a property be both `required` and accept `null`
-    // as its value (`type: [T, "null"]` + `required: [key]`). A plain
-    // `json[key] as T?` cast would then accept a missing key as a null
-    // value, silently violating `required`. Route the read through
-    // `checkedKey`, which throws `FormatException` when the key is
-    // absent — other combinations still read `json[key]` directly.
-    final jsonRead = jsonKeyIsRequired && property.common.nullable
-        ? "${ModelHelpers.checkedKey}(json, '$jsonName')"
-        : "json['$jsonName']";
-
-    // Means that the constructor parameter is required which is only true if
-    // both the json property is required and it does not have a default.
-    final isRequired =
-        requiredProperties.contains(jsonName) && !hasDefaultValue;
     // A property pinned to a constant of a named enum (the `allOf: [{$ref: E}]`
     // + single-value `enum` idiom) renders as a fixed getter rather than a
     // constructor parameter — the value is fully determined by the class, so
@@ -3795,6 +3774,32 @@ class RenderObject extends RenderNewType {
               '${property.constExpression(constValue)};'
         : null;
     final isConstGetter = constGetter != null;
+    // A const getter returns [RenderSchema.typeName] unconditionally, so its
+    // Dart storage is never nullable no matter what the `required` list says.
+    // Deriving this from the schema's optionality instead would emit `?.` on a
+    // non-nullable receiver in `toJson` (`invalid_null_aware_operator`).
+    final dartIsNullable =
+        !isConstGetter &&
+        (propertyDartIsNullable(
+              jsonName: jsonName,
+              context: context,
+              propertyHasDefaultValue: hasDefaultValue,
+            ) ||
+            property.common.nullable);
+    // OpenAPI 3.1 lets a property be both `required` and accept `null`
+    // as its value (`type: [T, "null"]` + `required: [key]`). A plain
+    // `json[key] as T?` cast would then accept a missing key as a null
+    // value, silently violating `required`. Route the read through
+    // `checkedKey`, which throws `FormatException` when the key is
+    // absent — other combinations still read `json[key]` directly.
+    final jsonRead = jsonKeyIsRequired && property.common.nullable
+        ? "${ModelHelpers.checkedKey}(json, '$jsonName')"
+        : "json['$jsonName']";
+
+    // Means that the constructor parameter is required which is only true if
+    // both the json property is required and it does not have a default.
+    final isRequired =
+        requiredProperties.contains(jsonName) && !hasDefaultValue;
     return {
       'dartName': dartName,
       'jsonName': quoteString(jsonName),
@@ -3837,12 +3842,18 @@ class RenderObject extends RenderNewType {
           dartIsNullable: dartIsNullable,
         ),
       ),
-      'fromJson': property.fromJsonExpression(
-        jsonRead,
-        context,
-        dartIsNullable: dartIsNullable,
-        jsonIsNullable: jsonIsNullable,
-      ),
+      // A const getter is absent from `fromJson` (the template skips it), so
+      // there is no read expression to build. Computing one anyway would ask
+      // for a non-nullable value from a nullable json key and throw looking
+      // for a default that a pinned constant has no need of.
+      'fromJson': isConstGetter
+          ? null
+          : property.fromJsonExpression(
+              jsonRead,
+              context,
+              dartIsNullable: dartIsNullable,
+              jsonIsNullable: jsonIsNullable,
+            ),
     };
   }
 

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -1128,6 +1128,43 @@ void main() {
       expect(pong, isNot(contains('() => Pong(')));
     });
 
+    // A const getter returns a non-nullable type whatever the `required`
+    // list says, so `toJson` must not reach through it with `?.` —  that
+    // is an `invalid_null_aware_operator` warning, not just a lint.
+    // Discord's `*UpsertRequestPartial.trigger_type` is the canonical
+    // site: pinned to one enum value but absent from `required`.
+    test('optional const-getter property serializes without null-aware', () {
+      final results = renderTestSchemas(
+        {
+          'Rule': {
+            'type': 'object',
+            'properties': {
+              'trigger_type': {
+                'type': 'integer',
+                'enum': [1],
+                'allOf': [
+                  {r'$ref': '#/components/schemas/TriggerType'},
+                ],
+              },
+            },
+            // Deliberately not required — that is what made the
+            // generator believe the getter was nullable.
+          },
+          'TriggerType': {
+            'type': 'integer',
+            'enum': [1, 4],
+          },
+        },
+        specUrl: Uri.parse('file:///spec.yaml'),
+      );
+      final rule = results['Rule'];
+      expect(rule, isNotNull);
+      // The getter itself is non-nullable.
+      expect(rule, contains('TriggerType get triggerType =>'));
+      expect(rule, contains("'trigger_type': triggerType.toJson()"));
+      expect(rule, isNot(contains('triggerType?.toJson()')));
+    });
+
     test('typed map variant walks each entry through fromJson/toJson', () {
       // Map with a non-trivial value schema. The wrapper must convert
       // each entry on fromJson and reverse on toJson.


### PR DESCRIPTION
## Summary

Fixed a const-getter property serializing through `?.` on a non-nullable
receiver, producing an `invalid_null_aware_operator` warning in generated
models.

## Details

A property pinned to a single enum value (the `allOf: [{$ref: E}]` +
single-value `enum` idiom) renders as a fixed getter returning a
non-nullable type. `toJson`, however, derived that property's nullability
from the schema's `required` list. When such a property was optional the
two disagreed and the generator emitted:

```dart
AutomodTriggerType get triggerType => AutomodTriggerType.keyword;  // non-nullable
...
'trigger_type': triggerType?.toJson(),                             // but null-aware
```

That is a **warning**, not just a lint — the generator was wrong about its
own nullability.

`dartIsNullable` now accounts for the const-getter branch, so both paths
read the single fact they were disagreeing about from one place. `fromJson`
is skipped for those properties as well: the template already omits them,
and computing a read expression anyway asked for a non-nullable value from
a nullable json key.

Only visible with the `dart fix --apply` call in `Formatter.formatAndFix`
disabled, since `dart fix` rewrote `?.` to `.` — which is what made it a
blocker for the dart-fix reduction arc.

## Testing

New unit test in `test/render/render_schema_test.dart`. The existing
const-getter test marks the property `required`, which is why it never
caught this; the new one mirrors the Discord shape with it optional.
Confirmed the test fails against the pre-fix code.

A/B regen under an identical package name across six specs:

| spec | diff |
|---|---|
| discord | 4 lines, `?.` -> `.` |
| github, backstage, petstore, spacetraders, train-travel | byte-identical |

Discord's analyzer output drops from 87 to 83 issues, diffed line-by-line
with no other movement. Full `dart test` green, `dart analyze` and
`dart format` clean.

Fixes #270
