### PR TITLE
chore: regen gen_tests goldens stale since #268/#273

### DIFF
--- a/gen_tests/multipart/lib/api/default_api.dart
+++ b/gen_tests/multipart/lib/api/default_api.dart
@@ -33,10 +33,7 @@ class DefaultApi {
     );
 
     if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException<Object?>(
-        response.statusCode,
-        response.body,
-      );
+      throw ApiException<Object?>(response.statusCode, response.body);
     }
   }
 
@@ -66,10 +63,7 @@ class DefaultApi {
     );
 
     if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException<Object?>(
-        response.statusCode,
-        response.body,
-      );
+      throw ApiException<Object?>(response.statusCode, response.body);
     }
   }
 
@@ -100,10 +94,7 @@ class DefaultApi {
     );
 
     if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException<Object?>(
-        response.statusCode,
-        response.body,
-      );
+      throw ApiException<Object?>(response.statusCode, response.body);
     }
   }
 
@@ -134,10 +125,7 @@ class DefaultApi {
     );
 
     if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException<Object?>(
-        response.statusCode,
-        response.body,
-      );
+      throw ApiException<Object?>(response.statusCode, response.body);
     }
   }
 
@@ -169,10 +157,7 @@ class DefaultApi {
     );
 
     if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException<Object?>(
-        response.statusCode,
-        response.body,
-      );
+      throw ApiException<Object?>(response.statusCode, response.body);
     }
   }
 }

--- a/gen_tests/multipart/test/model/upload_rich_scalars_request_visibility_test.dart
+++ b/gen_tests/multipart/test/model/upload_rich_scalars_request_visibility_test.dart
@@ -5,7 +5,7 @@ import 'package:test/test.dart';
 void main() {
   group('UploadRichScalarsRequestVisibility', () {
     test('round-trips via maybeFromJson/toJson', () {
-      final instance = UploadRichScalarsRequestVisibility.values.first;
+      const instance = UploadRichScalarsRequestVisibility.public;
       final parsed = UploadRichScalarsRequestVisibility.maybeFromJson(
         instance.toJson(),
       )!;

--- a/gen_tests/security/lib/api/default_api.dart
+++ b/gen_tests/security/lib/api/default_api.dart
@@ -20,10 +20,7 @@ class DefaultApi {
     );
 
     if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException<Object?>(
-        response.statusCode,
-        response.body,
-      );
+      throw ApiException<Object?>(response.statusCode, response.body);
     }
 
     if (response.body.isNotEmpty) {
@@ -41,10 +38,7 @@ class DefaultApi {
     );
 
     if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException<Object?>(
-        response.statusCode,
-        response.body,
-      );
+      throw ApiException<Object?>(response.statusCode, response.body);
     }
   }
 
@@ -61,10 +55,7 @@ class DefaultApi {
     );
 
     if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException<Object?>(
-        response.statusCode,
-        response.body,
-      );
+      throw ApiException<Object?>(response.statusCode, response.body);
     }
   }
 }

--- a/gen_tests/types/lib/api/default_api.dart
+++ b/gen_tests/types/lib/api/default_api.dart
@@ -16,10 +16,7 @@ class DefaultApi {
     final response = await client.invokeApi(method: Method.get, path: '/types');
 
     if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException<Object?>(
-        response.statusCode,
-        response.body,
-      );
+      throw ApiException<Object?>(response.statusCode, response.body);
     }
 
     if (response.body.isNotEmpty) {

--- a/gen_tests/types/test/model/status_test.dart
+++ b/gen_tests/types/test/model/status_test.dart
@@ -5,7 +5,7 @@ import 'package:types/api.dart';
 void main() {
   group('Status', () {
     test('round-trips via maybeFromJson/toJson', () {
-      final instance = Status.values.first;
+      const instance = Status.active;
       final parsed = Status.maybeFromJson(instance.toJson())!;
       expect(parsed, equals(instance));
       expect(parsed.hashCode, equals(instance.hashCode));

--- a/gen_tests/types/test/model/types200_response_test.dart
+++ b/gen_tests/types/test/model/types200_response_test.dart
@@ -13,10 +13,10 @@ void main() {
         timestamp: Timestamp(DateTime.utc(2024)),
         widget: Widget(
           id: 0,
-          tags: <String>['example'],
-          attributes: {'key': 'example'},
+          tags: const <String>['example'],
+          attributes: const {'key': 'example'},
         ),
-        status: Status.values.first,
+        status: Status.active,
       );
       final parsed = Types200Response.maybeFromJson(instance.toJson())!;
       expect(parsed, equals(instance));

--- a/gen_tests/types/test/model/widget_test.dart
+++ b/gen_tests/types/test/model/widget_test.dart
@@ -7,8 +7,8 @@ void main() {
     test('round-trips via maybeFromJson/toJson', () {
       final instance = Widget(
         id: 0,
-        tags: <String>['example'],
-        attributes: {'key': 'example'},
+        tags: const <String>['example'],
+        attributes: const {'key': 'example'},
       );
       final parsed = Widget.maybeFromJson(instance.toJson())!;
       expect(parsed, equals(instance));

--- a/gen_tests/unsupported_auth/lib/api/default_api.dart
+++ b/gen_tests/unsupported_auth/lib/api/default_api.dart
@@ -18,10 +18,7 @@ class DefaultApi {
     );
 
     if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException<Object?>(
-        response.statusCode,
-        response.body,
-      );
+      throw ApiException<Object?>(response.statusCode, response.body);
     }
   }
 
@@ -34,10 +31,7 @@ class DefaultApi {
     );
 
     if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException<Object?>(
-        response.statusCode,
-        response.body,
-      );
+      throw ApiException<Object?>(response.statusCode, response.body);
     }
   }
 
@@ -50,10 +44,7 @@ class DefaultApi {
     );
 
     if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException<Object?>(
-        response.statusCode,
-        response.body,
-      );
+      throw ApiException<Object?>(response.statusCode, response.body);
     }
   }
 }


### PR DESCRIPTION
## Summary

Regenerated eight `gen_tests` golden files that had drifted out of sync
with the generator's current output.

## Detail

Earlier output-changing PRs landed without a golden regen, so the
committed fixtures still show the pre-change output:

- `default_api.dart` (4 packages) — `ApiException<Object?>(...)` now
  fits on one line after the dart_style reflow.
- `status_test.dart` — `Status.values.first` is emitted as
  `const instance = Status.active` since the tearoff/const work.
- `types200_response_test.dart`, `widget_test.dart`,
  `upload_rich_scalars_request_visibility_test.dart` — same category.

No generator change here; this is purely `dart run tool/gen_tests.dart`
output.

## Verification

Confirmed this set is independent of any in-flight work by
regenerating at an unmodified `HEAD` in a detached worktree — it
produced exactly these eight files and no others.

## Why this drifted silently

The `Run end-to-end generator tests` CI step regenerates the `types`
fixture and runs its generated tests, but never diffs the regenerated
output against what is committed. A regen that changes a golden still
passes as long as the generated tests themselves pass, so the working
tree and the repo can disagree indefinitely.

A `git diff --exit-code gen_tests/` after the regen step would turn
this into a hard failure. Not included here to keep this PR to the
mechanical regen — happy to add it in a follow-up if wanted.
