### PR TITLE
fix: clear stale generated tests on regen

### DIFF
--- a/lib/src/render/file_renderer.dart
+++ b/lib/src/render/file_renderer.dart
@@ -1074,6 +1074,14 @@ class FileRenderer {
         // Current layout.
         p.join('lib', 'models'),
         p.join('lib', 'messages'),
+        // Generated model tests mirror the `lib/` layout under `test/`
+        // (see [testPath]), so they need the same treatment. A schema
+        // that changes file name leaves a test behind otherwise, and
+        // that test still references the class under its old name — so
+        // the regenerated package no longer analyzes.
+        p.join('test', 'model'),
+        p.join('test', 'models'),
+        p.join('test', 'messages'),
       };
       for (final dirName in dirs) {
         final path = p.join(fileWriter.outDir.path, dirName);

--- a/lib/src/render/file_renderer.dart
+++ b/lib/src/render/file_renderer.dart
@@ -1079,9 +1079,17 @@ class FileRenderer {
         // that changes file name leaves a test behind otherwise, and
         // that test still references the class under its old name — so
         // the regenerated package no longer analyzes.
-        p.join('test', 'model'),
-        p.join('test', 'models'),
-        p.join('test', 'messages'),
+        //
+        // Only when we are the ones writing them. `test/` is where a
+        // consumer's own tests live by Dart convention, so with
+        // [GeneratorConfig.generateTests] off these directories are not
+        // ours to delete — clearing them there would destroy files this
+        // run never produces.
+        if (config.generateTests) ...[
+          p.join('test', 'model'),
+          p.join('test', 'models'),
+          p.join('test', 'messages'),
+        ],
       };
       for (final dirName in dirs) {
         final path = p.join(fileWriter.outDir.path, dirName);

--- a/test/render/file_renderer_test.dart
+++ b/test/render/file_renderer_test.dart
@@ -2285,6 +2285,69 @@ void main() {
       );
     });
 
+    test('regen clears a stale generated test after a rename', () async {
+      // Generated model tests live under `test/`, mirroring the `lib/`
+      // layout. Regenerating into an existing package has to clear them
+      // the same way it clears `lib/`: a schema that changes file name
+      // otherwise leaves its old test behind, still referencing the
+      // class under its old name, and the package stops analyzing.
+      //
+      // Found by regenerating the spec repo after #207 renamed
+      // discord's `MLSpamTriggerMetadataResponse` file — both the old
+      // and new test survived and 13 suites failed to compile.
+      final out = MemoryFileSystem.test().directory('spacetraders');
+      Map<String, dynamic> specWithSchema(String name) => {
+        'openapi': '3.1.0',
+        'info': {'title': 'Space Traders API', 'version': '1.0.0'},
+        'servers': [
+          {'url': 'https://api.spacetraders.io/v2'},
+        ],
+        'paths': {
+          '/thing': {
+            'get': {
+              'operationId': 'getThing',
+              'responses': {
+                '200': {
+                  'description': 'ok',
+                  'content': {
+                    'application/json': {
+                      'schema': {r'$ref': '#/components/schemas/$name'},
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        'components': {
+          'schemas': {
+            name: {
+              'type': 'object',
+              'properties': {
+                'id': {'type': 'string'},
+              },
+            },
+          },
+        },
+      };
+
+      await renderToDirectory(spec: specWithSchema('OldName'), outDir: out);
+      final staleTest = out.childFile('test/models/old_name_test.dart');
+      expect(staleTest.existsSync(), isTrue, reason: 'sanity: first regen');
+
+      // Regenerate the same package with the schema renamed.
+      await renderToDirectory(spec: specWithSchema('NewName'), outDir: out);
+      expect(
+        out.childFile('test/models/new_name_test.dart').existsSync(),
+        isTrue,
+      );
+      expect(
+        staleTest.existsSync(),
+        isFalse,
+        reason: "the previous name's test must not survive the regen",
+      );
+    });
+
     test('colliding names are renamed', () async {
       // This sort of collision happens in the GitHub spec.
       // e.g. #/components/schemas/code-scanning-variant-analysis/properties/status

--- a/test/render/file_renderer_test.dart
+++ b/test/render/file_renderer_test.dart
@@ -126,6 +126,7 @@ void main() {
       required Map<String, dynamic> spec,
       Directory? outDir,
       Logger? logger,
+      bool generateTests = true,
     }) async {
       final out = outDir ?? MemoryFileSystem.test().directory('spacetraders');
       final fs = out.fileSystem;
@@ -142,6 +143,7 @@ void main() {
             templatesDir: templatesDir,
             runProcess: runProcess,
             logSchemas: false,
+            generateTests: generateTests,
           ),
         ),
       );
@@ -2346,6 +2348,67 @@ void main() {
         isFalse,
         reason: "the previous name's test must not survive the regen",
       );
+    });
+
+    test('regen leaves test/ alone when not generating tests', () async {
+      // `test/` is where a consumer's own tests live by Dart
+      // convention. With generateTests off we write nothing there, so
+      // clearing it would delete files this run never produces — worse
+      // than the stale-file problem the clearing exists to fix.
+      final out = MemoryFileSystem.test().directory('spacetraders');
+      final spec = {
+        'openapi': '3.1.0',
+        'info': {'title': 'Space Traders API', 'version': '1.0.0'},
+        'servers': [
+          {'url': 'https://api.spacetraders.io/v2'},
+        ],
+        'paths': {
+          '/thing': {
+            'get': {
+              'operationId': 'getThing',
+              'responses': {
+                '200': {
+                  'description': 'ok',
+                  'content': {
+                    'application/json': {
+                      'schema': {r'$ref': '#/components/schemas/Thing'},
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        'components': {
+          'schemas': {
+            'Thing': {
+              'type': 'object',
+              'properties': {
+                'id': {'type': 'string'},
+              },
+            },
+          },
+        },
+      };
+
+      await renderToDirectory(
+        spec: spec,
+        outDir: out,
+        generateTests: false,
+      );
+      // A hand-written test, in the layout a consumer would naturally
+      // mirror from lib/.
+      final handWritten = out.childFile('test/models/my_own_test.dart')
+        ..createSync(recursive: true)
+        ..writeAsStringSync('// mine');
+
+      await renderToDirectory(
+        spec: spec,
+        outDir: out,
+        generateTests: false,
+      );
+      expect(handWritten.existsSync(), isTrue);
+      expect(handWritten.readAsStringSync(), '// mine');
     });
 
     test('colliding names are renamed', () async {


### PR DESCRIPTION
## Summary

Regenerating a package in place left orphaned generated tests behind
after a schema file rename, breaking analysis of the regenerated
package.

## Detail

`clearDirectory` cleared `lib/api`, `lib/model`, `lib/models` and
`lib/messages`, so a renamed schema left no stale `lib/` file. Generated
model tests mirror that layout under `test/` — `testPath` is literally
`'test/' + modelPath` — but `test/` was never cleared. The old test
survived, still naming the class it was generated for:

```
error - test/messages/m_l_spam_trigger_metadata_response_test.dart:8:24 -
  The function 'MLSpamTriggerMetadataResponse' isn't defined.
```

## How it surfaced

Regenerating the parallel spec repo in place after #207 (a run of
capitals now snakes as one word, so
`m_l_spam_trigger_metadata_response` became
`ml_spam_trigger_metadata_response`). Both old and new tests were
present:

| package | analyzer errors | failing suites |
|---|---|---|
| discord | 70 | 13 |
| github | 42 | 9 |

**Worth noting how this evaded verification.** A fresh generation is
always clean, because the output directory starts empty — and #207's
A/B generated both sides into new directories, so it could not see
this. Only regenerating *over an existing package* reproduces it, which
is what every consumer does and what the spec repo does. I'd verified
"github and discord regenerate analyzer-clean" and that was true of the
scenario I tested and false of the one that matters.

## The `test/` clearing is gated on `generateTests`

Second commit, from self-review. `render` clears unconditionally but
only writes model tests when `GeneratorConfig.generateTests` is on, so
the first commit deleted `test/models` and `test/messages` even in
configurations that write nothing there.

`test/` is where a consumer's own tests live by Dart convention, so
with `generateTests: false` those directories are not ours to delete —
and that failure is worse than the one being fixed. Stale files break
analysis and are recoverable by regenerating; deleted hand-written
tests are not.

The `lib/` entries stay unconditional: a generated client's `lib/` is
wholly ours.

## Ownership is still convention, not fact

Nothing marks these directories as generated — there is no `gen/`
prefix. This PR keeps the existing convention and contains the sharp
edge; #302 proposes the durable fix (record what each run writes and
delete exactly that set), which removes the ownership question for
`lib/` too and would retire the `generateTests` special case here.

## Tests

Two, both verified to fail on the code they guard:

- Render, rename the schema, render again into the same directory →
  the old test file is gone.
- With `generateTests: false`, a hand-written
  `test/models/my_own_test.dart` written between two runs survives.

Fixes #299
