### PR TITLE
refactor: fromJsonExpression returns a DartExpression

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -10,6 +10,8 @@ words:
   - tearoff
   - tearoffs
   - parenthesization
+  - unparameterized
+  - inlines
   - interps
   - goldens
   - impls

--- a/doc/dart_expression.md
+++ b/doc/dart_expression.md
@@ -202,22 +202,27 @@ rather than plausible text.
 Roughly in value order. Counts are current as of #265; line numbers drift, so
 they are deliberately omitted.
 
-1. **`fromJsonExpression`** — 16 overrides, the other half of #265. Needs
-   cast (`as T`), `??` and null-aware nodes. Watch #255: a bare numeric cast
-   must not gain parentheses, which becomes a structural question about
-   whether the operand needs them rather than a string rule.
+1. ~~**`fromJsonExpression`**~~ — done (#291). Parenthesization is now a
+   serializer question answered from `DartPrecedence`, which is where the
+   #255 rule lives: a bare cast is not parenthesized, a cast under a
+   selector is. The parens around a cast on the left of `??` are the one
+   *elective* rule — `as` already binds tighter, so they are for
+   readability, and the serializer says so.
 2. **Dispatch predicates** — the `RenderOneOf` `caseExpression` closures and
    `Predicate.dartIfTest` in `lib/src/dispatch.dart` (6 sites).
-3. **The two remaining text-inspection sites**, both of which want a *domain
-   type* rather than an expression (see Scope above): `source ==
-   'response.body'`, which recovers which branch the producer took, and
-   `bodyContentTypeExpression == defaultBodyContentTypeExpression`, a constant
-   that exists only to be compared against.
-4. **Import derivation** — the real prize. `schema_renderer.dart` re-tokenizes
-   rendered file bodies so `file_renderer.dart` can decide imports; referenced
-   identifiers should instead accumulate while the tree is built. This is the
-   step that widens scope toward declarations, so revisit the code_builder
-   decision here rather than drifting into it.
+3. **One remaining text-inspection site**, which wants a *domain type*
+   rather than an expression (see Scope above):
+   `bodyContentTypeExpression == defaultBodyContentTypeExpression`, a
+   constant that exists only to be compared against. (`source ==
+   'response.body'` became an enum in #291.)
+4. **Library imports** — narrower than it first looked. #287 answered the
+   *schema* half structurally from the render tree, so what is left is
+   whether a rendered body called `jsonDecode`, named `Uint8List`, or
+   emitted a `validateXxx` — facts about what the template wrote, which
+   the render tree does not describe. That is a smaller surface than
+   "accumulate every referenced identifier", and correspondingly weaker
+   grounds for widening scope to declarations: **revisit the code_builder
+   decision only if this step actually demands it.**
 
 Each step stands alone: the codebase is strictly better if the arc stops at any
 point, which is the mitigation for the payoff sitting at the end.

--- a/lib/src/render/dart_expression.dart
+++ b/lib/src/render/dart_expression.dart
@@ -68,10 +68,10 @@ sealed class DartExpression extends Equatable {
 /// there is no arithmetic or comparison in generated `fromJson`/`toJson`
 /// code, and an unused level is a level nothing tests.
 ///
-/// The point of the enum is that composition asks rather than assumes.
-/// Before it, two overrides answered "does a cast on the left of `??` need
-/// parens" independently and disagreed: `RenderNumeric` emitted
-/// `(json['x'] as int?) ?? 0` and `RenderPod` emitted
+/// Composition asks rather than assumes. Before this, two
+/// `fromJsonExpression` overrides answered "does a cast on the left of
+/// `??` need parens" independently and disagreed — `RenderNumeric` emitted
+/// `(json['x'] as int?) ?? 0`, `RenderPod` emitted
 /// `json['x'] as bool? ?? false`.
 enum DartPrecedence {
   /// `throw x` — binds looser than everything, including a lambda body.
@@ -176,14 +176,24 @@ class DartExpressionSerializer extends Equatable {
             '${isNullAware ? '?.' : '.'}$name',
       DartFunctionCall(:final name, :final arguments) =>
         '$name(${arguments.map(children.serialize).join(', ')})',
+      DartIndex(:final target, :final index) =>
+        '${children._serializeAt(target, DartPrecedence.postfix)}'
+            '[${children.serialize(index)}]',
       // `as` binds tighter than `??`, so its operand has to be at least a
       // cast itself; `(a ?? b) as T` is where this earns the parens.
       DartCast(:final operand, :final type) =>
         '${children._serializeAt(operand, DartPrecedence.cast)} as $type',
-      // `??` is right-associative: the left side must bind tighter, the
-      // right side may be another `??` without parens.
+      // Elective parens, not required ones: `as` already binds tighter
+      // than `??`, so `json['x'] as int? ?? 0` compiles and doesn't trip
+      // `unnecessary_parenthesis`. It just reads badly — `? ??` runs two
+      // unrelated question marks together — and handwritten Dart brackets
+      // it. Asking for `postfix` rather than `cast` on the left is what
+      // buys that.
+      //
+      // `??` is right-associative, so the right side may be another `??`
+      // without parens.
       DartIfNull(:final value, :final ifNullValue) =>
-        '${children._serializeAt(value, DartPrecedence.cast)} ?? '
+        '${children._serializeAt(value, DartPrecedence.postfix)} ?? '
             '${children._serializeAt(ifNullValue, DartPrecedence.ifNull)}',
       DartThrow(:final value) => 'throw ${children.serialize(value)}',
       DartLambda(:final parameters, :final body) =>
@@ -488,6 +498,26 @@ class DartFunctionCall extends DartExpression {
 
   @override
   List<Object?> get props => [name, arguments];
+}
+
+/// An index read: `json['name']`.
+class DartIndex extends DartExpression {
+  const DartIndex({required this.target, required this.index});
+
+  final DartExpression target;
+
+  final DartExpression index;
+
+  /// `const` collections can be indexed in a constant expression, but the
+  /// generator only indexes the runtime JSON map.
+  @override
+  bool get canBeConst => false;
+
+  @override
+  DartPrecedence get precedence => DartPrecedence.postfix;
+
+  @override
+  List<Object?> get props => [target, index];
 }
 
 /// A cast: `json['x'] as String?`.

--- a/lib/src/render/dart_expression.dart
+++ b/lib/src/render/dart_expression.dart
@@ -13,7 +13,7 @@ import 'package:space_gen/src/string.dart';
 /// tree and not something a composite should have to thread by hand.
 ///
 /// Unlike [DartType], the tree does *not* render itself. Rendering lives in
-/// [DartExpressionSerializer], because the source for a given expression
+/// [serializeExpression], because the source for a given expression
 /// depends on where the text lands: `const` must be written when the
 /// destination evaluates at runtime, and must not be when the destination is
 /// already a constant context (an enclosing `const` declaration, a parameter
@@ -44,7 +44,7 @@ sealed class DartExpression extends Equatable {
   ///   qualifies. `[1, 2]` qualifies even though, written bare in a
   ///   runtime context, it allocates a fresh list each time.
   /// - **is written `const`** — the keyword, pure syntax. That is
-  ///   [DartExpressionSerializer.isConstContext]'s business, not the
+  ///   [_ExpressionSerializer.isConstContext]'s business, not the
   ///   tree's.
   ///
   /// Derived, never stored. That derivation is the reason this IR exists:
@@ -56,7 +56,7 @@ sealed class DartExpression extends Equatable {
   DartPrecedence get precedence;
 
   /// Debug form (`DartLiteral(5)`), not Dart source. Rendering goes
-  /// through [DartExpressionSerializer] — an expression cannot serialize
+  /// through [serializeExpression] — an expression cannot serialize
   /// itself, because how it renders depends on where the text lands.
   @override
   bool get stringify => true;
@@ -94,6 +94,29 @@ enum DartPrecedence {
   primary,
 }
 
+/// The Dart source for [expression], as the whole of whatever it is being
+/// written into.
+///
+/// [isConstContext] describes the destination: true for an enclosing
+/// `const` declaration or a parameter default, false for anything that
+/// evaluates at runtime.
+///
+/// **A free function, not a method.** This is the one entry that accepts
+/// any expression without parentheses — true at the root, false everywhere
+/// inside. [_ExpressionSerializer] is private and has no such member, so an
+/// arm rendering a child literally cannot reach this; it has to use
+/// `_serializeAt` or `_serializeDelimited` and say what that position
+/// accepts. A comment asking callers not to would be a convention; this is
+/// a compile error.
+String serializeExpression(
+  DartExpression expression, {
+  required bool isConstContext,
+}) =>
+    (isConstContext
+            ? _ExpressionSerializer.constContext
+            : _ExpressionSerializer.runtimeContext)
+        ._serializeAt(expression, DartPrecedence.throw_);
+
 /// Renders a [DartExpression] to Dart source.
 ///
 /// Separate from the tree on purpose. Whether a `const` keyword belongs in
@@ -109,55 +132,31 @@ enum DartPrecedence {
 /// what lets a constant child inside a runtime parent get one of its own
 /// (`Uint8List.fromList(const <int>[0])`).
 @immutable
-class DartExpressionSerializer extends Equatable {
-  const DartExpressionSerializer._({required this.isConstContext});
+class _ExpressionSerializer extends Equatable {
+  const _ExpressionSerializer({required this.isConstContext});
 
   /// For a destination that is already a constant context: an enclosing
   /// `const` declaration, a parameter default, or inside another `const`
   /// expression. No keyword is written; one would be `unnecessary_const`.
-  static const _constContext = DartExpressionSerializer._(isConstContext: true);
+  static const constContext = _ExpressionSerializer(isConstContext: true);
 
   /// For a destination that evaluates at runtime, such as the right-hand
   /// side of a `??`. A `const` keyword is written wherever it turns an
   /// allocation into a compile-time constant.
-  static const _runtimeContext = DartExpressionSerializer._(
-    isConstContext: false,
-  );
+  static const runtimeContext = _ExpressionSerializer(isConstContext: false);
 
   final bool isConstContext;
-
-  /// The Dart source for [expression], as the whole of whatever it is
-  /// being written into.
-  ///
-  /// **Static on purpose.** This is the one entry that accepts any
-  /// expression without parentheses — true at the root, false everywhere
-  /// inside. Dart forbids reaching a static through an instance, so an arm
-  /// below *cannot* call `children.serialize(...)`; it has to use
-  /// [_serializeAt] or [_serializeDelimited] and say what that position
-  /// accepts. The alternative — an instance method with a comment asking
-  /// callers not to — is a convention, and this is a compile error.
-  ///
-  /// [isConstContext] describes the destination: true for an enclosing
-  /// `const` declaration or a parameter default, false for anything that
-  /// evaluates at runtime.
-  static String serialize(
-    DartExpression expression, {
-    required bool isConstContext,
-  }) => (isConstContext ? _constContext : _runtimeContext)._serializeAt(
-    expression,
-    DartPrecedence.throw_,
-  );
 
   /// Source for a position already closed by a delimiter — an argument, a
   /// collection element, a map value, a lambda body.
   ///
   /// Nothing can bind looser than the bracket or comma that ends it, so no
-  /// expression needs parentheses. Spelled out rather than reusing
-  /// [serialize] so the claim is visible at the call site.
+  /// expression needs parentheses. Named rather than passing
+  /// [DartPrecedence.throw_] at each site so the claim is visible.
   String _serializeDelimited(DartExpression expression) =>
       _serializeAt(expression, DartPrecedence.throw_);
 
-  /// [serialize], parenthesizing when [expression] binds looser than the
+  /// Source for [expression], parenthesized when it binds looser than the
   /// position it is landing in requires.
   ///
   /// A written `const` keyword needs no accounting here: `const Foo(1)` is
@@ -171,8 +170,8 @@ class DartExpressionSerializer extends Equatable {
     // A keyword written here (or a context inherited from above) makes
     // every child a constant context.
     final children = isConstContext || expression.canBeConst
-        ? _constContext
-        : _runtimeContext;
+        ? constContext
+        : runtimeContext;
     return switch (expression) {
       // `const 5` and `const UserRole.admin` are syntax errors, so these
       // two arms never offer the keyword — that rule is expressed by the

--- a/lib/src/render/dart_expression.dart
+++ b/lib/src/render/dart_expression.dart
@@ -249,6 +249,19 @@ class DartExpressionSerializer extends Equatable {
   List<Object?> get props => [isConstContext];
 }
 
+/// A call to a top-level function: `call('jsonDecode', [body])`.
+///
+/// The free-function counterpart to [DartTypeExpressions.construct], and
+/// here for the same reason: so a call site reads like the Dart it emits,
+/// and so the two kinds of call look alike where a branch picks between
+/// them.
+///
+/// A function rather than an extension on `String`: an extension member
+/// named `call` would make every `String` implicitly invocable, and any
+/// other name reads worse than this does.
+DartExpression call(String name, [List<DartExpression> arguments = const []]) =>
+    DartFunctionCall(name: name, arguments: arguments);
+
 /// Expression builders for the forms that are *rooted at a type name* —
 /// `Foo(...)`, `Uri.parse(...)`, `UserRole.admin` — so a call site reads
 /// like the Dart it emits.

--- a/lib/src/render/dart_expression.dart
+++ b/lib/src/render/dart_expression.dart
@@ -110,27 +110,51 @@ enum DartPrecedence {
 /// (`Uint8List.fromList(const <int>[0])`).
 @immutable
 class DartExpressionSerializer extends Equatable {
-  const DartExpressionSerializer({required this.isConstContext});
+  const DartExpressionSerializer._({required this.isConstContext});
 
   /// For a destination that is already a constant context: an enclosing
   /// `const` declaration, a parameter default, or inside another `const`
   /// expression. No keyword is written; one would be `unnecessary_const`.
-  static const constContext = DartExpressionSerializer(isConstContext: true);
+  static const _constContext = DartExpressionSerializer._(isConstContext: true);
 
   /// For a destination that evaluates at runtime, such as the right-hand
   /// side of a `??`. A `const` keyword is written wherever it turns an
   /// allocation into a compile-time constant.
-  static const runtimeContext = DartExpressionSerializer(
+  static const _runtimeContext = DartExpressionSerializer._(
     isConstContext: false,
   );
 
   final bool isConstContext;
 
-  /// The Dart source for [expression].
+  /// The Dart source for [expression], as the whole of whatever it is
+  /// being written into.
   ///
-  /// Nothing wraps the outermost expression, so it is serialized at the
-  /// loosest level.
-  String serialize(DartExpression expression) =>
+  /// **Static on purpose.** This is the one entry that accepts any
+  /// expression without parentheses — true at the root, false everywhere
+  /// inside. Dart forbids reaching a static through an instance, so an arm
+  /// below *cannot* call `children.serialize(...)`; it has to use
+  /// [_serializeAt] or [_serializeDelimited] and say what that position
+  /// accepts. The alternative — an instance method with a comment asking
+  /// callers not to — is a convention, and this is a compile error.
+  ///
+  /// [isConstContext] describes the destination: true for an enclosing
+  /// `const` declaration or a parameter default, false for anything that
+  /// evaluates at runtime.
+  static String serialize(
+    DartExpression expression, {
+    required bool isConstContext,
+  }) => (isConstContext ? _constContext : _runtimeContext)._serializeAt(
+    expression,
+    DartPrecedence.throw_,
+  );
+
+  /// Source for a position already closed by a delimiter — an argument, a
+  /// collection element, a map value, a lambda body.
+  ///
+  /// Nothing can bind looser than the bracket or comma that ends it, so no
+  /// expression needs parentheses. Spelled out rather than reusing
+  /// [serialize] so the claim is visible at the call site.
+  String _serializeDelimited(DartExpression expression) =>
       _serializeAt(expression, DartPrecedence.throw_);
 
   /// [serialize], parenthesizing when [expression] binds looser than the
@@ -147,8 +171,8 @@ class DartExpressionSerializer extends Equatable {
     // A keyword written here (or a context inherited from above) makes
     // every child a constant context.
     final children = isConstContext || expression.canBeConst
-        ? constContext
-        : runtimeContext;
+        ? _constContext
+        : _runtimeContext;
     return switch (expression) {
       // `const 5` and `const UserRole.admin` are syntax errors, so these
       // two arms never offer the keyword — that rule is expressed by the
@@ -170,15 +194,15 @@ class DartExpressionSerializer extends Equatable {
         '${children._serializeAt(target, DartPrecedence.postfix)}'
             '${isNullAware ? '?.' : '.'}$name'
             '${_typeArgumentList(typeArguments)}'
-            '(${arguments.map(children.serialize).join(', ')})',
+            '${children._argumentList(arguments)}',
       DartPropertyAccess(:final target, :final name, :final isNullAware) =>
         '${children._serializeAt(target, DartPrecedence.postfix)}'
             '${isNullAware ? '?.' : '.'}$name',
       DartFunctionCall(:final name, :final arguments) =>
-        '$name(${arguments.map(children.serialize).join(', ')})',
+        '$name${children._argumentList(arguments)}',
       DartIndex(:final target, :final index) =>
         '${children._serializeAt(target, DartPrecedence.postfix)}'
-            '[${children.serialize(index)}]',
+            '[${children._serializeDelimited(index)}]',
       // `as` binds tighter than `??`, so its operand has to be at least a
       // cast itself; `(a ?? b) as T` is where this earns the parens.
       DartCast(:final operand, :final type) =>
@@ -195,13 +219,13 @@ class DartExpressionSerializer extends Equatable {
       DartIfNull(:final value, :final ifNullValue) =>
         '${children._serializeAt(value, DartPrecedence.postfix)} ?? '
             '${children._serializeAt(ifNullValue, DartPrecedence.ifNull)}',
-      DartThrow(:final value) => 'throw ${children.serialize(value)}',
+      DartThrow(:final value) => 'throw ${children._serializeDelimited(value)}',
       DartLambda(:final parameters, :final body) =>
-        '(${parameters.join(', ')}) => ${children.serialize(body)}',
+        '(${parameters.join(', ')}) => ${children._serializeDelimited(body)}',
       DartListLiteral(:final elementType, :final elements) => _maybeConst(
         expression,
         '${elementType == null ? '' : '<$elementType>'}'
-        '[${elements.map(children.serialize).join(', ')}]',
+        '[${elements.map(children._serializeDelimited).join(', ')}]',
       ),
       DartMapLiteral(:final keyType, :final valueType, :final entries) =>
         _maybeConst(expression, () {
@@ -221,19 +245,13 @@ class DartExpressionSerializer extends Equatable {
           final target = constructorName == null
               ? '$type'
               : '$type.$constructorName';
-          final rendered = [
-            ...arguments.map(children.serialize),
-            ...namedArguments.entries.map(
-              (entry) => '${entry.key}: ${children.serialize(entry.value)}',
-            ),
-          ];
-          return '$target(${rendered.join(', ')})';
+          return '$target${children._argumentList(arguments, namedArguments)}';
         }()),
     };
   }
 
   String _serializeEntry(DartMapEntry entry) =>
-      '${serialize(entry.key)}: ${serialize(entry.value)}';
+      '${_serializeDelimited(entry.key)}: ${_serializeDelimited(entry.value)}';
 
   /// Prefixes `const` when the destination is not already constant and the
   /// keyword buys a compile-time constant. Only called from the arms whose
@@ -242,14 +260,33 @@ class DartExpressionSerializer extends Equatable {
       !isConstContext && expression.canBeConst ? 'const $source' : source;
 
   /// `<A, B>`, or empty when there are none to write.
+  ///
+  /// Each argument renders through [DartType.toString], so a change to how
+  /// a type spells itself reaches method-call type arguments too.
   static String _typeArgumentList(List<DartType> typeArguments) =>
       typeArguments.isEmpty ? '' : '<${typeArguments.join(', ')}>';
+
+  /// `(a, b, c: d)` — the argument list shared by every call form.
+  ///
+  /// Named arguments render in iteration order, after the positional ones.
+  String _argumentList(
+    List<DartExpression> arguments, [
+    Map<String, DartExpression> namedArguments = const {},
+  ]) {
+    final rendered = [
+      ...arguments.map(_serializeDelimited),
+      ...namedArguments.entries.map(
+        (entry) => '${entry.key}: ${_serializeDelimited(entry.value)}',
+      ),
+    ];
+    return '(${rendered.join(', ')})';
+  }
 
   @override
   List<Object?> get props => [isConstContext];
 }
 
-/// A call to a top-level function: `call('jsonDecode', [body])`.
+/// A call to a top-level function: `callFunction('jsonDecode', [body])`.
 ///
 /// The free-function counterpart to [DartTypeExpressions.construct], and
 /// here for the same reason: so a call site reads like the Dart it emits,
@@ -257,10 +294,16 @@ class DartExpressionSerializer extends Equatable {
 /// them.
 ///
 /// A function rather than an extension on `String`: an extension member
-/// named `call` would make every `String` implicitly invocable, and any
-/// other name reads worse than this does.
-DartExpression call(String name, [List<DartExpression> arguments = const []]) =>
-    DartFunctionCall(name: name, arguments: arguments);
+/// named `call` would make every `String` implicitly invocable.
+///
+/// Not named plain `call` either. This is public and top-level, so it
+/// lands in the namespace of every importer — and `render_tree.dart`
+/// already has locals named `call`, which would shadow it and turn a
+/// misuse into a confusing "String is not a function".
+DartExpression callFunction(
+  String name, [
+  List<DartExpression> arguments = const [],
+]) => DartFunctionCall(name: name, arguments: arguments);
 
 /// Expression builders for the forms that are *rooted at a type name* —
 /// `Foo(...)`, `Uri.parse(...)`, `UserRole.admin` — so a call site reads

--- a/lib/src/render/dart_expression.dart
+++ b/lib/src/render/dart_expression.dart
@@ -51,11 +51,47 @@ sealed class DartExpression extends Equatable {
   /// see `doc/dart_expression.md`.
   bool get canBeConst;
 
+  /// How tightly this expression binds, so the serializer can decide where
+  /// parentheses are required instead of each producer reasoning it out.
+  DartPrecedence get precedence;
+
   /// Debug form (`DartLiteral(5)`), not Dart source. Rendering goes
   /// through [DartExpressionSerializer] — an expression cannot serialize
   /// itself, because how it renders depends on where the text lands.
   @override
   bool get stringify => true;
+}
+
+/// How tightly an expression binds, loosest first.
+///
+/// Only the levels the generator actually emits, not Dart's full table —
+/// there is no arithmetic or comparison in generated `fromJson`/`toJson`
+/// code, and an unused level is a level nothing tests.
+///
+/// The point of the enum is that composition asks rather than assumes.
+/// Before it, two overrides answered "does a cast on the left of `??` need
+/// parens" independently and disagreed: `RenderNumeric` emitted
+/// `(json['x'] as int?) ?? 0` and `RenderPod` emitted
+/// `json['x'] as bool? ?? false`.
+enum DartPrecedence {
+  /// `throw x` — binds looser than everything, including a lambda body.
+  throw_,
+
+  /// `(e) => body`.
+  lambda,
+
+  /// `x ?? y`.
+  ifNull,
+
+  /// `x as T`.
+  cast,
+
+  /// Selectors: `x.y`, `x?.y`, `f(...)`. Left-associative, so a target
+  /// must already be at this level or tighter.
+  postfix,
+
+  /// Literals, identifiers, and anything else that never needs parens.
+  primary,
 }
 
 /// Renders a [DartExpression] to Dart source.
@@ -91,7 +127,23 @@ class DartExpressionSerializer extends Equatable {
   final bool isConstContext;
 
   /// The Dart source for [expression].
-  String serialize(DartExpression expression) {
+  ///
+  /// Nothing wraps the outermost expression, so it is serialized at the
+  /// loosest level.
+  String serialize(DartExpression expression) =>
+      _serializeAt(expression, DartPrecedence.throw_);
+
+  /// [serialize], parenthesizing when [expression] binds looser than the
+  /// position it is landing in requires.
+  ///
+  /// A written `const` keyword needs no accounting here: `const Foo(1)` is
+  /// a primary, so `const Foo(1).bar` already means `(const Foo(1)).bar`.
+  String _serializeAt(DartExpression expression, DartPrecedence minimum) {
+    final source = _serializeBare(expression);
+    return expression.precedence.index < minimum.index ? '($source)' : source;
+  }
+
+  String _serializeBare(DartExpression expression) {
     // A keyword written here (or a context inherited from above) makes
     // every child a constant context.
     final children = isConstContext || expression.canBeConst
@@ -111,13 +163,29 @@ class DartExpressionSerializer extends Equatable {
       DartMethodCall(
         :final target,
         :final name,
+        :final typeArguments,
         :final arguments,
         :final isNullAware,
       ) =>
-        '${children.serialize(target)}${isNullAware ? '?.' : '.'}$name'
+        '${children._serializeAt(target, DartPrecedence.postfix)}'
+            '${isNullAware ? '?.' : '.'}$name'
+            '${_typeArgumentList(typeArguments)}'
             '(${arguments.map(children.serialize).join(', ')})',
       DartPropertyAccess(:final target, :final name, :final isNullAware) =>
-        '${children.serialize(target)}${isNullAware ? '?.' : '.'}$name',
+        '${children._serializeAt(target, DartPrecedence.postfix)}'
+            '${isNullAware ? '?.' : '.'}$name',
+      DartFunctionCall(:final name, :final arguments) =>
+        '$name(${arguments.map(children.serialize).join(', ')})',
+      // `as` binds tighter than `??`, so its operand has to be at least a
+      // cast itself; `(a ?? b) as T` is where this earns the parens.
+      DartCast(:final operand, :final type) =>
+        '${children._serializeAt(operand, DartPrecedence.cast)} as $type',
+      // `??` is right-associative: the left side must bind tighter, the
+      // right side may be another `??` without parens.
+      DartIfNull(:final value, :final ifNullValue) =>
+        '${children._serializeAt(value, DartPrecedence.cast)} ?? '
+            '${children._serializeAt(ifNullValue, DartPrecedence.ifNull)}',
+      DartThrow(:final value) => 'throw ${children.serialize(value)}',
       DartLambda(:final parameters, :final body) =>
         '(${parameters.join(', ')}) => ${children.serialize(body)}',
       DartListLiteral(:final elementType, :final elements) => _maybeConst(
@@ -162,6 +230,10 @@ class DartExpressionSerializer extends Equatable {
   /// node kind can legally carry it.
   String _maybeConst(DartExpression expression, String source) =>
       !isConstContext && expression.canBeConst ? 'const $source' : source;
+
+  /// `<A, B>`, or empty when there are none to write.
+  static String _typeArgumentList(List<DartType> typeArguments) =>
+      typeArguments.isEmpty ? '' : '<${typeArguments.join(', ')}>';
 
   @override
   List<Object?> get props => [isConstContext];
@@ -235,6 +307,9 @@ class DartLiteral extends DartExpression {
   @override
   bool get canBeConst => true;
 
+  @override
+  DartPrecedence get precedence => DartPrecedence.primary;
+
   // Includes the runtime type because `5 == 5.0` in Dart, but `5` and `5.0`
   // are different literals — equality here has to agree with [toString].
   @override
@@ -263,6 +338,9 @@ class DartListLiteral extends DartExpression {
   /// A list literal is constant when every element is.
   @override
   bool get canBeConst => elements.every((element) => element.canBeConst);
+
+  @override
+  DartPrecedence get precedence => DartPrecedence.primary;
 
   @override
   List<Object?> get props => [elementType, elements];
@@ -308,6 +386,9 @@ class DartMapLiteral extends DartExpression {
   bool get canBeConst => entries.every((entry) => entry.canBeConst);
 
   @override
+  DartPrecedence get precedence => DartPrecedence.primary;
+
+  @override
   List<Object?> get props => [keyType, valueType, entries];
 }
 
@@ -328,6 +409,9 @@ class DartIdentifier extends DartExpression {
   bool get canBeConst => false;
 
   @override
+  DartPrecedence get precedence => DartPrecedence.primary;
+
+  @override
   List<Object?> get props => [name];
 }
 
@@ -339,6 +423,7 @@ class DartMethodCall extends DartExpression {
   const DartMethodCall({
     required this.target,
     required this.name,
+    this.typeArguments = const [],
     this.arguments = const [],
     this.isNullAware = false,
   });
@@ -347,6 +432,12 @@ class DartMethodCall extends DartExpression {
   final DartExpression target;
 
   final String name;
+
+  /// Explicit type arguments: the `<Foo>` in `.map<Foo>(...)` and
+  /// `.cast<Foo>()`. Written out rather than inferred because the target
+  /// is a `List<dynamic>` off the wire, where inference would land on
+  /// `dynamic`.
+  final List<DartType> typeArguments;
 
   final List<DartExpression> arguments;
 
@@ -359,7 +450,107 @@ class DartMethodCall extends DartExpression {
   bool get canBeConst => false;
 
   @override
-  List<Object?> get props => [target, name, arguments, isNullAware];
+  DartPrecedence get precedence => DartPrecedence.postfix;
+
+  @override
+  List<Object?> get props => [
+    target,
+    name,
+    typeArguments,
+    arguments,
+    isNullAware,
+  ];
+}
+
+/// A call to a top-level function: `jsonDecode(json)`,
+/// `maybeParseDateTime(v)`.
+///
+/// Distinct from [DartInvocation], which is rooted at a [DartType]. The
+/// functions this models are the generator's own `model_helpers.dart`
+/// entries plus `dart:convert`'s `jsonDecode` — free functions with no
+/// enclosing type to name.
+///
+/// The name is a plain `String` because these are fixed, known functions;
+/// there is no question a consumer asks about one beyond which it is.
+class DartFunctionCall extends DartExpression {
+  const DartFunctionCall({required this.name, this.arguments = const []});
+
+  final String name;
+
+  final List<DartExpression> arguments;
+
+  /// The generator emits no `const` functions, so a call is never constant.
+  @override
+  bool get canBeConst => false;
+
+  @override
+  DartPrecedence get precedence => DartPrecedence.postfix;
+
+  @override
+  List<Object?> get props => [name, arguments];
+}
+
+/// A cast: `json['x'] as String?`.
+class DartCast extends DartExpression {
+  const DartCast({required this.operand, required this.type});
+
+  final DartExpression operand;
+
+  final DartType type;
+
+  /// A cast of a constant is itself a constant expression, but the
+  /// generator only ever casts a runtime JSON value, so claiming const here
+  /// would be untestable. False until something needs otherwise.
+  @override
+  bool get canBeConst => false;
+
+  @override
+  DartPrecedence get precedence => DartPrecedence.cast;
+
+  @override
+  List<Object?> get props => [operand, type];
+}
+
+/// A null-coalescing expression: `json['x'] as int? ?? 0`.
+class DartIfNull extends DartExpression {
+  const DartIfNull({required this.value, required this.ifNullValue});
+
+  /// The left side, used when it is not null.
+  final DartExpression value;
+
+  /// The right side, evaluated only when [value] is null.
+  final DartExpression ifNullValue;
+
+  /// `??` evaluates at runtime — it is not a constant expression even when
+  /// both sides could be.
+  @override
+  bool get canBeConst => false;
+
+  @override
+  DartPrecedence get precedence => DartPrecedence.ifNull;
+
+  @override
+  List<Object?> get props => [value, ifNullValue];
+}
+
+/// A throw expression: `throw UnimplementedError('...')`.
+///
+/// Grammatically an expression in Dart, which is what lets it stand in for
+/// a value the generator cannot produce — the no-JSON schemas (`void`,
+/// binary) parse to one.
+class DartThrow extends DartExpression {
+  const DartThrow(this.value);
+
+  final DartExpression value;
+
+  @override
+  bool get canBeConst => false;
+
+  @override
+  DartPrecedence get precedence => DartPrecedence.throw_;
+
+  @override
+  List<Object?> get props => [value];
 }
 
 /// A property access: `entry.value`, `response.body`.
@@ -386,6 +577,9 @@ class DartPropertyAccess extends DartExpression {
   bool get canBeConst => false;
 
   @override
+  DartPrecedence get precedence => DartPrecedence.postfix;
+
+  @override
   List<Object?> get props => [target, name, isNullAware];
 }
 
@@ -404,6 +598,9 @@ class DartLambda extends DartExpression {
   /// A closure is never a constant expression.
   @override
   bool get canBeConst => false;
+
+  @override
+  DartPrecedence get precedence => DartPrecedence.lambda;
 
   @override
   List<Object?> get props => [parameters, body];
@@ -475,6 +672,9 @@ class DartInvocation extends DartExpression {
       namedArguments.values.every((argument) => argument.canBeConst);
 
   @override
+  DartPrecedence get precedence => DartPrecedence.postfix;
+
+  @override
   List<Object?> get props => [
     type,
     constructorName,
@@ -501,6 +701,9 @@ class DartStaticMember extends DartExpression {
   /// only used for members that are; a static getter would not be.
   @override
   bool get canBeConst => true;
+
+  @override
+  DartPrecedence get precedence => DartPrecedence.postfix;
 
   @override
   List<Object?> get props => [type, name];

--- a/lib/src/render/dart_type.dart
+++ b/lib/src/render/dart_type.dart
@@ -16,10 +16,14 @@ class DartType extends Equatable {
     this.isNullable = false,
   });
 
-  /// A `List<T>` type. [element] defaults to `dynamic` (`List<dynamic>`).
+  /// A `List<T>` type, or bare `List` when [element] is omitted.
+  ///
+  /// Raw `List` and `List<dynamic>` are the same type in Dart, so the
+  /// no-argument form is spelling, not meaning: it is what a JSON array is
+  /// cast through, where there is no element type worth writing.
   DartType.list([DartType? element])
     : name = 'List',
-      typeArguments = [element ?? dynamic_],
+      typeArguments = element == null ? const [] : [element],
       isNullable = false;
 
   /// A `Map<K, V>` type.
@@ -67,14 +71,6 @@ class DartType extends Equatable {
   // of the core class (e.g. a space_gen-side constant, or built at the use
   // site) rather than living alongside the language-level types.
   static const uriTemplate = DartType('UriTemplate');
-
-  /// Bare `List`, with no type argument.
-  ///
-  /// Distinct from [DartType.list], which defaults its element to
-  /// `dynamic` and so renders `List<dynamic>`. This is the type a JSON
-  /// array is *cast through* before its items are converted, where naming
-  /// an element type would be a claim the wire value doesn't support.
-  static const rawList = DartType('List');
 
   /// `MapEntry` (`dart:core`) — built by the closure a map's `fromJson`
   /// maps through.

--- a/lib/src/render/dart_type.dart
+++ b/lib/src/render/dart_type.dart
@@ -68,6 +68,22 @@ class DartType extends Equatable {
   // site) rather than living alongside the language-level types.
   static const uriTemplate = DartType('UriTemplate');
 
+  /// Bare `List`, with no type argument.
+  ///
+  /// Distinct from [DartType.list], which defaults its element to
+  /// `dynamic` and so renders `List<dynamic>`. This is the type a JSON
+  /// array is *cast through* before its items are converted, where naming
+  /// an element type would be a claim the wire value doesn't support.
+  static const rawList = DartType('List');
+
+  /// `MapEntry` (`dart:core`) — built by the closure a map's `fromJson`
+  /// maps through.
+  static const mapEntry = DartType('MapEntry');
+
+  /// `UnimplementedError` (`dart:core`) — thrown where a schema has no
+  /// JSON form.
+  static const unimplementedError = DartType('UnimplementedError');
+
   /// The `String` type.
   static const string = DartType('String');
 

--- a/lib/src/render/dart_type.dart
+++ b/lib/src/render/dart_type.dart
@@ -18,9 +18,19 @@ class DartType extends Equatable {
 
   /// A `List<T>` type, or bare `List` when [element] is omitted.
   ///
-  /// Raw `List` and `List<dynamic>` are the same type in Dart, so the
-  /// no-argument form is spelling, not meaning: it is what a JSON array is
-  /// cast through, where there is no element type worth writing.
+  /// The two spellings are the same type — `List<E>` is unbounded, so raw
+  /// `List` instantiates to `List<dynamic>` — but they are *not*
+  /// interchangeable in output, which is why this does not canonicalize
+  /// one into the other:
+  ///
+  /// - A **declaration** wants `List<dynamic>`. Bare `List` there trips
+  ///   `strict_raw_type`, and generated models are public API for
+  ///   consumers who may enable it.
+  /// - A **cast** wants bare `List`. `as List` reads better than
+  ///   `as List<dynamic>` and raw types in an expression trip nothing.
+  ///
+  /// So `dartType` passes an element and `jsonStorageDartType` does not,
+  /// and `==` distinguishing them is the point rather than a defect.
   DartType.list([DartType? element])
     : name = 'List',
       typeArguments = element == null ? const [] : [element],

--- a/lib/src/render/file_renderer.dart
+++ b/lib/src/render/file_renderer.dart
@@ -1134,5 +1134,5 @@ class FileRenderer {
 /// context; a non-constant one is declared `final`, so any constant
 /// subtree inside it needs its own keyword.
 String _exampleSource(DartExpression example) => example.canBeConst
-    ? DartExpressionSerializer.serialize(example, isConstContext: true)
-    : DartExpressionSerializer.serialize(example, isConstContext: false);
+    ? serializeExpression(example, isConstContext: true)
+    : serializeExpression(example, isConstContext: false);

--- a/lib/src/render/file_renderer.dart
+++ b/lib/src/render/file_renderer.dart
@@ -1134,5 +1134,5 @@ class FileRenderer {
 /// context; a non-constant one is declared `final`, so any constant
 /// subtree inside it needs its own keyword.
 String _exampleSource(DartExpression example) => example.canBeConst
-    ? DartExpressionSerializer.constContext.serialize(example)
-    : DartExpressionSerializer.runtimeContext.serialize(example);
+    ? DartExpressionSerializer.serialize(example, isConstContext: true)
+    : DartExpressionSerializer.serialize(example, isConstContext: false);

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -2776,6 +2776,10 @@ abstract class RenderSchema extends Equatable implements ToTemplateContext {
   /// only as an operation's return. Getting one here means the tree was
   /// built wrong, so this reports that rather than propagating a null into
   /// an expression that has nowhere to put it.
+  ///
+  /// Only [RenderMap] can actually reach the throw: [RenderArray] asks
+  /// first whether its items need conversion, and [RenderVoid] answers no,
+  /// so an array of void takes the `.cast()` branch and never calls this.
   @protected
   DartExpression requireFromJsonExpression(
     DartExpression jsonValue,
@@ -2795,6 +2799,34 @@ abstract class RenderSchema extends Equatable implements ToTemplateContext {
     return expression;
   }
 
+  /// This schema parsed from [jsonValue]: cast to the wire type, handed to
+  /// the schema's own `fromJson` factory, with any default substituted
+  /// after.
+  ///
+  /// The whole conversion for every schema that renders its own factory,
+  /// which is why it is one method rather than the same three calls
+  /// written out per subclass.
+  ///
+  /// Not used by [RenderOneOf] or [RenderEmptyObject]: both would be
+  /// unchanged by [orDefault] today (their default is always null), but
+  /// routing them through it would newly subject them to its
+  /// nullable-without-a-default [StateError].
+  @protected
+  DartExpression parsedFromJson(
+    DartExpression jsonValue,
+    SchemaRenderer context, {
+    required bool jsonIsNullable,
+    required bool dartIsNullable,
+  }) => orDefault(
+    _fromJsonCall(
+      jsonCast(jsonValue, jsonIsNullable: jsonIsNullable),
+      jsonIsNullable: jsonIsNullable,
+    ),
+    context: context,
+    jsonIsNullable: jsonIsNullable,
+    dartIsNullable: dartIsNullable,
+  );
+
   /// `<Type>.fromJson(<argument>)`, or `maybeFromJson` when the JSON value
   /// can be null — the shape every schema that renders its own `fromJson`
   /// is parsed through.
@@ -2803,7 +2835,6 @@ abstract class RenderSchema extends Equatable implements ToTemplateContext {
   /// Those are the same string today, but only one of them is the type
   /// reference sites elsewhere emit, and a divergence would produce a call
   /// to a class that does not exist.
-  @protected
   DartExpression _fromJsonCall(
     DartExpression argument, {
     required bool jsonIsNullable,
@@ -2910,7 +2941,7 @@ abstract class RenderSchema extends Equatable implements ToTemplateContext {
 /// a `??` right-hand side, or a parameter default, where a `const` keyword
 /// turns an allocation into a compile-time constant.
 String _runtimeSource(DartExpression expression) =>
-    DartExpressionSerializer.runtimeContext.serialize(expression);
+    DartExpressionSerializer.serialize(expression, isConstContext: false);
 
 /// [_runtimeSource] for an expression that may be absent.
 String? _maybeRuntimeSource(DartExpression? expression) =>
@@ -3111,7 +3142,12 @@ class RenderPod extends RenderSchema {
     );
 
     if (createsNewType) {
-      return withDefault(_fromJsonCall(cast, jsonIsNullable: jsonIsNullable));
+      return parsedFromJson(
+        jsonValue,
+        context,
+        jsonIsNullable: jsonIsNullable,
+        dartIsNullable: dartIsNullable,
+      );
     }
 
     // Inline: convert the JSON string to a Dart value at the use site. A
@@ -3122,15 +3158,15 @@ class RenderPod extends RenderSchema {
       switch (type) {
         PodType.dateTime =>
           jsonIsNullable
-              ? call(ModelHelpers.maybeParseDateTime, [cast])
+              ? callFunction(ModelHelpers.maybeParseDateTime, [cast])
               : DartType.dateTime.construct([cast], name: 'parse'),
         PodType.uri =>
           jsonIsNullable
-              ? call(ModelHelpers.maybeParseUri, [cast])
+              ? callFunction(ModelHelpers.maybeParseUri, [cast])
               : DartType.uri.construct([cast], name: 'parse'),
         PodType.uriTemplate =>
           jsonIsNullable
-              ? call(ModelHelpers.maybeParseUriTemplate, [cast])
+              ? callFunction(ModelHelpers.maybeParseUriTemplate, [cast])
               : DartType.uriTemplate.construct([cast]),
         // Already JSON-native: the cast is the whole conversion.
         PodType.boolean || PodType.email || PodType.uuid => cast,
@@ -3311,21 +3347,6 @@ class RenderString extends RenderSchema {
   @override
   DartType get jsonStorageDartType => DartType.string;
 
-  DartExpression newTypeFromJsonExpression(
-    DartExpression jsonValue,
-    SchemaRenderer context, {
-    required bool jsonIsNullable,
-    required bool dartIsNullable,
-  }) => orDefault(
-    _fromJsonCall(
-      jsonCast(jsonValue, jsonIsNullable: jsonIsNullable),
-      jsonIsNullable: jsonIsNullable,
-    ),
-    context: context,
-    jsonIsNullable: jsonIsNullable,
-    dartIsNullable: dartIsNullable,
-  );
-
   @override
   DartExpression fromJsonExpression(
     DartExpression jsonValue,
@@ -3334,7 +3355,7 @@ class RenderString extends RenderSchema {
     required bool dartIsNullable,
   }) {
     if (createsNewType) {
-      return newTypeFromJsonExpression(
+      return parsedFromJson(
         jsonValue,
         context,
         jsonIsNullable: jsonIsNullable,
@@ -3579,21 +3600,6 @@ abstract class RenderNumeric<T extends num> extends RenderSchema {
     return '${jsonIsNullable ? '?.' : '.'}$method()';
   }
 
-  DartExpression newTypeFromJsonExpression(
-    DartExpression jsonValue,
-    SchemaRenderer context, {
-    required bool jsonIsNullable,
-    required bool dartIsNullable,
-  }) => orDefault(
-    _fromJsonCall(
-      jsonCast(jsonValue, jsonIsNullable: jsonIsNullable),
-      jsonIsNullable: jsonIsNullable,
-    ),
-    context: context,
-    jsonIsNullable: jsonIsNullable,
-    dartIsNullable: dartIsNullable,
-  );
-
   @override
   DartExpression fromJsonExpression(
     DartExpression jsonValue,
@@ -3602,7 +3608,7 @@ abstract class RenderNumeric<T extends num> extends RenderSchema {
     required bool dartIsNullable,
   }) {
     if (createsNewType) {
-      return newTypeFromJsonExpression(
+      return parsedFromJson(
         jsonValue,
         context,
         jsonIsNullable: jsonIsNullable,
@@ -4018,7 +4024,7 @@ class RenderObject extends RenderNewType {
     // `checkedKey`, which throws `FormatException` when the key is
     // absent — other combinations still read `json[key]` directly.
     final jsonRead = jsonKeyIsRequired && property.common.nullable
-        ? call(ModelHelpers.checkedKey, [
+        ? callFunction(ModelHelpers.checkedKey, [
             const DartIdentifier('json'),
             DartLiteral(jsonName),
           ])
@@ -4295,12 +4301,9 @@ class RenderObject extends RenderNewType {
     SchemaRenderer context, {
     required bool jsonIsNullable,
     required bool dartIsNullable,
-  }) => orDefault(
-    _fromJsonCall(
-      jsonCast(jsonValue, jsonIsNullable: jsonIsNullable),
-      jsonIsNullable: jsonIsNullable,
-    ),
-    context: context,
+  }) => parsedFromJson(
+    jsonValue,
+    context,
     jsonIsNullable: jsonIsNullable,
     dartIsNullable: dartIsNullable,
   );
@@ -5030,12 +5033,9 @@ abstract class RenderEnum<T extends Object> extends RenderNewType {
     SchemaRenderer context, {
     required bool jsonIsNullable,
     required bool dartIsNullable,
-  }) => orDefault(
-    _fromJsonCall(
-      jsonCast(jsonValue, jsonIsNullable: jsonIsNullable),
-      jsonIsNullable: jsonIsNullable,
-    ),
-    context: context,
+  }) => parsedFromJson(
+    jsonValue,
+    context,
     jsonIsNullable: jsonIsNullable,
     dartIsNullable: dartIsNullable,
   );
@@ -6546,7 +6546,7 @@ class RenderBase64Bytes extends RenderSchema {
     // null check (a ternary on a public-property `Uint8List?` doesn't
     // promote).
     return jsonIsNullable
-        ? call(ModelHelpers.maybeBase64Decode, [cast])
+        ? callFunction(ModelHelpers.maybeBase64Decode, [cast])
         : DartMethodCall(
             target: const DartIdentifier('base64'),
             name: 'decode',
@@ -6626,12 +6626,9 @@ class RenderDate extends RenderSchema {
     SchemaRenderer context, {
     required bool jsonIsNullable,
     required bool dartIsNullable,
-  }) => orDefault(
-    _fromJsonCall(
-      jsonCast(jsonValue, jsonIsNullable: jsonIsNullable),
-      jsonIsNullable: jsonIsNullable,
-    ),
-    context: context,
+  }) => parsedFromJson(
+    jsonValue,
+    context,
     jsonIsNullable: jsonIsNullable,
     dartIsNullable: dartIsNullable,
   );

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -2916,19 +2916,6 @@ String _runtimeSource(DartExpression expression) =>
 String? _maybeRuntimeSource(DartExpression? expression) =>
     expression == null ? null : _runtimeSource(expression);
 
-/// Bare `List`, the wire shape of any array before its items are
-/// converted. Deliberately unparameterized — `DartType.list` builds
-/// `List<T>`, which is what the *result* is, not what the cast goes
-/// through.
-const _list = DartType('List');
-const _nullableList = DartType('List', isNullable: true);
-
-/// `MapEntry`, built by the closure a map's `fromJson` maps through.
-const _mapEntry = DartType('MapEntry');
-
-/// `UnimplementedError`, thrown where a schema has no JSON form.
-const _unimplementedError = DartType('UnimplementedError');
-
 /// `DateTime.utc(2024)`.
 DartExpression _dateTimeUtc(int year) =>
     DartType.dateTime.construct([DartLiteral(year)], name: 'utc');
@@ -4626,7 +4613,7 @@ class RenderArray extends RenderSchema {
     // the wire value is a `List<dynamic>` whatever the items are.
     final cast = DartCast(
       operand: jsonValue,
-      type: jsonIsNullable ? _nullableList : _list,
+      type: jsonIsNullable ? DartType.rawList.asNullable() : DartType.rawList,
     );
     // Only a truly json-native item (Dart type == wire type: String, int,
     // bool, num) can be cast directly. Items that need conversion — newtypes,
@@ -4820,7 +4807,7 @@ class RenderMap extends RenderSchema {
       arguments: [
         DartLambda(
           parameters: const ['key', 'value'],
-          body: const DartType('MapEntry').construct([keyToJson, valueToJson]),
+          body: DartType.mapEntry.construct([keyToJson, valueToJson]),
         ),
       ],
       isNullAware: dartIsNullable,
@@ -4865,11 +4852,11 @@ class RenderMap extends RenderSchema {
       name: 'map',
       arguments: [
         if (isIdentity)
-          _mapEntry.member('new')
+          DartType.mapEntry.member('new')
         else
           DartLambda(
             parameters: [key.name, value.name],
-            body: _mapEntry.construct([keyFromJson, valueFromJson]),
+            body: DartType.mapEntry.construct([keyFromJson, valueFromJson]),
           ),
       ],
       isNullAware: jsonIsNullable,
@@ -6455,7 +6442,11 @@ abstract class RenderNoJson extends RenderSchema {
     DartExpression dartName,
     SchemaRenderer context, {
     required bool dartIsNullable,
-  }) => DartIdentifier('throw UnimplementedError("$runtimeType.toJson")');
+  }) => DartThrow(
+    DartType.unimplementedError.construct([
+      DartLiteral('$runtimeType.toJson'),
+    ]),
+  );
 
   @override
   DartExpression? fromJsonExpression(
@@ -6464,7 +6455,7 @@ abstract class RenderNoJson extends RenderSchema {
     required bool jsonIsNullable,
     required bool dartIsNullable,
   }) => DartThrow(
-    _unimplementedError.construct([
+    DartType.unimplementedError.construct([
       DartLiteral('$runtimeType.fromJson'),
     ]),
   );

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -2941,7 +2941,7 @@ abstract class RenderSchema extends Equatable implements ToTemplateContext {
 /// a `??` right-hand side, or a parameter default, where a `const` keyword
 /// turns an allocation into a compile-time constant.
 String _runtimeSource(DartExpression expression) =>
-    DartExpressionSerializer.serialize(expression, isConstContext: false);
+    serializeExpression(expression, isConstContext: false);
 
 /// [_runtimeSource] for an expression that may be absent.
 String? _maybeRuntimeSource(DartExpression? expression) =>

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -1768,7 +1768,7 @@ class Endpoint implements ToTemplateContext {
     final returnShape = operation.returnShape;
     final String returnType;
     final bool isVoidReturn;
-    final String? responseFromJson;
+    final DartExpression? responseFromJson;
     final _MultiStatusContext? multiStatusContext;
     switch (returnShape) {
       case SingleSchemaReturn(:final schema):
@@ -1782,11 +1782,11 @@ class Endpoint implements ToTemplateContext {
         // (text/plain) emitting clean Dart. The non-JSON path then
         // falls back to the raw body without going through
         // `fromJsonExpression`, since that expects JSON-shaped input.
-        final source = _responseBodySource(operation.successContentType);
-        responseFromJson = source == 'response.body'
-            ? source
+        final source = _ResponseBodySource.of(operation.successContentType);
+        responseFromJson = source == _ResponseBodySource.raw
+            ? source.expression
             : schema.fromJsonExpression(
-                source,
+                source.expression,
                 context,
                 jsonIsNullable: false,
                 dartIsNullable: false,
@@ -1804,7 +1804,7 @@ class Endpoint implements ToTemplateContext {
     final hasErrorType = errorSchema != null;
     final errorType = errorSchema?.typeName;
     final errorFromJson = errorSchema?.fromJsonExpression(
-      'jsonDecode(response.body)',
+      _ResponseBodySource.json.expression,
       context,
       jsonIsNullable: false,
       dartIsNullable: false,
@@ -1864,7 +1864,7 @@ class Endpoint implements ToTemplateContext {
       'multipartAssembly': _buildMultipartAssembly(context),
       'returnType': returnType,
       'isVoidReturn': isVoidReturn,
-      'responseFromJson': responseFromJson,
+      'responseFromJson': _maybeRuntimeSource(responseFromJson),
       // Mustache treats a non-empty map as a single-iteration section
       // that pushes the map onto the context — so
       // `{{#multiStatus}}...{{/multiStatus}}` doubles as both the
@@ -1882,7 +1882,7 @@ class Endpoint implements ToTemplateContext {
             },
       'hasErrorType': hasErrorType,
       'errorType': errorType,
-      'errorFromJson': errorFromJson,
+      'errorFromJson': _maybeRuntimeSource(errorFromJson),
       'validationStatements': validationStatementsString,
     };
   }
@@ -2650,11 +2650,21 @@ abstract class RenderSchema extends Equatable implements ToTemplateContext {
   @override
   List<Object?> get props => [snakeName, pointer];
 
-  String orDefaultExpression({
+  /// [expression], with this schema's default substituted when the JSON
+  /// value can be null but the value the expression produces still has to
+  /// land in a slot that needs one.
+  ///
+  /// Returns [expression] unchanged when no substitution is called for,
+  /// so composing is unconditional at the call site.
+  DartExpression orDefault(
+    DartExpression expression, {
     required SchemaRenderer context,
     required bool jsonIsNullable,
     required bool dartIsNullable,
   }) {
+    DartExpression coalesced(DartExpression defaultValue) =>
+        DartIfNull(value: expression, ifNullValue: defaultValue);
+
     final defaultValue = defaultValueExpression(context);
     if (defaultValue == null) {
       if (jsonIsNullable && !dartIsNullable) {
@@ -2666,13 +2676,13 @@ abstract class RenderSchema extends Equatable implements ToTemplateContext {
         // generator violated its own invariant, not user error.
         throw StateError('No default value for nullable property: $this');
       }
-      return '';
+      return expression;
     }
-    if (!jsonIsNullable) return '';
+    if (!jsonIsNullable) return expression;
     // Non-null Dart slot fed by nullable JSON: an `as T?` cast would
     // crash on null. Substitute the default whether the default is
     // const or not.
-    if (!dartIsNullable) return ' ?? ${_runtimeSource(defaultValue)}';
+    if (!dartIsNullable) return coalesced(defaultValue);
     // Nullable Dart slot with a const default: the constructor uses
     // `this.foo = default`, which only fires when the param is omitted.
     // `fromJson` always passes a value (possibly null), so substitute
@@ -2680,13 +2690,11 @@ abstract class RenderSchema extends Equatable implements ToTemplateContext {
     // produces `null` instead of the spec's default. Surfaced by a
     // real spec with `bool` properties marked `default: false` outside
     // the `required` array.
-    if (defaultValue.canBeConst) {
-      return ' ?? ${_runtimeSource(defaultValue)}';
-    }
+    if (defaultValue.canBeConst) return coalesced(defaultValue);
     // Nullable Dart slot with a non-const default: the constructor uses
     // an initializer list (`: foo = foo ?? default`) that substitutes
     // on null too, so the default lands without `fromJson`'s help.
-    return '';
+    return expression;
   }
 
   /// The structured Dart type for this schema — the single source of truth.
@@ -2734,12 +2742,78 @@ abstract class RenderSchema extends Equatable implements ToTemplateContext {
     required bool dartIsNullable,
   });
 
-  String fromJsonExpression(
-    String jsonValue,
+  /// The expression that converts [jsonValue] (a value in JSON wire form)
+  /// into this schema's Dart type.
+  ///
+  /// Null when the schema has no `fromJson` at all: [RenderVoid], whose
+  /// only use is a void return, produces no value to convert. Modeled as
+  /// an absent expression rather than an empty one so callers have to
+  /// decide what to do about it.
+  DartExpression? fromJsonExpression(
+    DartExpression jsonValue,
     SchemaRenderer context, {
     required bool jsonIsNullable,
     required bool dartIsNullable,
   });
+
+  /// `<jsonValue> as <this schema's wire type>`, the cast every
+  /// [fromJsonExpression] starts from.
+  @protected
+  DartExpression jsonCast(
+    DartExpression jsonValue, {
+    required bool jsonIsNullable,
+  }) => DartCast(
+    operand: jsonValue,
+    type: jsonIsNullable
+        ? jsonStorageDartType.asNullable()
+        : jsonStorageDartType,
+  );
+
+  /// [fromJsonExpression] where an absent expression has no meaning — as a
+  /// list element or a map value, whose Dart type cannot be `void`.
+  ///
+  /// [RenderVoid] is the only schema that returns null, and it is reachable
+  /// only as an operation's return. Getting one here means the tree was
+  /// built wrong, so this reports that rather than propagating a null into
+  /// an expression that has nowhere to put it.
+  @protected
+  DartExpression requireFromJsonExpression(
+    DartExpression jsonValue,
+    SchemaRenderer context, {
+    required bool jsonIsNullable,
+    required bool dartIsNullable,
+  }) {
+    final expression = fromJsonExpression(
+      jsonValue,
+      context,
+      jsonIsNullable: jsonIsNullable,
+      dartIsNullable: dartIsNullable,
+    );
+    if (expression == null) {
+      throw StateError('$runtimeType has no fromJson expression: $this');
+    }
+    return expression;
+  }
+
+  /// `<Type>.fromJson(<argument>)`, or `maybeFromJson` when the JSON value
+  /// can be null — the shape every schema that renders its own `fromJson`
+  /// is parsed through.
+  ///
+  /// Named off [dartType] rather than a separately-computed class name.
+  /// Those are the same string today, but only one of them is the type
+  /// reference sites elsewhere emit, and a divergence would produce a call
+  /// to a class that does not exist.
+  @protected
+  DartExpression _fromJsonCall(
+    DartExpression argument, {
+    required bool jsonIsNullable,
+  }) => DartInvocation(
+    type: dartType,
+    constructorName: jsonIsNullable ? 'maybeFromJson' : 'fromJson',
+    arguments: [argument],
+    // A factory that parses at runtime.
+    isConstConstructor: false,
+  );
 
   /// A Dart expression that constructs a valid in-memory instance of
   /// this schema, used by generated round-trip tests. Returns `null`
@@ -2841,6 +2915,19 @@ String _runtimeSource(DartExpression expression) =>
 /// [_runtimeSource] for an expression that may be absent.
 String? _maybeRuntimeSource(DartExpression? expression) =>
     expression == null ? null : _runtimeSource(expression);
+
+/// Bare `List`, the wire shape of any array before its items are
+/// converted. Deliberately unparameterized — `DartType.list` builds
+/// `List<T>`, which is what the *result* is, not what the cast goes
+/// through.
+const _list = DartType('List');
+const _nullableList = DartType('List', isNullable: true);
+
+/// `MapEntry`, built by the closure a map's `fromJson` maps through.
+const _mapEntry = DartType('MapEntry');
+
+/// `UnimplementedError`, thrown where a schema has no JSON form.
+const _unimplementedError = DartType('UnimplementedError');
 
 /// `DateTime.utc(2024)`.
 DartExpression _dateTimeUtc(int year) =>
@@ -3016,49 +3103,58 @@ class RenderPod extends RenderSchema {
   }
 
   @override
-  String fromJsonExpression(
-    String jsonValue,
+  DartExpression fromJsonExpression(
+    DartExpression jsonValue,
     SchemaRenderer context, {
     required bool jsonIsNullable,
     required bool dartIsNullable,
   }) {
-    final jsonType = jsonStorageType(isNullable: jsonIsNullable);
-    final orDefault = orDefaultExpression(
+    final cast = jsonCast(jsonValue, jsonIsNullable: jsonIsNullable);
+    // Applied to every branch: when the JSON value can't be null it
+    // returns the expression unchanged, so the branches don't each have
+    // to know whether a default is in play.
+    DartExpression withDefault(DartExpression expression) => orDefault(
+      expression,
       context: context,
       jsonIsNullable: jsonIsNullable,
       dartIsNullable: dartIsNullable,
     );
-    final castedValue = '$jsonValue as $jsonType';
 
     if (createsNewType) {
-      final jsonMethod = jsonIsNullable ? 'maybeFromJson' : 'fromJson';
-      return '$typeName.$jsonMethod($castedValue)$orDefault';
+      return withDefault(_fromJsonCall(cast, jsonIsNullable: jsonIsNullable));
     }
 
-    // Inline: convert json String -> Dart value at the use site. For
-    // nullable values we call a helper (so the expression remains a
-    // single nullable-aware expression), for non-nullable we inline.
-    switch (type) {
-      case PodType.dateTime:
-        if (jsonIsNullable) {
-          return '${ModelHelpers.maybeParseDateTime}($castedValue)$orDefault';
-        }
-        return 'DateTime.parse($castedValue)';
-      case PodType.uri:
-        if (jsonIsNullable) {
-          return '${ModelHelpers.maybeParseUri}($castedValue)$orDefault';
-        }
-        return 'Uri.parse($castedValue)';
-      case PodType.uriTemplate:
-        if (jsonIsNullable) {
-          final call = '${ModelHelpers.maybeParseUriTemplate}($castedValue)';
-          return '$call$orDefault';
-        }
-        return 'UriTemplate($castedValue)';
-      case PodType.boolean || PodType.email || PodType.uuid:
-        // 'as' has higher precedence than '??' so no parens are needed.
-        return '$castedValue$orDefault';
-    }
+    // Inline: convert the JSON string to a Dart value at the use site. A
+    // nullable value goes through a model helper, which keeps the result
+    // a single nullable-aware expression; a non-nullable one inlines the
+    // parse.
+    return withDefault(
+      switch (type) {
+        PodType.dateTime =>
+          jsonIsNullable
+              ? DartFunctionCall(
+                  name: ModelHelpers.maybeParseDateTime,
+                  arguments: [cast],
+                )
+              : DartType.dateTime.construct([cast], name: 'parse'),
+        PodType.uri =>
+          jsonIsNullable
+              ? DartFunctionCall(
+                  name: ModelHelpers.maybeParseUri,
+                  arguments: [cast],
+                )
+              : DartType.uri.construct([cast], name: 'parse'),
+        PodType.uriTemplate =>
+          jsonIsNullable
+              ? DartFunctionCall(
+                  name: ModelHelpers.maybeParseUriTemplate,
+                  arguments: [cast],
+                )
+              : DartType.uriTemplate.construct([cast]),
+        // Already JSON-native: the cast is the whole conversion.
+        PodType.boolean || PodType.email || PodType.uuid => cast,
+      },
+    );
   }
 
   @override
@@ -3234,27 +3330,24 @@ class RenderString extends RenderSchema {
   @override
   DartType get jsonStorageDartType => DartType.string;
 
-  String newTypeFromJsonExpression(
-    String jsonValue,
+  DartExpression newTypeFromJsonExpression(
+    DartExpression jsonValue,
     SchemaRenderer context, {
     required bool jsonIsNullable,
     required bool dartIsNullable,
-  }) {
-    final orDefault = orDefaultExpression(
-      context: context,
+  }) => orDefault(
+    _fromJsonCall(
+      jsonCast(jsonValue, jsonIsNullable: jsonIsNullable),
       jsonIsNullable: jsonIsNullable,
-      dartIsNullable: dartIsNullable,
-    );
-    final jsonMethod = jsonIsNullable ? 'maybeFromJson' : 'fromJson';
-    final className = camelFromSnake(snakeName);
-    final jsonType = jsonStorageType(isNullable: jsonIsNullable);
-    final castedValue = '$jsonValue as $jsonType';
-    return '$className.$jsonMethod($castedValue)$orDefault';
-  }
+    ),
+    context: context,
+    jsonIsNullable: jsonIsNullable,
+    dartIsNullable: dartIsNullable,
+  );
 
   @override
-  String fromJsonExpression(
-    String jsonValue,
+  DartExpression fromJsonExpression(
+    DartExpression jsonValue,
     SchemaRenderer context, {
     required bool jsonIsNullable,
     required bool dartIsNullable,
@@ -3267,14 +3360,13 @@ class RenderString extends RenderSchema {
         dartIsNullable: dartIsNullable,
       );
     }
-    final jsonType = jsonStorageType(isNullable: jsonIsNullable);
-    final orDefault = orDefaultExpression(
+    // A String is already JSON-native: the cast is the conversion.
+    return orDefault(
+      jsonCast(jsonValue, jsonIsNullable: jsonIsNullable),
       context: context,
       jsonIsNullable: jsonIsNullable,
       dartIsNullable: dartIsNullable,
     );
-    final castedValue = '$jsonValue as $jsonType';
-    return '$castedValue$orDefault';
   }
 
   @override
@@ -3493,29 +3585,37 @@ abstract class RenderNumeric<T extends num> extends RenderSchema {
     };
   }
 
-  String jsonToDartCall({required bool jsonIsNullable});
+  /// The method that narrows the JSON wire type to the Dart type — `num`
+  /// arrives off the wire where a `double` is wanted. Null when the two
+  /// already agree and no call is needed.
+  String? get jsonToDartMethod;
 
-  String newTypeFromJsonExpression(
-    String jsonValue,
+  /// [jsonToDartMethod] spelled as a call, for the newtype template, which
+  /// splices it into a body this class does not build.
+  String jsonToDartCall({required bool jsonIsNullable}) {
+    final method = jsonToDartMethod;
+    if (method == null) return '';
+    return '${jsonIsNullable ? '?.' : '.'}$method()';
+  }
+
+  DartExpression newTypeFromJsonExpression(
+    DartExpression jsonValue,
     SchemaRenderer context, {
     required bool jsonIsNullable,
     required bool dartIsNullable,
-  }) {
-    final orDefault = orDefaultExpression(
-      context: context,
+  }) => orDefault(
+    _fromJsonCall(
+      jsonCast(jsonValue, jsonIsNullable: jsonIsNullable),
       jsonIsNullable: jsonIsNullable,
-      dartIsNullable: dartIsNullable,
-    );
-    final jsonMethod = jsonIsNullable ? 'maybeFromJson' : 'fromJson';
-    final className = camelFromSnake(snakeName);
-    final jsonType = jsonStorageType(isNullable: jsonIsNullable);
-    final castedValue = '$jsonValue as $jsonType';
-    return '$className.$jsonMethod($castedValue)$orDefault';
-  }
+    ),
+    context: context,
+    jsonIsNullable: jsonIsNullable,
+    dartIsNullable: dartIsNullable,
+  );
 
   @override
-  String fromJsonExpression(
-    String jsonValue,
+  DartExpression fromJsonExpression(
+    DartExpression jsonValue,
     SchemaRenderer context, {
     required bool jsonIsNullable,
     required bool dartIsNullable,
@@ -3528,21 +3628,23 @@ abstract class RenderNumeric<T extends num> extends RenderSchema {
         dartIsNullable: dartIsNullable,
       );
     }
-    final jsonType = jsonStorageType(isNullable: jsonIsNullable);
-    final orDefault = orDefaultExpression(
+    // Where the wire type is wider than the Dart type (`num` -> `double`),
+    // narrow it. The serializer parenthesizes the cast because a selector
+    // binds tighter than `as`; a cast with no call on it stays bare (#255).
+    final cast = jsonCast(jsonValue, jsonIsNullable: jsonIsNullable);
+    final narrowed = jsonToDartMethod;
+    return orDefault(
+      narrowed == null
+          ? cast
+          : DartMethodCall(
+              target: cast,
+              name: narrowed,
+              isNullAware: jsonIsNullable,
+            ),
       context: context,
       jsonIsNullable: jsonIsNullable,
       dartIsNullable: dartIsNullable,
     );
-    final toDartCall = jsonToDartCall(jsonIsNullable: jsonIsNullable);
-    final cast = '$jsonValue as $jsonType';
-    // A bare cast needs no parens (`unnecessary_parenthesis`). Keep them
-    // to bind a trailing `.toX()` tighter than `as`
-    // (`(json['x'] as num).toDouble()`), or around a `?? default` where
-    // the analyzer leaves the parens for readability
-    // (`(json['x'] as int?) ?? 0`).
-    if (toDartCall.isEmpty && orDefault.isEmpty) return cast;
-    return '($cast)$toDartCall$orDefault';
   }
 
   @override
@@ -3612,8 +3714,7 @@ class RenderNumber extends RenderNumeric<double> {
   DartType get jsonStorageDartType => DartType.num_;
 
   @override
-  String jsonToDartCall({required bool jsonIsNullable}) =>
-      jsonIsNullable ? '?.toDouble()' : '.toDouble()';
+  String? get jsonToDartMethod => 'toDouble';
 
   @override
   DartExpression? exampleValue(SchemaRenderer context) =>
@@ -3651,9 +3752,9 @@ class RenderInteger extends RenderNumeric<int> {
   @override
   DartType get jsonStorageDartType => DartType.int_;
 
-  // jsonType and dartType are both int, so we don't need to do anything.
+  // jsonType and dartType are both int, so there is nothing to narrow.
   @override
-  String jsonToDartCall({required bool jsonIsNullable}) => '';
+  String? get jsonToDartMethod => null;
 
   @override
   DartExpression? exampleValue(SchemaRenderer context) => newtypeWrappedExample(
@@ -3936,8 +4037,14 @@ class RenderObject extends RenderNewType {
     // `checkedKey`, which throws `FormatException` when the key is
     // absent — other combinations still read `json[key]` directly.
     final jsonRead = jsonKeyIsRequired && property.common.nullable
-        ? "${ModelHelpers.checkedKey}(json, '$jsonName')"
-        : "json['$jsonName']";
+        ? DartFunctionCall(
+            name: ModelHelpers.checkedKey,
+            arguments: [const DartIdentifier('json'), DartLiteral(jsonName)],
+          )
+        : DartIndex(
+            target: const DartIdentifier('json'),
+            index: DartLiteral(jsonName),
+          );
 
     // Means that the constructor parameter is required which is only true if
     // both the json property is required and it does not have a default.
@@ -3982,11 +4089,13 @@ class RenderObject extends RenderNewType {
           dartIsNullable: dartIsNullable,
         ),
       ),
-      'fromJson': property.fromJsonExpression(
-        jsonRead,
-        context,
-        dartIsNullable: dartIsNullable,
-        jsonIsNullable: jsonIsNullable,
+      'fromJson': _maybeRuntimeSource(
+        property.fromJsonExpression(
+          jsonRead,
+          context,
+          dartIsNullable: dartIsNullable,
+          jsonIsNullable: jsonIsNullable,
+        ),
       ),
     };
   }
@@ -4170,11 +4279,16 @@ class RenderObject extends RenderNewType {
           dartIsNullable: isNullable,
         ),
       ),
-      'entryValueFromJson': valueSchema?.fromJsonExpression(
-        'entry.value',
-        context,
-        jsonIsNullable: isNullable,
-        dartIsNullable: isNullable,
+      'entryValueFromJson': _maybeRuntimeSource(
+        valueSchema?.fromJsonExpression(
+          const DartPropertyAccess(
+            target: DartIdentifier('entry'),
+            name: 'value',
+          ),
+          context,
+          jsonIsNullable: isNullable,
+          dartIsNullable: isNullable,
+        ),
       ),
       // The set of named-property JSON keys to exclude from
       // `entries` on round-trip. A `const <String>{...}` literal —
@@ -4195,21 +4309,20 @@ class RenderObject extends RenderNewType {
   }
 
   @override
-  String fromJsonExpression(
-    String jsonValue,
+  DartExpression fromJsonExpression(
+    DartExpression jsonValue,
     SchemaRenderer context, {
     required bool jsonIsNullable,
     required bool dartIsNullable,
-  }) {
-    final jsonType = jsonStorageType(isNullable: jsonIsNullable);
-    final orDefault = orDefaultExpression(
-      context: context,
+  }) => orDefault(
+    _fromJsonCall(
+      jsonCast(jsonValue, jsonIsNullable: jsonIsNullable),
       jsonIsNullable: jsonIsNullable,
-      dartIsNullable: dartIsNullable,
-    );
-    final jsonMethod = jsonIsNullable ? 'maybeFromJson' : 'fromJson';
-    return '$className.$jsonMethod($jsonValue as $jsonType)$orDefault';
-  }
+    ),
+    context: context,
+    jsonIsNullable: jsonIsNullable,
+    dartIsNullable: dartIsNullable,
+  );
 
   // This would probably be easier if we did a copyWith and then compared with
   // normal equals provided by Equatable.
@@ -4419,11 +4532,13 @@ class RenderArray extends RenderSchema {
     // `.cast<Uri>()` over a `List<String>` is a lazy view that throws on
     // access; those items must be mapped through `fromJsonExpression`.
     if (items.shouldCallToJson) {
-      final itemFrom = items.fromJsonExpression(
-        'e',
-        context,
-        jsonIsNullable: false,
-        dartIsNullable: false,
+      final itemFrom = _runtimeSource(
+        items.requireFromJsonExpression(
+          const DartIdentifier('e'),
+          context,
+          jsonIsNullable: false,
+          dartIsNullable: false,
+        ),
       );
       fromJson = 'v.map<$itemTypeName>((e) => $itemFrom).toList()';
     } else {
@@ -4507,40 +4622,61 @@ class RenderArray extends RenderSchema {
   }
 
   @override
-  String fromJsonExpression(
-    String jsonValue,
+  DartExpression fromJsonExpression(
+    DartExpression jsonValue,
     SchemaRenderer context, {
     required bool jsonIsNullable,
     required bool dartIsNullable,
   }) {
-    final orDefault = orDefaultExpression(
-      context: context,
-      jsonIsNullable: jsonIsNullable,
-      dartIsNullable: dartIsNullable,
-    );
-    final itemTypeName = items.typeName;
-    // List has special handling for nullability since we want to cast
-    // through List<dynamic> first before casting to the item type.
-    final castAsList = jsonIsNullable
-        ? '($jsonValue as List?)?'
-        : '($jsonValue as List)';
-    final itemsFromJson = items.fromJsonExpression(
-      'e',
-      context,
-      dartIsNullable: false,
-      // Unless itemSchema itself has a nullable type this is always false.
-      jsonIsNullable: false,
+    // Cast through a bare `List` first, then convert to the item type —
+    // the wire value is a `List<dynamic>` whatever the items are.
+    final cast = DartCast(
+      operand: jsonValue,
+      type: jsonIsNullable ? _nullableList : _list,
     );
     // Only a truly json-native item (Dart type == wire type: String, int,
     // bool, num) can be cast directly. Items that need conversion — newtypes,
     // enums, and pods like `Uri`/`DateTime` whose wire type is a String —
     // must be mapped through `fromJsonExpression`; a bare `.cast<Uri>()` is a
     // lazy view over the wire Strings that throws on element access.
-    if (!items.shouldCallToJson) {
-      return '$castAsList.cast<$itemTypeName>()$orDefault';
+    final DartExpression converted;
+    if (items.shouldCallToJson) {
+      const element = DartIdentifier('e');
+      converted = DartMethodCall(
+        target: DartMethodCall(
+          target: cast,
+          name: 'map',
+          typeArguments: [items.dartType],
+          arguments: [
+            DartLambda(
+              parameters: [element.name],
+              body: items.requireFromJsonExpression(
+                element,
+                context,
+                dartIsNullable: false,
+                // Unless the item schema itself is nullable, always false.
+                jsonIsNullable: false,
+              ),
+            ),
+          ],
+          isNullAware: jsonIsNullable,
+        ),
+        name: 'toList',
+      );
+    } else {
+      converted = DartMethodCall(
+        target: cast,
+        name: 'cast',
+        typeArguments: [items.dartType],
+        isNullAware: jsonIsNullable,
+      );
     }
-    return '$castAsList.map<$itemTypeName>('
-        '(e) => $itemsFromJson).toList()$orDefault';
+    return orDefault(
+      converted,
+      context: context,
+      jsonIsNullable: jsonIsNullable,
+      dartIsNullable: dartIsNullable,
+    );
   }
 
   @override
@@ -4624,11 +4760,13 @@ class RenderMap extends RenderSchema {
     final keyFromJson = keyEnum == null
         ? 'k'
         : '${keyEnum.typeName}.fromJson(k)';
-    final valueFromJson = value.fromJsonExpression(
-      'val',
-      context,
-      jsonIsNullable: false,
-      dartIsNullable: false,
+    final valueFromJson = _runtimeSource(
+      value.requireFromJsonExpression(
+        const DartIdentifier('val'),
+        context,
+        jsonIsNullable: false,
+        dartIsNullable: false,
+      ),
     );
     final keyToJson = keyEnum == null ? 'k' : 'k.toJson()';
     final valueToJson = value.toJsonExpression(
@@ -4696,45 +4834,52 @@ class RenderMap extends RenderSchema {
   }
 
   @override
-  String fromJsonExpression(
-    String jsonValue,
+  DartExpression fromJsonExpression(
+    DartExpression jsonValue,
     SchemaRenderer context, {
     required bool jsonIsNullable,
     required bool dartIsNullable,
   }) {
     // We could probably do a smaller cast if the value schema is only json
     // types.
-    final jsonType = jsonStorageType(isNullable: jsonIsNullable);
-    const keyName = 'key';
-    const valueName = 'value';
+    const key = DartIdentifier('key');
+    const value = DartIdentifier('value');
+    final keySchema = this.keySchema;
     final keyFromJson = keySchema == null
-        ? keyName
-        : '${keySchema!.typeName}.fromJson($keyName)';
-    final valueFromJson = valueSchema.fromJsonExpression(
-      valueName,
+        ? key
+        : keySchema._fromJsonCall(key, jsonIsNullable: false);
+    final valueFromJson = valueSchema.requireFromJsonExpression(
+      value,
       context,
       jsonIsNullable: false,
       dartIsNullable: false,
     );
     // TODO(eseidel): Support orDefault?
     // Should this have a leading ? to skip the key on null?
-    final callMap = jsonIsNullable ? '?.map' : '.map';
-    // When neither key nor value transforms, the closure is
+    //
+    // When neither side transforms, the closure is
     // `(key, value) => MapEntry(key, value)` — a tearoff written the long
-    // way (`unnecessary_lambdas`). Asking whether each side returned the
-    // name it was handed is a stopgap: once `fromJsonExpression` returns a
-    // `DartExpression` (see doc/dart_expression.md), identity becomes
-    // `expr == DartIdentifier(valueName)` structurally.
+    // way (`unnecessary_lambdas`), so emit the tearoff. Identity is a
+    // structural question now: did each side hand back the identifier it
+    // was given?
     //
     // The better output drops the `.map(...)` altogether, since an
-    // identity map only copies. That needs the same migration, because
-    // the result is then a bare cast whose parenthesization is a
-    // structural question (#255) rather than one this string can answer.
-    final isIdentity = keyFromJson == keyName && valueFromJson == valueName;
-    final transform = isIdentity
-        ? 'MapEntry.new'
-        : '(key, value) => MapEntry($keyFromJson, $valueFromJson)';
-    return '($jsonValue as $jsonType)$callMap($transform)';
+    // identity map only copies (#272).
+    final isIdentity = keyFromJson == key && valueFromJson == value;
+    return DartMethodCall(
+      target: jsonCast(jsonValue, jsonIsNullable: jsonIsNullable),
+      name: 'map',
+      arguments: [
+        if (isIdentity)
+          _mapEntry.member('new')
+        else
+          DartLambda(
+            parameters: [key.name, value.name],
+            body: _mapEntry.construct([keyFromJson, valueFromJson]),
+          ),
+      ],
+      isNullAware: jsonIsNullable,
+    );
   }
 
   @override
@@ -4902,21 +5047,20 @@ abstract class RenderEnum<T extends Object> extends RenderNewType {
       '$className.${variableNameFor(value as T)}';
 
   @override
-  String fromJsonExpression(
-    String jsonValue,
+  DartExpression fromJsonExpression(
+    DartExpression jsonValue,
     SchemaRenderer context, {
     required bool jsonIsNullable,
     required bool dartIsNullable,
-  }) {
-    final jsonType = jsonStorageType(isNullable: jsonIsNullable);
-    final orDefault = orDefaultExpression(
-      context: context,
+  }) => orDefault(
+    _fromJsonCall(
+      jsonCast(jsonValue, jsonIsNullable: jsonIsNullable),
       jsonIsNullable: jsonIsNullable,
-      dartIsNullable: dartIsNullable,
-    );
-    final jsonMethod = jsonIsNullable ? 'maybeFromJson' : 'fromJson';
-    return '$className.$jsonMethod($jsonValue as $jsonType)$orDefault';
-  }
+    ),
+    context: context,
+    jsonIsNullable: jsonIsNullable,
+    dartIsNullable: dartIsNullable,
+  );
 
   String variableNameFor(T value) => names[values.indexOf(value)];
 
@@ -5542,16 +5686,15 @@ class RenderOneOf extends RenderNewType {
   }
 
   @override
-  String fromJsonExpression(
-    String jsonValue,
+  DartExpression fromJsonExpression(
+    DartExpression jsonValue,
     SchemaRenderer context, {
     required bool jsonIsNullable,
     required bool dartIsNullable,
-  }) {
-    final jsonType = jsonStorageType(isNullable: jsonIsNullable);
-    final jsonMethod = jsonIsNullable ? 'maybeFromJson' : 'fromJson';
-    return '$className.$jsonMethod($jsonValue as $jsonType)';
-  }
+  }) => _fromJsonCall(
+    jsonCast(jsonValue, jsonIsNullable: jsonIsNullable),
+    jsonIsNullable: jsonIsNullable,
+  );
 
   @override
   dynamic get defaultValue => null;
@@ -5583,10 +5726,32 @@ class RenderOneOf extends RenderNewType {
 /// else (`text/plain`, `text/html`, `application/octet-stream`, …).
 /// Used by both the single-schema return path and the per-arm
 /// decode in multi-status dispatch.
-String _responseBodySource(String? contentType) =>
-    contentType == null || contentType == 'application/json'
-    ? 'jsonDecode(response.body)'
-    : 'response.body';
+/// `response.body`, the raw string an api method gets back.
+const _responseBody = DartPropertyAccess(
+  target: DartIdentifier('response'),
+  name: 'body',
+);
+
+/// Where an api method reads its response body from.
+///
+/// An enum rather than the expression alone because callers branch on
+/// *which* of the two it is — a raw body skips `fromJson` entirely — and
+/// recovering that by comparing the rendered text against
+/// `'response.body'` is the coupling `doc/dart_expression.md` calls out.
+enum _ResponseBodySource {
+  /// The body is JSON and has to be decoded before parsing.
+  json(DartFunctionCall(name: 'jsonDecode', arguments: [_responseBody])),
+
+  /// A non-JSON content type: the body is the value.
+  raw(_responseBody);
+
+  const _ResponseBodySource(this.expression);
+
+  final DartExpression expression;
+
+  static _ResponseBodySource of(String? contentType) =>
+      contentType == null || contentType == 'application/json' ? json : raw;
+}
 
 /// One status-code entry in a multi-status response: the status, the
 /// wrapper subclass name (`<Parent>200`), the body schema (null for
@@ -5635,11 +5800,13 @@ final class _StatusInfo {
     if (body == null) {
       construction = 'const $wrapperTypeName()';
     } else {
-      final decoded = body.fromJsonExpression(
-        _responseBodySource(contentType),
-        context,
-        jsonIsNullable: false,
-        dartIsNullable: false,
+      final decoded = _runtimeSource(
+        body.requireFromJsonExpression(
+          _ResponseBodySource.of(contentType).expression,
+          context,
+          jsonIsNullable: false,
+          dartIsNullable: false,
+        ),
       );
       construction = '$wrapperTypeName($decoded)';
     }
@@ -6224,8 +6391,8 @@ class RenderUnknown extends RenderSchema {
   }) => dartName;
 
   @override
-  String fromJsonExpression(
-    String jsonValue,
+  DartExpression fromJsonExpression(
+    DartExpression jsonValue,
     SchemaRenderer context, {
     required bool jsonIsNullable,
     required bool dartIsNullable,
@@ -6256,14 +6423,15 @@ class RenderVoid extends RenderNoJson {
   String equalsExpression(String name, SchemaRenderer context) =>
       'throw UnimplementedError("RenderVoid.equalsExpression")';
 
+  /// Null, not an expression: a void return has no value to convert.
+  /// The sole caller checks for a void return before asking.
   @override
-  String fromJsonExpression(
-    String jsonValue,
+  DartExpression? fromJsonExpression(
+    DartExpression jsonValue,
     SchemaRenderer context, {
     required bool jsonIsNullable,
     required bool dartIsNullable,
-  }) => ''; // Unclear if this is correct. The one usage is for returning
-  // a void type, maybe we need a "return expression" value instead?
+  }) => null;
 
   @override
   DartExpression? exampleValue(SchemaRenderer context) => null;
@@ -6295,12 +6463,16 @@ abstract class RenderNoJson extends RenderSchema {
   }) => DartIdentifier('throw UnimplementedError("$runtimeType.toJson")');
 
   @override
-  String fromJsonExpression(
-    String jsonValue,
+  DartExpression? fromJsonExpression(
+    DartExpression jsonValue,
     SchemaRenderer context, {
     required bool jsonIsNullable,
     required bool dartIsNullable,
-  }) => 'throw UnimplementedError("$runtimeType.fromJson")';
+  }) => DartThrow(
+    _unimplementedError.construct([
+      DartLiteral('$runtimeType.fromJson'),
+    ]),
+  );
 
   @override
   Map<String, dynamic> toTemplateContext(SchemaRenderer context) =>
@@ -6379,20 +6551,27 @@ class RenderBase64Bytes extends RenderSchema {
   String hashCodeExpression(String name) => '${ModelHelpers.listHash}($name)';
 
   @override
-  String fromJsonExpression(
-    String jsonValue,
+  DartExpression fromJsonExpression(
+    DartExpression jsonValue,
     SchemaRenderer context, {
     required bool jsonIsNullable,
     required bool dartIsNullable,
   }) {
-    final jsonType = jsonStorageType(isNullable: jsonIsNullable);
-    if (jsonIsNullable) {
-      // Use the model_helpers wrapper so `Uint8List?` parses cleanly
-      // without forcing the call site to write its own null check (a
-      // ternary on a public-property `Uint8List?` doesn't promote).
-      return '${ModelHelpers.maybeBase64Decode}($jsonValue as $jsonType)';
-    }
-    return 'base64.decode($jsonValue as $jsonType)';
+    final cast = jsonCast(jsonValue, jsonIsNullable: jsonIsNullable);
+    // The nullable case goes through the model_helpers wrapper so
+    // `Uint8List?` parses cleanly without the call site writing its own
+    // null check (a ternary on a public-property `Uint8List?` doesn't
+    // promote).
+    return jsonIsNullable
+        ? DartFunctionCall(
+            name: ModelHelpers.maybeBase64Decode,
+            arguments: [cast],
+          )
+        : DartMethodCall(
+            target: const DartIdentifier('base64'),
+            name: 'decode',
+            arguments: [cast],
+          );
   }
 
   @override
@@ -6462,24 +6641,20 @@ class RenderDate extends RenderSchema {
   }
 
   @override
-  String fromJsonExpression(
-    String jsonValue,
+  DartExpression fromJsonExpression(
+    DartExpression jsonValue,
     SchemaRenderer context, {
     required bool jsonIsNullable,
     required bool dartIsNullable,
-  }) {
-    final castedValue =
-        '$jsonValue as ${jsonStorageType(isNullable: jsonIsNullable)}';
-    final orDefault = orDefaultExpression(
-      context: context,
+  }) => orDefault(
+    _fromJsonCall(
+      jsonCast(jsonValue, jsonIsNullable: jsonIsNullable),
       jsonIsNullable: jsonIsNullable,
-      dartIsNullable: dartIsNullable,
-    );
-    final call = jsonIsNullable
-        ? 'Date.maybeFromJson($castedValue)'
-        : 'Date.fromJson($castedValue)';
-    return '$call$orDefault';
-  }
+    ),
+    context: context,
+    jsonIsNullable: jsonIsNullable,
+    dartIsNullable: dartIsNullable,
+  );
 
   @override
   DartExpression toJsonExpression(
@@ -6554,16 +6729,15 @@ class RenderEmptyObject extends RenderNewType {
   );
 
   @override
-  String fromJsonExpression(
-    String jsonValue,
+  DartExpression fromJsonExpression(
+    DartExpression jsonValue,
     SchemaRenderer context, {
     required bool jsonIsNullable,
     required bool dartIsNullable,
-  }) {
-    final jsonType = jsonStorageType(isNullable: jsonIsNullable);
-    final jsonMethod = jsonIsNullable ? 'maybeFromJson' : 'fromJson';
-    return '$className.$jsonMethod($jsonValue as $jsonType)';
-  }
+  }) => _fromJsonCall(
+    jsonCast(jsonValue, jsonIsNullable: jsonIsNullable),
+    jsonIsNullable: jsonIsNullable,
+  );
 
   @override
   Map<String, dynamic> toTemplateContext(SchemaRenderer context) => {
@@ -6632,21 +6806,20 @@ class RenderRecursiveRef extends RenderSchema {
   }
 
   @override
-  String fromJsonExpression(
-    String jsonValue,
+  DartExpression fromJsonExpression(
+    DartExpression jsonValue,
     SchemaRenderer context, {
     required bool jsonIsNullable,
     required bool dartIsNullable,
-  }) {
-    final jsonType = jsonStorageType(isNullable: jsonIsNullable);
-    final jsonMethod = jsonIsNullable ? 'maybeFromJson' : 'fromJson';
-    final orDefault = orDefaultExpression(
-      context: context,
+  }) => orDefault(
+    _fromJsonCall(
+      jsonCast(jsonValue, jsonIsNullable: jsonIsNullable),
       jsonIsNullable: jsonIsNullable,
-      dartIsNullable: dartIsNullable,
-    );
-    return '$typeName.$jsonMethod($jsonValue as $jsonType)$orDefault';
-  }
+    ),
+    context: context,
+    jsonIsNullable: jsonIsNullable,
+    dartIsNullable: dartIsNullable,
+  );
 
   @override
   Map<String, dynamic> toTemplateContext(SchemaRenderer context) =>

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -3065,11 +3065,14 @@ class RenderPod extends RenderSchema {
     DartExpression name, {
     required bool nameIsNullable,
   }) {
-    DartExpression call(String method) =>
-        DartMethodCall(target: name, name: method, isNullAware: nameIsNullable);
+    DartExpression method(String methodName) => DartMethodCall(
+      target: name,
+      name: methodName,
+      isNullAware: nameIsNullable,
+    );
     return switch (type) {
-      PodType.dateTime => call('toIso8601String'),
-      PodType.uri || PodType.uriTemplate => call('toString'),
+      PodType.dateTime => method('toIso8601String'),
+      PodType.uri || PodType.uriTemplate => method('toString'),
       // String- and bool-backed types: no conversion; `name` already
       // has the correct nullable/non-nullable type.
       PodType.email || PodType.uuid || PodType.boolean => name,
@@ -3132,24 +3135,15 @@ class RenderPod extends RenderSchema {
       switch (type) {
         PodType.dateTime =>
           jsonIsNullable
-              ? DartFunctionCall(
-                  name: ModelHelpers.maybeParseDateTime,
-                  arguments: [cast],
-                )
+              ? call(ModelHelpers.maybeParseDateTime, [cast])
               : DartType.dateTime.construct([cast], name: 'parse'),
         PodType.uri =>
           jsonIsNullable
-              ? DartFunctionCall(
-                  name: ModelHelpers.maybeParseUri,
-                  arguments: [cast],
-                )
+              ? call(ModelHelpers.maybeParseUri, [cast])
               : DartType.uri.construct([cast], name: 'parse'),
         PodType.uriTemplate =>
           jsonIsNullable
-              ? DartFunctionCall(
-                  name: ModelHelpers.maybeParseUriTemplate,
-                  arguments: [cast],
-                )
+              ? call(ModelHelpers.maybeParseUriTemplate, [cast])
               : DartType.uriTemplate.construct([cast]),
         // Already JSON-native: the cast is the whole conversion.
         PodType.boolean || PodType.email || PodType.uuid => cast,
@@ -4037,10 +4031,10 @@ class RenderObject extends RenderNewType {
     // `checkedKey`, which throws `FormatException` when the key is
     // absent — other combinations still read `json[key]` directly.
     final jsonRead = jsonKeyIsRequired && property.common.nullable
-        ? DartFunctionCall(
-            name: ModelHelpers.checkedKey,
-            arguments: [const DartIdentifier('json'), DartLiteral(jsonName)],
-          )
+        ? call(ModelHelpers.checkedKey, [
+            const DartIdentifier('json'),
+            DartLiteral(jsonName),
+          ])
         : DartIndex(
             target: const DartIdentifier('json'),
             index: DartLiteral(jsonName),
@@ -5740,6 +5734,7 @@ const _responseBody = DartPropertyAccess(
 /// `'response.body'` is the coupling `doc/dart_expression.md` calls out.
 enum _ResponseBodySource {
   /// The body is JSON and has to be decoded before parsing.
+  // Not `call(...)`: a const initializer needs the constructor directly.
   json(DartFunctionCall(name: 'jsonDecode', arguments: [_responseBody])),
 
   /// A non-JSON content type: the body is the value.
@@ -6563,10 +6558,7 @@ class RenderBase64Bytes extends RenderSchema {
     // null check (a ternary on a public-property `Uint8List?` doesn't
     // promote).
     return jsonIsNullable
-        ? DartFunctionCall(
-            name: ModelHelpers.maybeBase64Decode,
-            arguments: [cast],
-          )
+        ? call(ModelHelpers.maybeBase64Decode, [cast])
         : DartMethodCall(
             target: const DartIdentifier('base64'),
             name: 'decode',

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -4610,11 +4610,8 @@ class RenderArray extends RenderSchema {
     required bool dartIsNullable,
   }) {
     // Cast through a bare `List` first, then convert to the item type —
-    // the wire value is a `List<dynamic>` whatever the items are.
-    final cast = DartCast(
-      operand: jsonValue,
-      type: jsonIsNullable ? DartType.rawList.asNullable() : DartType.rawList,
-    );
+    // the wire value is a list of anything whatever the items are.
+    final cast = jsonCast(jsonValue, jsonIsNullable: jsonIsNullable);
     // Only a truly json-native item (Dart type == wire type: String, int,
     // bool, num) can be cast directly. Items that need conversion — newtypes,
     // enums, and pods like `Uri`/`DateTime` whose wire type is a String —

--- a/test/render/dart_expression_test.dart
+++ b/test/render/dart_expression_test.dart
@@ -498,10 +498,21 @@ void main() {
       );
     });
 
-    test('the two serializers are distinct values', () {
+    test('the two destinations render the same tree differently', () {
+      // The reason rendering is not a method on the node: a constant
+      // destination must not repeat the keyword (`unnecessary_const`),
+      // a runtime one wants it.
+      const constable = DartInvocation(
+        type: DartType('Foo'),
+        isConstConstructor: true,
+      );
       expect(
-        DartExpressionSerializer.constContext,
-        isNot(DartExpressionSerializer.runtimeContext),
+        DartExpressionSerializer.serialize(constable, isConstContext: false),
+        'const Foo()',
+      );
+      expect(
+        DartExpressionSerializer.serialize(constable, isConstContext: true),
+        'Foo()',
       );
     });
 

--- a/test/render/dart_expression_test.dart
+++ b/test/render/dart_expression_test.dart
@@ -677,4 +677,44 @@ void main() {
       expect(withArgs, isNot(without));
     });
   });
+
+  group('equality', () {
+    // Not incidental: `RenderMap.fromJsonExpression` decides whether its
+    // closure is the identity by asking whether each side handed back the
+    // identifier it was given, so structural equality is load-bearing.
+    const a = DartIdentifier('a');
+    const b = DartIdentifier('b');
+
+    test('DartFunctionCall compares name and arguments', () {
+      const call = DartFunctionCall(name: 'f', arguments: [a]);
+      expect(call, const DartFunctionCall(name: 'f', arguments: [a]));
+      expect(call, isNot(const DartFunctionCall(name: 'g', arguments: [a])));
+      expect(call, isNot(const DartFunctionCall(name: 'f', arguments: [b])));
+    });
+
+    test('DartIndex compares target and index', () {
+      const index = DartIndex(target: a, index: DartLiteral('k'));
+      expect(index, const DartIndex(target: a, index: DartLiteral('k')));
+      expect(index, isNot(const DartIndex(target: b, index: DartLiteral('k'))));
+      expect(index, isNot(const DartIndex(target: a, index: DartLiteral('j'))));
+    });
+
+    test('DartCast compares operand and type', () {
+      const cast = DartCast(operand: a, type: DartType.int_);
+      expect(cast, const DartCast(operand: a, type: DartType.int_));
+      expect(cast, isNot(const DartCast(operand: b, type: DartType.int_)));
+      expect(cast, isNot(const DartCast(operand: a, type: DartType.string)));
+    });
+
+    test('DartIfNull compares both sides', () {
+      const ifNull = DartIfNull(value: a, ifNullValue: b);
+      expect(ifNull, const DartIfNull(value: a, ifNullValue: b));
+      expect(ifNull, isNot(const DartIfNull(value: b, ifNullValue: a)));
+    });
+
+    test('DartThrow compares its value', () {
+      expect(const DartThrow(a), const DartThrow(a));
+      expect(const DartThrow(a), isNot(const DartThrow(b)));
+    });
+  });
 }

--- a/test/render/dart_expression_test.dart
+++ b/test/render/dart_expression_test.dart
@@ -507,11 +507,11 @@ void main() {
         isConstConstructor: true,
       );
       expect(
-        DartExpressionSerializer.serialize(constable, isConstContext: false),
+        serializeExpression(constable, isConstContext: false),
         'const Foo()',
       );
       expect(
-        DartExpressionSerializer.serialize(constable, isConstContext: true),
+        serializeExpression(constable, isConstContext: true),
         'Foo()',
       );
     });

--- a/test/render/dart_expression_test.dart
+++ b/test/render/dart_expression_test.dart
@@ -550,4 +550,131 @@ void main() {
       expect(member, const DartStaticMember(type: DartType('Foo'), name: 'a'));
     });
   });
+
+  group('parenthesization', () {
+    const json = DartIdentifier('json');
+    const read = DartIndex(target: json, index: DartLiteral('x'));
+
+    test('a bare cast keeps no parens', () {
+      // #255: `(json['x'] as int)` would be `unnecessary_parenthesis`.
+      expect(
+        const DartCast(operand: read, type: DartType.int_).source,
+        "json['x'] as int",
+      );
+    });
+
+    test('a cast under a selector is parenthesized', () {
+      expect(
+        const DartMethodCall(
+          target: DartCast(operand: read, type: DartType.num_),
+          name: 'toDouble',
+        ).source,
+        "(json['x'] as num).toDouble()",
+      );
+    });
+
+    test('a cast on the left of ?? is parenthesized', () {
+      // Elective, not required — `as` already binds tighter. See the arm
+      // in the serializer.
+      expect(
+        const DartIfNull(
+          value: DartCast(
+            operand: read,
+            type: DartType('int', isNullable: true),
+          ),
+          ifNullValue: DartLiteral(0),
+        ).source,
+        "(json['x'] as int?) ?? 0",
+      );
+    });
+
+    test('?? nests to the right without parens', () {
+      expect(
+        const DartIfNull(
+          value: json,
+          ifNullValue: DartIfNull(
+            value: read,
+            ifNullValue: DartLiteral(0),
+          ),
+        ).source,
+        "json ?? json['x'] ?? 0",
+      );
+    });
+
+    test('?? under a cast is parenthesized', () {
+      expect(
+        const DartCast(
+          operand: DartIfNull(value: json, ifNullValue: DartLiteral(0)),
+          type: DartType.int_,
+        ).source,
+        '(json ?? 0) as int',
+      );
+    });
+  });
+
+  group('new nodes', () {
+    test('DartFunctionCall renders a top-level call', () {
+      const call = DartFunctionCall(
+        name: 'jsonDecode',
+        arguments: [DartIdentifier('body')],
+      );
+      expect(call.source, 'jsonDecode(body)');
+      expect(call.canBeConst, isFalse);
+    });
+
+    test('DartIndex renders a subscript', () {
+      expect(
+        const DartIndex(
+          target: DartIdentifier('json'),
+          index: DartLiteral('a'),
+        ).source,
+        "json['a']",
+      );
+    });
+
+    test('DartIndex quotes a key that needs escaping', () {
+      // The read used to interpolate the JSON key raw, emitting
+      // `json['don't']`, which does not parse.
+      expect(
+        const DartIndex(
+          target: DartIdentifier('json'),
+          index: DartLiteral("don't"),
+        ).source,
+        r"json['don\'t']",
+      );
+    });
+
+    test('DartThrow renders a throw expression', () {
+      const thrown = DartThrow(
+        DartInvocation(
+          type: DartType('UnimplementedError'),
+          isConstConstructor: false,
+          arguments: [DartLiteral('nope')],
+        ),
+      );
+      expect(thrown.source, "throw UnimplementedError('nope')");
+      expect(thrown.canBeConst, isFalse);
+    });
+
+    test('DartMethodCall writes type arguments', () {
+      expect(
+        const DartMethodCall(
+          target: DartIdentifier('v'),
+          name: 'cast',
+          typeArguments: [DartType.string],
+        ).source,
+        'v.cast<String>()',
+      );
+    });
+
+    test('type arguments participate in equality', () {
+      const withArgs = DartMethodCall(
+        target: DartIdentifier('v'),
+        name: 'cast',
+        typeArguments: [DartType.string],
+      );
+      const without = DartMethodCall(target: DartIdentifier('v'), name: 'cast');
+      expect(withArgs, isNot(without));
+    });
+  });
 }

--- a/test/render/dart_expression_test.dart
+++ b/test/render/dart_expression_test.dart
@@ -378,7 +378,7 @@ void main() {
       expect(
         DartLambda(
           parameters: const ['key', 'value'],
-          body: const DartType('MapEntry').construct(const [
+          body: DartType.mapEntry.construct(const [
             DartIdentifier('key'),
             DartIdentifier('value'),
           ]),
@@ -647,7 +647,7 @@ void main() {
     test('DartThrow renders a throw expression', () {
       const thrown = DartThrow(
         DartInvocation(
-          type: DartType('UnimplementedError'),
+          type: DartType.unimplementedError,
           isConstConstructor: false,
           arguments: [DartLiteral('nope')],
         ),

--- a/test/render/dart_type_test.dart
+++ b/test/render/dart_type_test.dart
@@ -37,7 +37,7 @@ void main() {
 
     test('DartType.list builds List<T>, defaulting the element to dynamic', () {
       expect(DartType.list(DartType.string).toString(), 'List<String>');
-      expect(DartType.list().toString(), 'List<dynamic>');
+      expect(DartType.list().toString(), 'List');
       expect(
         DartType.list(DartType.list(DartType.int_)).toString(),
         'List<List<int>>',

--- a/test/render/expression_source.dart
+++ b/test/render/expression_source.dart
@@ -8,9 +8,10 @@ import 'package:space_gen/src/render/dart_expression.dart';
 /// whole point of separating rendering from the tree.
 extension ExpressionSource on DartExpression {
   /// Source for a destination that is already a constant context.
-  String get source => DartExpressionSerializer.constContext.serialize(this);
+  String get source =>
+      DartExpressionSerializer.serialize(this, isConstContext: true);
 
   /// Source for a destination that evaluates at runtime.
   String get runtimeSource =>
-      DartExpressionSerializer.runtimeContext.serialize(this);
+      DartExpressionSerializer.serialize(this, isConstContext: false);
 }

--- a/test/render/expression_source.dart
+++ b/test/render/expression_source.dart
@@ -1,17 +1,15 @@
 import 'package:space_gen/src/render/dart_expression.dart';
 
-/// Test-only sugar over [DartExpressionSerializer], so assertions read
-/// `expr.source` instead of naming a serializer at every call.
+/// Test-only sugar over [serializeExpression], so assertions read
+/// `expr.source` instead of naming a destination at every call.
 ///
-/// Production code names the serializer explicitly: which context applies
-/// is a decision about the destination, and picking it deliberately is the
-/// whole point of separating rendering from the tree.
+/// Production code names the destination explicitly: which context applies
+/// is a decision about where the text lands, and picking it deliberately is
+/// the whole point of separating rendering from the tree.
 extension ExpressionSource on DartExpression {
   /// Source for a destination that is already a constant context.
-  String get source =>
-      DartExpressionSerializer.serialize(this, isConstContext: true);
+  String get source => serializeExpression(this, isConstContext: true);
 
   /// Source for a destination that evaluates at runtime.
-  String get runtimeSource =>
-      DartExpressionSerializer.serialize(this, isConstContext: false);
+  String get runtimeSource => serializeExpression(this, isConstContext: false);
 }

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -4160,7 +4160,9 @@ void main() {
         "            n123: json['123'] as String?,\n"
         "            plus1: json['+1'] as String?,\n"
         "            minus1: json['-1'] as String?,\n"
-        "            dont: json['don't'] as String?,\n"
+        // The apostrophe is escaped: this read used to interpolate the
+        // JSON key raw, emitting `json['don't']`, which does not parse.
+        "            dont: json['don\\'t'] as String?,\n"
         "            default_: json['default'] as String?,\n"
         '        ));\n'
         '    }\n'

--- a/test/render/render_tree_test.dart
+++ b/test/render/render_tree_test.dart
@@ -10,6 +10,13 @@ import 'package:test/test.dart';
 
 import 'expression_source.dart';
 
+/// `json`, the parameter every generated `fromJson` receives.
+const _json = DartIdentifier('json');
+
+/// `json['<key>']`, the read a property's `fromJson` starts from.
+DartExpression _jsonKey(String key) =>
+    DartIndex(target: _json, index: DartLiteral(key));
+
 class _Collector extends RenderTreeVisitor {
   final List<RenderSchema> visited = [];
 
@@ -1020,21 +1027,25 @@ void main() {
       final templates = TemplateProvider.defaultLocation();
       final context = SchemaRenderer(templates: templates);
       expect(
-        ref.fromJsonExpression(
-          'json',
-          context,
-          jsonIsNullable: false,
-          dartIsNullable: false,
-        ),
+        ref
+            .fromJsonExpression(
+              _json,
+              context,
+              jsonIsNullable: false,
+              dartIsNullable: false,
+            )
+            ?.runtimeSource,
         'Node.fromJson(json as Map<String, dynamic>)',
       );
       expect(
-        ref.fromJsonExpression(
-          'json',
-          context,
-          jsonIsNullable: true,
-          dartIsNullable: true,
-        ),
+        ref
+            .fromJsonExpression(
+              _json,
+              context,
+              jsonIsNullable: true,
+              dartIsNullable: true,
+            )
+            ?.runtimeSource,
         'Node.maybeFromJson(json as Map<String, dynamic>?)',
       );
     });
@@ -1976,21 +1987,25 @@ void main() {
 
     test('fromJson routes to Date.fromJson / maybeFromJson', () {
       expect(
-        date.fromJsonExpression(
-          "json['d']",
-          context,
-          jsonIsNullable: false,
-          dartIsNullable: false,
-        ),
+        date
+            .fromJsonExpression(
+              _jsonKey('d'),
+              context,
+              jsonIsNullable: false,
+              dartIsNullable: false,
+            )
+            ?.runtimeSource,
         "Date.fromJson(json['d'] as String)",
       );
       expect(
-        date.fromJsonExpression(
-          "json['d']",
-          context,
-          jsonIsNullable: true,
-          dartIsNullable: true,
-        ),
+        date
+            .fromJsonExpression(
+              _jsonKey('d'),
+              context,
+              jsonIsNullable: true,
+              dartIsNullable: true,
+            )
+            ?.runtimeSource,
         "Date.maybeFromJson(json['d'] as String?)",
       );
     });
@@ -2147,33 +2162,39 @@ void main() {
         'when a newtype', () {
       final schema = pod(PodType.dateTime, createsNewType: true);
       expect(
-        schema.fromJsonExpression(
-          "json['d']",
-          context,
-          jsonIsNullable: false,
-          dartIsNullable: false,
-        ),
+        schema
+            .fromJsonExpression(
+              _jsonKey('d'),
+              context,
+              jsonIsNullable: false,
+              dartIsNullable: false,
+            )
+            ?.runtimeSource,
         "FooBar.fromJson(json['d'] as String)",
       );
       expect(
-        schema.fromJsonExpression(
-          "json['d']",
-          context,
-          jsonIsNullable: true,
-          dartIsNullable: true,
-        ),
+        schema
+            .fromJsonExpression(
+              _jsonKey('d'),
+              context,
+              jsonIsNullable: true,
+              dartIsNullable: true,
+            )
+            ?.runtimeSource,
         "FooBar.maybeFromJson(json['d'] as String?)",
       );
     });
 
     test('fromJsonExpression inline routes nullable uuid correctly', () {
       expect(
-        pod(PodType.uuid).fromJsonExpression(
-          "json['u']",
-          context,
-          jsonIsNullable: false,
-          dartIsNullable: false,
-        ),
+        pod(PodType.uuid)
+            .fromJsonExpression(
+              _jsonKey('u'),
+              context,
+              jsonIsNullable: false,
+              dartIsNullable: false,
+            )
+            ?.runtimeSource,
         "json['u'] as String",
       );
     });

--- a/test/render/render_tree_test.dart
+++ b/test/render/render_tree_test.dart
@@ -1034,7 +1034,7 @@ void main() {
               jsonIsNullable: false,
               dartIsNullable: false,
             )
-            ?.runtimeSource,
+            .runtimeSource,
         'Node.fromJson(json as Map<String, dynamic>)',
       );
       expect(
@@ -1045,7 +1045,7 @@ void main() {
               jsonIsNullable: true,
               dartIsNullable: true,
             )
-            ?.runtimeSource,
+            .runtimeSource,
         'Node.maybeFromJson(json as Map<String, dynamic>?)',
       );
     });
@@ -1296,6 +1296,36 @@ void main() {
     test('void returns null (no round-trip possible)', () {
       const schema = RenderVoid(common: common);
       expect(schema.exampleValue(context)?.source, isNull);
+    });
+
+    test('void has no fromJson expression, and array items must', () {
+      const void_ = RenderVoid(common: common);
+      expect(
+        void_.fromJsonExpression(
+          const DartIdentifier('json'),
+          context,
+          jsonIsNullable: false,
+          dartIsNullable: false,
+        ),
+        isNull,
+      );
+      // A map value's type can't be void, so an absent expression there
+      // means the tree was built wrong — say so rather than propagating a
+      // null into an expression with nowhere to put it.
+      const map = RenderMap(
+        common: common,
+        valueSchema: void_,
+        keySchema: null,
+      );
+      expect(
+        () => map.fromJsonExpression(
+          const DartIdentifier('json'),
+          context,
+          jsonIsNullable: false,
+          dartIsNullable: false,
+        ),
+        throwsStateError,
+      );
     });
 
     test('binary (NoJson) returns null', () {
@@ -1994,7 +2024,7 @@ void main() {
               jsonIsNullable: false,
               dartIsNullable: false,
             )
-            ?.runtimeSource,
+            .runtimeSource,
         "Date.fromJson(json['d'] as String)",
       );
       expect(
@@ -2005,7 +2035,7 @@ void main() {
               jsonIsNullable: true,
               dartIsNullable: true,
             )
-            ?.runtimeSource,
+            .runtimeSource,
         "Date.maybeFromJson(json['d'] as String?)",
       );
     });
@@ -2169,7 +2199,7 @@ void main() {
               jsonIsNullable: false,
               dartIsNullable: false,
             )
-            ?.runtimeSource,
+            .runtimeSource,
         "FooBar.fromJson(json['d'] as String)",
       );
       expect(
@@ -2180,7 +2210,7 @@ void main() {
               jsonIsNullable: true,
               dartIsNullable: true,
             )
-            ?.runtimeSource,
+            .runtimeSource,
         "FooBar.maybeFromJson(json['d'] as String?)",
       );
     });
@@ -2194,7 +2224,7 @@ void main() {
               jsonIsNullable: false,
               dartIsNullable: false,
             )
-            ?.runtimeSource,
+            .runtimeSource,
         "json['u'] as String",
       );
     });

--- a/test/render/render_tree_test.dart
+++ b/test/render/render_tree_test.dart
@@ -1333,6 +1333,35 @@ void main() {
       expect(schema.exampleValue(context)?.source, isNull);
     });
 
+    test('a no-JSON schema converts to a throw in both directions', () {
+      // `toJson` used to spell this as a DartIdentifier holding the whole
+      // `throw ...` string, because no node could express a throw. Both
+      // directions now build one, so the message is a real string literal
+      // and is quoted like every other.
+      const schema = RenderBinary(common: common);
+      expect(
+        schema
+            .fromJsonExpression(
+              const DartIdentifier('json'),
+              context,
+              jsonIsNullable: false,
+              dartIsNullable: false,
+            )
+            ?.runtimeSource,
+        "throw UnimplementedError('RenderBinary.fromJson')",
+      );
+      expect(
+        schema
+            .toJsonExpression(
+              const DartIdentifier('value'),
+              context,
+              dartIsNullable: false,
+            )
+            .runtimeSource,
+        "throw UnimplementedError('RenderBinary.toJson')",
+      );
+    });
+
     test('recursive ref returns null', () {
       const schema = RenderRecursiveRef(
         common: common,
@@ -2318,6 +2347,43 @@ void main() {
     // that catches naming-pass bypasses (a test forgot to populate
     // `SpecResolver.names`, or a render path didn't go through one of
     // the documented entry points).
+    test('a newtype fromJson names the assigned type, not the snake name', () {
+      // The `fromJson` call used to be built from
+      // `camelFromSnake(snakeName)` while every type *reference* around it
+      // came from the assigned name. Those agree whenever the naming pass
+      // hands back the snake-derived name, which is why this went
+      // unnoticed — when they disagree the old form called a class that
+      // does not exist.
+      const schema = RenderString(
+        common: CommonProperties.test(
+          snakeName: 'foo_bar',
+          pointer: JsonPointer.empty(),
+        ),
+        defaultValue: null,
+        maxLength: null,
+        minLength: null,
+        pattern: null,
+        createsNewType: true,
+        assignedName: 'CustomName',
+      );
+      expect(schema.typeName, 'CustomName');
+      final context = SchemaRenderer(
+        templates: TemplateProvider.defaultLocation(),
+      );
+      expect(
+        schema
+            .fromJsonExpression(
+              _json,
+              context,
+              jsonIsNullable: false,
+              dartIsNullable: false,
+            )
+            .runtimeSource,
+        // Not `FooBar.fromJson(...)`.
+        'CustomName.fromJson(json as String)',
+      );
+    });
+
     test('newtype RenderObject without assignedName throws on typeName', () {
       const schema = RenderObject(
         common: CommonProperties.test(

--- a/test/render/render_tree_test.dart
+++ b/test/render/render_tree_test.dart
@@ -2372,7 +2372,7 @@ void main() {
       expect(schema.typeName, 'CustomName');
     });
 
-    test('jsonStorageType: RenderArray stores as List<dynamic>', () {
+    test('jsonStorageType: RenderArray stores as a bare List', () {
       const array = RenderArray(
         common: CommonProperties.test(
           snakeName: 'a',
@@ -2387,8 +2387,11 @@ void main() {
           ),
         ),
       );
-      expect(array.jsonStorageType(isNullable: false), 'List<dynamic>');
-      expect(array.jsonStorageType(isNullable: true), 'List<dynamic>?');
+      // Raw `List` and `List<dynamic>` are the same type — `List<E>` is
+      // unbounded, so the raw form instantiates its parameter to
+      // `dynamic`. This is the spelling the cast uses.
+      expect(array.jsonStorageType(isNullable: false), 'List');
+      expect(array.jsonStorageType(isNullable: true), 'List?');
     });
 
     test('jsonStorageDartType throws for schemas with no JSON form', () {


### PR DESCRIPTION
## Summary

`fromJsonExpression` returns a `DartExpression` instead of a `String` —
the other half of #265, and `doc/dart_expression.md` remaining-work item 1.
All 16 overrides build a tree. Closes #291.

## Parenthesization stops being restated

The overrides were each reasoning about parens in prose, and two of them
reached opposite conclusions:

```dart
// RenderNumeric
if (toDartCall.isEmpty && orDefault.isEmpty) return cast;
return '($cast)$toDartCall$orDefault';          // (json['x'] as int?) ?? 0

// RenderPod
// 'as' has higher precedence than '??' so no parens are needed.
return '$castedValue$orDefault';                // json['x'] as bool? ?? false
```

Both compile and neither trips `unnecessary_parenthesis`; it was a coin
flip resolved twice. Now nodes carry a `DartPrecedence` and the serializer
parenthesizes a child that binds looser than its position requires — which
is also where #255 lives (a bare cast stays bare, a cast under a selector
gets parens).

The one place the rule is **elective** is a cast on the left of `??`: `as`
already binds tighter, so `json['x'] as int? ?? 0` is legal. It just reads
badly — `? ??` runs two unrelated question marks together — so the
serializer asks for `postfix` there and says why. That unifies the two
overrides on `RenderNumeric`'s existing output.

## Two things that fell out

Neither was aimed at; both are consequences of the JSON key and the
identity check becoming structural.

- **A property named `don't` was generating code that does not parse.**
  The read interpolated the key raw (`"json['$jsonName']"`), emitting
  ``json['don't']``. As a `DartLiteral` it is quoted properly. The test
  asserting the broken output is corrected, not deleted (#241 → #243).
- **`RenderMap`'s identity check** compares `expr == DartIdentifier(...)`
  rather than rendered text against the name it passed in — the stopgap
  its own comment flagged, and what #272 was waiting on.

`_responseBodySource`'s two magic strings, recovered by comparing against
`'response.body'`, become an enum — one of the two sites in the ADR's
remaining-work item 3. `RenderVoid` returns `null` rather than `''`: a void
return has no value to convert, and that is now representable.

## Validation

- **A/B regen of all six tracked specs**, same package names, `dart fix`
  applied both sides: five byte-identical. github differs on **138 lines,
  all one change** — `x as bool? ?? false` → `(x as bool?) ?? false` — plus
  4 lines of `dart_style` reflow where the added parens crossed 80 columns.
  Nothing else moved.
- **Raw lint tally with `dart fix` disabled on both sides** (the gate a
  post-fix diff can't see): identical, 12 lints across the same 4
  categories. `unnecessary_parenthesis` does not appear, which is what
  makes the elective parens defensible.
- All six specs `dart analyze` clean. Generated suites pass: petstore (28),
  spacetraders (732), discord (1530).
- 708 unit tests pass. `dart run tool/gen_tests.dart` produces no golden
  drift.

## Note on the ADR

Item 4 ("import derivation — the real prize") is narrower than written.
#287 answered the *schema* half structurally from the render tree, so the
expression IR only owes the *library* half — whether a body called
`jsonDecode` or named `Uint8List`. That is weaker grounds for widening
scope to declarations than the ADR assumed, so the `code_builder` question
should be reopened only if that step actually demands it. Corrected in
place.
