### PR TITLE
refactor: give const-getter properties a context of their own

### DIFF
--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -3846,35 +3846,34 @@ class RenderObject extends RenderNewType {
     required SchemaRenderer context,
   }) {
     final dartName = variableSafeName(context.quirks, jsonName);
-    final hasDefaultValue = property.hasDefaultValue(context);
-    final jsonKeyIsRequired = requiredProperties.contains(jsonName);
-    final jsonIsNullable = !jsonKeyIsRequired || property.common.nullable;
     // A property pinned to a constant of a named enum (the `allOf: [{$ref: E}]`
     // + single-value `enum` idiom) renders as a fixed getter rather than a
     // constructor parameter — the value is fully determined by the class, so
-    // the caller neither passes it nor can set it wrong. It still serializes
-    // (toJson references the getter) but is absent from the constructor,
-    // `fromJson`, and equality.
+    // the caller neither passes it nor can set it wrong. It has no storage, no
+    // constructor argument, no JSON read and no part in equality, so it gets a
+    // context of its own rather than a full one with most keys discarded.
     // Matches [rendersAsConstGetter]; bound locally so flow analysis promotes
     // `property`/`constValue` for the getter expression (no cast, no `!`).
     final constValue = constProperties[jsonName];
-    final constGetter = (constValue != null && property is RenderEnum)
-        ? '${property.typeName} get $dartName => '
-              '${property.constExpression(constValue)};'
-        : null;
-    final isConstGetter = constGetter != null;
-    // A const getter returns [RenderSchema.typeName] unconditionally, so its
-    // Dart storage is never nullable no matter what the `required` list says.
-    // Deriving this from the schema's optionality instead would emit `?.` on a
-    // non-nullable receiver in `toJson` (`invalid_null_aware_operator`).
+    if (constValue != null && property is RenderEnum) {
+      return _constGetterPropertyContext(
+        jsonName: jsonName,
+        dartName: dartName,
+        property: property,
+        constValue: constValue,
+        context: context,
+      );
+    }
+    final hasDefaultValue = property.hasDefaultValue(context);
+    final jsonKeyIsRequired = requiredProperties.contains(jsonName);
+    final jsonIsNullable = !jsonKeyIsRequired || property.common.nullable;
     final dartIsNullable =
-        !isConstGetter &&
-        (propertyDartIsNullable(
-              jsonName: jsonName,
-              context: context,
-              propertyHasDefaultValue: hasDefaultValue,
-            ) ||
-            property.common.nullable);
+        propertyDartIsNullable(
+          jsonName: jsonName,
+          context: context,
+          propertyHasDefaultValue: hasDefaultValue,
+        ) ||
+        property.common.nullable;
     // OpenAPI 3.1 lets a property be both `required` and accept `null`
     // as its value (`type: [T, "null"]` + `required: [key]`). A plain
     // `json[key] as T?` cast would then accept a missing key as a null
@@ -3900,22 +3899,19 @@ class RenderObject extends RenderNewType {
       // constructor (`always_put_required_named_parameters_first`); see
       // the required/optional split in the object template context.
       'isRequired': isRequired,
-      'isConstGetter': isConstGetter,
-      'constGetter': constGetter,
+      'isConstGetter': false,
       'argumentLine': argumentLine(
         jsonName,
         property,
         context,
         isRequired: isRequired,
       ),
-      'assignmentsLine': isConstGetter
-          ? null
-          : assignmentsLine(
-              jsonName,
-              property,
-              context,
-              isRequired: isRequired,
-            ),
+      'assignmentsLine': assignmentsLine(
+        jsonName,
+        property,
+        context,
+        isRequired: isRequired,
+      ),
       'storageTypeDeclaration': propertyStorageTypeDeclaration(
         property: property,
         context: context,
@@ -3931,18 +3927,46 @@ class RenderObject extends RenderNewType {
           dartIsNullable: dartIsNullable,
         ),
       ),
-      // A const getter is absent from `fromJson` (the template skips it), so
-      // there is no read expression to build. Computing one anyway would ask
-      // for a non-nullable value from a nullable json key and throw looking
-      // for a default that a pinned constant has no need of.
-      'fromJson': isConstGetter
-          ? null
-          : property.fromJsonExpression(
-              jsonRead,
-              context,
-              dartIsNullable: dartIsNullable,
-              jsonIsNullable: jsonIsNullable,
-            ),
+      'fromJson': property.fromJsonExpression(
+        jsonRead,
+        context,
+        dartIsNullable: dartIsNullable,
+        jsonIsNullable: jsonIsNullable,
+      ),
+    };
+  }
+
+  /// Template context for a property pinned to a single enum value, which
+  /// renders as a fixed getter. Deliberately much narrower than the stored-
+  /// property context: a const getter appears only in the field declaration,
+  /// `operator[]` and `toJson`, so those are the only keys it carries. The
+  /// getter returns [RenderSchema.typeName], so it is never nullable and
+  /// `toJson` must not reach through it with `?.`.
+  Map<String, dynamic> _constGetterPropertyContext({
+    required String jsonName,
+    required String dartName,
+    required RenderEnum property,
+    required Object constValue,
+    required SchemaRenderer context,
+  }) {
+    return {
+      'dartName': dartName,
+      'jsonName': quoteString(jsonName),
+      'property_doc_comment': createDocComment(
+        common: property.common,
+        indent: 4,
+      ),
+      'isConstGetter': true,
+      'constGetter':
+          '${property.typeName} get $dartName => '
+          '${property.constExpression(constValue)};',
+      'toJson': _runtimeSource(
+        property.toJsonExpression(
+          DartIdentifier(dartName),
+          context,
+          dartIsNullable: false,
+        ),
+      ),
     };
   }
 
@@ -3967,19 +3991,25 @@ class RenderObject extends RenderNewType {
       );
     }).toList();
 
-    final assignmentsLine = buildAssignmentsLine(renderProperties);
+    // Properties with actual storage. A const getter is fully determined by
+    // the class, so it takes no constructor argument, is not read back in
+    // `fromJson`, and plays no part in equality — every site that cares about
+    // storage iterates this list rather than filtering `properties` itself.
+    final storedProperties = renderProperties
+        .where((p) => p['isConstGetter'] != true)
+        .toList();
+
+    final assignmentsLine = buildAssignmentsLine(storedProperties);
 
     final valueSchema = additionalProperties;
     final hasAdditionalProperties = valueSchema != null;
     if (renderProperties.isEmpty && !hasAdditionalProperties) {
       throw StateError('Object schema has no properties: $this');
     }
-    // Const-getter properties aren't constructor parameters or equality
-    // members, so the constructor-braces and single-property-hashCode
-    // decisions count only the "real" (non-getter) properties.
+    // The constructor-braces and single-property-hashCode decisions count
+    // only stored properties, for the same reason.
     final realPropertiesCount =
-        renderProperties.where((p) => p['isConstGetter'] != true).length +
-        (hasAdditionalProperties ? 1 : 0);
+        storedProperties.length + (hasAdditionalProperties ? 1 : 0);
     // Force named properties to be rendered if hasAdditionalProperties is true.
     final hasProperties = realPropertiesCount > 0;
     const isNullable = false;
@@ -4035,6 +4065,7 @@ class RenderObject extends RenderNewType {
       // Special case behavior hashCode with only one property.
       'hasOneProperty': realPropertiesCount == 1,
       'properties': renderProperties,
+      'storedProperties': storedProperties,
       // Constructor named params, partitioned so `required` ones come
       // first (`always_put_required_named_parameters_first`). Each
       // group keeps its spec order, so the result matches a stable sort.
@@ -4043,10 +4074,10 @@ class RenderObject extends RenderNewType {
       // `entries` param (additionalProperties) renders between the two
       // groups in the template — last among required, matching the
       // stable sort.
-      'requiredConstructorProperties': renderProperties
+      'requiredConstructorProperties': storedProperties
           .where((p) => p['isRequired'] == true)
           .toList(),
-      'optionalConstructorProperties': renderProperties
+      'optionalConstructorProperties': storedProperties
           .where((p) => p['isRequired'] != true)
           .toList(),
       'hasAdditionalProperties': hasAdditionalProperties,

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -3852,8 +3852,9 @@ class RenderObject extends RenderNewType {
     // the caller neither passes it nor can set it wrong. It has no storage, no
     // constructor argument, no JSON read and no part in equality, so it gets a
     // context of its own rather than a full one with most keys discarded.
-    // Matches [rendersAsConstGetter]; bound locally so flow analysis promotes
-    // `property`/`constValue` for the getter expression (no cast, no `!`).
+    // This is [rendersAsConstGetter]'s test, spelled inline: bound locally so
+    // flow analysis promotes `property`/`constValue` for the getter expression
+    // (no cast, no `!`), which a `bool` return cannot do. Keep the two in step.
     final constValue = constProperties[jsonName];
     if (constValue != null && property is RenderEnum) {
       return _constGetterPropertyContext(
@@ -3981,23 +3982,28 @@ class RenderObject extends RenderNewType {
   /// Template context for an object schema.
   @override
   Map<String, dynamic> toTemplateContext(SchemaRenderer context) {
-    final renderProperties = properties.entries.map((entry) {
-      final jsonName = entry.key;
-      final schema = entry.value;
-      return propertyTemplateContext(
-        jsonName: jsonName,
-        property: schema,
+    // Built in one pass so the two lists stay in spec order and the
+    // const-getter question is asked once, through [rendersAsConstGetter],
+    // rather than re-derived from a key in the map we just built.
+    //
+    // [storedProperties] is the properties with actual storage. A const getter
+    // is fully determined by the class, so it takes no constructor argument,
+    // is not read back in `fromJson`, and plays no part in equality — every
+    // site that cares about storage iterates it instead of walking all
+    // [properties] and skipping as it goes.
+    final renderProperties = <Map<String, dynamic>>[];
+    final storedProperties = <Map<String, dynamic>>[];
+    for (final entry in properties.entries) {
+      final propertyContext = propertyTemplateContext(
+        jsonName: entry.key,
+        property: entry.value,
         context: context,
       );
-    }).toList();
-
-    // Properties with actual storage. A const getter is fully determined by
-    // the class, so it takes no constructor argument, is not read back in
-    // `fromJson`, and plays no part in equality — every site that cares about
-    // storage iterates this list rather than filtering `properties` itself.
-    final storedProperties = renderProperties
-        .where((p) => p['isConstGetter'] != true)
-        .toList();
+      renderProperties.add(propertyContext);
+      if (!rendersAsConstGetter(entry.key, entry.value)) {
+        storedProperties.add(propertyContext);
+      }
+    }
 
     final assignmentsLine = buildAssignmentsLine(storedProperties);
 
@@ -4192,8 +4198,16 @@ class RenderObject extends RenderNewType {
   /// a constructor field (the `allOf: [{$ref: E}]` + single-value `enum`
   /// idiom pinning it to one member of enum `E`). Such properties are absent
   /// from the constructor, `fromJson`, equality, and example synthesis.
+  ///
+  /// The definition of the const-getter shape. `propertyTemplateContext`
+  /// spells the same test inline — `constProperties[jsonName]` bound to a
+  /// local, plus `is RenderEnum` — because it needs the promoted value and
+  /// type to build the getter, which a `bool` return cannot give it. Written
+  /// as a lookup rather than `containsKey` so the two are the same test:
+  /// `constProperties` is non-nullable-valued, so they agree today, and this
+  /// keeps them agreeing if that ever changes.
   bool rendersAsConstGetter(String jsonName, RenderSchema property) =>
-      constProperties.containsKey(jsonName) && property is RenderEnum;
+      constProperties[jsonName] != null && property is RenderEnum;
 
   /// Whether the generated constructor is declared `const`.
   ///

--- a/lib/templates/schema_object.mustache
+++ b/lib/templates/schema_object.mustache
@@ -2,7 +2,7 @@
 {{#parentSealedTypeName}}final {{/parentSealedTypeName}}class {{ typeName }}{{#parentSealedTypeName}} extends {{ parentSealedTypeName }}{{/parentSealedTypeName}} {
     {{{ constructor_doc_comment }}}{{#canBeConst}}const {{/canBeConst}}{{ typeName }}(
         {{#hasProperties}}
-        { {{#requiredConstructorProperties}}{{^isConstGetter}}{{{ argumentLine }}}, {{/isConstGetter}}{{/requiredConstructorProperties}}{{#hasAdditionalProperties}}required this.{{additionalPropertiesName}}, {{/hasAdditionalProperties}}{{#optionalConstructorProperties}}{{^isConstGetter}}{{{ argumentLine }}}, {{/isConstGetter}}{{/optionalConstructorProperties}} }
+        { {{#requiredConstructorProperties}}{{{ argumentLine }}}, {{/requiredConstructorProperties}}{{#hasAdditionalProperties}}required this.{{additionalPropertiesName}}, {{/hasAdditionalProperties}}{{#optionalConstructorProperties}}{{{ argumentLine }}}, {{/optionalConstructorProperties}} }
         {{/hasProperties}}
     ){{{assignmentsLine}}};
 
@@ -33,9 +33,9 @@
     {{^hasNoJsonProperty}}
         {{#hasProperties}}
         return parseFromJson('{{ typeName }}', json, () => {{ typeName }}(
-            {{#properties}}
-            {{^isConstGetter}}{{ dartName }}: {{{ fromJson }}},{{/isConstGetter}}
-            {{/properties}}
+            {{#storedProperties}}
+            {{ dartName }}: {{{ fromJson }}},
+            {{/storedProperties}}
             {{#hasAdditionalProperties}}
             {{additionalPropertiesName}}: <String, {{{ valueSchema }}}>{
                 for (final entry in json.entries)
@@ -103,18 +103,18 @@
     @override
     int get hashCode =>
         {{#hasOneProperty}}
-          {{#properties}}
-          {{^isConstGetter}}{{{ hashCode }}}.hashCode;{{/isConstGetter}}
-          {{/properties}}
+          {{#storedProperties}}
+          {{{ hashCode }}}.hashCode;
+          {{/storedProperties}}
           {{#hasAdditionalProperties}}
           mapHash({{additionalPropertiesName}});
           {{/hasAdditionalProperties}}
         {{/hasOneProperty}}
         {{^hasOneProperty}}
         Object.hashAll([
-          {{#properties}}
-          {{^isConstGetter}}{{{ hashCode }}},{{/isConstGetter}}
-          {{/properties}}
+          {{#storedProperties}}
+          {{{ hashCode }}},
+          {{/storedProperties}}
           {{#hasAdditionalProperties}}
           mapHash({{additionalPropertiesName}}),
           {{/hasAdditionalProperties}}
@@ -125,9 +125,9 @@
     bool operator ==(Object other) {
         if (identical(this, other)) return true;
         return other is {{ typeName }}
-            {{#properties}}
-            {{^isConstGetter}}&& {{ equals}}{{/isConstGetter}}
-            {{/properties}}
+            {{#storedProperties}}
+            && {{ equals}}
+            {{/storedProperties}}
             {{#hasAdditionalProperties}}
             && mapsEqual({{additionalPropertiesName}}, other.{{additionalPropertiesName}})
             {{/hasAdditionalProperties}}


### PR DESCRIPTION
## Summary

Gave const-getter properties their own template context, removing five
computed-then-discarded keys and six `{{^isConstGetter}}` negations, and
cleaning up 62 stray blank lines in generated models.

## Details

A property pinned to a single enum value renders as a fixed getter. It has
no storage, no constructor argument, no JSON read, and no part in equality
— but it was built with the full stored-property context and then skipped
at four template sites via `{{^isConstGetter}}`. Five keys were computed
and thrown away, and one of them (`fromJson`) could not be computed at all:
once #270 corrected the nullability it threw on a real spec, asking for a
non-nullable value from a nullable json key. That was patched there with a
`isConstGetter ? null :` guard; this removes the reason for the guard.

Two changes:

- `propertyTemplateContext` returns early into `_constGetterPropertyContext`,
  carrying only the six keys such a property actually uses (declaration,
  `operator[]`, `toJson`).
- A `storedProperties` list holds the rest. The four exclusion sites —
  constructor args, `fromJson`, `hashCode`, `==` — iterate it directly
  instead of iterating everything and negating a flag.

The three sites that legitimately include const getters (the field
declaration, `operator[]`, `toJson`) keep using `properties`.

### Incidental fix

Mustache emits the line for each skipped property, so every const-getter
property left a stray blank line in `fromJson` and `hashCode`:

```dart
     listHash(exemptChannels),
-
     triggerMetadata,
```

62 of those across 27 Discord files.

## Testing

A/B regen under identical package names with `dart fix` **disabled on both
sides** — strictly stronger than the usual gate, since identical pre-fix
output also proves no new raw-lint category appeared (`dart fix` would
otherwise launder one).

| spec | diff |
|---|---|
| github, backstage, petstore, spacetraders, train-travel | byte-identical |
| discord | 62 blank lines removed, 0 added, **0 non-blank changes** |

Discord's raw lint count is unmoved at 2. Full `dart test` green,
`dart analyze` and `dart format` clean.

Note: eight `gen_tests/` fixtures regenerate dirty on this branch. Verified
byte-identical to what clean `origin/main` produces, so the drift is
pre-existing (unrelated `Status.values.first` → `Status.active` and
`default_api.dart` changes) and left alone here.

---

## Self-review follow-up (e60570c)

Reviewing my own diff for DRY turned up that the first commit left **three**
encodings of one predicate:

| where | form |
|---|---|
| `render_tree.dart` | `rendersAsConstGetter()` — canonical, 3 other call sites |
| `propertyTemplateContext` | `constValue != null && property is RenderEnum` |
| `toTemplateContext` | `p['isConstGetter'] != true` |

The third was mine and the worst of them: it re-derived the partition by
peeking at a string key in a map it had just built, when the canonical
predicate was right there. `toTemplateContext` now builds both lists in one
pass and calls `rendersAsConstGetter` directly.

The inline test stays — it binds `constValue` and promotes `property` to
`RenderEnum` to build the getter, which a `bool` return cannot do, and
reaching for `!` to avoid it would be worse. But the two were not even
textually the same test: the canonical used `containsKey`, the inline used
`!= null`. They agree only because `constProperties` is `Map<String, Object>`.
`rendersAsConstGetter` is now written as the same lookup so they cannot drift,
and both sides carry a comment naming the other.

Re-validated rather than assumed, since the partition mechanism changed: all
six specs byte-identical to the previous commit, and the diff against
origin/main is unchanged (Discord's 62 blank lines, zero non-blank changes).