### PR TITLE
feat: compile and test the synthetic fixtures in CI

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -39,16 +39,18 @@ jobs:
 
       - name: Run end-to-end generator tests
         run: |
-          # Regenerate every fixture and run the generated tests —
-          # catches runtime issues in emitted code (toJson/fromJson
-          # round-tripping, hashCode consistency with ==, etc.) that
-          # the unit tests above can't see.
+          # Regenerate every fixture, then compile and test the ones
+          # marked `verify: true` in their manifest (the synthetic
+          # fixtures — the real-world corpus in third_party/ is already
+          # compiled by Workflow Discovery). `--verify` catches emitted
+          # code that doesn't analyze (#307) as well as runtime issues
+          # the unit tests above can't see — toJson/fromJson
+          # round-tripping, hashCode consistency with ==, etc.
           #
-          # All fixtures, not just `types`, because the next step diffs
-          # the result: a fixture that is never regenerated can never be
-          # caught drifting.
-          dart run tool/gen_tests.dart
-          cd gen_tests/types && dart pub get && dart test
+          # Every fixture is regenerated regardless of `verify`, because
+          # the next step diffs the result: a fixture that is never
+          # regenerated can never be caught drifting.
+          dart run tool/gen_tests.dart --verify
 
       - name: Verify goldens match the generator
         run: |

--- a/gen_tests/gen_tests.yaml
+++ b/gen_tests/gen_tests.yaml
@@ -17,6 +17,13 @@
 # nullability and mutability.
 openapi: true
 
+# `--verify` compiles and tests these (dart pub get + analyze + test).
+# They are generated and diff-gated but were otherwise never compiled,
+# so a generator change emitting code that does not analyze would land
+# green (#307). This is the default; spelled out because it is the
+# coverage these fixtures exist to provide. `third_party/` opts out.
+verify: true
+
 # `package:` defaults to the spec's filename with the extension dropped
 # and `.`/`-` folded to `_`, which is what every fixture here wants.
 specs:

--- a/gen_tests/third_party/gen_tests.yaml
+++ b/gen_tests/third_party/gen_tests.yaml
@@ -19,6 +19,13 @@
 # package into `lib/model/` with different nullability and mutability.
 openapi: false
 
+# `--verify` skips these. They are already compiled and tested by
+# Shorebird's Workflow Discovery, and github alone builds ~1700 test
+# kernels (~68 GB of scratch, ~104s) — too heavy to do a second time
+# here. The synthetic fixtures one level up are the ones that lacked
+# any compile/test coverage (#307), so they keep the default `true`.
+verify: false
+
 # `package:` defaults to the spec's filename with the extension dropped
 # and `.`/`-` folded to `_`, so it is only spelled out below where that
 # default is not what we want.

--- a/tool/gen_tests.dart
+++ b/tool/gen_tests.dart
@@ -12,6 +12,7 @@ class TestCase {
     required this.spec,
     required this.outDir,
     required this.quirks,
+    required this.verify,
   });
   final File spec;
   final Directory outDir;
@@ -25,6 +26,17 @@ class TestCase {
   /// generated with it; the parallel spec repo is generated without.
   /// Hardcoding either one silently rewrites the other's output.
   final Quirks quirks;
+
+  /// Whether `--verify` should compile and test this package's generated
+  /// output (`dart pub get` + `dart analyze` + `dart test`).
+  ///
+  /// The synthetic fixtures set this: they are generated and diff-gated
+  /// but otherwise never compiled, so a generator change that emits code
+  /// which does not analyze would land green (#307). `third_party/`
+  /// clears it — those packages are already compiled by Shorebird's
+  /// Workflow Discovery, and github's ~1700 test kernels are too
+  /// disk-hungry to build a second time here.
+  final bool verify;
 
   String get packageName => outDir.basename;
 }
@@ -74,10 +86,14 @@ List<TestCase> _testsFromManifest(Directory testDir) {
   if (doc is! Map || doc['specs'] is! List) {
     throw Exception('${manifest.path}: expected a top-level `specs:` list');
   }
-  // Directory-wide default, overridable per spec. `true` matches what
-  // a directory without a manifest gets below, so adding a manifest to
-  // an existing directory changes nothing until you say otherwise.
+  // Directory-wide defaults, overridable per spec. `openapi: true`
+  // matches what a directory without a manifest gets below, so adding a
+  // manifest to an existing directory changes nothing until you say
+  // otherwise. `verify: true` is fail-closed: a new fixture is compiled
+  // and tested unless its directory explicitly opts out, so nothing can
+  // silently slip past `--verify` the way the synthetic fixtures did.
   final dirOpenapi = doc['openapi'] as bool? ?? true;
+  final dirVerify = doc['verify'] as bool? ?? true;
   final tests = <TestCase>[];
   for (final entry in doc['specs'] as List) {
     if (entry is! Map || entry['spec'] is! String) {
@@ -90,11 +106,13 @@ List<TestCase> _testsFromManifest(Directory testDir) {
     final packageName =
         (entry['package'] as String?) ?? _derivePackageName(specFile);
     final openapi = entry['openapi'] as bool? ?? dirOpenapi;
+    final verify = entry['verify'] as bool? ?? dirVerify;
     tests.add(
       TestCase(
         spec: specFile,
         outDir: testDir.childDirectory(packageName),
         quirks: openapi ? const Quirks.openapi() : const Quirks(),
+        verify: verify,
       ),
     );
   }
@@ -157,9 +175,48 @@ Future<void> runTest({
   );
 }
 
+/// Runs [command] in [workingDirectory], streaming its output to the
+/// logger, and throws if it exits non-zero.
+Future<void> _run(
+  String command,
+  List<String> args, {
+  required String workingDirectory,
+}) async {
+  final result = await io.Process.run(
+    command,
+    args,
+    workingDirectory: workingDirectory,
+  );
+  logger
+    ..info(result.stdout as String)
+    ..info(result.stderr as String);
+  if (result.exitCode != 0) {
+    throw Exception(
+      '`$command ${args.join(' ')}` failed in $workingDirectory '
+      '(exit ${result.exitCode})',
+    );
+  }
+}
+
+/// Compiles and tests a generated package: `dart pub get`, then
+/// `dart analyze`, then `dart test` when the package has a `test/`
+/// directory. Fixtures like `unsupported_auth` generate no model tests,
+/// and `dart test` errors when there is nothing to run, so testing is
+/// skipped there — analysis still covers that the code compiles.
+Future<void> _verify(TestCase test) async {
+  final dir = test.outDir.path;
+  logger.info('Verifying ${test.packageName}');
+  await _run('dart', ['pub', 'get'], workingDirectory: dir);
+  await _run('dart', ['analyze'], workingDirectory: dir);
+  if (test.outDir.childDirectory('test').existsSync()) {
+    await _run('dart', ['test'], workingDirectory: dir);
+  }
+}
+
 Future<void> run({
   bool verbose = false,
   bool dryRun = false,
+  bool verify = false,
   List<String> skipList = const [],
   List<String> globList = const [],
   List<String> extraDirs = const [],
@@ -213,19 +270,21 @@ Future<void> run({
   }
 
   // Run the unit tests.
-  final result = await io.Process.run(
+  await _run(
     'dart',
     ['test', '.'],
-    workingDirectory: packageRoot
-        .childDirectory('gen_tests')
-        .childDirectory('tests')
-        .path,
+    workingDirectory: genTests.childDirectory('tests').path,
   );
-  logger
-    ..info(result.stdout as String)
-    ..info(result.stderr as String);
-  if (result.exitCode != 0) {
-    throw Exception('Unit tests failed');
+
+  // Compile and test the generated packages that ask for it. Off by
+  // default because it is slow and needs the network (a `dart pub get`
+  // per package); CI turns it on. Regeneration above already ran for
+  // every fixture, so the goldens are settled before anything here
+  // touches a `pubspec.lock` (gitignored, so it never reaches the diff).
+  if (verify) {
+    for (final test in tests.where((t) => t.verify)) {
+      await _verify(test);
+    }
   }
 }
 
@@ -235,6 +294,13 @@ void main(List<String> args) async {
     ..addFlag(
       'dry-run',
       help: 'Print each spec -> output directory mapping and exit',
+    )
+    ..addFlag(
+      'verify',
+      help:
+          'After generating, compile and test each generated package '
+          '(dart pub get + analyze + test) that its manifest marks '
+          '`verify: true`',
     )
     ..addMultiOption(
       'ignore',
@@ -256,6 +322,7 @@ void main(List<String> args) async {
     () => run(
       verbose: verbose,
       dryRun: results['dry-run'] as bool,
+      verify: results['verify'] as bool,
       skipList: ignoreList,
       globList: globList,
       extraDirs: extraDirs,


### PR DESCRIPTION
## Summary

Compile and test the synthetic `gen_tests/` fixtures in CI, so a generator
change that emits code which does not analyze can no longer land green.

The synthetic fixtures (`multipart`, `security`, `types`, `unsupported_auth`)
are regenerated and diff-gated on every CI run, so they cannot go stale — but
they were never compiled or run. CI's only per-package step hardcoded
`cd gen_tests/types && dart pub get && dart test`, leaving `multipart`,
`security`, and `unsupported_auth` output uncompiled: it could stop analyzing
and CI would stay green as long as it changed deterministically (#307). The
real-world corpus in `third_party/` is covered by Shorebird's Workflow
Discovery; the synthetic ones predate that and slipped through.

Adds a `--verify` flag to `tool/gen_tests.dart`: after regenerating, it runs
`dart pub get` + `dart analyze` + `dart test` on each generated package whose
manifest marks `verify: true`, and exits non-zero on the first failure.
`dart test` is skipped when a package has no `test/` directory
(`unsupported_auth` generates no model tests, and `dart test` errors with
nothing to run); analysis still covers that it compiles.

`verify` is a per-directory manifest flag mirroring the existing `openapi` one
— directory-wide default, per-entry overridable — rather than a second
hardcoded package list in `dart.yml`. It defaults to `true` (fail-closed: a new
fixture is compiled and tested unless its directory opts out), and
`third_party/gen_tests.yaml` sets it to `false` with the reason: those packages
are already compiled by Workflow Discovery, and github alone builds ~1700 test
kernels (~68 GB of scratch) — too heavy to do twice.

CI now calls `dart run tool/gen_tests.dart --verify` and drops the hardcoded
`types` line. `pub get` writes a `pubspec.lock`, but that is gitignored and
regeneration finishes before verification runs, so the goldens are settled
before the diff step and nothing new reaches it.

Fixes #307

## Test plan

- A full `dart run tool/gen_tests.dart --verify` run leaves the golden tree
  byte-identical (only the manifest edits show in `git diff`), and
  compiles+tests all four synthetic fixtures (`multipart` 5 tests, `security`
  3, `types` 18; `unsupported_auth` analyze-only, test correctly skipped).
- Injecting a type error into a fixture's `lib/` makes the run exit non-zero at
  the `dart analyze` step with a precise message — the failure mode this gates.
- `dart analyze`, `dart format`, and the root suite (740 tests) all clean.
