### PR TITLE
fix: accept date and base64 properties in a multipart body (#294)

### DIFF
--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -2430,12 +2430,32 @@ DartExpression _multipartValueExpr(
   return _stringifyWireValue(property, jsonExpr);
 }
 
+/// Whether [schema] serializes to a single value on the wire, and so can
+/// become one `Map<String, String>` field of a multipart body.
+///
+/// An allowlist rather than "not object/array/map-shaped" on purpose: a
+/// new [RenderSchema] subtype should land here as a loud
+/// `FormatException` naming the type, not be waved through to
+/// [_multipartValueExpr] to emit something quietly wrong.
+///
+/// The resolver asks the same "one value on the wire" question over
+/// `Resolved*` for query parameters. The two lists can't share an
+/// implementation — the resolver is deliberately Dart-blind — but they
+/// describe one rule, so a divergence between them is a bug in one of
+/// them by construction. Keep them in sync.
 bool _isMultipartScalar(RenderSchema schema) {
   return schema is RenderString ||
       schema is RenderInteger ||
       schema is RenderNumber ||
       schema is RenderPod ||
-      schema is RenderEnum;
+      schema is RenderEnum ||
+      // `Date.toJson()` is a `String` — the wire value a multipart field
+      // wants. Omitted here until #294; the resolver-side list had it.
+      schema is RenderDate ||
+      // `format: byte`, not `format: binary` — a distinct type that the
+      // [RenderBinary] file-part branch above does not cover. Its wire
+      // value is the base64 `String`, so it is a text field, not a file.
+      schema is RenderBase64Bytes;
 }
 
 class RenderResponse {

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -2433,28 +2433,32 @@ DartExpression _multipartValueExpr(
 /// Whether [schema] serializes to a single value on the wire, and so can
 /// become one `Map<String, String>` field of a multipart body.
 ///
-/// An allowlist rather than "not object/array/map-shaped" on purpose: a
-/// new [RenderSchema] subtype should land here as a loud
-/// `FormatException` naming the type, not be waved through to
-/// [_multipartValueExpr] to emit something quietly wrong.
-///
-/// The resolver asks the same "one value on the wire" question over
-/// `Resolved*` for query parameters. The two lists can't share an
-/// implementation — the resolver is deliberately Dart-blind — but they
-/// describe one rule, so a divergence between them is a bug in one of
-/// them by construction. Keep them in sync.
+/// An allowlist rather than a structural test on
+/// [RenderSchema.jsonStorageDartType] ("not map- or list-shaped"), for
+/// two reasons that both come down to failing loudly. A new
+/// [RenderSchema] subtype should arrive here as a `FormatException`
+/// naming the type rather than be waved through to
+/// [_multipartValueExpr] and emit something quietly wrong. And the
+/// structural form isn't total over the tree anyway: [RenderBinary]
+/// extends [RenderNoJson], whose override of that getter throws.
 bool _isMultipartScalar(RenderSchema schema) {
+  // TODO(eseidel): #292 adds the same "one value on the wire" rule over
+  // `Resolved*`, for query parameters. The resolver is deliberately
+  // Dart-blind, so the two can't share an implementation — but they
+  // describe one rule and must not drift. Point them at each other by
+  // name once that lands.
   return schema is RenderString ||
       schema is RenderInteger ||
       schema is RenderNumber ||
       schema is RenderPod ||
       schema is RenderEnum ||
-      // `Date.toJson()` is a `String` — the wire value a multipart field
-      // wants. Omitted here until #294; the resolver-side list had it.
+      // `Date.toJson()` is a `String`, exactly the wire value a multipart
+      // text field carries.
       schema is RenderDate ||
-      // `format: byte`, not `format: binary` — a distinct type that the
-      // [RenderBinary] file-part branch above does not cover. Its wire
-      // value is the base64 `String`, so it is a text field, not a file.
+      // Base64 bytes (`contentEncoding: base64`) are a distinct type from
+      // [RenderBinary], so the file-part branch above does not cover
+      // them. The wire value is the base64 `String` — a text field, not
+      // a file.
       schema is RenderBase64Bytes;
 }
 

--- a/test/render/render_operation_test.dart
+++ b/test/render/render_operation_test.dart
@@ -301,6 +301,60 @@ void main() {
       );
     });
 
+    // #294: `format: date` and base64 bytes were missing from
+    // `_isMultipartScalar`, so either one crashed the generator with
+    // "must be a scalar or binary" instead of rendering. Both serialize
+    // to a `String` on the wire, which is exactly what a multipart text
+    // field carries — base64 bytes in particular are a *text* field
+    // holding base64, not a file part like `format: binary`.
+    test('multipart/form-data with date and base64 fields', () {
+      final operation = {
+        'tags': ['files'],
+        'operationId': 'uploadFile',
+        'requestBody': {
+          'required': true,
+          'content': {
+            'multipart/form-data': {
+              'schema': {
+                'type': 'object',
+                'required': ['when', 'blob'],
+                'properties': {
+                  'when': {'type': 'string', 'format': 'date'},
+                  'until': {'type': 'string', 'format': 'date'},
+                  // base64 bytes come from `contentEncoding`, not
+                  // `format: byte` — see `parseFormat` in parser.dart.
+                  'blob': {'type': 'string', 'contentEncoding': 'base64'},
+                },
+              },
+            },
+          },
+        },
+        'responses': {
+          '200': {'description': 'OK'},
+        },
+      };
+      final result = renderTestOperation(
+        path: '/upload',
+        operationJson: operation,
+        serverUrl: Uri.parse('https://example.com'),
+      );
+      // `Date.toJson()` is already a String — no `.toString()` on top
+      // of it (that would be a `noop_primitive_operations` lint).
+      expect(result, contains("'when': uploadFileRequest.when.toJson(),"));
+      // Optional date: captured to a local, null-checked before set.
+      expect(result, contains('final v = uploadFileRequest.until;'));
+      expect(
+        result,
+        contains("if (v != null) multipartFields['until'] = v.toJson();"),
+      );
+      // `format: byte` is a text field carrying base64, not a file part.
+      expect(
+        result,
+        contains("'blob': base64.encode(uploadFileRequest.blob),"),
+      );
+      expect(result, isNot(contains("MultipartFile.fromBytes('blob'")));
+    });
+
     test('multipart/form-data with optional file', () {
       final operation = {
         'tags': ['files'],

--- a/test/render/render_operation_test.dart
+++ b/test/render/render_operation_test.dart
@@ -347,7 +347,7 @@ void main() {
         result,
         contains("if (v != null) multipartFields['until'] = v.toJson();"),
       );
-      // `format: byte` is a text field carrying base64, not a file part.
+      // Base64 bytes are a text field carrying base64, not a file part.
       expect(
         result,
         contains("'blob': base64.encode(uploadFileRequest.blob),"),


### PR DESCRIPTION
## Summary

Fixed `format: date` and base64-encoded properties crashing the generator when they appear in a `multipart/form-data` request body.

`_isMultipartScalar` enumerated `RenderString`/`Integer`/`Number`/`Pod`/`Enum`, so a `format: date` property threw `multipart/form-data property must be a scalar or binary` at render time instead of rendering. `Date.toJson()` is a `String` — exactly the wire value a multipart text field carries — and `_multipartValueExpr` already handled it correctly. A pure omission, not a decision.

Base64 bytes (`contentEncoding: base64`) were missing for the same reason. `RenderBase64Bytes` is a distinct type from `RenderBinary`, so the file-part branch above it does not cover them; their wire value is the base64 `String`, which makes them a text field rather than a file part.

## Notes

Kept as an allowlist rather than inverting to "not object/array/map-shaped". The negative form fails open: a new `RenderSchema` subtype would be waved through to `_multipartValueExpr` and emit something quietly wrong. The allowlist fails closed, as a `FormatException` naming the type.

#294 asked for a cross-reference comment against `_isSingleWireValue` in `resolver.dart` — that symbol arrives with #292 and isn't on `main` yet, so the comment describes the counterpart rule without naming the symbol. Worth a follow-up pointing the two at each other by name once #292 lands.

Incidental finding while writing the test: **`format: byte` is not recognized at all.** `parseFormat` doesn't list it among the known `string` formats, so it falls through the unknown-format path to a plain `String`. Base64 support is reachable only via `contentEncoding: base64`. `format: byte` is the OAS 3.0 spelling and `contentEncoding` is the 3.1 one, so 3.0 specs get silently degraded output. Filed separately rather than folded in here.

## Test plan

- New unit test in `test/render/render_operation_test.dart` covering required date, optional date, and base64 properties in one multipart body. Verified it fails on `main` with the exact `FormatException` from the issue, and asserts the rendered output:
  - `'when': uploadFileRequest.when.toJson(),` — no `.toString()` on a value already a `String`
  - `if (v != null) multipartFields['until'] = v.toJson();` — optional captured to a local
  - `'blob': base64.encode(uploadFileRequest.blob),` — a text field, not a `MultipartFile`
- Full suite (716 tests), `dart analyze`, `dart format` all clean.

Fixes #294
