### PR TITLE
refactor: ask the tree which schemas a file names, not the text

### DIFF
--- a/lib/src/render.dart
+++ b/lib/src/render.dart
@@ -276,6 +276,32 @@ String renderTestSchema(
   Quirks quirks = const Quirks(),
   bool asComponent = false,
 }) {
+  final templates = TemplateProvider.defaultLocation();
+  final schemaRenderer = SchemaRenderer(templates: templates, quirks: quirks);
+  return schemaRenderer
+      .renderSchema(
+        renderTestSchemaTree(
+          schemaJson,
+          schemaName: schemaName,
+          quirks: quirks,
+          asComponent: asComponent,
+        ),
+      )
+      .body;
+}
+
+/// Parse, resolve, and name [schemaJson], stopping at the render tree.
+///
+/// The same pipeline [renderTestSchema] runs, minus the templates —
+/// for tests that ask questions of the tree itself (what a schema
+/// names, how it dispatches) rather than of the emitted text.
+@visibleForTesting
+RenderSchema renderTestSchemaTree(
+  Map<String, dynamic> schemaJson, {
+  String schemaName = 'test',
+  Quirks quirks = const Quirks(),
+  bool asComponent = false,
+}) {
   final MapContext context;
   // If asComponent is true, we need to parse the schema as though it were
   // defined in #/components/schemas/schemaName, this is used to make
@@ -299,11 +325,7 @@ String renderTestSchema(
   );
   final resolver = SpecResolver(quirks)
     ..names = assignNamesForSchema(resolvedSchema);
-  final templates = TemplateProvider.defaultLocation();
-
-  final renderSchema = resolver.toRenderSchema(resolvedSchema);
-  final schemaRenderer = SchemaRenderer(templates: templates, quirks: quirks);
-  return schemaRenderer.renderSchema(renderSchema).body;
+  return resolver.toRenderSchema(resolvedSchema);
 }
 
 /// Render a set of schemas to separate strings.

--- a/lib/src/render/file_renderer.dart
+++ b/lib/src/render/file_renderer.dart
@@ -132,18 +132,6 @@ Set<RenderSchema> collectAllSchemas(RenderSpec spec) {
   return collector.schemas;
 }
 
-Set<RenderSchema> collectSchemasUnderApi(Api api) {
-  final collector = _ModelCollector();
-  RenderTreeWalker(visitor: collector).walkApi(api);
-  return collector.schemas;
-}
-
-Set<RenderSchema> collectSchemasUnderSchema(RenderSchema schema) {
-  final collector = _ModelCollector();
-  RenderTreeWalker(visitor: collector).walkSchema(schema);
-  return collector.schemas;
-}
-
 @visibleForTesting
 void logNameCollisions(Iterable<RenderSchema> schemas) {
   // List schemas with name collisions but different pointers.
@@ -791,6 +779,29 @@ class FileRenderer {
     return imports.where((i) => seen.add((i.path, i.asName)));
   }
 
+  /// The imports implied by the schemas a file names.
+  ///
+  /// Both file kinds need the same three things once [schemasNamedBy] /
+  /// [schemasNamedByApi] has answered: a directive per newtype, the
+  /// library imports contributed by the schemas rendered inline, and
+  /// `date.dart` when a `format: date` field is among them. Only the
+  /// question of *which* schemas differs between an api file and a
+  /// model file, so only that is asked separately.
+  ///
+  /// [names] gates the library imports on what the body actually
+  /// emitted — whether a `format: date` field survived into this file
+  /// is a fact about the template, not about the tree.
+  Iterable<Import> _importsForNamedSchemas(
+    NamedSchemas named, {
+    required bool Function(String) names,
+  }) => {
+    ...named.inline
+        .expand((s) => s.additionalImports)
+        .where((i) => i.library.isNeededBy(names)),
+    ..._dateImportFor(named.inline, bodyNamesDate: names('Date')),
+    ...named.imported.map((s) => Import.path(modelPackageImport(this, s))),
+  };
+
   @visibleForTesting
   Iterable<Import> importsForApi(
     Api api,
@@ -829,33 +840,15 @@ class FileRenderer {
       ...usage.importsFor(packageName),
     };
 
-    final apiSchemas = collectSchemasUnderApi(api);
-    final inlineSchemas = apiSchemas.where((s) => !s.createsNewType);
-    // Every newtype (including RenderRecursiveRef, which points at one)
-    // lives in its own file and needs an import at the use site —
-    // except smooshed variants, which are emitted inline in their
-    // sealed parent's file. The sealed parent is itself imported
-    // here, so the variant's class name resolves through that import.
-    // A newtype under the api that the body never names (e.g. a type
-    // nested inside another model, referenced only in that model's own
-    // file) is not imported.
-    final importedSchemas = apiSchemas
-        .where((s) => s.createsNewType)
-        .where((s) => !s.isSmooshed)
-        .where((s) => names(s.typeName));
-    final apiImports = importedSchemas
-        .map((s) => Import.path(modelPackageImport(this, s)))
-        .toList();
-    imports.addAll({
-      // Gated on what each library provides, the same as the fixed
-      // imports above — see [Import.provides].
-      ...inlineSchemas
-          .expand((s) => s.additionalImports)
-          .where((i) => i.library.isNeededBy(names)),
-      ..._dateImportFor(inlineSchemas, bodyNamesDate: names('Date')),
-      ...apiImports,
-    });
-    return _dedupeRenderedImports(imports);
+    // Which schemas the endpoint methods name — asked of the render
+    // tree, not of the rendered text. Every newtype (including
+    // RenderRecursiveRef, which points at one) lives in its own file
+    // and needs an import at the use site; smooshed variants resolve
+    // through their sealed parent, which is imported instead.
+    return _dedupeRenderedImports(
+      imports
+        ..addAll(_importsForNamedSchemas(schemasNamedByApi(api), names: names)),
+    );
   }
 
   /// Emit one `lib/api/<tag>_api.dart` per [Api]. Returns the list of
@@ -914,39 +907,21 @@ class FileRenderer {
     required String body,
   }) {
     final referenced = referencedIdentifiers(body);
-    final referencedSchemas = collectSchemasUnderSchema(schema);
-    final localSchemas = referencedSchemas.where(
-      (s) => !s.createsNewType,
-    );
-    // Every newtype (including RenderRecursiveRef) imports the target's
-    // file — except smooshed variants, which the sealed parent emits
-    // inline (same library, no separate file to import). A newtype the
-    // body never names (a type nested inside another model, referenced
-    // only in that model's own file) is not imported.
-    final importedSchemas = referencedSchemas
-        .where((s) => s.createsNewType)
-        .where((s) => !s.isSmooshed)
-        .where((s) => referenced.contains(s.typeName))
-        .toSet();
-    final referencedImports = importedSchemas
-        .map((s) => Import.path(modelPackageImport(this, s)))
-        .toList();
+    bool names(String token) => referenced.contains(token);
 
-    // `additionalImports` are collected from the schema *tree*, but the
-    // body only emits code for part of it, so each is gated on what its
-    // library provides (see [Import.provides]). Same discipline
-    // [importsForApi] applies to the api file's fixed imports.
-    bool bodyNeeds(Import i) => i.library.isNeededBy(referenced.contains);
+    // Which schemas this file's own declarations name — asked of the
+    // render tree, not of the rendered text. Every newtype (including
+    // RenderRecursiveRef) resolves through an import; smooshed variants
+    // and inline structure are rendered here and resolve locally.
+    final named = schemasNamedBy(schema);
 
     final imports = {
       ...usage.importsFor(packageName),
-      ...schema.additionalImports.where(bodyNeeds),
-      ...localSchemas.expand((s) => s.additionalImports).where(bodyNeeds),
-      ..._dateImportFor(
-        localSchemas,
-        bodyNamesDate: referenced.contains('Date'),
-      ),
-      ...referencedImports,
+      // The root schema's own contributions; the rest come from what it
+      // names. Gated on the body, like every library import — see
+      // [_importsForNamedSchemas].
+      ...schema.additionalImports.where((i) => i.library.isNeededBy(names)),
+      ..._importsForNamedSchemas(named, names: names),
     };
     // A file never imports itself.
     final selfPath = modelPackageImport(this, schema);

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -1798,39 +1798,9 @@ class Endpoint implements ToTemplateContext {
         responseFromJson = null;
     }
 
-    // Collect error-body schemas from `default:`, `4XX:`, and `5XX:` and
-    // deduplicate by structural equality. When they all resolve to the same
-    // schema (the common case — most specs alias every error to a single
-    // `ErrorResponse`), emit a typed `ApiException<ErrorType>` throw.
-    // When they disagree, fall back to untyped — picking one would lie
-    // to callers about what they'll actually catch.
-    //
-    // Skip `RenderNoJson` subclasses (RenderVoid, RenderBinary) — a
-    // `default:` response with no content resolves to `RenderVoid`, whose
-    // `fromJsonExpression` returns empty string and `typeName` is `void`,
-    // which produced uncompilable Dart like `ApiException<void>(body: ,)`
-    // before this skip (most famously on petstore, whose 4xx/default
-    // responses carry only a description).
-    final errorSchemas = <RenderSchema>[
-      ?operation.defaultResponse?.content,
-      ...operation.rangeResponses
-          .where(
-            (e) =>
-                e.range == StatusCodeRange.clientError ||
-                e.range == StatusCodeRange.serverError,
-          )
-          .map((e) => e.content),
-    ];
-    final distinctErrorSchemas = <RenderSchema>[];
-    for (final schema in errorSchemas) {
-      if (schema is RenderNoJson) continue;
-      if (!distinctErrorSchemas.any((e) => e.equalsIgnoringName(schema))) {
-        distinctErrorSchemas.add(schema);
-      }
-    }
-    final errorSchema = distinctErrorSchemas.length == 1
-        ? distinctErrorSchemas.first
-        : null;
+    // See [RenderOperation.errorSchema] for which error body this is
+    // and why it lives on the operation.
+    final errorSchema = operation.errorSchema;
     final hasErrorType = errorSchema != null;
     final errorType = errorSchema?.typeName;
     final errorFromJson = errorSchema?.fromJsonExpression(
@@ -2007,6 +1977,48 @@ class RenderOperation {
   /// so the referenced type is always generated even when no specific
   /// 4xx/5xx status code also references it.
   final RenderDefaultResponse? defaultResponse;
+
+  /// The error body the API method's `throw` names, or null when it
+  /// throws untyped.
+  ///
+  /// Collects error-body schemas from `default:`, `4XX:` and `5XX:` and
+  /// deduplicates them by structural equality. When they all resolve to
+  /// one schema — the common case, since most specs alias every error
+  /// to a single `ErrorResponse` — the method emits a typed
+  /// `ApiException<ErrorType>`. When they disagree, it falls back to
+  /// untyped: picking one would lie to callers about what they will
+  /// actually catch.
+  ///
+  /// `RenderNoJson` subclasses (`RenderVoid`, `RenderBinary`) are
+  /// skipped. A `default:` response with no content resolves to
+  /// `RenderVoid`, whose `typeName` is `void`, which used to emit
+  /// uncompilable `ApiException<void>(body: ,)` (petstore, whose
+  /// 4xx/default responses carry only a description).
+  ///
+  /// A getter rather than a local in the template-context builder
+  /// because the import decision has to ask the same question: the api
+  /// file names this type, so it imports it. Two readers of one
+  /// definition cannot disagree about what was emitted.
+  RenderSchema? get errorSchema {
+    final candidates = <RenderSchema>[
+      ?defaultResponse?.content,
+      ...rangeResponses
+          .where(
+            (e) =>
+                e.range == StatusCodeRange.clientError ||
+                e.range == StatusCodeRange.serverError,
+          )
+          .map((e) => e.content),
+    ];
+    final distinct = <RenderSchema>[];
+    for (final schema in candidates) {
+      if (schema is RenderNoJson) continue;
+      if (!distinct.any((e) => e.equalsIgnoringName(schema))) {
+        distinct.add(schema);
+      }
+    }
+    return distinct.length == 1 ? distinct.first : null;
+  }
 
   /// What the operation's API method returns. Sealed so emit-time code
   /// (template context, walker) pattern-matches on the case rather than
@@ -5130,6 +5142,21 @@ class RenderOneOf extends RenderNewType {
       toJson: conversion.toJson,
       positionalBoolIgnore: conversion.positionalBoolIgnore,
     );
+  }
+
+  /// Whether the emitted body dispatches on the variants — and so
+  /// names them — or falls back to the `UnimplementedError` stub, which
+  /// names nothing.
+  ///
+  /// This is the `decideDispatch(source) is! NoDispatch` prediction that
+  /// [additionalImports] below deliberately stopped asking. It is sound
+  /// here and unsound there for the same reason: the case that broke it
+  /// is a oneOf whose dispatch fires with *no* variants, which emits no
+  /// `@immutable` but also has no variant to name. A prediction only
+  /// hurts where it can disagree with what was emitted.
+  bool get emitsVariantDispatch {
+    final src = source;
+    return src != null && decideDispatch(src) is! NoDispatch;
   }
 
   @override

--- a/lib/src/render/tree_visitor.dart
+++ b/lib/src/render/tree_visitor.dart
@@ -125,3 +125,147 @@ class RenderTreeWalker {
     walkSchema(response.content);
   }
 }
+
+/// The schemas one generated file's own declarations name, split by how
+/// the name resolves.
+///
+/// This is a different question from the one [RenderTreeWalker] answers,
+/// and conflating the two is what forced import decisions to be made by
+/// re-reading rendered output. The walker answers **what must exist**:
+/// every schema reachable from the spec, so that each one gets a file.
+/// This answers **what does this file name**, which is what decides the
+/// file's imports. They differ because a newtype's internals are named
+/// only inside the newtype's own file — walking through it over-reports
+/// for import purposes.
+class NamedSchemas {
+  const NamedSchemas({required this.imported, required this.inline});
+
+  /// Newtypes the body names. Each renders to its own file, so each
+  /// needs an import at this use site.
+  final Set<RenderSchema> imported;
+
+  /// Schemas whose code this file renders itself: inline structure
+  /// (arrays, maps, non-newtype objects) and smooshed variants, which
+  /// a sealed parent emits into its own library. Named without an
+  /// import, but they can still contribute library imports of their
+  /// own (see `RenderSchema.additionalImports`).
+  final Set<RenderSchema> inline;
+}
+
+/// Collects the schemas named by the file rendered for [root].
+///
+/// Descends through everything this file renders and stops at every
+/// newtype boundary, which is exactly where a name starts resolving
+/// through an import instead of through local code.
+NamedSchemas schemasNamedBy(RenderSchema root) =>
+    (_NamedSchemaCollector()..collectRoot(root)).result;
+
+/// The schemas the api file's endpoint methods name.
+///
+/// An api method names its parameter types, its request body, whatever
+/// its return dispatch emits, and the one error body it throws — and
+/// nothing else. Notably it does not name every response the spec
+/// declares: per-status 4xx/5xx bodies that disagree with each other
+/// collapse to `ApiException<Object?>`, so the tree carries response
+/// schemas the file never mentions. (Those schemas still get their own
+/// files and barrel exports; that is [RenderTreeWalker]'s question, not
+/// this one.)
+///
+/// Asking [RenderOperation.returnShape] and [RenderOperation.errorSchema]
+/// rather than the raw response lists is what keeps this honest as the
+/// generator grows: both are the same values the template renders from,
+/// so when error dispatch lands they grow and this grows with them, with
+/// no second place to remember to update.
+NamedSchemas schemasNamedByApi(Api api) {
+  final collector = _NamedSchemaCollector();
+  for (final endpoint in api.endpoints) {
+    final operation = endpoint.operation;
+    for (final parameter in operation.parameters) {
+      collector.collect(parameter.type);
+    }
+    final requestBody = operation.requestBody;
+    if (requestBody != null) collector.collect(requestBody.schema);
+    // The method throws `ApiException<ErrorType>` when the spec's error
+    // responses agree on one body, so that type is named too.
+    final errorSchema = operation.errorSchema;
+    if (errorSchema != null) collector.collect(errorSchema);
+    switch (operation.returnShape) {
+      case SingleSchemaReturn(:final schema):
+        collector.collect(schema);
+      case MultiStatusReturn(:final responses):
+        // The sealed wrapper and its per-status subclasses are emitted
+        // into the api file itself, so what needs importing is each
+        // status's body type.
+        for (final response in responses.values) {
+          collector.collect(response.content);
+        }
+    }
+  }
+  return collector.result;
+}
+
+class _NamedSchemaCollector {
+  final Set<RenderSchema> imported = {};
+  final Set<RenderSchema> inline = {};
+
+  NamedSchemas get result => NamedSchemas(imported: imported, inline: inline);
+
+  /// Collects from [schema] itself, which this file renders — so it is
+  /// never its own import.
+  void collectRoot(RenderSchema schema) => _collect(schema, isRoot: true);
+
+  /// Collects a schema the file refers to rather than declares.
+  void collect(RenderSchema schema) => _collect(schema, isRoot: false);
+
+  void _collect(RenderSchema schema, {required bool isRoot}) {
+    if (!isRoot) {
+      // A smooshed variant creates a type but has no file of its own —
+      // its sealed parent renders it — so it resolves locally, and this
+      // file goes on to name whatever the variant names.
+      if (schema.createsNewType && !schema.isSmooshed) {
+        imported.add(schema);
+        return;
+      }
+      // Descend each inline schema once. An api file's endpoints share
+      // structure freely, so without this the same subtree is re-walked
+      // per endpoint that reaches it.
+      if (!inline.add(schema)) return;
+    }
+    switch (schema) {
+      case RenderObject():
+        for (final property in schema.properties.values) {
+          _collect(property, isRoot: false);
+        }
+        final additional = schema.additionalProperties;
+        if (additional != null) _collect(additional, isRoot: false);
+      case RenderArray():
+        _collect(schema.items, isRoot: false);
+      case RenderOneOf():
+        // A oneOf with no dispatch emits an `UnimplementedError` stub
+        // that names no variant, so it imports none of them. Asking the
+        // oneOf rather than assuming keeps this in step with what the
+        // dispatch actually emits.
+        if (schema.emitsVariantDispatch) {
+          for (final variant in schema.schemas) {
+            _collect(variant, isRoot: false);
+          }
+        }
+      case RenderMap():
+        _collect(schema.valueSchema, isRoot: false);
+        final keySchema = schema.keySchema;
+        if (keySchema != null) _collect(keySchema, isRoot: false);
+      // Leaves: a recursive ref is handled above (it creates a type and
+      // points at the file that renders it), and the rest name nothing
+      // beyond themselves.
+      case RenderRecursiveRef():
+      case RenderEnum():
+      case RenderString():
+      case RenderInteger():
+      case RenderNumber():
+      case RenderPod():
+      case RenderUnknown():
+      case RenderVoid():
+        break;
+    }
+  }
+}

--- a/test/render/render_tree_test.dart
+++ b/test/render/render_tree_test.dart
@@ -1050,8 +1050,9 @@ void main() {
 
     test('walker visits it as a leaf (collected, not recursed)', () {
       // RenderObject holds a RenderRecursiveRef among its properties.
-      // collectSchemasUnderSchema returns them both so the file renderer
-      // can emit the import for the ref target.
+      // The walker collects both without recursing through the ref, so
+      // the ref target still gets a file. (Which files *name* it — and
+      // so import it — is `schemasNamedBy`, a separate question.)
       const nodeObject = RenderObject(
         common: CommonProperties.test(
           snakeName: 'node',

--- a/test/render/tree_visitor_test.dart
+++ b/test/render/tree_visitor_test.dart
@@ -128,5 +128,54 @@ void main() {
       expect((oneOf as RenderOneOf).emitsVariantDispatch, isTrue);
       expect(schemasNamedBy(oneOf).inline, isNotEmpty);
     });
+
+    test('descends into additionalProperties', () {
+      // `Map<String, Deep>` as a schema's additionalProperties names
+      // Deep, the same as a declared field of that type would.
+      final deep = _object('Deep');
+      final outer = RenderObject(
+        common: CommonProperties.test(
+          snakeName: 'outer',
+          pointer: JsonPointer.parse('#/components/schemas/outer'),
+          description: 'Outer',
+        ),
+        assignedName: 'Outer',
+        properties: const {},
+        additionalProperties: deep,
+      );
+
+      expect(schemasNamedBy(outer).imported, contains(deep));
+    });
+
+    test('descends into a map key schema', () {
+      // A typed key is an enum the file round-trips each key through, so
+      // it is named just like the value type.
+      final keyEnum = RenderStringEnum(
+        common: CommonProperties.test(
+          snakeName: 'key_kind',
+          pointer: JsonPointer.parse('#/components/schemas/key_kind'),
+          description: 'KeyKind',
+        ),
+        assignedName: 'KeyKind',
+        values: const ['a'],
+        names: const ['a'],
+        descriptions: null,
+      );
+      final value = _object('Value');
+      final map = RenderMap(
+        common: CommonProperties.test(
+          snakeName: 'map',
+          pointer: JsonPointer.parse('#/components/schemas/outer/map'),
+          description: 'Map',
+        ),
+        valueSchema: value,
+        keySchema: keyEnum,
+      );
+      final outer = _object('Outer', properties: {'map': map});
+
+      final imported = schemasNamedBy(outer).imported;
+      expect(imported, contains(keyEnum));
+      expect(imported, contains(value));
+    });
   });
 }

--- a/test/render/tree_visitor_test.dart
+++ b/test/render/tree_visitor_test.dart
@@ -1,0 +1,132 @@
+import 'package:space_gen/src/render.dart';
+import 'package:space_gen/src/render/render_tree.dart';
+import 'package:space_gen/src/render/tree_visitor.dart';
+import 'package:space_gen/src/types.dart';
+import 'package:test/test.dart';
+
+RenderObject _object(
+  String name, {
+  Map<String, RenderSchema> properties = const {},
+  String? parentSealedTypeName,
+}) => RenderObject(
+  common: CommonProperties.test(
+    snakeName: name.toLowerCase(),
+    pointer: JsonPointer.parse('#/components/schemas/${name.toLowerCase()}'),
+    description: name,
+  ),
+  assignedName: name,
+  properties: properties,
+  parentSealedTypeName: parentSealedTypeName,
+);
+
+void main() {
+  group('schemasNamedBy', () {
+    test('stops at a newtype boundary', () {
+      // Outer names a Nested-typed field; Nested owns a Deep-typed one.
+      // Deep is named only in Nested's own file, so Outer must not
+      // import it — this is the over-reporting that made the import
+      // decision fall back to grepping rendered output.
+      final deep = _object('Deep');
+      final nested = _object('Nested', properties: {'deep': deep});
+      final outer = _object('Outer', properties: {'nested': nested});
+
+      final named = schemasNamedBy(outer);
+      expect(named.imported, contains(nested));
+      expect(named.imported, isNot(contains(deep)));
+      expect(named.imported, isNot(contains(outer)));
+    });
+
+    test('descends through inline structure to the newtype inside', () {
+      // `List<Deep>` names Deep even though the array itself is inline.
+      final deep = _object('Deep');
+      final list = RenderArray(
+        common: CommonProperties.test(
+          snakeName: 'list',
+          pointer: JsonPointer.parse('#/components/schemas/outer/list'),
+          description: 'List',
+        ),
+        items: deep,
+      );
+      final outer = _object('Outer', properties: {'list': list});
+
+      final named = schemasNamedBy(outer);
+      expect(named.imported, contains(deep));
+      expect(named.inline, contains(list));
+    });
+
+    test('descends into a smooshed variant, which has no file of its '
+        'own', () {
+      // A smooshed variant is emitted inline in its sealed parent's
+      // library, so the parent names whatever the variant names — and
+      // must not import the variant itself.
+      final deep = _object('Deep');
+      final variant = _object(
+        'Variant',
+        properties: {'deep': deep},
+        parentSealedTypeName: 'Outer',
+      );
+      final outer = _object('Outer', properties: {'variant': variant});
+
+      final named = schemasNamedBy(outer);
+      expect(variant.isSmooshed, isTrue);
+      expect(named.inline, contains(variant));
+      expect(named.imported, isNot(contains(variant)));
+      expect(named.imported, contains(deep));
+    });
+
+    test('a oneOf that emits the stub names none of its variants', () {
+      // A synthesized oneOf (no resolved source) falls back to the
+      // `UnimplementedError` stub, whose body names no variant. github's
+      // `IssueEventForIssue` is the real case: 15 variants, none of
+      // which the emitted file mentions.
+      final variantA = _object('VariantA');
+      final variantB = _object('VariantB');
+      final oneOf = RenderOneOf(
+        common: CommonProperties.test(
+          snakeName: 'choice',
+          pointer: JsonPointer.parse('#/components/schemas/choice'),
+          description: 'Choice',
+        ),
+        schemas: [variantA, variantB],
+        discriminator: null,
+        source: null,
+        assignedName: 'Choice',
+        assignedSnakeName: 'choice',
+      );
+
+      expect(oneOf.emitsVariantDispatch, isFalse);
+      final named = schemasNamedBy(oneOf);
+      expect(named.imported, isEmpty);
+    });
+
+    test('a oneOf that dispatches descends into its variants', () {
+      // The other side of the stub case. These two variants dispatch on
+      // which required key is present, so the emitted body constructs
+      // each one and names what it names. They are inline, so they are
+      // smooshed into the parent's library rather than imported — but
+      // the descent is the point: no dispatch, no descent.
+      final oneOf = renderTestSchemaTree({
+        'oneOf': [
+          {
+            'type': 'object',
+            'required': ['a'],
+            'properties': {
+              'a': {'type': 'string'},
+            },
+          },
+          {
+            'type': 'object',
+            'required': ['b'],
+            'properties': {
+              'b': {'type': 'string'},
+            },
+          },
+        ],
+      }, schemaName: 'choice');
+
+      expect(oneOf, isA<RenderOneOf>());
+      expect((oneOf as RenderOneOf).emitsVariantDispatch, isTrue);
+      expect(schemasNamedBy(oneOf).inline, isNotEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Import decisions now ask the render tree which schemas a file names,
instead of rendering the file and grepping it for identifier tokens.
`unused_import` across the six tracked specs goes **23 → 0**, closing
#271.

## Why this shape, and not #281

#281 read #271 as a prose problem — spec descriptions repeat type names
in English ("GitHub Enterprise Cloud"), which kept imports nothing
referenced — and stripped comment prose before the scan. Measuring the
structural alternative against the grep
([writeup in #271](https://github.com/eseidel/space_gen/issues/271))
showed prose was noise on top of a different cause, so #281 is closed.

**One walker was answering two questions.** `RenderTreeWalker` answers
*what must exist*: every schema reachable from the spec, so each one
gets a file. Imports need *what does this file name* — a different set,
because a newtype's internals are named only inside the newtype's own
file. Reusing the broad walk over-reports, and the grep existed to
narrow it back down. On github the two already agreed on 1811 of 1826
model files.

## What changed

`schemasNamedBy` / `schemasNamedByApi` ask the second question directly:
descend through what the file renders, stop at every newtype boundary —
exactly where a name starts resolving through an import rather than
local code. The answer is split because the halves are used
differently: `imported` needs a directive, `inline` (non-newtype
structure plus smooshed variants) contributes only its own library
imports.

**Three places the tree describes more than the templates emit.** Each
has to be asked rather than assumed, and all three were found by
measuring, not by reading:

1. **A oneOf with no dispatch** emits an `UnimplementedError` stub
   naming no variant. `RenderOneOf.emitsVariantDispatch` reports it.
   Without this, github's `IssueEventForIssue` and `TimelineIssueEvents`
   gain **37 unused imports**.
2. **A typed error throw.** An api method emits
   `ApiException<ErrorType>` only when the spec's error responses agree
   on one body. That selection was a local inside the template-context
   builder; it is now `RenderOperation.errorSchema`, read by both the
   template and the import decision. Without it discord and backstage
   **stop compiling** — 231 and 19 errors.
3. **Smooshed variants** create a type but have no file, so the walk
   descends into them rather than importing them.

Point 1 is the judgement call most worth a second opinion: it is the
same `decideDispatch(source) is! NoDispatch` prediction that
`RenderOneOf.additionalImports` **deliberately stopped making**. Its doc
comment argues why it is sound here and unsound there — the case that
broke it is a dispatch firing with *no* variants, which emits no
`@immutable` but equally has no variant to name. A prediction only hurts
where it can disagree with what was emitted.

Library imports still come from the text: whether the body called
`jsonDecode` or named `Uint8List` is a fact about what the *template*
emitted, which the tree does not describe. That is the expression IR's
half (`doc/dart_expression.md`, remaining work 1–2).

`collectSchemasUnderApi` and `collectSchemasUnderSchema` have no callers
left and are deleted.

## Validation

- `unused_import` across all six tracked specs (fix disabled):
  **23 → 0**, no new lint category.
- Post-fix regen of all six is byte-identical to `main` **except two
  imports `dart fix` had been keeping**: `[Link header](url)` and
  `[Market Overview page](url)` — markdown labels whose leading word the
  analyzer resolves as a comment reference. Both files already suppress
  `comment_references`; both analyze clean.
- All six specs `dart analyze` clean. Generated suites pass: petstore
  (28), spacetraders (732), discord (1530).
- 694 unit tests pass, including a new `test/render/tree_visitor_test.dart`
  covering the newtype boundary, inline descent, smoosh descent, and
  both sides of the dispatch/stub split.
- `dart run tool/gen_tests.dart` produces no golden drift.
