### PR TITLE
fix: sort .dart template imports at render time

### DIFF
--- a/lib/src/render/file_renderer.dart
+++ b/lib/src/render/file_renderer.dart
@@ -41,6 +41,32 @@ class _ImportCollector extends RenderTreeVisitor {
 /// An `import '<path>';` directive, capturing the path.
 final _importDirectivePattern = RegExp("^import '([^']+)'");
 
+/// [directives] in the order `directives_ordering` wants: `dart:` first,
+/// then everything else, each section alphabetical by path. Returns the
+/// ordered list and the index where the second section starts, which is
+/// also where the conventional blank line goes (0 when there is only one
+/// section).
+///
+/// The rule lives here rather than at each call site because the two
+/// sites express the separator differently — `renderPublicApi` sets a
+/// `separatorBefore` flag its mustache template reads, while
+/// [sortDartImports] writes a real blank line into `.dart` output — and
+/// duplicating the ordering to accommodate that is how the two drift.
+/// If they drift, the symptom is `directives_ordering`, the very lint
+/// this ordering exists to satisfy.
+({List<T> ordered, int sectionBreak}) orderDirectives<T>(
+  Iterable<T> directives,
+  String Function(T) pathOf,
+) {
+  bool isDart(T d) => pathOf(d).startsWith('dart:');
+  final dartOnes = directives.where(isDart).sortedBy(pathOf);
+  final others = directives.whereNot(isDart).sortedBy(pathOf);
+  return (
+    ordered: [...dartOnes, ...others],
+    sectionBreak: dartOnes.isEmpty || others.isEmpty ? 0 : dartOnes.length,
+  );
+}
+
 /// [source] with its leading `import` directives sorted the way
 /// `directives_ordering` wants them: `dart:` first, then everything
 /// else, each section alphabetical by path, one blank line between.
@@ -84,16 +110,14 @@ String sortDartImports(String source) {
     return source;
   }
 
-  final imports = span.where((l) => l.trim().isNotEmpty).toList();
-  String pathOf(String line) =>
-      _importDirectivePattern.firstMatch(line)!.group(1)!;
-  bool isDart(String line) => pathOf(line).startsWith('dart:');
-  final dartImports = imports.where(isDart).sortedBy(pathOf);
-  final otherImports = imports.whereNot(isDart).sortedBy(pathOf);
+  final (:ordered, :sectionBreak) = orderDirectives(
+    span.where((l) => l.trim().isNotEmpty),
+    (line) => _importDirectivePattern.firstMatch(line)!.group(1)!,
+  );
   final sorted = [
-    ...dartImports,
-    if (dartImports.isNotEmpty && otherImports.isNotEmpty) '',
-    ...otherImports,
+    ...ordered.take(sectionBreak),
+    if (sectionBreak > 0) '',
+    ...ordered.skip(sectionBreak),
   ];
   return [
     ...lines.sublist(0, first),
@@ -667,12 +691,12 @@ class FileRenderer {
       for (final path in paths) Import.path('package:$packageName/$path'),
       ...externalExports,
     ];
-    bool isDart(Import e) => e.path.startsWith('dart:');
-    final dartExports = allExports.where(isDart).sortedBy((e) => e.path);
-    final packageExports = allExports.whereNot(isDart).sortedBy((e) => e.path);
-    final orderedExports = [...dartExports, ...packageExports];
+    final (:ordered, :sectionBreak) = orderDirectives(
+      allExports,
+      (e) => e.path,
+    );
     final exportContexts = [
-      for (final (index, e) in orderedExports.indexed)
+      for (final (index, e) in ordered.indexed)
         {
           'path': e.path,
           'hasShow': e.shown.isNotEmpty,
@@ -680,8 +704,7 @@ class FileRenderer {
           // Blank line between the `dart:` and `package:` sections, the
           // conventional Dart grouping (and what `dart fix` inserts when
           // it reorders these itself).
-          'separatorBefore':
-              dartExports.isNotEmpty && index == dartExports.length,
+          'separatorBefore': sectionBreak > 0 && index == sectionBreak,
         },
     ];
     _renderTemplate(

--- a/lib/src/render/file_renderer.dart
+++ b/lib/src/render/file_renderer.dart
@@ -38,6 +38,70 @@ class _ImportCollector extends RenderTreeVisitor {
   }
 }
 
+/// An `import '<path>';` directive, capturing the path.
+final _importDirectivePattern = RegExp("^import '([^']+)'");
+
+/// [source] with its leading `import` directives sorted the way
+/// `directives_ordering` wants them: `dart:` first, then everything
+/// else, each section alphabetical by path, one blank line between.
+///
+/// The `.dart` file templates are real Dart — they analyze and format
+/// in this repo — so their imports are written in a fixed order. That
+/// order cannot be right for every consumer, because a same-package
+/// import's position depends on the package name:
+/// `package:aaa_petstore/auth.dart` sorts before `package:http/http.dart`
+/// and `package:zzz_petstore/auth.dart` after. `api_client.dart` mixes
+/// the two and so tripped `directives_ordering` on any package naming
+/// itself before `http` (#282). `dart fix` was reordering it, which is
+/// why it stayed invisible.
+///
+/// Applied to every `.dart` template rather than just that one, so a
+/// template that later grows a same-package import cannot reintroduce
+/// the bug.
+///
+/// Only the contiguous run of directives at the top is touched, and
+/// only when it holds nothing but imports and blank lines; anything
+/// else (a leading comment inside the run, an `export`) leaves the
+/// source alone. Sorting what we do not fully understand risks
+/// reordering across a directive whose position is load-bearing.
+@visibleForTesting
+String sortDartImports(String source) {
+  final lines = source.split('\n');
+  final first = lines.indexWhere(_importDirectivePattern.hasMatch);
+  if (first == -1) return source;
+  var last = first;
+  for (var i = first; i < lines.length; i++) {
+    if (_importDirectivePattern.hasMatch(lines[i])) {
+      last = i;
+    } else if (lines[i].trim().isNotEmpty) {
+      break;
+    }
+  }
+  final span = lines.sublist(first, last + 1);
+  if (span.any(
+    (l) => l.trim().isNotEmpty && !_importDirectivePattern.hasMatch(l),
+  )) {
+    return source;
+  }
+
+  final imports = span.where((l) => l.trim().isNotEmpty).toList();
+  String pathOf(String line) =>
+      _importDirectivePattern.firstMatch(line)!.group(1)!;
+  bool isDart(String line) => pathOf(line).startsWith('dart:');
+  final dartImports = imports.where(isDart).sortedBy(pathOf);
+  final otherImports = imports.whereNot(isDart).sortedBy(pathOf);
+  final sorted = [
+    ...dartImports,
+    if (dartImports.isNotEmpty && otherImports.isNotEmpty) '',
+    ...otherImports,
+  ];
+  return [
+    ...lines.sublist(0, first),
+    ...sorted,
+    ...lines.sublist(last + 1),
+  ].join('\n');
+}
+
 Set<RenderSchema> collectAllSchemas(RenderSpec spec) {
   final collector = _ModelCollector();
   RenderTreeWalker(visitor: collector).walkRoot(spec);
@@ -462,7 +526,10 @@ class FileRenderer {
   }) {
     final output = templates.loadDartTemplate(name);
     final content = applyMandatoryReplacements(output, replacements);
-    fileWriter.writeFile(path: outPath, content: content);
+    // After replacement, not before: the same-package imports only get
+    // their real paths here, and where those sort among the third-party
+    // ones depends on the package name.
+    fileWriter.writeFile(path: outPath, content: sortDartImports(content));
   }
 
   /// Emit `lib/api_exception.dart`. Override to no-op if the package

--- a/test/render/file_renderer_test.dart
+++ b/test/render/file_renderer_test.dart
@@ -2680,6 +2680,87 @@ void main() {
     );
   });
 
+  group('sortDartImports', () {
+    test('orders the package section by path, not by template order', () {
+      // The #282 shape: a same-package import's position depends on the
+      // package name, so the template cannot hard-code it.
+      const template = '''
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:http/http.dart';
+import 'package:aaa_petstore/api_exception.dart';
+import 'package:aaa_petstore/auth.dart';
+
+export 'package:aaa_petstore/auth.dart';
+''';
+      expect(sortDartImports(template), '''
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:aaa_petstore/api_exception.dart';
+import 'package:aaa_petstore/auth.dart';
+import 'package:http/http.dart';
+
+export 'package:aaa_petstore/auth.dart';
+''');
+    });
+
+    test('a package sorting after http keeps its order', () {
+      const template =
+          "import 'package:http/http.dart';\n"
+          "import 'package:zzz_petstore/auth.dart';\n";
+      expect(sortDartImports(template), template);
+    });
+
+    test('dart: imports come first, with a blank line after', () {
+      expect(
+        sortDartImports("import 'package:a/a.dart';\nimport 'dart:io';\n"),
+        "import 'dart:io';\n\nimport 'package:a/a.dart';\n",
+      );
+    });
+
+    test('no blank line is added when a section is empty', () {
+      const onlyPackages =
+          "import 'package:a/a.dart';\nimport 'package:b/b.dart';\n";
+      expect(sortDartImports(onlyPackages), onlyPackages);
+      const onlyDart = "import 'dart:async';\nimport 'dart:io';\n";
+      expect(sortDartImports(onlyDart), onlyDart);
+    });
+
+    test('a source with no imports is untouched', () {
+      const source = '// just a comment\nvoid main() {}\n';
+      expect(sortDartImports(source), source);
+    });
+
+    test('leaves the source alone when the run holds a non-import', () {
+      // Rather than reorder across a directive whose position might be
+      // load-bearing.
+      const source =
+          "import 'package:b/b.dart';\n"
+          '// a comment between directives\n'
+          "import 'package:a/a.dart';\n";
+      expect(sortDartImports(source), source);
+    });
+
+    test('preserves content before and after the import run', () {
+      const source =
+          '// License header.\n'
+          "import 'package:b/b.dart';\n"
+          "import 'package:a/a.dart';\n"
+          '\n'
+          'void main() {}\n';
+      expect(
+        sortDartImports(source),
+        '// License header.\n'
+        "import 'package:a/a.dart';\n"
+        "import 'package:b/b.dart';\n"
+        '\n'
+        'void main() {}\n',
+      );
+    });
+  });
+
   group('FileRenderer', () {
     test('imports for model', () {
       final templates = TemplateProvider.defaultLocation();


### PR DESCRIPTION
## Summary

Fixed `api_client.dart` tripping `directives_ordering` for any generated
package whose name sorts before `http`, by sorting `.dart` template imports
at render time.

## Details

`lib/api_client.dart` comes from a `.dart` file template — real Dart that
analyzes and formats in this repo — so its imports are written in a fixed
order, mixing `package:http/http.dart` with two same-package imports. No
fixed order can be right for every consumer, because a same-package import's
position depends on the package name:

```dart
// aaa_petstore                          // zzz_petstore
import 'package:aaa_petstore/auth.dart'; import 'package:http/http.dart';
import 'package:http/http.dart';         import 'package:zzz_petstore/auth.dart';
```

`_renderDartFile` now sorts the leading import run **after** applying
replacements — after, because that is when same-package imports get their
real paths and the ordering question becomes answerable.

Applied to every `.dart` template rather than only `api_client`, so a
template that later grows a same-package import cannot reintroduce this.

The sort is deliberately narrow: it touches a contiguous run of imports and
blank lines, and if that run holds anything else it returns the source
untouched rather than risk reordering across a directive whose position is
load-bearing.

### Audit

The issue asks to check the other `.dart` templates. `api_exception`, `auth`
and `date` each carry a single `package:meta` import with no same-package
sibling, so none has the hazard today. The render-time sort covers them
anyway.

## Testing

Seven unit tests on `sortDartImports` covering the `#282` shape, the
after-`http` case, `dart:` section placement, empty sections, no-imports,
the bail-out, and content preserved around the run.

Raw lints across the six tracked specs, `dart fix` disabled:

| | before | after |
|---|---|---|
| `directives_ordering` | 3 | **0** |
| every other category | unchanged | unchanged |
| analyzer errors | 0 | 0 |

A/B against `origin/main`:

| spec | diff |
|---|---|
| github, backstage, discord | `api_client.dart` only, imports reordered, **0** non-import lines |
| petstore, spacetraders, train_travel | byte-identical (p/s/t sort after h) |

Full `dart test` green, `dart analyze` and `dart format` clean.

Fixes #282

---

## Self-review follow-up (0bfdb56)

Reviewing for DRY: the first commit added a **second** encoding of the
`directives_ordering` rule, alongside the one `renderPublicApi` already
had for exports.

| site | elements | separator expressed as |
|---|---|---|
| `renderPublicApi` | `Import` objects | `separatorBefore` flag for mustache |
| `sortDartImports` | lines of text | a real blank line |

Same rule — `dart:` first, each section alphabetical by path, blank line
between — written twice. That difference in how the separator is rendered is
precisely what would have justified keeping them apart, and it is also how
they would have drifted. If they drifted, the symptom is
`directives_ordering`: the very lint the ordering exists to satisfy.

`orderDirectives` now holds the rule and returns the ordered list plus the
index where the second section begins; each caller renders its own separator.

Checked by regeneration rather than unit tests alone, since
`renderPublicApi` emits `lib/api.dart` for every spec: all six byte-identical
to the previous commit, lint tally unmoved.