### PR TITLE
fix: treat a run of capitals as one word when snake-casing

### DIFF
--- a/lib/src/string.dart
+++ b/lib/src/string.dart
@@ -1,10 +1,30 @@
-// Convert CamelCase to snake_case
+/// Zero-width word boundaries inside a CamelCase identifier.
+///
+/// Two alternatives, which together treat a run of capitals as one
+/// word rather than one word per letter:
+///
+/// - `(?<=[a-z0-9])(?=[A-Z])` — the ordinary case change, `fooBar`.
+/// - `(?<=[A-Z])(?=[A-Z][a-z])` — the end of an acronym, splitting
+///   `XMLHttp` into `XML` + `Http` by breaking before the last capital
+///   of the run only when a lowercase letter follows it.
+///
+/// A capital run with nothing after it (`MACOS`) matches neither, so it
+/// stays whole.
+final _camelWordBoundary = RegExp(
+  '(?<=[a-z0-9])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])',
+);
+
+/// Convert CamelCase to snake_case.
+///
+/// Splits on word boundaries rather than before every capital, so
+/// github's SCREAMING_CAPS property names (`MACOS`, `UBUNTU`) become
+/// `macos` / `ubuntu` instead of `m_a_c_o_s` / `u_b_u_n_t_u`.
 String snakeFromCamel(String camel) {
-  final snake = camel.splitMapJoin(
-    RegExp('[A-Z]'),
-    onMatch: (m) => '_${m.group(0)}'.toLowerCase(),
-    onNonMatch: (n) => n.toLowerCase(),
-  );
+  final snake = camel.split(_camelWordBoundary).join('_').toLowerCase();
+  // A leading underscore is dropped. Callers that compose a name as
+  // `'${parent}_${snakeFromCamel(part)}'` would otherwise emit `__`
+  // for github's `_links` properties — [toSnakeCase] collapses runs,
+  // but the direct callers don't.
   return snake.startsWith('_') ? snake.substring(1) : snake;
 }
 

--- a/test/render/file_renderer_test.dart
+++ b/test/render/file_renderer_test.dart
@@ -2275,9 +2275,12 @@ void main() {
         hasGeneratedSchemaFiles([
           'workflow_usage.dart',
           'workflow_usage_billable.dart',
-          'workflow_usage_billable_u_b_u_n_t_u.dart',
-          'workflow_usage_billable_m_a_c_o_s.dart',
-          'workflow_usage_billable_w_i_n_d_o_w_s.dart',
+          // github declares these properties in SCREAMING_CAPS
+          // (`UBUNTU`, `MACOS`, `WINDOWS`). A run of capitals is one
+          // word, so it snakes to `ubuntu`, not `u_b_u_n_t_u` (#207).
+          'workflow_usage_billable_ubuntu.dart',
+          'workflow_usage_billable_macos.dart',
+          'workflow_usage_billable_windows.dart',
         ]),
       );
     });

--- a/test/string_test.dart
+++ b/test/string_test.dart
@@ -10,6 +10,38 @@ void main() {
     expect(snakeFromCamel('snakeFromCamel'), 'snake_from_camel');
   });
 
+  test('snakeFromCamel treats a run of capitals as one word', () {
+    // github declares properties in SCREAMING_CAPS; splitting before
+    // every capital produced `workflow_usage_billable_m_a_c_o_s` (#207).
+    expect(snakeFromCamel('MACOS'), 'macos');
+    expect(
+      snakeFromCamel('WorkflowUsageBillableMACOS'),
+      'workflow_usage_billable_macos',
+    );
+    // An acronym followed by a word breaks before the last capital of
+    // the run, not after it.
+    expect(snakeFromCamel('XMLHttpRequest'), 'xml_http_request');
+    expect(snakeFromCamel('IOError'), 'io_error');
+    // A trailing acronym and a two-letter one both stay whole.
+    expect(snakeFromCamel('userID'), 'user_id');
+    expect(snakeFromCamel('ID'), 'id');
+    // Digits do not start a new word, but a capital after one does.
+    expect(snakeFromCamel('Types200Response'), 'types200_response');
+    expect(snakeFromCamel('HTTPCode2'), 'http_code2');
+    // Degenerate inputs.
+    expect(snakeFromCamel('A'), 'a');
+    expect(snakeFromCamel(''), '');
+  });
+
+  test('snakeFromCamel drops a leading underscore', () {
+    // github declares `_links` properties. Direct callers compose
+    // `'${parent}_${snakeFromCamel(part)}'`, so keeping the leading
+    // underscore would yield `pull_request__links`. Regression guard:
+    // toSnakeCase collapses `_+`, but these callers do not.
+    expect(snakeFromCamel('_links'), 'links');
+    expect(snakeFromCamel('_Links'), 'links');
+  });
+
   test('toSnakeCase', () {
     expect(toSnakeCase('snakeFromCamel'), 'snake_from_camel');
     expect(toSnakeCase('SnakeFromCamel'), 'snake_from_camel');


### PR DESCRIPTION
## Summary

`snakeFromCamel` split before every capital, so github's SCREAMING_CAPS
property names snaked character-by-character:

```
WorkflowUsageBillableMACOS  →  workflow_usage_billable_m_a_c_o_s
```

Now splits on word boundaries, so a run of capitals is one word:
`workflow_usage_billable_macos`.

## How

Two zero-width alternatives:

- `(?<=[a-z0-9])(?=[A-Z])` — the ordinary case change, `fooBar`.
- `(?<=[A-Z])(?=[A-Z][a-z])` — the end of an acronym run, breaking
  before the *last* capital only when a lowercase letter follows, so
  `XMLHttpRequest` → `xml_http_request`.

A capital run with nothing after it (`MACOS`) matches neither and stays
whole.

## This renames generated classes

Class names follow file names through `camelFromSnake`, so
`WorkflowUsageBillableMACOS` becomes **`WorkflowUsageBillableMacos`**.

That is the Effective Dart convention ("capitalize acronyms longer than
two letters like words" — `HttpRequest`, not `HTTPRequest`), so the
output gets more idiomatic, but it is a visible rename for anyone
regenerating against github or discord. Flagging it as the one
judgement call in this PR.

## Verification: A/B regen across six specs

Both sides generated under **identical package names** (a differing
output dir name changes every import line and swamps the real diff):

| spec | result |
|---|---|
| spacetraders | byte-identical |
| backstage | byte-identical |
| train-travel | byte-identical |
| petstore | byte-identical |
| github | 18 files renamed — all acronym fixes |
| discord | 8 files renamed — all acronym fixes |

Every rename is the intended improvement, e.g.
`s_d_k_message_request` → `sdk_message_request`, `user_p_i_i_response`
→ `user_pii_response`.

Both regenerate analyzer-clean, with **no new name collisions** (the
main risk: two schemas that used to snake differently could now
collide) and no new warnings — github's single warning is pre-existing
and identical on both sides.

## The A/B caught a regression the unit tests didn't

Dropping the leading-underscore strip turned github's `_links`
properties into `pull_request__links`. Direct callers compose
`'${parent}_${snakeFromCamel(part)}'`, and only `toSnakeCase` collapses
`_+` — so the double underscore survived. Every unit test still passed;
only the real-spec regen showed it. Restored, with a test pinning it.

No `gen_tests` golden drift.

Fixes #207
