### PR TITLE
fix: comment prose is not a reference (#271)

### DIFF
--- a/lib/src/render/file_renderer.dart
+++ b/lib/src/render/file_renderer.dart
@@ -705,16 +705,15 @@ class FileRenderer {
   Iterable<Import> importsForApi(
     Api api,
     ApiUsage usage, {
-    required String body,
+    required String code,
   }) {
-    // Import only what the rendered [body] actually names. Each fixed
+    // Import only what the rendered [code] actually names. Each fixed
     // import is gated on a sentinel identifier that must appear if the
     // import is used (e.g. `HttpStatus` for `dart:io`), and each model
     // newtype on its own class name. Keeping an import requires the
     // token to be present, so a used import is never dropped; the
     // effect is purely to stop emitting imports the api file never
     // references (which `dart fix` would otherwise strip).
-    final code = stripComments(body);
     final referenced = referencedIdentifiers(code);
     bool names(String token) => referenced.contains(token);
 
@@ -782,7 +781,7 @@ class FileRenderer {
       final imports = importsForApi(
         api,
         renderedApi.usage,
-        body: renderedApi.body,
+        code: renderedApi.code,
       );
       final importsContext = imports
           .sortedBy((i) => i.path)
@@ -822,9 +821,9 @@ class FileRenderer {
   Iterable<Import> importsForModel(
     RenderSchema schema,
     SchemaUsage usage, {
-    required String body,
+    required String code,
   }) {
-    final referenced = referencedIdentifiers(stripComments(body));
+    final referenced = referencedIdentifiers(code);
     final referencedSchemas = collectSchemasUnderSchema(schema);
     final localSchemas = referencedSchemas.where(
       (s) => !s.createsNewType,
@@ -872,7 +871,7 @@ class FileRenderer {
       final imports = importsForModel(
         schema,
         rendered.usage,
-        body: rendered.body,
+        code: rendered.code,
       );
       final importsContext = imports
           .sortedBy((i) => i.path)

--- a/lib/src/render/file_renderer.dart
+++ b/lib/src/render/file_renderer.dart
@@ -714,7 +714,8 @@ class FileRenderer {
     // token to be present, so a used import is never dropped; the
     // effect is purely to stop emitting imports the api file never
     // references (which `dart fix` would otherwise strip).
-    final referenced = referencedIdentifiers(body);
+    final code = stripComments(body);
+    final referenced = referencedIdentifiers(code);
     bool names(String token) => referenced.contains(token);
 
     final imports = {
@@ -733,9 +734,9 @@ class FileRenderer {
       if (names('ApiException'))
         Import.path('package:$packageName/api_exception.dart'),
       // `as http` is only ever used via the `http.` prefix, so it is
-      // gated on that rather than on a bare identifier: a `http` token in
-      // a URL doc-comment must not keep it.
-      if (body.contains('http.')) const Import(Libraries.http, asName: 'http'),
+      // gated on that rather than on a bare identifier: a plain `http`
+      // token in a URL string literal must not keep it.
+      if (code.contains('http.')) const Import(Libraries.http, asName: 'http'),
       ...usage.importsFor(packageName),
     };
 
@@ -823,7 +824,7 @@ class FileRenderer {
     SchemaUsage usage, {
     required String body,
   }) {
-    final referenced = referencedIdentifiers(body);
+    final referenced = referencedIdentifiers(stripComments(body));
     final referencedSchemas = collectSchemasUnderSchema(schema);
     final localSchemas = referencedSchemas.where(
       (s) => !s.createsNewType,

--- a/lib/src/render/schema_renderer.dart
+++ b/lib/src/render/schema_renderer.dart
@@ -5,26 +5,169 @@ import 'package:space_gen/src/render/templates.dart';
 /// A maximal Dart identifier: `[a-zA-Z_$]` head, `[\w$]*` tail.
 final _identifierPattern = RegExp(r'[a-zA-Z_$][\w$]*');
 
+/// A single character that can appear inside a Dart identifier.
+final _identifierCharPattern = RegExp(r'[\w$]');
+
 /// [ModelHelpers.all] as a set, for O(1) membership while scanning.
 final Set<String> _helperNames = ModelHelpers.all.toSet();
 
-/// Every whole-identifier token appearing in [body].
+/// A `[Bracketed]` doc-comment reference. The analyzer resolves these,
+/// so they count as uses of an import just like code does.
+///
+/// Whitespace inside the brackets disqualifies it: a real reference is
+/// a single identifier chain (`[Foo]`, `[Foo.bar]`), never a phrase.
+/// What phrases are is markdown link labels — github writes `[Link
+/// header](https://…)` and spacetraders `[Market Overview page](…)`,
+/// where `Link` and `Market` also happen to be model class names. The
+/// analyzer resolves the leading word of those and so counts the import
+/// as used, which is why `dart fix` kept two imports nothing references.
+/// Requiring a whitespace-free reference drops them without putting any
+/// genuine one at risk.
+final _docReferencePattern = RegExp(r'\[([^\]\s]+)\]');
+
+/// [body] with comment prose removed, keeping the parts that can name a
+/// Dart identifier.
+///
+/// A comment survives only as its `[Bracketed]` references; the rest of
+/// the prose is replaced by spaces, so offsets and line structure are
+/// unaffected and patterns anchored on `\b` still see what they expect.
+/// Code and string literals are kept verbatim: a string can carry an
+/// identifier through interpolation (`'${Foo.bar}'`), and reproducing
+/// Dart's interpolation grammar to find out buys nothing, since keeping
+/// an extra identifier only ever keeps an extra import.
+///
+/// Strings are still *recognized* — not to drop them, but to skip past
+/// them. `Uri.parse('https://example.com/x')` embeds a `//` that a
+/// string-blind scan would read as starting a comment, discarding the
+/// real code that follows it on that line. That is the one direction
+/// this function must never fail in: dropping code loses a genuine
+/// reference, and losing a reference drops a needed import and breaks
+/// compilation.
+String stripComments(String body) {
+  final out = StringBuffer();
+  // Start of the run of kept text not yet flushed to [out]. Everything
+  // that is not a comment is kept verbatim, so the scan only has to find
+  // comment boundaries and copy whole runs between them.
+  var runStart = 0;
+  var i = 0;
+
+  /// Advances [i] past the string literal starting there, handling raw,
+  /// multiline, and escaped quotes. The literal itself needs no special
+  /// copying — it stays part of the current run.
+  void skipStringLiteral() {
+    // In a raw string a backslash is literal, so it cannot escape the
+    // closing quote.
+    final isRaw = body[i] == 'r';
+    if (isRaw) i++;
+    final quote = body[i];
+    // `'''` / `"""` — a multiline string ends only on the full triple.
+    final delimiter = body.startsWith(quote * 3, i) ? quote * 3 : quote;
+    i += delimiter.length;
+    while (i < body.length) {
+      if (!isRaw && body[i] == r'\') {
+        i += 2;
+        continue;
+      }
+      if (body.startsWith(delimiter, i)) {
+        i += delimiter.length;
+        return;
+      }
+      i++;
+    }
+  }
+
+  /// Advances [i] past the comment starting there, returning its text.
+  String skipComment({required bool isBlock}) {
+    final start = i;
+    if (isBlock) {
+      // Dart nests block comments, so track depth rather than stopping
+      // at the first `*/`.
+      var depth = 0;
+      while (i < body.length) {
+        if (body.startsWith('/*', i)) {
+          depth++;
+          i += 2;
+        } else if (body.startsWith('*/', i)) {
+          depth--;
+          i += 2;
+          if (depth == 0) break;
+        } else {
+          i++;
+        }
+      }
+    } else {
+      while (i < body.length && body[i] != '\n') {
+        i++;
+      }
+    }
+    return body.substring(start, i);
+  }
+
+  /// The replacement for [comment]: its doc references at their original
+  /// offsets, everything else blanked. Same length as [comment], so the
+  /// surrounding text keeps its line structure.
+  String elided(String comment) {
+    final kept = List.filled(comment.length, ' ');
+    for (final match in _docReferencePattern.allMatches(comment)) {
+      final reference = match[1]!;
+      for (var k = 0; k < reference.length; k++) {
+        kept[match.start + 1 + k] = reference[k];
+      }
+    }
+    return kept.join();
+  }
+
+  while (i < body.length) {
+    final char = body[i];
+    if (char == '/' && i + 1 < body.length) {
+      final next = body[i + 1];
+      if (next == '/' || next == '*') {
+        out
+          ..write(body.substring(runStart, i))
+          ..write(elided(skipComment(isBlock: next == '*')));
+        runStart = i;
+        continue;
+      }
+    }
+    // A quote, or the `r` of a raw string — as opposed to an `r` ending
+    // a longer identifier that happens to precede one.
+    if (char == "'" ||
+        char == '"' ||
+        (char == 'r' &&
+            i + 1 < body.length &&
+            (body[i + 1] == "'" || body[i + 1] == '"') &&
+            (i == 0 || !_identifierCharPattern.hasMatch(body[i - 1])))) {
+      skipStringLiteral();
+      continue;
+    }
+    i++;
+  }
+  out.write(body.substring(runStart));
+  return out.toString();
+}
+
+/// Every whole-identifier token appearing in [code], which callers pass
+/// through [stripComments] first.
 ///
 /// Used to prune an emitted file's imports down to the symbols it
 /// actually names: an import is kept only when its type/sentinel token
-/// is in this set. Tokenizing (rather than `body.contains(name)`)
+/// is in this set. Tokenizing (rather than `code.contains(name)`)
 /// avoids substring false positives — the same whole-identifier
-/// discipline [_referencedModelHelpers] relies on. Keeping an import on
-/// *any* appearance (including doc comments) is deliberately
-/// conservative: it can never drop a genuinely-used import, so it can
-/// never break compilation.
-Set<String> referencedIdentifiers(String body) =>
-    _identifierPattern.allMatches(body).map((m) => m[0]!).toSet();
-
-/// The subset of [ModelHelpers.all] that [body] references as whole
-/// identifiers.
+/// discipline [_referencedModelHelpers] relies on.
 ///
-/// We tokenize [body] into identifiers in a single pass and match each
+/// Taking stripped code rather than the raw body is what makes comment
+/// prose not count. Spec descriptions routinely repeat a type's name in
+/// English ("GitHub Enterprise Cloud", "Register New Agent"), which kept
+/// 23 imports across the tracked specs that the file never referenced.
+Set<String> referencedIdentifiers(String code) =>
+    _identifierPattern.allMatches(code).map((m) => m[0]!).toSet();
+
+/// The subset of [ModelHelpers.all] that [code] references as whole
+/// identifiers. [code] has already been through [stripComments]: a
+/// helper named in prose is not a call, and pulling an uncalled helper
+/// into `model_helpers.dart` is exactly the dead-code problem below.
+///
+/// We tokenize [code] into identifiers in a single pass and match each
 /// token against [_helperNames] by exact equality. A plain
 /// `body.contains(name)` would over-match helper names that are
 /// prefixes of others — `maybeParseDateTime` contains `maybeParseDate`,
@@ -33,9 +176,9 @@ Set<String> referencedIdentifiers(String body) =>
 /// one into `model_helpers.dart` as a dead function: uncovered lines
 /// that fail the consuming package's coverage gate. Comparing whole
 /// tokens makes that impossible by construction.
-Set<String> _referencedModelHelpers(String body) {
+Set<String> _referencedModelHelpers(String code) {
   final found = <String>{};
-  for (final match in _identifierPattern.allMatches(body)) {
+  for (final match in _identifierPattern.allMatches(code)) {
     final token = match[0]!;
     if (_helperNames.contains(token)) found.add(token);
   }
@@ -60,10 +203,11 @@ class SchemaUsage {
 
   /// Derives usage by inspecting a rendered body.
   factory SchemaUsage.fromBody(String body) {
+    final code = stripComments(body);
     return SchemaUsage(
-      usesMetaAnnotations: body.contains('@immutable'),
-      usesValidationExtensions: _validationCallPattern.hasMatch(body),
-      modelHelpers: _referencedModelHelpers(body),
+      usesMetaAnnotations: code.contains('@immutable'),
+      usesValidationExtensions: _validationCallPattern.hasMatch(code),
+      modelHelpers: _referencedModelHelpers(code),
     );
   }
 
@@ -111,10 +255,13 @@ class ApiUsage {
     this.modelHelpers = const {},
   });
 
-  factory ApiUsage.fromBody(String body) => ApiUsage(
-    usesMetaAnnotations: body.contains('@immutable'),
-    modelHelpers: _referencedModelHelpers(body),
-  );
+  factory ApiUsage.fromBody(String body) {
+    final code = stripComments(body);
+    return ApiUsage(
+      usesMetaAnnotations: code.contains('@immutable'),
+      modelHelpers: _referencedModelHelpers(code),
+    );
+  }
 
   /// True when the body emits `@immutable` (multi-status response
   /// wrappers do; the legacy single-return path does not). Drives the

--- a/lib/src/render/schema_renderer.dart
+++ b/lib/src/render/schema_renderer.dart
@@ -5,9 +5,6 @@ import 'package:space_gen/src/render/templates.dart';
 /// A maximal Dart identifier: `[a-zA-Z_$]` head, `[\w$]*` tail.
 final _identifierPattern = RegExp(r'[a-zA-Z_$][\w$]*');
 
-/// A single character that can appear inside a Dart identifier.
-final _identifierCharPattern = RegExp(r'[\w$]');
-
 /// [ModelHelpers.all] as a set, for O(1) membership while scanning.
 final Set<String> _helperNames = ModelHelpers.all.toSet();
 
@@ -25,129 +22,57 @@ final Set<String> _helperNames = ModelHelpers.all.toSet();
 /// genuine one at risk.
 final _docReferencePattern = RegExp(r'\[([^\]\s]+)\]');
 
+/// A string literal or a line comment: the two spans of a rendered body
+/// that must not be read as ordinary code.
+///
+/// One pattern for both, because each is what stops the other from being
+/// misread — the leftmost match wins, so in `Uri.parse('https://x')` the
+/// quote comes first and the `//` is part of the string, while in
+/// `/// don't` the `//` comes first and the apostrophe never opens a
+/// string.
+///
+/// Block comments are deliberately absent: the generator emits none, and
+/// every `/*` in the tracked specs' output is a glob inside a `///`
+/// line, which the comment branch already consumes. Should one ever
+/// appear its prose would be tokenized as code, which over-keeps an
+/// import — a lint, never a broken build.
+final _stringOrLineComment = RegExp(
+  // Raw strings first: their backslash is literal, so it must not be
+  // read as escaping the closing quote.
+  r"""r'[^'\n]*'|r"[^"\n]*"|"""
+  // Then ordinary strings, where a backslash does escape.
+  r"""'(?:\\.|[^'\\\n])*'|"(?:\\.|[^"\\\n])*"|"""
+  // Then line comments, which run to the end of the line.
+  r'//[^\n]*',
+);
+
+/// The `[Bracketed]` references in [comment] — the only part of it that
+/// can name a type. Space-prefixed so that replacing a comment cannot
+/// fuse it with the code before it (`foo//[Bar]` must not become
+/// `fooBar`).
+String _docReferencesIn(String comment) =>
+    ' ${_docReferencePattern.allMatches(comment).map((m) => m[1]!).join(' ')}';
+
 /// [body] with comment prose removed, keeping the parts that can name a
 /// Dart identifier.
 ///
-/// A comment survives only as its `[Bracketed]` references; the rest of
-/// the prose is replaced by spaces rather than deleted, so that the code
-/// on either side stays separated. Deleting it would fuse
-/// `foo/*c*/bar` into the identifier `foobar`, inventing a reference
-/// that never appeared.
+/// A comment survives only as its `[Bracketed]` references. Code and
+/// string literals are kept verbatim: a string can carry an identifier
+/// through interpolation (`'${Foo.bar}'`), and reproducing Dart's
+/// interpolation grammar to find out buys nothing, since keeping an
+/// extra identifier only ever keeps an extra import.
 ///
-/// Code and string literals are kept verbatim: a string can carry an
-/// identifier through interpolation (`'${Foo.bar}'`), and reproducing
-/// Dart's interpolation grammar to find out buys nothing, since keeping
-/// an extra identifier only ever keeps an extra import.
-///
-/// Strings are still *recognized* — not to drop them, but to skip past
-/// them. `Uri.parse('https://example.com/x')` embeds a `//` that a
+/// Strings are matched only so the scan can skip past them.
+/// `Uri.parse('https://example.com/x')` embeds a `//` that a
 /// string-blind scan would read as starting a comment, discarding the
 /// real code that follows it on that line. That is the one direction
-/// this function must never fail in: dropping code loses a genuine
-/// reference, and losing a reference drops a needed import and breaks
-/// compilation.
-String stripComments(String body) {
-  final out = StringBuffer();
-  // Start of the run of kept text not yet flushed to [out]. Everything
-  // that is not a comment is kept verbatim, so the scan only has to find
-  // comment boundaries and copy whole runs between them.
-  var runStart = 0;
-  var i = 0;
-
-  /// Advances [i] past the string literal starting there, handling raw,
-  /// multiline, and escaped quotes. The literal itself needs no special
-  /// copying — it stays part of the current run.
-  void skipStringLiteral() {
-    // In a raw string a backslash is literal, so it cannot escape the
-    // closing quote.
-    final isRaw = body[i] == 'r';
-    if (isRaw) i++;
-    final quote = body[i];
-    // `'''` / `"""` — a multiline string ends only on the full triple.
-    final delimiter = body.startsWith(quote * 3, i) ? quote * 3 : quote;
-    i += delimiter.length;
-    while (i < body.length) {
-      if (!isRaw && body[i] == r'\') {
-        i += 2;
-        continue;
-      }
-      if (body.startsWith(delimiter, i)) {
-        i += delimiter.length;
-        return;
-      }
-      i++;
-    }
-  }
-
-  /// Advances [i] past the comment starting there, returning its text.
-  String skipComment({required bool isBlock}) {
-    final start = i;
-    if (isBlock) {
-      // Dart nests block comments, so track depth rather than stopping
-      // at the first `*/`.
-      var depth = 0;
-      while (i < body.length) {
-        if (body.startsWith('/*', i)) {
-          depth++;
-          i += 2;
-        } else if (body.startsWith('*/', i)) {
-          depth--;
-          i += 2;
-          if (depth == 0) break;
-        } else {
-          i++;
-        }
-      }
-    } else {
-      while (i < body.length && body[i] != '\n') {
-        i++;
-      }
-    }
-    return body.substring(start, i);
-  }
-
-  /// The replacement for [comment]: its doc references at their original
-  /// offsets, everything else blanked. Never empty, so the code on
-  /// either side of the comment cannot fuse into one token.
-  String elided(String comment) {
-    final kept = List.filled(comment.length, ' ');
-    for (final match in _docReferencePattern.allMatches(comment)) {
-      final reference = match[1]!;
-      for (var k = 0; k < reference.length; k++) {
-        kept[match.start + 1 + k] = reference[k];
-      }
-    }
-    return kept.join();
-  }
-
-  while (i < body.length) {
-    final char = body[i];
-    if (char == '/' && i + 1 < body.length) {
-      final next = body[i + 1];
-      if (next == '/' || next == '*') {
-        out
-          ..write(body.substring(runStart, i))
-          ..write(elided(skipComment(isBlock: next == '*')));
-        runStart = i;
-        continue;
-      }
-    }
-    // A quote, or the `r` of a raw string — as opposed to an `r` ending
-    // a longer identifier that happens to precede one.
-    if (char == "'" ||
-        char == '"' ||
-        (char == 'r' &&
-            i + 1 < body.length &&
-            (body[i + 1] == "'" || body[i + 1] == '"') &&
-            (i == 0 || !_identifierCharPattern.hasMatch(body[i - 1])))) {
-      skipStringLiteral();
-      continue;
-    }
-    i++;
-  }
-  out.write(body.substring(runStart));
-  return out.toString();
-}
+/// this must never fail in: dropping code loses a genuine reference,
+/// and losing a reference drops a needed import and breaks compilation.
+String stripComments(String body) =>
+    body.replaceAllMapped(_stringOrLineComment, (match) {
+      final text = match[0]!;
+      return text.startsWith('//') ? _docReferencesIn(text) : text;
+    });
 
 /// Every whole-identifier token appearing in [code], which callers pass
 /// through [stripComments] first.

--- a/lib/src/render/schema_renderer.dart
+++ b/lib/src/render/schema_renderer.dart
@@ -29,8 +29,11 @@ final _docReferencePattern = RegExp(r'\[([^\]\s]+)\]');
 /// Dart identifier.
 ///
 /// A comment survives only as its `[Bracketed]` references; the rest of
-/// the prose is replaced by spaces, so offsets and line structure are
-/// unaffected and patterns anchored on `\b` still see what they expect.
+/// the prose is replaced by spaces rather than deleted, so that the code
+/// on either side stays separated. Deleting it would fuse
+/// `foo/*c*/bar` into the identifier `foobar`, inventing a reference
+/// that never appeared.
+///
 /// Code and string literals are kept verbatim: a string can carry an
 /// identifier through interpolation (`'${Foo.bar}'`), and reproducing
 /// Dart's interpolation grammar to find out buys nothing, since keeping
@@ -104,8 +107,8 @@ String stripComments(String body) {
   }
 
   /// The replacement for [comment]: its doc references at their original
-  /// offsets, everything else blanked. Same length as [comment], so the
-  /// surrounding text keeps its line structure.
+  /// offsets, everything else blanked. Never empty, so the code on
+  /// either side of the comment cannot fuse into one token.
   String elided(String comment) {
     final kept = List.filled(comment.length, ' ');
     for (final match in _docReferencePattern.allMatches(comment)) {
@@ -202,14 +205,15 @@ class SchemaUsage {
   });
 
   /// Derives usage by inspecting a rendered body.
-  factory SchemaUsage.fromBody(String body) {
-    final code = stripComments(body);
-    return SchemaUsage(
-      usesMetaAnnotations: code.contains('@immutable'),
-      usesValidationExtensions: _validationCallPattern.hasMatch(code),
-      modelHelpers: _referencedModelHelpers(code),
-    );
-  }
+  factory SchemaUsage.fromBody(String body) =>
+      SchemaUsage.fromCode(stripComments(body));
+
+  /// Derives usage from a body already reduced by [stripComments].
+  factory SchemaUsage.fromCode(String code) => SchemaUsage(
+    usesMetaAnnotations: code.contains('@immutable'),
+    usesValidationExtensions: _validationCallPattern.hasMatch(code),
+    modelHelpers: _referencedModelHelpers(code),
+  );
 
   /// Matches any `validateXxx` extension-method call. The
   /// `api_exception.dart` file declares them as extensions on
@@ -255,13 +259,14 @@ class ApiUsage {
     this.modelHelpers = const {},
   });
 
-  factory ApiUsage.fromBody(String body) {
-    final code = stripComments(body);
-    return ApiUsage(
-      usesMetaAnnotations: code.contains('@immutable'),
-      modelHelpers: _referencedModelHelpers(code),
-    );
-  }
+  factory ApiUsage.fromBody(String body) =>
+      ApiUsage.fromCode(stripComments(body));
+
+  /// Derives usage from a body already reduced by [stripComments].
+  factory ApiUsage.fromCode(String code) => ApiUsage(
+    usesMetaAnnotations: code.contains('@immutable'),
+    modelHelpers: _referencedModelHelpers(code),
+  );
 
   /// True when the body emits `@immutable` (multi-status response
   /// wrappers do; the legacy single-return path does not). Drives the
@@ -284,15 +289,59 @@ class ApiUsage {
 
 /// A rendered schema body paired with the usage of that body.
 class RenderedSchema {
-  const RenderedSchema({required this.body, required this.usage});
+  /// Scans [body] once: [code] and [usage] are both derived from that
+  /// single pass, which is also what keeps them consistent with each
+  /// other.
+  factory RenderedSchema.fromBody(String body) {
+    final code = stripComments(body);
+    return RenderedSchema._(
+      body: body,
+      code: code,
+      usage: SchemaUsage.fromCode(code),
+    );
+  }
+
+  const RenderedSchema._({
+    required this.body,
+    required this.usage,
+    required this.code,
+  });
+
+  /// What gets written to the file.
   final String body;
+
+  /// [body] reduced to the parts that can name a Dart identifier — what
+  /// import decisions are made against. See [stripComments].
+  final String code;
+
   final SchemaUsage usage;
 }
 
 /// A rendered api body paired with the usage of that body.
 class RenderedApi {
-  const RenderedApi({required this.body, required this.usage});
+  /// Scans [body] once; see [RenderedSchema.fromBody].
+  factory RenderedApi.fromBody(String body) {
+    final code = stripComments(body);
+    return RenderedApi._(
+      body: body,
+      code: code,
+      usage: ApiUsage.fromCode(code),
+    );
+  }
+
+  const RenderedApi._({
+    required this.body,
+    required this.usage,
+    required this.code,
+  });
+
+  /// What gets written to the file.
   final String body;
+
+  /// [body] reduced to the parts that can name a Dart identifier. See
+  /// [stripComments].
+  final String code;
+
   final ApiUsage usage;
 }
 
@@ -329,7 +378,7 @@ class SchemaRenderer {
     final body = templates
         .loadTemplate(template)
         .renderString(schema.toTemplateContext(this));
-    return RenderedSchema(body: body, usage: SchemaUsage.fromBody(body));
+    return RenderedSchema.fromBody(body);
   }
 
   String renderEndpoints({
@@ -356,6 +405,6 @@ class SchemaRenderer {
       endpoints: api.endpoints,
       removePrefix: api.removePrefix,
     );
-    return RenderedApi(body: body, usage: ApiUsage.fromBody(body));
+    return RenderedApi.fromBody(body);
   }
 }

--- a/test/render/file_renderer_test.dart
+++ b/test/render/file_renderer_test.dart
@@ -2681,23 +2681,26 @@ void main() {
   });
 
   group('FileRenderer', () {
-    test('imports for model', () {
+    /// A [FileRenderer] over an in-memory file system, for the import
+    /// tests below — they all want the same one.
+    FileRenderer testFileRenderer() {
       final templates = TemplateProvider.defaultLocation();
-      final schemaRenderer = SchemaRenderer(templates: templates);
-      final formatter = Formatter();
-      final spellChecker = SpellChecker();
-      final fileRenderer = FileRenderer(
+      return FileRenderer(
         FileRendererConfig(
           packageName: 'spacetraders',
-          schemaRenderer: schemaRenderer,
+          schemaRenderer: SchemaRenderer(templates: templates),
           templates: templates,
-          formatter: formatter,
+          formatter: Formatter(),
           fileWriter: FileWriter(
             outDir: MemoryFileSystem.test().directory('spacetraders'),
           ),
-          spellChecker: spellChecker,
+          spellChecker: SpellChecker(),
         ),
       );
+    }
+
+    test('imports for model', () {
+      final fileRenderer = testFileRenderer();
       final schema = RenderObject(
         common: CommonProperties.test(
           snakeName: 'foo',
@@ -2719,8 +2722,11 @@ void main() {
         usesMetaAnnotations: true,
         modelHelpers: {ModelHelpers.parseFromJson},
       );
-      Iterable<Import> importsFor(String body) =>
-          fileRenderer.importsForModel(schema, usage, body: body);
+      Iterable<Import> importsFor(String body) => fileRenderer.importsForModel(
+        schema,
+        usage,
+        code: stripComments(body),
+      );
 
       // `dart:typed_data` comes from the nested RenderBinary, but is
       // gated on the body naming `Uint8List` — a schema in the tree does
@@ -2738,22 +2744,7 @@ void main() {
 
     test('importsForModel imports a newtype field the body names, not '
         'types nested only inside it', () {
-      final templates = TemplateProvider.defaultLocation();
-      final schemaRenderer = SchemaRenderer(templates: templates);
-      final formatter = Formatter();
-      final spellChecker = SpellChecker();
-      final fileRenderer = FileRenderer(
-        FileRendererConfig(
-          packageName: 'spacetraders',
-          schemaRenderer: schemaRenderer,
-          templates: templates,
-          formatter: formatter,
-          fileWriter: FileWriter(
-            outDir: MemoryFileSystem.test().directory('spacetraders'),
-          ),
-          spellChecker: spellChecker,
-        ),
-      );
+      final fileRenderer = testFileRenderer();
       // Outer names a Nested-typed field; Nested itself owns a
       // Deep-typed field. Outer's file references Nested but never Deep
       // (that lives in Nested's own file), so only Nested is imported.
@@ -2787,7 +2778,7 @@ void main() {
       final imports = fileRenderer.importsForModel(
         outer,
         const SchemaUsage(),
-        body: 'class Outer { final Nested nested; }',
+        code: stripComments('class Outer { final Nested nested; }'),
       );
       expect(
         imports,
@@ -2908,6 +2899,15 @@ final x = Ship();
       }
     });
 
+    test('stripComments does not fuse the code on either side of a '
+        'comment', () {
+      // Blanking rather than deleting is what keeps these apart —
+      // deleting would invent the identifier `foobar`.
+      final code = stripComments('foo/* c */bar');
+      expect(referencedIdentifiers(code), containsAll(['foo', 'bar']));
+      expect(referencedIdentifiers(code), isNot(contains('foobar')));
+    });
+
     test('stripComments handles nested block comments', () {
       // Dart nests these, so stopping at the first `*/` would resume
       // treating comment prose as code.
@@ -2917,19 +2917,7 @@ final x = Ship();
     });
 
     test('importsForModel drops a model named only in prose', () {
-      final templates = TemplateProvider.defaultLocation();
-      final fileRenderer = FileRenderer(
-        FileRendererConfig(
-          packageName: 'spacetraders',
-          schemaRenderer: SchemaRenderer(templates: templates),
-          templates: templates,
-          formatter: Formatter(),
-          fileWriter: FileWriter(
-            outDir: MemoryFileSystem.test().directory('spacetraders'),
-          ),
-          spellChecker: SpellChecker(),
-        ),
-      );
+      final fileRenderer = testFileRenderer();
       final nested = RenderObject(
         common: CommonProperties.test(
           snakeName: 'nested',
@@ -2952,7 +2940,7 @@ final x = Ship();
         outer,
         const SchemaUsage(),
         // `Nested` appears, but only as English in the doc comment.
-        body: '/// A Nested thing.\nclass Outer {}',
+        code: stripComments('/// A Nested thing.\nclass Outer {}'),
       );
       expect(
         imports,
@@ -2970,22 +2958,7 @@ final x = Ship();
     });
 
     test('imports for api', () {
-      final templates = TemplateProvider.defaultLocation();
-      final schemaRenderer = SchemaRenderer(templates: templates);
-      final formatter = Formatter();
-      final spellChecker = SpellChecker();
-      final fileRenderer = FileRenderer(
-        FileRendererConfig(
-          packageName: 'spacetraders',
-          schemaRenderer: schemaRenderer,
-          templates: templates,
-          formatter: formatter,
-          fileWriter: FileWriter(
-            outDir: MemoryFileSystem.test().directory('spacetraders'),
-          ),
-          spellChecker: spellChecker,
-        ),
-      );
+      final fileRenderer = testFileRenderer();
       final api = Api(
         snakeName: 'foo',
         description: 'Foo description',
@@ -3056,7 +3029,7 @@ final x = Ship();
       final imports = fileRenderer.importsForApi(
         api,
         const ApiUsage(),
-        body: fullBody,
+        code: stripComments(fullBody),
       );
       expect(imports, {
         const Import(Libraries.dartAsync),
@@ -3071,22 +3044,7 @@ final x = Ship();
     });
 
     test('imports for api prunes fixed imports the body never names', () {
-      final templates = TemplateProvider.defaultLocation();
-      final schemaRenderer = SchemaRenderer(templates: templates);
-      final formatter = Formatter();
-      final spellChecker = SpellChecker();
-      final fileRenderer = FileRenderer(
-        FileRendererConfig(
-          packageName: 'spacetraders',
-          schemaRenderer: schemaRenderer,
-          templates: templates,
-          formatter: formatter,
-          fileWriter: FileWriter(
-            outDir: MemoryFileSystem.test().directory('spacetraders'),
-          ),
-          spellChecker: spellChecker,
-        ),
-      );
+      final fileRenderer = testFileRenderer();
       const api = Api(
         snakeName: 'foo',
         description: 'Foo description',
@@ -3098,7 +3056,7 @@ final x = Ship();
       final imports = fileRenderer.importsForApi(
         api,
         const ApiUsage(),
-        body: 'class FooApi {}\n',
+        code: stripComments('class FooApi {}\n'),
       );
       expect(imports, isEmpty);
     });

--- a/test/render/file_renderer_test.dart
+++ b/test/render/file_renderer_test.dart
@@ -2845,6 +2845,121 @@ void main() {
       expect(usedBy('maybeParseUri'), {ModelHelpers.maybeParseUri});
     });
 
+    test('stripComments drops prose but keeps [Bracketed] references', () {
+      // The prose case is why this exists: github's spec says "GitHub
+      // Enterprise Cloud" in a description, which is not a reference to
+      // the `Enterprise` model. A `[Bracketed]` ref is one — the
+      // analyzer resolves those, so dropping the import would leave a
+      // dangling comment reference.
+      final code = stripComments('''
+/// Uses [Enterprise] and mentions GitHub Milestone Server.
+/* Block Contract */
+final x = Ship();
+''');
+      expect(referencedIdentifiers(code), contains('Enterprise'));
+      expect(referencedIdentifiers(code), contains('Ship'));
+      expect(referencedIdentifiers(code), isNot(contains('Milestone')));
+      expect(referencedIdentifiers(code), isNot(contains('Contract')));
+    });
+
+    test('stripComments does not treat a markdown link label as a '
+        'reference', () {
+      // `[Link header](url)` is prose, not a doc reference, even though
+      // the analyzer resolves its leading word and counts the import as
+      // used. A real reference has no whitespace in it.
+      final code = stripComments('/// See the [Link header](https://x/y).');
+      expect(referencedIdentifiers(code), isNot(contains('Link')));
+    });
+
+    test('stripComments keeps code following a // inside a string', () {
+      // The dangerous direction: a URL literal embeds `//`. Reading that
+      // as a comment start would discard the rest of the line, losing a
+      // real reference and dropping an import the file needs.
+      final code = stripComments(
+        "final u = Uri.parse('https://example.com/x'); final s = Ship();",
+      );
+      expect(referencedIdentifiers(code), contains('Ship'));
+    });
+
+    test('stripComments keeps identifiers inside string interpolation', () {
+      // Interpolated code is code. Keeping whole string literals is the
+      // conservative way to cover it.
+      final code = stripComments(r"final s = '${Ship.symbol}';");
+      expect(referencedIdentifiers(code), contains('Ship'));
+    });
+
+    test('stripComments handles raw, multiline, and escaped strings', () {
+      // Each of these can swallow the rest of the file if its end is
+      // mis-detected: a raw string's backslash does not escape, a
+      // multiline string ends only on the full triple quote, and an
+      // escaped quote does not end an ordinary one.
+      for (final literal in [
+        r"r'a\'",
+        "'''multi ' line'''",
+        r"'it\'s'",
+        r'"say \"hi\""',
+      ]) {
+        final code = stripComments('final s = $literal; final x = Ship();');
+        expect(
+          referencedIdentifiers(code),
+          contains('Ship'),
+          reason: 'literal $literal swallowed the code after it',
+        );
+      }
+    });
+
+    test('stripComments handles nested block comments', () {
+      // Dart nests these, so stopping at the first `*/` would resume
+      // treating comment prose as code.
+      final code = stripComments('/* a /* b */ Milestone */ final x = Ship();');
+      expect(referencedIdentifiers(code), contains('Ship'));
+      expect(referencedIdentifiers(code), isNot(contains('Milestone')));
+    });
+
+    test('importsForModel drops a model named only in prose', () {
+      final templates = TemplateProvider.defaultLocation();
+      final fileRenderer = FileRenderer(
+        FileRendererConfig(
+          packageName: 'spacetraders',
+          schemaRenderer: SchemaRenderer(templates: templates),
+          templates: templates,
+          formatter: Formatter(),
+          fileWriter: FileWriter(
+            outDir: MemoryFileSystem.test().directory('spacetraders'),
+          ),
+          spellChecker: SpellChecker(),
+        ),
+      );
+      final nested = RenderObject(
+        common: CommonProperties.test(
+          snakeName: 'nested',
+          pointer: JsonPointer.parse('#/components/schemas/nested'),
+          description: 'Nested',
+        ),
+        assignedName: 'Nested',
+        properties: const {},
+      );
+      final outer = RenderObject(
+        common: CommonProperties.test(
+          snakeName: 'outer',
+          pointer: JsonPointer.parse('#/components/schemas/outer'),
+          description: 'Outer',
+        ),
+        assignedName: 'Outer',
+        properties: {'nested': nested},
+      );
+      final imports = fileRenderer.importsForModel(
+        outer,
+        const SchemaUsage(),
+        // `Nested` appears, but only as English in the doc comment.
+        body: '/// A Nested thing.\nclass Outer {}',
+      );
+      expect(
+        imports,
+        isNot(contains(Import.path('package:spacetraders/models/nested.dart'))),
+      );
+    });
+
     test('ApiUsage.fromBody uses the same whole-identifier match', () {
       // ApiUsage derives modelHelpers independently of SchemaUsage; pin
       // that it doesn't regress to a substring scan on its own.

--- a/test/render/file_renderer_test.dart
+++ b/test/render/file_renderer_test.dart
@@ -2844,13 +2844,11 @@ void main() {
       // dangling comment reference.
       final code = stripComments('''
 /// Uses [Enterprise] and mentions GitHub Milestone Server.
-/* Block Contract */
 final x = Ship();
 ''');
       expect(referencedIdentifiers(code), contains('Enterprise'));
       expect(referencedIdentifiers(code), contains('Ship'));
       expect(referencedIdentifiers(code), isNot(contains('Milestone')));
-      expect(referencedIdentifiers(code), isNot(contains('Contract')));
     });
 
     test('stripComments does not treat a markdown link label as a '
@@ -2879,17 +2877,12 @@ final x = Ship();
       expect(referencedIdentifiers(code), contains('Ship'));
     });
 
-    test('stripComments handles raw, multiline, and escaped strings', () {
-      // Each of these can swallow the rest of the file if its end is
-      // mis-detected: a raw string's backslash does not escape, a
-      // multiline string ends only on the full triple quote, and an
-      // escaped quote does not end an ordinary one.
-      for (final literal in [
-        r"r'a\'",
-        "'''multi ' line'''",
-        r"'it\'s'",
-        r'"say \"hi\""',
-      ]) {
+    test('stripComments finds the end of raw and escaped strings', () {
+      // Either can swallow the rest of the file if its end is
+      // mis-detected: an escaped quote does not close an ordinary
+      // string, and a raw string's backslash does not escape at all, so
+      // it cannot be read as protecting the closing quote.
+      for (final literal in [r"r'a\'", r"'it\'s'", r'"say \"hi\""']) {
         final code = stripComments('final s = $literal; final x = Ship();');
         expect(
           referencedIdentifiers(code),
@@ -2899,21 +2892,14 @@ final x = Ship();
       }
     });
 
-    test('stripComments does not fuse the code on either side of a '
-        'comment', () {
-      // Blanking rather than deleting is what keeps these apart —
-      // deleting would invent the identifier `foobar`.
-      final code = stripComments('foo/* c */bar');
-      expect(referencedIdentifiers(code), containsAll(['foo', 'bar']));
-      expect(referencedIdentifiers(code), isNot(contains('foobar')));
-    });
-
-    test('stripComments handles nested block comments', () {
-      // Dart nests these, so stopping at the first `*/` would resume
-      // treating comment prose as code.
-      final code = stripComments('/* a /* b */ Milestone */ final x = Ship();');
-      expect(referencedIdentifiers(code), contains('Ship'));
-      expect(referencedIdentifiers(code), isNot(contains('Milestone')));
+    test('stripComments does not fuse a comment replacement with the '
+        'code before it', () {
+      // The replacement is space-prefixed for this: an unformatted body
+      // can put a comment straight after an identifier, and `fooBar` is
+      // a reference that never appeared.
+      final code = stripComments('foo//[Bar]');
+      expect(referencedIdentifiers(code), containsAll(['foo', 'Bar']));
+      expect(referencedIdentifiers(code), isNot(contains('fooBar')));
     });
 
     test('importsForModel drops a model named only in prose', () {


### PR DESCRIPTION
## Summary

Stopped counting doc-comment prose as a code reference when deciding a
generated file's imports, closing the last 23 `unused_import` warnings
across the six tracked specs.

## Details

The import gate asks `referencedIdentifiers(body)` whether the rendered
body names a type, but tokenized the *whole* body — doc comments
included. Spec descriptions copy prose verbatim into dartdoc, and that
prose routinely repeats a type's name in English: "GitHub Enterprise
Cloud", "Register New Agent", "Get Market". Every one of the 23
survivors of #269's gate was a sentence, not a reference.

`stripComments` blanks comment prose before the scan. Two things it
deliberately keeps:

- **`[Bracketed]` doc references**, which the analyzer does resolve and
  which do count as uses — but only whitespace-free ones. A real
  reference is an identifier chain; a phrase is a markdown link label.
  github writes `[Link header](https://…)` and spacetraders
  `[Market Overview page](…)`, whose leading words happen to be model
  class names, which is why `dart fix` kept two imports nothing
  references. Those two now go too.
- **String literals, verbatim.** Interpolation carries real references
  (`'${Foo.bar}'`), and keeping an extra identifier only ever keeps an
  extra import. Strings are still *recognized* so the scan can skip past
  them: `Uri.parse('https://x/y')` embeds a `//` that a string-blind
  scan would read as starting a comment, discarding the real code after
  it on that line. That is the one direction this must never fail in —
  dropping code loses a genuine reference, which drops a needed import
  and breaks compilation.

`SchemaUsage`/`ApiUsage` scan the stripped code too: a helper named in
prose is not a call, and an uncalled helper pulled into
`model_helpers.dart` is dead, uncovered code.

## Validation

- Raw lint tail (fix disabled) across the six tracked specs: **35 → 12**,
  `unused_import` closed, no new category introduced.
- Post-fix A/B against `origin/main` on github, spacetraders, and
  discord: byte-identical apart from the two markdown-label imports
  described above.
- All six specs regen `dart analyze`-clean; spacetraders' 732 generated
  tests pass.

## Note

Re-measuring surfaced a `directives_ordering` warning in
`lib/api_client.dart` — **pre-existing on `main`**, not from this
change. It only appears when the package name sorts before `http`
(my A/B output dirs happened to be named that way). `api_client.dart`
is a `.dart` file template with hard-coded import order, so it has the
package-name-dependent hazard that `testImportsContext` already
documents and sorts around. Filed separately.
