### PR TITLE
fix: parse a map of json types as a bare cast (#272)

### DIFF
--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -4935,26 +4935,24 @@ class RenderMap extends RenderSchema {
     // TODO(eseidel): Support orDefault?
     // Should this have a leading ? to skip the key on null?
     //
-    // When neither side transforms, the closure is
-    // `(key, value) => MapEntry(key, value)` — a tearoff written the long
-    // way (`unnecessary_lambdas`), so emit the tearoff. Identity is a
-    // structural question now: did each side hand back the identifier it
-    // was given?
-    //
-    // The better output drops the `.map(...)` altogether, since an
-    // identity map only copies (#272).
-    final isIdentity = keyFromJson == key && valueFromJson == value;
+    // When neither side transforms, there is nothing to map: every entry
+    // would be rebuilt exactly as it came in, so the `.map` only copies.
+    // The cast alone already has the right static type, because the Dart
+    // type of a map whose key and value are both json types *is* the json
+    // storage type. Identity is a structural question: did each side hand
+    // back the identifier it was given?
+    final cast = jsonCast(jsonValue, jsonIsNullable: jsonIsNullable);
+    if (keyFromJson == key && valueFromJson == value) {
+      return cast;
+    }
     return DartMethodCall(
-      target: jsonCast(jsonValue, jsonIsNullable: jsonIsNullable),
+      target: cast,
       name: 'map',
       arguments: [
-        if (isIdentity)
-          DartType.mapEntry.member('new')
-        else
-          DartLambda(
-            parameters: [key.name, value.name],
-            body: DartType.mapEntry.construct([keyFromJson, valueFromJson]),
-          ),
+        DartLambda(
+          parameters: [key.name, value.name],
+          body: DartType.mapEntry.construct([keyFromJson, valueFromJson]),
+        ),
       ],
       isNullAware: jsonIsNullable,
     );

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -4885,25 +4885,30 @@ class RenderMap extends RenderSchema {
     SchemaRenderer context, {
     required bool dartIsNullable,
   }) {
-    // Nothing to do if both key and value are json types.
-    if (keySchema == null && !valueSchema.shouldCallToJson) {
-      return dartName;
-    }
     const key = DartIdentifier('key');
+    const value = DartIdentifier('value');
     final keyToJson = keySchema == null
         ? key
         : const DartMethodCall(target: key, name: 'toJson');
     final valueToJson = valueSchema.toJsonExpression(
-      const DartIdentifier('value'),
+      value,
       context,
       dartIsNullable: false,
     );
+    // Nothing to do if neither side transforms — the same question, and
+    // now the same structural answer, as [fromJsonExpression]. Asking the
+    // built expression rather than predicting from the schema is what
+    // keeps the two directions from disagreeing about what counts as
+    // identity.
+    if (keyToJson == key && valueToJson == value) {
+      return dartName;
+    }
     return DartMethodCall(
       target: dartName,
       name: 'map',
       arguments: [
         DartLambda(
-          parameters: const ['key', 'value'],
+          parameters: [key.name, value.name],
           body: DartType.mapEntry.construct([keyToJson, valueToJson]),
         ),
       ],

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -819,6 +819,44 @@ void main() {
       expect(result, contains('.contains(entry.key)'));
     });
 
+    test('map of json types parses as a bare cast, with no identity map', () {
+      // Neither key nor value transforms, so `.map(MapEntry.new)` would
+      // rebuild every entry exactly as it came in — a copy and nothing
+      // else (#272). The cast alone already has the right static type.
+      //
+      // Dropping the call also drops the parentheses the old form needed
+      // to be a valid method-call target; the serializer decides that from
+      // precedence rather than anyone spelling it out.
+      final schema = {
+        'type': 'object',
+        'properties': {
+          'headers': {'type': 'object', 'additionalProperties': true},
+        },
+      };
+      final result = renderTestSchema(schema);
+      expect(
+        result,
+        contains("headers: json['headers'] as Map<String, dynamic>?,"),
+      );
+      expect(result, isNot(contains('MapEntry.new')));
+    });
+
+    test('map with a transforming value still maps its entries', () {
+      // The counterpart: a `date-time` value needs `DateTime.parse` per
+      // entry, so the `.map` earns its place and must not be dropped.
+      final schema = {
+        'type': 'object',
+        'properties': {
+          'seenAt': {
+            'type': 'object',
+            'additionalProperties': {'type': 'string', 'format': 'date-time'},
+          },
+        },
+      };
+      final result = renderTestSchema(schema);
+      expect(result, contains('MapEntry(key, DateTime.parse('));
+    });
+
     test('oneOf of allOf variants tagged by single-value enum', () {
       // Each variant is `allOf: [<rule>, <info>]` where the first
       // member tags itself with a single-value enum on `type`. After
@@ -3509,9 +3547,10 @@ void main() {
         "            mUri: (json['m_uri'] as Map<String, dynamic>?)?.map((key, value) => MapEntry(key, Uri.parse(value as String))),\n"
         "            mMapOfString: (json['m_map_of_string'] as Map<String, dynamic>?)?.map((key, value) => MapEntry(key, (value as Map<String, dynamic>).map((key, value) => MapEntry(key, value as String)))),\n"
         "            mEnum: (json['m_enum'] as Map<String, dynamic>?)?.map((key, value) => MapEntry(key, TestMEnum.fromJson(value as String))),\n"
-        // Neither key nor value transforms, so the identity closure is
-        // emitted as the tearoff it is.
-        "            mUnknown: (json['m_unknown'] as Map<String, dynamic>?)?.map(MapEntry.new),\n"
+        // Neither key nor value transforms, so there is nothing to map and
+        // the cast stands alone — no `.map`, and so no parentheses around
+        // the cast either (#272). Contrast every line above.
+        "            mUnknown: json['m_unknown'] as Map<String, dynamic>?,\n"
         '        ));\n'
         '    }\n'
         '\n'

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -841,6 +841,27 @@ void main() {
       expect(result, isNot(contains('MapEntry.new')));
     });
 
+    test('array of open maps round-trips without per-entry conversion', () {
+      // Reaches `RenderMap.shouldCallToJson` through
+      // `RenderArray.items.shouldCallToJson`, which is the only production
+      // caller left now that `RenderMap.toJsonExpression` asks the built
+      // expression instead of predicting from the schema. An open map needs
+      // no conversion in either direction, so neither side maps its
+      // elements.
+      final schema = {
+        'type': 'object',
+        'properties': {
+          'rows': {
+            'type': 'array',
+            'items': {'type': 'object', 'additionalProperties': true},
+          },
+        },
+      };
+      final result = renderTestSchema(schema);
+      expect(result, contains('final List<Map<String, dynamic>>? rows;'));
+      expect(result, isNot(contains('MapEntry')));
+    });
+
     test('map with a transforming value still maps its entries', () {
       // The counterpart: a `date-time` value needs `DateTime.parse` per
       // entry, so the `.map` earns its place and must not be dropped.


### PR DESCRIPTION
## Summary

A map whose key and value are both json types now parses as a bare cast instead of an identity `.map(MapEntry.new)` that only copied it.

## The change

`RenderMap.fromJsonExpression` wrapped every map, even when neither side transformed:

```dart
headers: (checkedKey(json, 'headers') as Map<String, dynamic>?)?.map(MapEntry.new),
```

Every entry came back out exactly as it went in, so the call was a copy and nothing else. Now:

```dart
headers: checkedKey(json, 'headers') as Map<String, dynamic>?,
```

The cast alone already has the right static type: the Dart type of a map whose key and value are both json types *is* the json storage type. `toJsonExpression` already short-circuited this case, so this makes the two directions symmetric.

**18 sites across 11 files in github.** No other tracked spec had any.

## Why now — #293 unblocked it

The issue was explicitly parked on the expression-IR migration, and #293 landed the prerequisite (`fromJsonExpression` returns a `DartExpression`). Both blockers named in the description dissolve:

- **Parenthesization.** Dropping the `.map` leaves a bare cast, and whether it needs parens was the open question. `DartCast` carries `DartPrecedence.cast`, so the serializer decides structurally — the parens disappear on their own because the cast is no longer a method-call target. Nobody spells it out.
- **Identity detection.** Now `expr == DartIdentifier(value)` on the built tree, not the string comparison the stopgap used.

## Second commit: one identity question, not two

Self-review turned up the same question asked two ways inside `RenderMap`:

- `toJsonExpression` *predicted* identity from the schema: `!valueSchema.shouldCallToJson`
- `fromJsonExpression` *asks* the built expression: `valueToJson == value`

Only the structural one can't disagree with what is actually emitted, so `toJsonExpression` now asks the same way. Kept as its own commit because it is a pure refactor and wanted its own byte-identical gate.

## Validation

- **A/B regen, both sides under the same package name** (never sed'd afterward): the fromJson change touches exactly those 11 github files, every hunk the same shape, nothing else moved.
- **The refactor commit is byte-identical** across github, discord, spacetraders and petstore — 0 files differing on each, diffed between two worktrees pinned at the two commits.
- All six specs `dart analyze`-clean; discord's 1530 and petstore's 28 generated round-trip tests pass.
- In-repo `gen_tests/` goldens unchanged.
- Two new unit tests: the identity case parses as a bare cast with no `MapEntry.new`, and the counterpart (a `date-time` value) still maps its entries.

One note on the first A/B I ran for the refactor commit: it reported 0 differences because a stray `cd` left both sides running the same worktree. Redone with explicit per-side directories and a commit-SHA sanity line; the numbers above are from the corrected run.

Closes #272
