### PR TITLE
fix: serialize scalar-or-array query params per variant (#233)

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -4,6 +4,11 @@ ignorePaths:
   - "coverage/**"
   - "*.txt" # ignore text files at the root of the project
 words:
+  # Plural of "arity" — a union whose variants differ in how many wire
+  # values they produce (one vs many).
+  - arities
+  # github's `cwes` query parameter (Common Weakness Enumeration ids).
+  - cwes
   - subtyping
   - dedupe
   - dedupes

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -1556,9 +1556,21 @@ class Endpoint implements ToTemplateContext {
   /// single values (discord's `oneOf: [enum]`) already stringify correctly,
   /// so they stay on the simpler path and their output is unchanged.
   ///
-  /// Returns null when [type] isn't such a union, or when the naming pass
-  /// assigned no wrapper subclasses to switch over (a `NoDispatch` union,
-  /// which renders the `UnimplementedError` stub instead).
+  /// Returns null when [type] isn't such a union, or when any variant lacks
+  /// a wrapper subclass to switch over. That second guard is load-bearing in
+  /// two ways:
+  ///
+  /// - A `NoDispatch` union gets no wrappers at all; it renders the
+  ///   `UnimplementedError` stub instead.
+  /// - A *smooshed* variant extends the sealed parent directly and holds its
+  ///   own fields, so it has no `value` to destructure — an arm written
+  ///   against it would not compile. `_claimWrapperNames` skips the wrapper
+  ///   claim for exactly those variants, which is what surfaces here as a
+  ///   null name.
+  ///
+  /// Both fall back to the direct path, which stringifies. For a shape that
+  /// deserves better than that, the resolver's `_canBeQueryParameter` has
+  /// already warned.
   static RenderOneOf? _arityMixedUnion(RenderSchema type) {
     if (type is! RenderOneOf) return null;
     if (!type.schemas.any((v) => v is RenderArray)) return null;

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -1450,39 +1450,127 @@ class Endpoint implements ToTemplateContext {
     // spreads each list across repeated keys (form/explode=true), so a
     // 1-element list yields `?k=v` and an N-element list yields
     // `?k=v1&k=v2&…`. Scalars wrap into a single-element list; arrays
-    // come through directly. Items must be `String`, so each item runs
-    // through `.toString()` — a no-op when the json expression already
-    // produces a `String` (raw string, dateTime/date/uri pods, enums)
-    // and the conversion when it doesn't (int/double/bool).
+    // come through directly.
+    //
+    // A union that mixes the two arities can't pick one form at render
+    // time — the arm held at the call site decides — so it emits a
+    // `switch` and each arm contributes its own. Every other shape has a
+    // single form and takes the direct path.
     final dartName = p.dartParameterName(context.quirks);
     final paramType = p.type;
+    final arityMixedUnion = _arityMixedUnion(paramType);
     final String value;
-    if (paramType is RenderArray) {
-      final itemsToJson = paramType.items.toJsonExpression(
-        const DartIdentifier('e'),
-        context,
-        dartIsNullable: false,
-      );
-      final item = _stringifyWireValue(paramType.items, itemsToJson);
-      final items = '$dartName.map((e) => ${_runtimeSource(item)})';
-      // `explode: false` (style=form) comma-joins the array into a single
-      // value (`?k=a,b,c`) rather than repeating the key. Wrap the joined
-      // string in a 1-element list so it flows through the same
-      // `Map<String, List<String>>` shape.
-      value = p.explode ? '$items.toList()' : "[$items.join(',')]";
+    if (arityMixedUnion != null) {
+      value = _unionQueryValue(arityMixedUnion, dartName, p, context);
     } else {
-      final scalarToJson = paramType.toJsonExpression(
-        DartIdentifier(dartName),
-        context,
-        dartIsNullable: false,
-      );
-      final stringified = _stringifyWireValue(paramType, scalarToJson);
-      value = '[${_runtimeSource(stringified)}]';
+      value = _queryValue(paramType, dartName, p, context);
     }
     if (p.isNullable) {
       return "${innerIndent}if ($dartName != null) '${p.name}': $value,";
     }
     return "$innerIndent'${p.name}': $value,";
+  }
+
+  /// The source for converting one element of [type] to its wire `String`,
+  /// written against the element variable `e` — or null when elements are
+  /// already `String` and need no conversion at all.
+  ///
+  /// Null is the signal to skip the surrounding `.map` entirely. Emitting it
+  /// anyway would produce `xs.map((e) => e)`, which copies the list and
+  /// changes nothing — the sort of line that gives away generated code.
+  static String? _elementWireConversion(
+    RenderArray type,
+    SchemaRenderer context,
+  ) {
+    const element = DartIdentifier('e');
+    final itemsToJson = type.items.toJsonExpression(
+      element,
+      context,
+      dartIsNullable: false,
+    );
+    final item = _stringifyWireValue(type.items, itemsToJson);
+    return item == element ? null : _runtimeSource(item);
+  }
+
+  /// The `Map<String, List<String>>` value expression for a query parameter
+  /// of type [type], reading the Dart value from [access].
+  ///
+  /// [access] is the parameter name at the top level, and a variant's
+  /// destructured `value` when called per-arm from [_unionQueryValue].
+  static String _queryValue(
+    RenderSchema type,
+    String access,
+    RenderParameter p,
+    SchemaRenderer context,
+  ) {
+    if (type is RenderArray) {
+      final conversion = _elementWireConversion(type, context);
+      final items = conversion == null
+          ? access
+          : '$access.map((e) => $conversion)';
+      // `explode: false` (style=form) comma-joins the array into a single
+      // value (`?k=a,b,c`) rather than repeating the key. Wrap the joined
+      // string in a 1-element list so it flows through the same
+      // `Map<String, List<String>>` shape.
+      if (!p.explode) return "[$items.join(',')]";
+      // Without a conversion the value is already the `List<String>` the
+      // query map wants, so there is nothing to `.toList()`.
+      return conversion == null ? items : '$items.toList()';
+    }
+    final scalarToJson = type.toJsonExpression(
+      DartIdentifier(access),
+      context,
+      dartIsNullable: false,
+    );
+    final stringified = _stringifyWireValue(type, scalarToJson);
+    return '[${_runtimeSource(stringified)}]';
+  }
+
+  /// A `switch` over [union]'s sealed variants, each arm producing that
+  /// variant's own query value.
+  ///
+  /// The arms destructure `value` — every wrapper subclass declares exactly
+  /// that field (see `objectWrapperContext` and the `schema_one_of`
+  /// template) — so each arm hands its variant's real Dart type to
+  /// [_queryValue] rather than the union's `dynamic` `toJson()`.
+  static String _unionQueryValue(
+    RenderOneOf union,
+    String access,
+    RenderParameter p,
+    SchemaRenderer context,
+  ) {
+    final arms = union.schemas.map((variant) {
+      final wrapper = union.wrapperTypeName(variant);
+      final value = _queryValue(variant, 'value', p, context);
+      return '$wrapper(:final value) => $value,';
+    });
+    return 'switch ($access) { ${arms.join(' ')} }';
+  }
+
+  /// [type] as a union that mixes single values with arrays — the one union
+  /// shape whose wire form the default scalar path gets *wrong*.
+  ///
+  /// Such a union's `toJson()` is `dynamic`, so the scalar path stringifies
+  /// it; for the array variant that yields Dart's list `toString()`
+  /// (`"[a, b]"`) instead of repeated keys. Unions whose variants are all
+  /// single values (discord's `oneOf: [enum]`) already stringify correctly,
+  /// so they stay on the simpler path and their output is unchanged.
+  ///
+  /// Returns null when [type] isn't such a union, or when the naming pass
+  /// assigned no wrapper subclasses to switch over (a `NoDispatch` union,
+  /// which renders the `UnimplementedError` stub instead).
+  static RenderOneOf? _arityMixedUnion(RenderSchema type) {
+    if (type is! RenderOneOf) return null;
+    if (!type.schemas.any((v) => v is RenderArray)) return null;
+    // Nested arrays have no `form` wire encoding — leave them to the warning.
+    if (type.schemas.any((v) => v is RenderArray && v.items is RenderArray)) {
+      return null;
+    }
+    final names = type.wrapperNames;
+    if (names.length != type.schemas.length || names.any((n) => n == null)) {
+      return null;
+    }
+    return type;
   }
 
   List<String> _bodyArgLines(String indent, SchemaRenderer context) =>
@@ -1528,13 +1616,10 @@ class Endpoint implements ToTemplateContext {
     final paramType = p.type;
     if (paramType is RenderArray) {
       final dartName = p.dartParameterName(context.quirks);
-      final itemsToJson = paramType.items.toJsonExpression(
-        const DartIdentifier('e'),
-        context,
-        dartIsNullable: false,
-      );
-      final item = _stringifyWireValue(paramType.items, itemsToJson);
-      final mapCall = ".map((e) => ${_runtimeSource(item)}).join(',')";
+      final conversion = _elementWireConversion(paramType, context);
+      final mapCall = conversion == null
+          ? ".join(',')"
+          : ".map((e) => $conversion).join(',')";
       final value = p.isNullable ? '?$dartName?$mapCall' : '$dartName$mapCall';
       return "$innerIndent'${p.name}': $value,";
     }

--- a/lib/src/resolver.dart
+++ b/lib/src/resolver.dart
@@ -605,6 +605,71 @@ bool _canBePathParameter(ResolvedSchema schema) {
   return false;
 }
 
+/// True when [schema] serializes to a single value on the wire — the shape a
+/// query parameter may take on its own, and the element type an array-shaped
+/// one may hold.
+///
+/// Deliberately a superset of what [_canBePathParameter] accepts: `number`
+/// is a legal query value (`?ratio=0.5`) whether or not we want one in a URL
+/// path segment. Keeping the two predicates separate lets the path rule stay
+/// as strict as it is.
+bool _isSingleWireValue(ResolvedSchema schema) {
+  if (schema is ResolvedString ||
+      schema is ResolvedInteger ||
+      schema is ResolvedNumber ||
+      schema is ResolvedEnum) {
+    return true;
+  }
+  // Pods (uuid, email, date-time, uri, uri-template, boolean) and `Date` all
+  // serialize to a single string on the wire via their `toJson`.
+  return schema is ResolvedPod || schema is ResolvedDate;
+}
+
+/// True when [schema] is a shape the query renderer knows how to put on the
+/// wire under `style: form` — the only style the generator emits.
+///
+/// That is a single wire value, an array of those, or a union whose every
+/// variant is one of the two. A union may mix arities: github's `cwes` is
+/// `oneOf: [string, array<string>]`, which serializes as either `?k=a` or
+/// `?k=a&k=b` depending on the variant held at the call site.
+///
+/// Object shapes are rejected. `form`/`deepObject` object serialization isn't
+/// implemented, and no spec in the validation rotation uses it — so rather
+/// than guess at a wire format, the caller warns and the renderer's existing
+/// fallback stringifies the value. The warning is the record that we're
+/// dropping spec semantics; implement the real encoding when a spec needs it.
+bool _canBeQueryParameter(ResolvedSchema schema) {
+  if (_isSingleWireValue(schema)) {
+    return true;
+  }
+  if (schema is ResolvedArray) {
+    return _isSingleWireValue(schema.items);
+  }
+  // `anyOf` as well as `oneOf`: both render as a sealed union (anyOf becomes
+  // a `RenderOneOf`), and both appear in this position in the wild —
+  // spacetraders' `traits` is an `anyOf`. `allOf` is a
+  // [ResolvedSchemaCollection] too, but it intersects rather than unions its
+  // members, so it is deliberately not accepted here.
+  final variants = switch (schema) {
+    ResolvedOneOf(:final schemas) => schemas,
+    ResolvedAnyOf(:final schemas) => schemas,
+    _ => null,
+  };
+  if (variants == null) {
+    return false;
+  }
+  // Variants are checked one level deep rather than recursively. The renderer
+  // switches over this union's own wrapper subclasses and emits a wire form
+  // per arm, so a variant that is itself a union has no single form to emit.
+  // Holding this in step with the renderer is what keeps an accepted shape
+  // from silently rendering wrong instead of warning.
+  return variants.every(
+    (v) =>
+        _isSingleWireValue(v) ||
+        (v is ResolvedArray && _isSingleWireValue(v.items)),
+  );
+}
+
 List<ResolvedParameter> _resolveParameters(
   List<RefOr<Parameter>> parameters,
   ResolveContext context,
@@ -616,6 +681,17 @@ List<ResolvedParameter> _resolveParameters(
           !_canBePathParameter(type)) {
         _error(
           'Path parameters must be strings or integers',
+          resolved.pointer,
+        );
+      }
+      // Warn rather than error: an unsupported query shape still renders
+      // (as a stringified value), so this is a "we're dropping spec
+      // semantics" signal, not a reason to fail the whole spec.
+      if (resolved.inLocation == ParameterLocation.query &&
+          !_canBeQueryParameter(type)) {
+        _warn(
+          'Unsupported query parameter shape; generator emits a stringified '
+          'value, which is unlikely to match what the server expects',
           resolved.pointer,
         );
       }

--- a/test/render/render_operation_test.dart
+++ b/test/render/render_operation_test.dart
@@ -1162,7 +1162,7 @@ void main() {
         '            method: Method.post,\n'
         "            path: '/users',\n"
         '            queryParameters: {\n'
-        "                if (foo != null) 'foo': foo.map((e) => e).toList(),\n"
+        "                if (foo != null) 'foo': foo,\n"
         '            },\n'
         '        );\n'
         '\n'
@@ -1201,9 +1201,11 @@ void main() {
       );
       // explode: false → one comma-joined value, not repeated keys. The joined
       // string is wrapped in a 1-element list for the Map<String, List<String>>.
+      // The elements are already `String`, so they join directly — no
+      // intervening identity `.map`.
       expect(
         result,
-        contains("'foo': [foo.map((e) => e).join(',')],"),
+        contains("'foo': [foo.join(',')],"),
       );
     });
 
@@ -1405,6 +1407,47 @@ void main() {
           '        }\n'
           '    }\n'
           '}\n',
+        );
+      });
+
+      test('string or array of string switches on the variant', () {
+        // github's `cwes` / `affects`: a union mixing a single value with an
+        // array of them. The union's `toJson()` is `dynamic`, so the scalar
+        // path would stringify the list variant to `"[a, b]"` instead of
+        // repeating the key. Each arm must contribute its own wire shape.
+        final json = {
+          'summary': 'Get user',
+          'parameters': [
+            {
+              'name': 'cwes',
+              'in': 'query',
+              'schema': {
+                'oneOf': [
+                  {'type': 'string'},
+                  {
+                    'type': 'array',
+                    'items': {'type': 'string'},
+                  },
+                ],
+              },
+            },
+          ],
+          'responses': {
+            '200': {'description': 'OK'},
+          },
+        };
+        final result = renderTestOperation(
+          path: '/users',
+          operationJson: json,
+          serverUrl: Uri.parse('https://api.spacetraders.io/v2'),
+        );
+        expect(
+          result,
+          contains(
+            "if (cwes != null) 'cwes': switch (cwes) { "
+            'UsersParameter0String(:final value) => [value], '
+            'UsersParameter0List(:final value) => value, }',
+          ),
         );
       });
     });

--- a/test/render/render_operation_test.dart
+++ b/test/render/render_operation_test.dart
@@ -1450,6 +1450,57 @@ void main() {
           ),
         );
       });
+
+      test('union with a smooshed object variant stays on the direct path', () {
+        // An object variant is smooshed — it extends the sealed parent
+        // directly and carries its own fields, so there is no `value` to
+        // destructure and a switch arm written against it would not
+        // compile. The union has an array variant, so only the
+        // missing-wrapper guard keeps this off the switch path.
+        final json = {
+          'summary': 'Get user',
+          'parameters': [
+            {
+              'name': 'filter',
+              'in': 'query',
+              'schema': {
+                'oneOf': [
+                  {
+                    'type': 'object',
+                    'properties': {
+                      'a': {'type': 'string'},
+                    },
+                  },
+                  {
+                    'type': 'array',
+                    'items': {'type': 'string'},
+                  },
+                ],
+              },
+            },
+          ],
+          'responses': {
+            '200': {'description': 'OK'},
+          },
+        };
+        // The object variant also makes this a shape the resolver warns
+        // about, so it needs a logger scope.
+        final result = runWithLogger(
+          _MockLogger(),
+          () => renderTestOperation(
+            path: '/users',
+            operationJson: json,
+            serverUrl: Uri.parse('https://api.spacetraders.io/v2'),
+          ),
+        );
+        expect(result, isNot(contains('switch (filter)')));
+        expect(
+          result,
+          contains(
+            "if (filter != null) 'filter': [filter.toJson().toString()]",
+          ),
+        );
+      });
     });
   });
 

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -5034,7 +5034,7 @@ void main() {
 
     group('array parameters', () {
       test(
-        'nullable string-array query param emits .map((e) => e.toString()).toList()',
+        'nullable string-array query param passes the list through unchanged',
         () {
           // Default OpenAPI style=form, explode=true: each value gets its own
           // ?key=v repetition. Generated client emits an Iterable<String>
@@ -5059,11 +5059,11 @@ void main() {
             operationJson: operation,
             serverUrl: Uri.parse('https://example.com'),
           );
+          // Elements are already `String`, so there is no per-element
+          // conversion and the list goes straight into the query map.
           expect(
             result,
-            contains(
-              "                if (tags != null) 'tags': tags.map((e) => e).toList(),",
-            ),
+            contains("                if (tags != null) 'tags': tags,"),
           );
           // The buggy old emission must be gone — `?tags?.toString()` would
           // ship the list as `[a, b]` literal on the wire.
@@ -5098,9 +5098,7 @@ void main() {
         );
         expect(
           result,
-          contains(
-            "                'X-Tags': xTags.map((e) => e).join(','),",
-          ),
+          contains("                'X-Tags': xTags.join(','),"),
         );
       });
     });

--- a/test/resolver_test.dart
+++ b/test/resolver_test.dart
@@ -49,6 +49,119 @@ void main() {
       return spec.paths.first.operations.first.responses.first.content;
     }
 
+    group('query parameter shapes', () {
+      Map<String, dynamic> specWithQueryParam(Map<String, dynamic> schema) => {
+        'openapi': '3.1.0',
+        'info': {'title': 'Test API', 'version': '1.0.0'},
+        'servers': [
+          {'url': 'https://example.com'},
+        ],
+        'paths': {
+          '/things': {
+            'get': {
+              'summary': 'List things',
+              'parameters': [
+                {'name': 'q', 'in': 'query', 'schema': schema},
+              ],
+              'responses': {
+                '200': {'description': 'OK'},
+              },
+            },
+          },
+        },
+      };
+
+      const unsupportedWarning =
+          'Unsupported query parameter shape; generator emits a stringified '
+          'value, which is unlikely to match what the server expects '
+          'in #/paths/~1things/get/parameters/0';
+
+      // `form`/`deepObject` object serialization is not implemented. The
+      // warning is how that stays visible instead of silently shipping a
+      // Dart map's `toString()` as the query value.
+      test('object query param warns', () {
+        final logger = _MockLogger();
+        runWithLogger(
+          logger,
+          () => parseAndResolveTestSpec(
+            specWithQueryParam({
+              'type': 'object',
+              'properties': {
+                'a': {'type': 'string'},
+              },
+            }),
+          ),
+        );
+        verify(() => logger.warn(unsupportedWarning)).called(1);
+      });
+
+      test('array of objects warns', () {
+        final logger = _MockLogger();
+        runWithLogger(
+          logger,
+          () => parseAndResolveTestSpec(
+            specWithQueryParam({
+              'type': 'array',
+              'items': {
+                'type': 'object',
+                'properties': {
+                  'a': {'type': 'string'},
+                },
+              },
+            }),
+          ),
+        );
+        verify(() => logger.warn(unsupportedWarning)).called(1);
+      });
+
+      test('supported shapes do not warn', () {
+        for (final schema in <Map<String, dynamic>>[
+          {'type': 'string'},
+          {'type': 'integer'},
+          // `number` is legal in a query even though `_canBePathParameter`
+          // rejects it for path segments.
+          {'type': 'number'},
+          {'type': 'boolean'},
+          {'type': 'string', 'format': 'uuid'},
+          {
+            'type': 'string',
+            'enum': ['a', 'b'],
+          },
+          {
+            'type': 'array',
+            'items': {'type': 'string'},
+          },
+          // github's `cwes`: a union mixing a single value with an array.
+          {
+            'oneOf': [
+              {'type': 'string'},
+              {
+                'type': 'array',
+                'items': {'type': 'string'},
+              },
+            ],
+          },
+          // spacetraders' `traits` uses `anyOf` for the same shape.
+          {
+            'anyOf': [
+              {'type': 'string'},
+              {
+                'type': 'array',
+                'items': {'type': 'string'},
+              },
+            ],
+          },
+        ]) {
+          final logger = _MockLogger();
+          runWithLogger(
+            logger,
+            () => parseAndResolveTestSpec(specWithQueryParam(schema)),
+          );
+          verifyNever(() => logger.warn(unsupportedWarning));
+        }
+      });
+    });
+
     test('path parameters must be strings or integers', () {
       final json = {
         'openapi': '3.1.0',


### PR DESCRIPTION
## Summary

Query parameters typed as a union of a single value and an array of them now serialize per variant instead of stringifying the union, and unsupported query shapes warn instead of silently rendering wrong.

## The bug

github's `cwes` is `oneOf: [string, array<string>]`. It rendered as:

```dart
if (cwes != null) 'cwes': [cwes.toJson().toString()],
```

The union's `toJson()` is `dynamic`, so the array variant reached `.toString()` and went on the wire as a Dart list literal — `?cwes=%5Ba%2C+b%5D` — rather than repeated keys.

Which arity a call site holds isn't knowable at render time, so the parameter now emits a `switch` over the union's sealed variants, each arm contributing its own wire form:

```dart
if (cwes != null)
  'cwes': switch (cwes) {
    SecurityAdvisoriesListGlobalAdvisoriesParameter5String(:final value) => [value],
    SecurityAdvisoriesListGlobalAdvisoriesParameter5List(:final value) => value,
  },
```

Only unions that actually mix arities take this path. Unions whose variants are all single values (discord's `oneOf: [enum]`) already stringified correctly and stay on the direct path — their output is unchanged.

**6 sites fixed:** github's `cwes`, `affects`, `has` (×3); discord's `sku_ids` (×2), `tag`, `include_roles`.

## The warning half

Adds `_canBeQueryParameter`, the query-side mirror of `_canBePathParameter`, warning on shapes with no wire form — objects above all.

#232 honored `explode: false` for query arrays and in doing so dropped the incidental `explode` warning that was the only thing making object query params visible. This puts a direct warning back, so the unhandled shape shows up in the log for *every* object query param rather than just the non-default-explode one.

Deliberately a warning rather than an error: the shape still renders, just not the way the server expects.

## Why not full form/deepObject

The issue proposed object serialization as the follow-on. Measuring first: across **~350 query parameters** in github, discord, petstore, spacetraders, backstage and train-travel there are **zero object-shaped query params, zero `deepObject`, and zero non-`form` styles**. The single non-default thing in the rotation is one backstage `explode: false` array, already handled by #232.

So there's nothing to validate a `deepObject` implementation against, and per the project's "require a real-world validation target" rule it stays unimplemented with the warning as the record. Worth noting the issue's own framing — it says the case was surfaced *while* working on Backstage, not that Backstage contains one; the object case appears to have been anticipatory.

This subsumes the query-parameter half of #100.

The predicate accepts one level of variant rather than recursing, matching what the renderer can actually emit — a variant that is itself a union has no single wire form, so it warns rather than silently rendering wrong.

## Folded in: the identity `.map`

Array query and header params emitted an identity map when elements were already `String`:

```dart
'tags': tags.map((e) => e).toList(),      ->  'tags': tags,
'X-Tags': xTags.map((e) => e).join(','),  ->  'X-Tags': xTags.join(','),
```

The `.map` only copied the list. That rule now lives in one place — `_elementWireConversion`, which returns null when there's nothing to convert — read by both the query and header paths so they can't drift.

Touches 5 pre-existing sites plus the 2 the union fix would otherwise have added. Inlined rather than filed separately since it's in the exact function being restructured, and leaving newly-generated code with `value.map((e) => e).toList()` would miss the bar.

## Validation

- All six specs `dart analyze`-clean
- discord's 1530 and petstore's 28 generated round-trip tests pass
- In-repo `gen_tests/` goldens unchanged (no drift)
- Zero new warnings fire on any tracked spec — the warning is latent by design, covered by direct unit tests
- New unit tests: resolver predicate (object / array-of-object warn; scalars, `number`, arrays, and both `oneOf` and `anyOf` arity-mixed unions don't), render switch emission

One bug caught during the work: the predicate initially delegated to `_canBePathParameter`, which rejects `ResolvedNumber` — that would have warned on every legal `number` query param. The two predicates are now separate, so the path rule stays as strict as it is.

Closes #233
