### PR TITLE
tool: describe gen_tests dirs with a manifest instead of inference

### DIFF
--- a/gen_tests/gen_tests.yaml
+++ b/gen_tests/gen_tests.yaml
@@ -1,0 +1,22 @@
+# Manifest for `tool/gen_tests.dart` — the list of fixtures this
+# directory generates, and how.
+#
+#     dart run tool/gen_tests.dart            # all of them
+#     dart run tool/gen_tests.dart types      # just one
+#     dart run tool/gen_tests.dart --dry-run  # show the mapping only
+#
+# These fixtures are generated WITH `Quirks.openapi()`, unlike the
+# parallel spec repo, which sets `openapi: false`. The quirks flip six
+# flags (dynamicJson, mutableModels, nonNullableDefaultValues,
+# allListsDefaultToEmpty, screamingCapsEnums, flatModelDir), so the
+# setting decides both the `lib/model/` layout and the emitted
+# nullability and mutability.
+openapi: true
+
+# `package:` defaults to the spec's filename with the extension dropped
+# and `.`/`-` folded to `_`, which is what every fixture here wants.
+specs:
+  - spec: multipart.json
+  - spec: security.json
+  - spec: types.json
+  - spec: unsupported_auth.json

--- a/tool/gen_tests.dart
+++ b/tool/gen_tests.dart
@@ -5,16 +5,104 @@ import 'package:file/file.dart';
 import 'package:file/local.dart';
 import 'package:path/path.dart' as p;
 import 'package:space_gen/space_gen.dart';
+import 'package:yaml/yaml.dart';
 
 class TestCase {
   TestCase({
     required this.spec,
     required this.outDir,
+    required this.quirks,
   });
   final File spec;
   final Directory outDir;
 
+  /// Generation settings for this spec.
+  ///
+  /// Not a constant across all test dirs: `Quirks.openapi()` flips six
+  /// flags that change emitted *semantics* (`dynamicJson`,
+  /// `mutableModels`, `nonNullableDefaultValues`, …), not just the
+  /// `lib/model/` vs `lib/models/` layout. This repo's fixtures are
+  /// generated with it; the parallel spec repo is generated without.
+  /// Hardcoding either one silently rewrites the other's output.
+  final Quirks quirks;
+
   String get packageName => outDir.basename;
+}
+
+/// Spec file extensions [collectTests] will pick up when a directory
+/// has no manifest.
+///
+/// A directory holding YAML that is *not* a spec (`cspell.config.yaml`,
+/// `analysis_options.yaml`) must use a manifest, which replaces the
+/// scan; otherwise that file is treated as a spec.
+const _specExtensions = ['.json', '.yaml', '.yml'];
+
+/// Name of the optional per-directory manifest, e.g.
+///
+/// ```yaml
+/// specs:
+///   - spec: api.github.com.json
+///     package: github          # optional; defaults to the derived name
+///   - spec: train-travel.yaml
+///     package: train_travel
+/// ```
+///
+/// A directory carrying one is described entirely by it — the spec list
+/// is explicit rather than scanned, and each entry may override the
+/// package name. Without a manifest the directory is scanned as before,
+/// which is why `gen_tests/` in this repo needs no config.
+///
+/// The override exists because the package name is otherwise forced to
+/// be a mangling of the spec's filename: `api.github.com.json` would
+/// have to live in `api_github_com/`. The parallel spec repo prefers
+/// `github/`, and renaming the *input* files to control the output
+/// directory is the wrong lever.
+const _manifestName = 'gen_tests.yaml';
+
+/// The package name [spec]'s filename implies: extension dropped, and
+/// `.`/`-` (illegal in a Dart package name) folded to `_`.
+String _derivePackageName(File spec) => p
+    .basenameWithoutExtension(spec.path)
+    .replaceAll('.', '_')
+    .replaceAll('-', '_');
+
+/// Reads [_manifestName] from [testDir], or returns null if absent.
+///
+/// Throws on a malformed manifest or a listed spec that does not exist
+/// — a typo'd entry silently generating nothing is exactly the failure
+/// this file is meant to remove.
+List<TestCase>? _testsFromManifest(Directory testDir) {
+  final manifest = testDir.childFile(_manifestName);
+  if (!manifest.existsSync()) return null;
+  final doc = loadYaml(manifest.readAsStringSync());
+  if (doc is! Map || doc['specs'] is! List) {
+    throw Exception('${manifest.path}: expected a top-level `specs:` list');
+  }
+  // Directory-wide default, overridable per spec. `true` matches the
+  // unmanifested behavior below, so adding a manifest to an existing
+  // directory changes nothing until you say otherwise.
+  final dirOpenapi = doc['openapi'] as bool? ?? true;
+  final tests = <TestCase>[];
+  for (final entry in doc['specs'] as List) {
+    if (entry is! Map || entry['spec'] is! String) {
+      throw Exception('${manifest.path}: each entry needs a `spec:` path');
+    }
+    final specFile = testDir.childFile(entry['spec'] as String);
+    if (!specFile.existsSync()) {
+      throw Exception('${manifest.path}: no such spec ${specFile.path}');
+    }
+    final packageName =
+        (entry['package'] as String?) ?? _derivePackageName(specFile);
+    final openapi = entry['openapi'] as bool? ?? dirOpenapi;
+    tests.add(
+      TestCase(
+        spec: specFile,
+        outDir: testDir.childDirectory(packageName),
+        quirks: openapi ? const Quirks.openapi() : const Quirks(),
+      ),
+    );
+  }
+  return tests;
 }
 
 List<TestCase> collectTests({
@@ -41,19 +129,31 @@ List<TestCase> collectTests({
 
   final tests = <TestCase>[];
   for (final testDir in testDirs) {
-    final specFiles = testDir
-        .listSync()
-        .whereType<File>()
-        .where((file) => file.path.endsWith('.json'))
-        .toList();
-    for (final specFile in specFiles) {
-      final specName = p.basenameWithoutExtension(specFile.path);
-      final packageName = specName.replaceAll('.', '_').replaceAll('-', '_');
-      if (!shouldInclude(specFile: specFile, packageName: packageName)) {
+    // A manifest, when present, replaces the directory scan — it is the
+    // list, including any package-name overrides. Skip/glob still apply
+    // on top so `gen_tests.dart github` keeps working either way.
+    final candidates =
+        _testsFromManifest(testDir) ??
+        testDir
+            .listSync()
+            .whereType<File>()
+            .where((f) => _specExtensions.contains(p.extension(f.path)))
+            .map(
+              (f) => TestCase(
+                spec: f,
+                outDir: testDir.childDirectory(_derivePackageName(f)),
+                quirks: const Quirks.openapi(),
+              ),
+            )
+            .toList();
+    for (final test in candidates) {
+      if (!shouldInclude(
+        specFile: test.spec,
+        packageName: test.packageName,
+      )) {
         continue;
       }
-      final outDir = testDir.childDirectory(packageName);
-      tests.add(TestCase(spec: specFile, outDir: outDir));
+      tests.add(test);
     }
   }
   return tests;
@@ -62,7 +162,6 @@ List<TestCase> collectTests({
 Future<void> runTest({
   required TestCase testCase,
   required Directory templatesDir,
-  required Quirks quirks,
 }) async {
   final specFile = testCase.spec;
   final outDir = testCase.outDir;
@@ -71,7 +170,7 @@ Future<void> runTest({
       specUrl: specFile.uri,
       outDir: outDir,
       packageName: testCase.packageName,
-      quirks: quirks,
+      quirks: testCase.quirks,
       templatesDir: templatesDir,
     ),
   );
@@ -79,8 +178,10 @@ Future<void> runTest({
 
 Future<void> run({
   bool verbose = false,
+  bool dryRun = false,
   List<String> skipList = const [],
   List<String> globList = const [],
+  List<String> extraDirs = const [],
 }) async {
   if (verbose) {
     setVerboseLogging();
@@ -89,8 +190,11 @@ Future<void> run({
   final packageRoot = fs.currentDirectory;
   final potentialTestDirs = [
     packageRoot.childDirectory('gen_tests'),
+    // The spec repo currently sits beside the space_gen checkout. That
+    // only resolves from the primary clone — from a git worktree it
+    // does not — so `--dir` exists to name it explicitly.
     packageRoot.childDirectory('../gen_tests'),
-    packageRoot.childDirectory('../private_gen_tests'),
+    ...extraDirs.map(fs.directory),
   ];
   final testDirs = potentialTestDirs.where((dir) => dir.existsSync()).toList();
   final tests = collectTests(
@@ -98,14 +202,18 @@ Future<void> run({
     globList: globList,
     skipList: skipList,
   );
+  if (dryRun) {
+    for (final test in tests) {
+      logger.info(
+        '${test.spec.path} -> ${test.outDir.path} '
+        '(package: ${test.packageName})',
+      );
+    }
+    return;
+  }
   final templatesDir = fs.directory('lib/templates');
-  const quirks = Quirks.openapi();
   for (final test in tests) {
-    await runTest(
-      testCase: test,
-      templatesDir: templatesDir,
-      quirks: quirks,
-    );
+    await runTest(testCase: test, templatesDir: templatesDir);
   }
 
   // Run the unit tests.
@@ -128,21 +236,33 @@ Future<void> run({
 void main(List<String> args) async {
   final parser = ArgParser()
     ..addFlag('verbose', abbr: 'v', help: 'Verbose output')
+    ..addFlag(
+      'dry-run',
+      help: 'Print each spec -> output directory mapping and exit',
+    )
     ..addMultiOption(
       'ignore',
       abbr: 'i',
       help: 'Comma separated list of specs to skip',
+    )
+    ..addMultiOption(
+      'dir',
+      abbr: 'd',
+      help: 'Additional directory of specs to generate (repeatable)',
     );
   final results = parser.parse(args);
   final verbose = results['verbose'] as bool;
   final ignoreList = results['ignore'] as List<String>? ?? <String>[];
+  final extraDirs = results['dir'] as List<String>? ?? <String>[];
   final globList = results.rest;
   await runWithLogger(
     Logger(),
     () => run(
       verbose: verbose,
+      dryRun: results['dry-run'] as bool,
       skipList: ignoreList,
       globList: globList,
+      extraDirs: extraDirs,
     ),
   );
 }

--- a/tool/gen_tests.dart
+++ b/tool/gen_tests.dart
@@ -29,34 +29,28 @@ class TestCase {
   String get packageName => outDir.basename;
 }
 
-/// Spec file extensions [collectTests] will pick up when a directory
-/// has no manifest.
-///
-/// A directory holding YAML that is *not* a spec (`cspell.config.yaml`,
-/// `analysis_options.yaml`) must use a manifest, which replaces the
-/// scan; otherwise that file is treated as a spec.
-const _specExtensions = ['.json', '.yaml', '.yml'];
-
-/// Name of the optional per-directory manifest, e.g.
+/// Name of the per-directory manifest that describes a spec directory:
 ///
 /// ```yaml
+/// openapi: false             # directory-wide default, per-entry overridable
 /// specs:
 ///   - spec: api.github.com.json
-///     package: github          # optional; defaults to the derived name
+///     package: github        # optional; defaults to the derived name
 ///   - spec: train-travel.yaml
-///     package: train_travel
 /// ```
 ///
-/// A directory carrying one is described entirely by it — the spec list
-/// is explicit rather than scanned, and each entry may override the
-/// package name. Without a manifest the directory is scanned as before,
-/// which is why `gen_tests/` in this repo needs no config.
+/// A spec directory is described entirely by its manifest — point the
+/// tool at a directory and it generates what the manifest says. There
+/// is deliberately no fallback that infers the list from the
+/// filesystem: inference cannot express the two things that actually
+/// vary. `api.github.com.json` needs to generate `github/` rather than
+/// `api_github_com/`, and a directory's quirks are not guessable at all
+/// (this repo's fixtures use `Quirks.openapi()`; the parallel spec repo
+/// does not, and generating it with them rewrites every package).
 ///
-/// The override exists because the package name is otherwise forced to
-/// be a mangling of the spec's filename: `api.github.com.json` would
-/// have to live in `api_github_com/`. The parallel spec repo prefers
-/// `github/`, and renaming the *input* files to control the output
-/// directory is the wrong lever.
+/// It also removes a trap: a scan would treat any stray
+/// `cspell.config.yaml` or `analysis_options.yaml` sitting beside the
+/// specs as a spec.
 const _manifestName = 'gen_tests.yaml';
 
 /// The package name [spec]'s filename implies: extension dropped, and
@@ -66,14 +60,16 @@ String _derivePackageName(File spec) => p
     .replaceAll('.', '_')
     .replaceAll('-', '_');
 
-/// Reads [_manifestName] from [testDir], or returns null if absent.
+/// Reads [_manifestName] from [testDir].
 ///
-/// Throws on a malformed manifest or a listed spec that does not exist
-/// — a typo'd entry silently generating nothing is exactly the failure
-/// this file is meant to remove.
-List<TestCase>? _testsFromManifest(Directory testDir) {
+/// Throws if it is missing or malformed, or if a listed spec does not
+/// exist — a typo'd entry silently generating nothing is exactly the
+/// failure this file is meant to remove.
+List<TestCase> _testsFromManifest(Directory testDir) {
   final manifest = testDir.childFile(_manifestName);
-  if (!manifest.existsSync()) return null;
+  if (!manifest.existsSync()) {
+    throw Exception('${testDir.path}: no $_manifestName');
+  }
   final doc = loadYaml(manifest.readAsStringSync());
   if (doc is! Map || doc['specs'] is! List) {
     throw Exception('${manifest.path}: expected a top-level `specs:` list');
@@ -129,24 +125,9 @@ List<TestCase> collectTests({
 
   final tests = <TestCase>[];
   for (final testDir in testDirs) {
-    // A manifest, when present, replaces the directory scan — it is the
-    // list, including any package-name overrides. Skip/glob still apply
-    // on top so `gen_tests.dart github` keeps working either way.
-    final candidates =
-        _testsFromManifest(testDir) ??
-        testDir
-            .listSync()
-            .whereType<File>()
-            .where((f) => _specExtensions.contains(p.extension(f.path)))
-            .map(
-              (f) => TestCase(
-                spec: f,
-                outDir: testDir.childDirectory(_derivePackageName(f)),
-                quirks: const Quirks.openapi(),
-              ),
-            )
-            .toList();
-    for (final test in candidates) {
+    // The manifest is the list. Skip/glob still narrow it, so
+    // `gen_tests.dart types` keeps working.
+    for (final test in _testsFromManifest(testDir)) {
       if (!shouldInclude(
         specFile: test.spec,
         packageName: test.packageName,

--- a/tool/gen_tests.dart
+++ b/tool/gen_tests.dart
@@ -78,9 +78,9 @@ List<TestCase>? _testsFromManifest(Directory testDir) {
   if (doc is! Map || doc['specs'] is! List) {
     throw Exception('${manifest.path}: expected a top-level `specs:` list');
   }
-  // Directory-wide default, overridable per spec. `true` matches the
-  // unmanifested behavior below, so adding a manifest to an existing
-  // directory changes nothing until you say otherwise.
+  // Directory-wide default, overridable per spec. `true` matches what
+  // a directory without a manifest gets below, so adding a manifest to
+  // an existing directory changes nothing until you say otherwise.
   final dirOpenapi = doc['openapi'] as bool? ?? true;
   final tests = <TestCase>[];
   for (final entry in doc['specs'] as List) {


### PR DESCRIPTION
## Summary

`tool/gen_tests.dart` inferred everything about a spec directory from
the filesystem. That works for this repo's `gen_tests/` and silently
misgenerates the parallel spec repo the tool has always probed via
`../gen_tests`.

Now every spec directory carries a `gen_tests.yaml` describing what it
generates and how. Point the tool at a directory and it does what the
manifest says — there is no inference left.

## What inference got wrong

| | inferred | actually wanted |
|---|---|---|
| `api.github.com.json` | `api_github_com/` | `github/` |
| `backstage.yaml`, `train-travel.yaml` | skipped — `.json` filter | generated |
| quirks | `Quirks.openapi()`, hardcoded | plain `Quirks()` |

The last one is the dangerous one. `Quirks.openapi()` flips **six**
flags — `dynamicJson`, `mutableModels`, `nonNullableDefaultValues`,
`allListsDefaultToEmpty`, `screamingCapsEnums`, `flatModelDir` — so
running the tool over that repo didn't just relocate files, it rewrote
all six packages into `lib/model/` with different nullability and
mutability. I found this by doing it: 5245 files showed as deleted
against a tree that looked superficially fine.

None of it was discoverable. The spec→package mapping existed only as
directory names, so "regen the spec repo" meant hand-typing six
invocations and knowing which quirks each wanted — exactly the kind of
unrepeatable one-off this replaces.

## Manifest

```yaml
openapi: false          # directory-wide default, per-entry overridable
specs:
  - spec: api.github.com.json
    package: github     # default would be api_github_com
  - spec: backstage.yaml
  - spec: train-travel.yaml
```

`gen_tests/gen_tests.yaml` is added here for this repo's four fixtures,
which also records that they are the `openapi: true` ones.

The manifest is the **only** source of specs — no scan fallback. One
way a directory is read instead of two, and the surviving one is the
only one that can express what varies. It also removes a trap the
`.yaml` support would otherwise introduce: the spec repo keeps a
`cspell.config.yaml` beside its specs, and a scan would read it as one.

Missing or malformed manifests, and listed specs that don't exist, all
throw — a typo'd entry silently generating nothing is the failure this
is meant to remove.

## Also

- Accepts `.yaml`/`.yml` specs, not just `.json`.
- `--dir` names a spec directory explicitly. The `../gen_tests` probe
  resolves only from the primary clone, not from a git worktree, which
  is why I couldn't verify any of this without it.
- `--dry-run` prints each `spec -> outDir (package)` mapping and exits,
  so the destination is checkable before anything is written.
- Drops the `../private_gen_tests` probe: Eric confirmed no such
  directory exists, and all the specs involved are public.

## Verification

1. `--dry-run` — all ten packages across both directories resolve to
   their existing directories.
2. Regenerated the spec repo's `petstore` through the manifest →
   **byte-identical** to what was committed, proving the tool now
   reproduces that tree rather than rewriting it.
3. Full regen of the spec repo → only the expected #288 acronym
   renames.
4. After deleting the scan, regenerated both directories again →
   **zero drift on both sides**, so the manifest-only path reproduces
   the scan's output byte for byte.
5. Full suite, analyze, cspell and format clean.
