### PR TITLE
ci: fail when gen_tests goldens drift from the generator

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -39,12 +39,29 @@ jobs:
 
       - name: Run end-to-end generator tests
         run: |
-          # Regenerate the `types` fixture and run its generated tests —
+          # Regenerate every fixture and run the generated tests —
           # catches runtime issues in emitted code (toJson/fromJson
           # round-tripping, hashCode consistency with ==, etc.) that
           # the unit tests above can't see.
-          dart run tool/gen_tests.dart types
+          #
+          # All fixtures, not just `types`, because the next step diffs
+          # the result: a fixture that is never regenerated can never be
+          # caught drifting.
+          dart run tool/gen_tests.dart
           cd gen_tests/types && dart pub get && dart test
+
+      - name: Verify goldens match the generator
+        run: |
+          # The step above regenerated every fixture in place. Anything
+          # it changed means the committed goldens are stale — an
+          # output-changing PR landed without a regen. Fix by running
+          # `dart run tool/gen_tests.dart` locally and committing.
+          #
+          # Without this, drift is silent: the generated tests pass
+          # against the freshly regenerated tree regardless of what is
+          # committed, so the repo and the generator can disagree
+          # indefinitely (see #280).
+          git diff --exit-code -- gen_tests/
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5


### PR DESCRIPTION
## Summary

CI now fails when the committed `gen_tests` goldens disagree with what
the generator actually produces.

## The gap

The `Run end-to-end generator tests` step regenerated the `types`
fixture and ran its generated tests, but never compared the regenerated
output against what is committed. Those tests pass against the freshly
regenerated tree regardless of the repo's state, so an output-changing
PR could land without a regen and nothing would notice.

That is exactly how the eight stale files in #280 accumulated, across
#268 and #273 — caught only because I happened to regen while working
on something else.

## Change

Two parts:

1. `git diff --exit-code -- gen_tests/` after the regen.
2. The regen widens from `types` to every fixture. A fixture that is
   never regenerated can never be caught drifting, and three of #280's
   four affected packages (`multipart`, `security`, `unsupported_auth`)
   were outside `types`.

## Verification

Simulated the real failure mode rather than just asserting the command
is correct — an output-changing template edit landed without a regen:

| state | `git diff --exit-code -- gen_tests/` |
|---|---|
| clean tree | exits 0 |
| generator changed, goldens not regenerated | exits 1, flags all 4 fixtures |

The 4-fixture result is the part that matters: under the old
`types`-only regen, three of those would have stayed invisible.

## CI time cost: ~+2.6s

Measured, 3 runs each:

| | run 1 | run 2 | run 3 | median |
|---|---|---|---|---|
| `gen_tests.dart types` (before) | 7.67 | 7.31 | 7.14 | **7.4s** |
| `gen_tests.dart` (after, all 4) | 10.15 | 9.98 | 9.76 | **10.0s** |

The diff step itself is 0.02s.

It stays this small because both invocations pay the same fixed cost:
`gen_tests.dart` always runs the `gen_tests/tests` unit suite at the
end, whichever fixtures are named. Going from 1 fixture to 4 adds only
the three extra generations.

Caveat: each added fixture runs its own `dart pub get`, and these
numbers come from a warm pub cache. A fresh CI runner will pay more,
though the deps are ones the root `pub get` already fetches, so it
should stay the same order.

No tracked lockfiles exist under `gen_tests/`, so pub resolution cannot
produce a spurious diff, and `--exit-code` ignores untracked files.
