### PR TITLE
fix: percent-encode path parameters at substitution time

### DIFF
--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -1372,7 +1372,18 @@ class Endpoint implements ToTemplateContext {
   /// Otherwise the value is interpolated to stringify it, with the
   /// braces dropped for a bare identifier
   /// (`unnecessary_brace_in_string_interps`).
+  ///
+  /// The result is percent-encoded unless the type makes that provably
+  /// a no-op — see [_pathValueNeedsEncoding].
   String _pathReplacement(RenderParameter p, SchemaRenderer context) {
+    final source = _pathStringExpression(p, context);
+    if (!_pathValueNeedsEncoding(p)) return source;
+    return 'Uri.encodeComponent($source)';
+  }
+
+  /// The `String`-valued expression for path parameter [p], before any
+  /// percent-encoding.
+  String _pathStringExpression(RenderParameter p, SchemaRenderer context) {
     final expr = p.toJsonExpression(context);
     final source = _runtimeSource(expr);
     if (p.type.jsonStorageDartType == DartType.string) return source;
@@ -1381,6 +1392,37 @@ class Endpoint implements ToTemplateContext {
     // question about the expression's shape, which the tree answers
     // directly — it used to be a regex over the rendered text.
     return expr is DartIdentifier ? "'\$$source'" : "'\${$source}'";
+  }
+
+  /// Whether [p]'s value has to be percent-encoded before it is
+  /// substituted into the path.
+  ///
+  /// Substitution is textual, so a value carrying a URL-reserved
+  /// character would otherwise change the *structure* of the URL rather
+  /// than ride along as data — a `/` in particular splits one segment
+  /// into two and addresses a different endpoint. Encoding at
+  /// substitution time is the only place the parameter boundary is
+  /// still known.
+  ///
+  /// Numbers and bools are skipped: their `toString()` can only produce
+  /// `[0-9.eE+-]` or `true`/`false`, none of which
+  /// `Uri.encodeComponent` would alter, so wrapping them would be noise
+  /// in the generated source. Every other type — `String`, enums,
+  /// `DateTime`, `Uri` — can contain a reserved character and is
+  /// encoded.
+  //
+  // TODO(eseidel): `allowReserved: true` should select the raw form
+  // here once the parser keeps it (#100).
+  static bool _pathValueNeedsEncoding(RenderParameter p) {
+    // Not `const`: [DartType] overrides `==`, so it cannot be a const
+    // set element.
+    final unreserved = {
+      DartType.int_,
+      DartType.double_,
+      DartType.num_,
+      DartType.bool_,
+    };
+    return !unreserved.contains(p.type.jsonStorageDartType.asNonNullable());
   }
 
   List<String> _queryParamsLines(

--- a/test/render/render_operation_test.dart
+++ b/test/render/render_operation_test.dart
@@ -105,9 +105,73 @@ void main() {
           serverUrl: Uri.parse('https://example.com'),
         ),
       );
-      expect(result, contains(".replaceAll('{name}', name)"));
+      expect(
+        result,
+        contains(".replaceAll('{name}', Uri.encodeComponent(name))"),
+      );
       expect(result, isNot(contains(r"'${ name }'")));
       expect(result, isNot(contains(r"'$name'")));
+    });
+
+    test('path parameter is percent-encoded', () {
+      // Substitution is textual, so an unencoded value carrying a
+      // reserved character changes the URL's structure: a `/` splits
+      // one segment into two and addresses a different endpoint.
+      final operation = {
+        'tags': ['pet'],
+        'operationId': 'getByName',
+        'parameters': [
+          {
+            'name': 'name',
+            'in': 'path',
+            'required': true,
+            'schema': {'type': 'string'},
+          },
+        ],
+        'responses': {
+          '200': {'description': 'ok'},
+        },
+      };
+      final result = runWithLogger(
+        _MockLogger(),
+        () => renderTestOperation(
+          path: '/pet/{name}',
+          operationJson: operation,
+          serverUrl: Uri.parse('https://example.com'),
+        ),
+      );
+      expect(result, contains('Uri.encodeComponent(name)'));
+    });
+
+    test('numeric path parameter is not encoded', () {
+      // `int.toString()` can only produce `[0-9-]`, none of which
+      // `Uri.encodeComponent` alters, so wrapping it would be noise in
+      // the generated source.
+      final operation = {
+        'tags': ['pet'],
+        'operationId': 'getById',
+        'parameters': [
+          {
+            'name': 'petId',
+            'in': 'path',
+            'required': true,
+            'schema': {'type': 'integer'},
+          },
+        ],
+        'responses': {
+          '200': {'description': 'ok'},
+        },
+      };
+      final result = runWithLogger(
+        _MockLogger(),
+        () => renderTestOperation(
+          path: '/pet/{petId}',
+          operationJson: operation,
+          serverUrl: Uri.parse('https://example.com'),
+        ),
+      );
+      expect(result, contains(r".replaceAll('{petId}', '$petId')"));
+      expect(result, isNot(contains('Uri.encodeComponent')));
     });
 
     test('String query parameter is not stringified with .toString()', () {

--- a/test/templates/api_client_test.dart
+++ b/test/templates/api_client_test.dart
@@ -150,6 +150,32 @@ void main() {
       });
     });
 
+    test('an already-encoded path parameter is not re-encoded', () async {
+      // The generated api layer percent-encodes path parameters before
+      // handing the path over (#283), so the graft must leave those
+      // escapes alone: `Uri(path:)` preserves an existing `%2F` rather
+      // than escaping the `%` into `%252F`. Each half is exercised on
+      // its own elsewhere; this pins that they compose.
+      const value = 'a/b';
+      final path = '/things/{id}'.replaceAll(
+        '{id}',
+        Uri.encodeComponent(value),
+      );
+      Uri? captured;
+      final client = ApiClient(
+        baseUri: Uri.parse('https://example.com/v2'),
+        client: MockClient((req) async {
+          captured = req.url;
+          return Response('', 200);
+        }),
+      );
+      await client.invokeApi(method: Method.get, path: path);
+      expect(captured.toString(), 'https://example.com/v2/things/a%2Fb');
+      // The decisive assertion: the value survives as exactly one
+      // segment, so it addresses the intended endpoint.
+      expect(captured!.pathSegments, ['v2', 'things', 'a/b']);
+    });
+
     // The query renderer builds the `List<String>` for each param. These
     // tests pin what the *actual* sent URL looks like for the two shapes it
     // produces, exercising the real `Uri.replace` encoding — not the


### PR DESCRIPTION
## Summary

Path parameters are now percent-encoded when substituted into the URL,
so a value containing a URL-reserved character is carried as data
instead of changing the structure of the request URL.

## Detail

Substitution was raw text:

```dart
path: '/my/ships/{shipSymbol}'.replaceAll('{shipSymbol}', shipSymbol),
```

A caller-supplied value containing `/` silently addressed a different
endpoint:

```
shipSymbol = 'a/b'  →  /v2/my/ships/a/b     // three segments, wrong route
```

#279 closed the `?` half of this by composing the request `Uri`
field-by-field rather than reparsing a concatenated string — that makes
`Uri(path:)` escape `?`, `#` and space. But it cannot help with `/`,
which is a legal path character and indistinguishable from a separator
once the string is built. Substitution time is the only point where the
parameter boundary is still known.

## Numbers and bools stay unwrapped

`int.toString()` can only produce `[0-9-]`, and `bool` only
`true`/`false` — none of which `Uri.encodeComponent` alters. Wrapping
them would be pure noise in the generated source, so the emit is
unchanged for them:

```dart
path: '/pet/{petId}'.replaceAll('{petId}', '$petId'),           // unchanged
path: '/pet/{name}'.replaceAll('{name}', Uri.encodeComponent(name)),
```

## Verification

Every reserved character round-trips to exactly one path segment, with
no double-encoding — `Uri(path:)` preserves existing escapes, so it
composes correctly with `_appendPath` from #279:

| value | encoded path | `pathSegments` recovers |
|---|---|---|
| `ABC-1` | `/v2/my/ships/ABC-1` | `ABC-1` |
| `a/b` | `/v2/my/ships/a%2Fb` | `a/b` |
| `a?admin=true` | `/v2/my/ships/a%3Fadmin%3Dtrue` | `a?admin=true` |
| `a%2Fb` | `/v2/my/ships/a%252Fb` | `a%2Fb` |
| `100%` | `/v2/my/ships/100%25` | `100%` |

spacetraders (the spec with the most path parameters) regenerates
analyzer-clean.

## Scope

This is the `simple` style default for path parameters, not the whole
of #100 — arrays, objects, and the matrix/label styles are still
unhandled. `allowReserved`, once the parser keeps it, should select the
raw form here; marked with a TODO pointing at #100.

No `gen_tests` fixture declares a path parameter, so there is no golden
churn.

Fixes #283
