### PR TITLE
fix: recognize `format: byte` as base64 bytes (#298)

### DIFF
--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -1089,6 +1089,10 @@ TypeAndFormat parseTypeAndFormat(MapContext json) {
     final expectedFormats = {
       'string': {
         'binary',
+        // OAS 3.0 / JSON Schema draft-4 for base64-encoded bytes. Dropped
+        // in 3.1 in favor of `contentEncoding: base64`; both are handled
+        // and converge on the same schema node.
+        'byte',
         'date-time',
         'uri',
         'uri-template',
@@ -1322,9 +1326,6 @@ Schema _createCorrectSchemaSubtype(MapContext json) {
     // bytes' MIME type. Not actionable on the Dart side beyond
     // documentation; consume to suppress the unused-key warning.
     _ignored<String>(json, 'contentMediaType');
-    if (contentEncoding == 'base64') {
-      return SchemaBase64Bytes(common: common);
-    }
     // `contentEncoding: binary` is the OpenAPI 3.1 successor to
     // `format: binary`, but on a non-multipart response body (e.g.
     // an `image/png` content type) it implies the response method
@@ -1341,6 +1342,19 @@ Schema _createCorrectSchemaSubtype(MapContext json) {
         'Ignoring: contentEncoding=$contentEncoding (String) in '
         '${json.pointer}',
       );
+    }
+    // `format: byte` (OAS 3.0 / draft-4) and `contentEncoding: base64`
+    // (OAS 3.1 / 2020-12) are the same statement in the vocabulary of
+    // two spec versions: a JSON string whose value is base64-encoded
+    // binary. They converge on one node, so a 3.0 spec gets the same
+    // `Uint8List` a 3.1 spec does rather than a `String` the caller has
+    // to decode by hand.
+    //
+    // A spec that sets both is accepted rather than flagged: they agree,
+    // and belt-and-braces declarations are common in specs that straddle
+    // versions.
+    if (typeAndFormat.format == 'byte' || contentEncoding == 'base64') {
+      return SchemaBase64Bytes(common: common);
     }
   }
 

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -2518,6 +2518,31 @@ void main() {
         final schema = runWithLogger(logger, () => parseTestSchema(json));
         expect(schema, isA<SchemaBase64Bytes>());
       });
+      test('format=byte parses as SchemaBase64Bytes', () {
+        // OAS 3.0's spelling of the same thing, and the only one 3.0 has.
+        // Before this it fell through to the unknown-format branch and
+        // rendered a plain `String` the caller had to decode by hand.
+        final json = {'type': 'string', 'format': 'byte'};
+        final logger = _MockLogger();
+        final schema = runWithLogger(logger, () => parseTestSchema(json));
+        expect(schema, isA<SchemaBase64Bytes>());
+        // A recognized format, so no "unknown format" chatter.
+        verifyNever(
+          () => logger.detail(any(that: contains('unknown string format'))),
+        );
+      });
+      test('format=byte and contentEncoding=base64 together agree', () {
+        // Specs straddling 3.0 and 3.1 declare both. They say the same
+        // thing, so this is accepted rather than treated as a conflict.
+        final json = {
+          'type': 'string',
+          'format': 'byte',
+          'contentEncoding': 'base64',
+        };
+        final logger = _MockLogger();
+        final schema = runWithLogger(logger, () => parseTestSchema(json));
+        expect(schema, isA<SchemaBase64Bytes>());
+      });
       test('contentEncoding=binary stays a SchemaString (deferred)', () {
         // Routing `contentEncoding: binary` to `SchemaBinary` (a no-
         // JSON type) breaks generated response handlers for non-JSON


### PR DESCRIPTION
## Summary

`format: byte` now parses as base64-encoded bytes, so an OAS 3.0 spec gets the same `Uint8List` a 3.1 spec does instead of a `String` the caller has to decode by hand.

## The gap

`parseFormat` did not list `byte` among the known string formats, so `{type: string, format: byte}` fell through the unknown-format branch, logged a `detail`, and rendered a plain `String`. Base64 was reachable only via `contentEncoding: base64`.

Those are the same statement in two spec vocabularies:

- **OAS 3.0 / draft-4** — `format: byte` means base64-encoded.
- **OAS 3.1 / 2020-12** — dropped in favor of `contentEncoding: base64`.

Since `format: byte` is the only way 3.0 *can* say this, a 3.0 spec was silently degraded. Both spellings now converge on `SchemaBase64Bytes` — the node `contentEncoding` already produced — so no new render path is involved.

A spec setting both is accepted rather than flagged: they agree, and belt-and-braces declarations are common in specs straddling versions.

## On the validation target

Measured before starting, since "no spec uses it" is what parked the deepObject half of #233:

| spec | `format: byte` | `contentEncoding: base64` |
|---|---|---|
| github, petstore, spacetraders, backstage, train-travel | 0 | 0 |
| discord | 0 | 26 |

**Nothing in the rotation exercises `format: byte`**, and I want that stated plainly rather than buried. I judged it worth doing anyway, and the difference from the deepObject case is the whole argument:

- deepObject needed a **new serialization strategy** with no real spec to say whether it was right. This is a **one-line alias onto an existing node** whose render path discord already exercises at 26 sites — the destination is validated, only the spelling reaching it is new.
- `format: byte` is a standard OAS 3.0 format. Our rotation being 3.1-flavored is a sampling artifact, not evidence it's unused in the wild.

If you'd rather hold this until a 3.0 spec joins the rotation, that's a reasonable call and I'll park it.

## Validation

- **End-to-end convergence:** a 3.0 spec using `format: byte` and the same spec rewritten 3.1-style with `contentEncoding: base64` generate **byte-identical output** — `Uint8List` with `maybeBase64Decode` / `maybeBase64Encode`.
- **A/B regen, 0 files differing** on github, discord, petstore, spacetraders (both sides same package name, two worktrees, commit SHAs printed to prove they differed). Expected: no tracked spec uses the format, so this is a pure addition.
- All four analyze-clean; in-repo `gen_tests/` goldens unchanged.
- New parser tests: `format: byte` → `SchemaBase64Bytes` with no unknown-format chatter, and the both-set case.

Closes #298
