### PR TITLE
refactor: pass the const-context predicate instead of branching on it

### DIFF
--- a/lib/src/render/file_renderer.dart
+++ b/lib/src/render/file_renderer.dart
@@ -1133,6 +1133,5 @@ class FileRenderer {
 /// example is declared `const`, which makes its whole tree a constant
 /// context; a non-constant one is declared `final`, so any constant
 /// subtree inside it needs its own keyword.
-String _exampleSource(DartExpression example) => example.canBeConst
-    ? serializeExpression(example, isConstContext: true)
-    : serializeExpression(example, isConstContext: false);
+String _exampleSource(DartExpression example) =>
+    serializeExpression(example, isConstContext: example.canBeConst);


### PR DESCRIPTION
## Summary

`_exampleSource` called `serializeExpression` twice from a ternary whose
only difference was the flag it passed — and the condition it branched on
*is* that flag:

```dart
example.canBeConst
    ? serializeExpression(example, isConstContext: true)
    : serializeExpression(example, isConstContext: false)
```

Follow-up to #293. Written while that PR was open and pushed a minute
after it merged, so it missed the squash.

## Validation

- 715 unit tests pass; `dart analyze` clean.
- Output byte-identical across all six tracked specs (verified on the
  #293 branch before the split-out; the change is the same two lines).
