### PR TITLE
fix: compose the request Uri field-by-field instead of concatenating

### DIFF
--- a/gen_tests/multipart/lib/api_client.dart
+++ b/gen_tests/multipart/lib/api_client.dart
@@ -38,6 +38,30 @@ enum BodyContentType {
   final String value;
 }
 
+/// Grafts an operation [path] onto [baseUri], keeping baseUri's own
+/// path and discarding its query and fragment.
+///
+/// The method we wish `Uri` had. `Uri` can set a query but never clear
+/// one (no `removeQuery()` to match `removeFragment()`), which is the
+/// only reason these fields are copied by hand — if that ever lands,
+/// this collapses to `baseUri.replace(path: ...).removeQuery()`. The
+/// obvious alternatives (`resolveUri`, `pathSegments:`) are wrong for
+/// subtler reasons; see
+/// https://github.com/eseidel/space_gen/issues/139.
+Uri _appendPath(Uri baseUri, String path) {
+  // [path] is absolute, so a trailing slash would emit an empty `//`.
+  final basePath = baseUri.path.endsWith('/')
+      ? baseUri.path.substring(0, baseUri.path.length - 1)
+      : baseUri.path;
+  return Uri(
+    scheme: baseUri.scheme,
+    userInfo: baseUri.userInfo,
+    host: baseUri.host,
+    port: baseUri.port,
+    path: '$basePath$path',
+  );
+}
+
 /// The client interface for the API.
 /// Subclasses can override [invokeApi] to add custom behavior.
 class ApiClient {
@@ -62,7 +86,8 @@ class ApiClient {
     // baseUri can contain a path, so we need to resolve the passed path
     // relative to it.  The passed path will always be absolute (leading slash)
     // but should be interpreted as relative to the baseUri.
-    final uri = Uri.parse('$baseUri$path');
+    // baseUri's query is dropped here and re-enters via [mergedParameters].
+    final uri = _appendPath(baseUri, path);
     // Single-shape map: every value is a `List<String>`. `Uri.replace`
     // spreads each list across repeated keys, so a 1-element list yields
     // `?k=v` and an N-element list yields `?k=v1&k=v2&…` (the OpenAPI

--- a/gen_tests/security/lib/api_client.dart
+++ b/gen_tests/security/lib/api_client.dart
@@ -38,6 +38,30 @@ enum BodyContentType {
   final String value;
 }
 
+/// Grafts an operation [path] onto [baseUri], keeping baseUri's own
+/// path and discarding its query and fragment.
+///
+/// The method we wish `Uri` had. `Uri` can set a query but never clear
+/// one (no `removeQuery()` to match `removeFragment()`), which is the
+/// only reason these fields are copied by hand — if that ever lands,
+/// this collapses to `baseUri.replace(path: ...).removeQuery()`. The
+/// obvious alternatives (`resolveUri`, `pathSegments:`) are wrong for
+/// subtler reasons; see
+/// https://github.com/eseidel/space_gen/issues/139.
+Uri _appendPath(Uri baseUri, String path) {
+  // [path] is absolute, so a trailing slash would emit an empty `//`.
+  final basePath = baseUri.path.endsWith('/')
+      ? baseUri.path.substring(0, baseUri.path.length - 1)
+      : baseUri.path;
+  return Uri(
+    scheme: baseUri.scheme,
+    userInfo: baseUri.userInfo,
+    host: baseUri.host,
+    port: baseUri.port,
+    path: '$basePath$path',
+  );
+}
+
 /// The client interface for the API.
 /// Subclasses can override [invokeApi] to add custom behavior.
 class ApiClient {
@@ -62,7 +86,8 @@ class ApiClient {
     // baseUri can contain a path, so we need to resolve the passed path
     // relative to it.  The passed path will always be absolute (leading slash)
     // but should be interpreted as relative to the baseUri.
-    final uri = Uri.parse('$baseUri$path');
+    // baseUri's query is dropped here and re-enters via [mergedParameters].
+    final uri = _appendPath(baseUri, path);
     // Single-shape map: every value is a `List<String>`. `Uri.replace`
     // spreads each list across repeated keys, so a 1-element list yields
     // `?k=v` and an N-element list yields `?k=v1&k=v2&…` (the OpenAPI

--- a/gen_tests/types/lib/api_client.dart
+++ b/gen_tests/types/lib/api_client.dart
@@ -38,6 +38,30 @@ enum BodyContentType {
   final String value;
 }
 
+/// Grafts an operation [path] onto [baseUri], keeping baseUri's own
+/// path and discarding its query and fragment.
+///
+/// The method we wish `Uri` had. `Uri` can set a query but never clear
+/// one (no `removeQuery()` to match `removeFragment()`), which is the
+/// only reason these fields are copied by hand — if that ever lands,
+/// this collapses to `baseUri.replace(path: ...).removeQuery()`. The
+/// obvious alternatives (`resolveUri`, `pathSegments:`) are wrong for
+/// subtler reasons; see
+/// https://github.com/eseidel/space_gen/issues/139.
+Uri _appendPath(Uri baseUri, String path) {
+  // [path] is absolute, so a trailing slash would emit an empty `//`.
+  final basePath = baseUri.path.endsWith('/')
+      ? baseUri.path.substring(0, baseUri.path.length - 1)
+      : baseUri.path;
+  return Uri(
+    scheme: baseUri.scheme,
+    userInfo: baseUri.userInfo,
+    host: baseUri.host,
+    port: baseUri.port,
+    path: '$basePath$path',
+  );
+}
+
 /// The client interface for the API.
 /// Subclasses can override [invokeApi] to add custom behavior.
 class ApiClient {
@@ -62,7 +86,8 @@ class ApiClient {
     // baseUri can contain a path, so we need to resolve the passed path
     // relative to it.  The passed path will always be absolute (leading slash)
     // but should be interpreted as relative to the baseUri.
-    final uri = Uri.parse('$baseUri$path');
+    // baseUri's query is dropped here and re-enters via [mergedParameters].
+    final uri = _appendPath(baseUri, path);
     // Single-shape map: every value is a `List<String>`. `Uri.replace`
     // spreads each list across repeated keys, so a 1-element list yields
     // `?k=v` and an N-element list yields `?k=v1&k=v2&…` (the OpenAPI

--- a/gen_tests/unsupported_auth/lib/api_client.dart
+++ b/gen_tests/unsupported_auth/lib/api_client.dart
@@ -38,6 +38,30 @@ enum BodyContentType {
   final String value;
 }
 
+/// Grafts an operation [path] onto [baseUri], keeping baseUri's own
+/// path and discarding its query and fragment.
+///
+/// The method we wish `Uri` had. `Uri` can set a query but never clear
+/// one (no `removeQuery()` to match `removeFragment()`), which is the
+/// only reason these fields are copied by hand — if that ever lands,
+/// this collapses to `baseUri.replace(path: ...).removeQuery()`. The
+/// obvious alternatives (`resolveUri`, `pathSegments:`) are wrong for
+/// subtler reasons; see
+/// https://github.com/eseidel/space_gen/issues/139.
+Uri _appendPath(Uri baseUri, String path) {
+  // [path] is absolute, so a trailing slash would emit an empty `//`.
+  final basePath = baseUri.path.endsWith('/')
+      ? baseUri.path.substring(0, baseUri.path.length - 1)
+      : baseUri.path;
+  return Uri(
+    scheme: baseUri.scheme,
+    userInfo: baseUri.userInfo,
+    host: baseUri.host,
+    port: baseUri.port,
+    path: '$basePath$path',
+  );
+}
+
 /// The client interface for the API.
 /// Subclasses can override [invokeApi] to add custom behavior.
 class ApiClient {
@@ -62,7 +86,8 @@ class ApiClient {
     // baseUri can contain a path, so we need to resolve the passed path
     // relative to it.  The passed path will always be absolute (leading slash)
     // but should be interpreted as relative to the baseUri.
-    final uri = Uri.parse('$baseUri$path');
+    // baseUri's query is dropped here and re-enters via [mergedParameters].
+    final uri = _appendPath(baseUri, path);
     // Single-shape map: every value is a `List<String>`. `Uri.replace`
     // spreads each list across repeated keys, so a 1-element list yields
     // `?k=v` and an N-element list yields `?k=v1&k=v2&…` (the OpenAPI

--- a/lib/templates/api_client.dart
+++ b/lib/templates/api_client.dart
@@ -38,6 +38,30 @@ enum BodyContentType {
   final String value;
 }
 
+/// Grafts an operation [path] onto [baseUri], keeping baseUri's own
+/// path and discarding its query and fragment.
+///
+/// The method we wish `Uri` had. `Uri` can set a query but never clear
+/// one (no `removeQuery()` to match `removeFragment()`), which is the
+/// only reason these fields are copied by hand — if that ever lands,
+/// this collapses to `baseUri.replace(path: ...).removeQuery()`. The
+/// obvious alternatives (`resolveUri`, `pathSegments:`) are wrong for
+/// subtler reasons; see
+/// https://github.com/eseidel/space_gen/issues/139.
+Uri _appendPath(Uri baseUri, String path) {
+  // [path] is absolute, so a trailing slash would emit an empty `//`.
+  final basePath = baseUri.path.endsWith('/')
+      ? baseUri.path.substring(0, baseUri.path.length - 1)
+      : baseUri.path;
+  return Uri(
+    scheme: baseUri.scheme,
+    userInfo: baseUri.userInfo,
+    host: baseUri.host,
+    port: baseUri.port,
+    path: '$basePath$path',
+  );
+}
+
 /// The client interface for the API.
 /// Subclasses can override [invokeApi] to add custom behavior.
 class ApiClient {
@@ -62,7 +86,8 @@ class ApiClient {
     // baseUri can contain a path, so we need to resolve the passed path
     // relative to it.  The passed path will always be absolute (leading slash)
     // but should be interpreted as relative to the baseUri.
-    final uri = Uri.parse('$baseUri$path');
+    // baseUri's query is dropped here and re-enters via [mergedParameters].
+    final uri = _appendPath(baseUri, path);
     // Single-shape map: every value is a `List<String>`. `Uri.replace`
     // spreads each list across repeated keys, so a 1-element list yields
     // `?k=v` and an N-element list yields `?k=v1&k=v2&…` (the OpenAPI

--- a/test/templates/api_client_test.dart
+++ b/test/templates/api_client_test.dart
@@ -90,6 +90,66 @@ void main() {
       },
     );
 
+    // Regression for issue #139. The operation path is grafted onto
+    // baseUri field-by-field rather than by string concatenation, so
+    // baseUri's own path survives and its query/fragment can't swallow
+    // the path.
+    group('grafts the operation path onto baseUri', () {
+      Future<String> sentUrlFor(String baseUri) async {
+        Uri? captured;
+        final client = ApiClient(
+          baseUri: Uri.parse(baseUri),
+          client: MockClient((req) async {
+            captured = req.url;
+            return Response('', 200);
+          }),
+        );
+        await client.invokeApi(method: Method.get, path: '/things');
+        return captured.toString();
+      }
+
+      test('keeps a path already on baseUri', () async {
+        expect(
+          await sentUrlFor('https://example.com/v2'),
+          'https://example.com/v2/things',
+        );
+      });
+
+      test('collapses a trailing slash instead of emitting //', () async {
+        expect(
+          await sentUrlFor('https://example.com/v2/'),
+          'https://example.com/v2/things',
+        );
+      });
+
+      test('keeps the path when baseUri carries a query', () async {
+        // The concatenation this replaced produced
+        // `https://example.com?ext=1/things`, which parses with an empty
+        // path and `ext=1/things` as the query — the path was lost
+        // entirely once `Uri.replace` rewrote the query.
+        expect(
+          await sentUrlFor('https://example.com?ext=1'),
+          'https://example.com/things?ext=1',
+        );
+      });
+
+      test('keeps both a path and a query on baseUri', () async {
+        expect(
+          await sentUrlFor('https://example.com/v2?ext=1'),
+          'https://example.com/v2/things?ext=1',
+        );
+      });
+
+      test('preserves userInfo and port, drops the fragment', () async {
+        // A fragment is never sent to a server, so dropping it is
+        // correct; concatenation used to mangle it into the path.
+        expect(
+          await sentUrlFor('https://user@example.com:8080/v2#frag'),
+          'https://user@example.com:8080/v2/things',
+        );
+      });
+    });
+
     // The query renderer builds the `List<String>` for each param. These
     // tests pin what the *actual* sent URL looks like for the two shapes it
     // produces, exercising the real `Uri.replace` encoding — not the


### PR DESCRIPTION
## Summary

Fixed `ApiClient._resolveUri` losing the operation path when `baseUri`
carries its own query string, collapsing a trailing slash on `baseUri`
that produced an empty `//` segment, and closing a query-injection hole
in path parameters.

## Detail

The request URL was built as `Uri.parse('$baseUri$path')`. String
concatenation appends the operation path *after* baseUri's query and
fragment, so the path is swallowed:

```
baseUri  https://example.com?ext=1
path     /things
concat   https://example.com?ext=1/things   // path: "", query: "ext=1/things"
```

`Uri.replace` then rewrote the query from the merged parameter map, and
the path was gone — the request went to `https://example.com?ext=1`.

Now grafted by `_appendPath`, "the method we wish `Uri` had". Naming it
means the workaround is removable on purpose rather than by
archaeology: `Uri` can set a query but never clear one (no
`removeQuery()` to match `removeFragment()`), which is the *only*
reason the fields are copied by hand. If that ever lands, the body
collapses to `baseUri.replace(path: ...).removeQuery()`.

`api_client.dart` is copied verbatim into every generated package, so
the comparison of rejected alternatives lives on
[#139](https://github.com/eseidel/space_gen/issues/139#issuecomment-5013470092)
rather than in every consumer's source; the doc comment links there.
Emitted delta is 26 lines.

## Path parameters could inject query parameters

The generator substitutes path parameters raw —
`'/my/ships/{shipSymbol}'.replaceAll('{shipSymbol}', shipSymbol)` — so
caller data reached `Uri.parse` as live URL text. A value containing
`?` became a real query parameter:

```dart
shipSymbol = 'ABC?admin=true'
old → path=/v2/my/ships/ABC   query={admin: true}   // injected
new → path=/v2/my/ships/ABC%3Fadmin=true   query={}
```

`Uri(path: ...)` escapes reserved characters instead of reparsing them.
Not the motivation for this PR, but it means the change is worth
landing on its own.

A value containing `/` still splits into segments — encoding path
parameters at substitution time is a separate fix, not attempted here.

## Tests

Five cases in `test/templates/api_client_test.dart`, all verified to
fail against the previous implementation: baseUri with a path, with a
trailing slash, with a query, with both, and with userInfo + port +
fragment.

Fixes #139
