### PR TITLE
fix: the output directory belongs to the generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,25 @@ a consensus towards a better Dart generator, so releasing this one.
   off to FileRenderer which uses SchemaRenderer to render api (operation) and
   model (schema) files and imports.
 
+### The output directory belongs to the generator
+
+By default space_gen empties the output directory before each run,
+keeping only `.dart_tool/`, `pubspec.lock`, and `.git/`. A schema you
+rename or delete would otherwise leave its old file behind, and that
+file still refers to the class under its old name — so the regenerated
+package stops analyzing.
+
+Pass `--no-clear` (or `GeneratorConfig.clearDirectory: false`) to
+generate into a package that also holds hand-written code. Nothing is
+deleted then, and removing stale output becomes your job.
+
+There is no middle setting, because there is nothing reliable to base
+one on. Layout is yours to change through `FileRenderer.modelPath` and
+`FileRenderer.testPath`, so no fixed set of paths is "the generated
+ones" — a consumer who moves models to `lib/src/models/` would get
+nothing cleaned by a rule naming `lib/models/`. Owning the directory is
+the only rule that stays true whatever the layout.
+
 ### Lint suppression lives in the generated `.dart` files
 
 space_gen supports consumers who don't use the `analysis_options.yaml` it

--- a/lib/src/cli.dart
+++ b/lib/src/cli.dart
@@ -48,7 +48,16 @@ Future<int> _runCli(
       mandatory: true,
     )
     ..addFlag('verbose', abbr: 'v', help: 'Verbose output')
-    ..addFlag('openapi', help: 'Use OpenAPI quirks');
+    ..addFlag('openapi', help: 'Use OpenAPI quirks')
+    ..addFlag(
+      'clear',
+      defaultsTo: true,
+      help:
+          'Empty the output directory first, so a renamed or deleted '
+          'schema leaves no stale file behind. Pass --no-clear when '
+          'generating into a package that also holds hand-written '
+          'code; you then own removing stale output.',
+    );
   final results = parser.parse(arguments);
   if (results.rest.isNotEmpty) {
     logger
@@ -88,6 +97,7 @@ Future<int> _runCli(
       outDir: outDir,
       quirks: quirks,
       templatesDir: templatesDir,
+      clearDirectory: results['clear'] as bool,
       fileRendererBuilder: fileRendererBuilder,
     ),
   );

--- a/lib/src/render.dart
+++ b/lib/src/render.dart
@@ -163,6 +163,7 @@ class GeneratorConfig {
     this.quirks = const Quirks(),
     this.logSchemas = true,
     this.generateTests = true,
+    this.clearDirectory = true,
     this.fileRendererBuilder = FileRenderer.new,
   });
 
@@ -199,6 +200,20 @@ class GeneratorConfig {
   /// skipped automatically when no safe example value can be
   /// constructed (recursive types, no-JSON types).
   final bool generateTests;
+
+  /// Whether [outDir] belongs to the generator. Default `true`, which
+  /// empties it before each run so a renamed or deleted schema cannot
+  /// leave a stale file behind — a stale file still references its
+  /// class under the old name, so the regenerated package stops
+  /// analyzing.
+  ///
+  /// Turn this off to generate into a package that also holds
+  /// hand-written code, and remove stale output yourself. We cannot
+  /// tell your files from ours in a directory we do not own: layout is
+  /// yours to change via [FileRenderer.modelPath] and
+  /// [FileRenderer.testPath], so there is no set of paths we could
+  /// assume are generated and be right.
+  final bool clearDirectory;
 
   /// Hook for plugging in a custom [FileRenderer] subclass. Defaults
   /// to `FileRenderer.new`.
@@ -266,7 +281,7 @@ Future<void> loadAndRenderSpec(GeneratorConfig config) async {
           generateTests: config.generateTests,
         ),
       )
-      .render(renderSpec);
+      .render(renderSpec, clearDirectory: config.clearDirectory);
 }
 
 @visibleForTesting

--- a/lib/src/render/file_renderer.dart
+++ b/lib/src/render/file_renderer.dart
@@ -1060,44 +1060,38 @@ class FileRenderer {
     );
   }
 
+  /// Build artifacts left in the output directory by tooling rather
+  /// than by us. [_clearOutDir] keeps these: they are reproducible, but
+  /// deleting them makes every regeneration re-resolve dependencies
+  /// from scratch, and `.git` would take a repository with it.
+  static const _preservedOnClear = {'.dart_tool', 'pubspec.lock', '.git'};
+
+  /// Empty the output directory, keeping only [_preservedOnClear].
+  ///
+  /// The contract is deliberately blunt: name a directory as the output
+  /// and turn clearing on, and that directory is ours. It is the only
+  /// rule that stays true no matter how a subclass moves files around
+  /// via [modelPath] and [testPath] — anything narrower has to guess at
+  /// which paths are generated, and guesses wrong for exactly the
+  /// consumers who use those hooks.
+  ///
+  /// Generating into a package that also holds hand-written code means
+  /// turning clearing off (`GeneratorConfig.clearDirectory`, or
+  /// `--no-clear`) and removing stale output yourself. There is no way
+  /// for us to tell your files from ours in a directory we do not own.
+  void _clearOutDir() {
+    final outDir = fileWriter.outDir;
+    if (!outDir.existsSync()) return;
+    for (final entity in outDir.listSync()) {
+      if (_preservedOnClear.contains(p.basename(entity.path))) continue;
+      entity.deleteSync(recursive: true);
+    }
+  }
+
   /// Render the entire spec.
   void render(RenderSpec spec, {bool clearDirectory = true}) {
     if (clearDirectory) {
-      // Only delete the directories we make to handle the case of changing
-      // directory structure or adding/removing files.
-      // All other files we make can be overwritten.
-      final dirs = {
-        p.join('lib', 'api'),
-        // Previous output layouts we might inherit from — clear so stale
-        // files from an earlier layout don't linger.
-        p.join('lib', 'model'),
-        // Current layout.
-        p.join('lib', 'models'),
-        p.join('lib', 'messages'),
-        // Generated model tests mirror the `lib/` layout under `test/`
-        // (see [testPath]), so they need the same treatment. A schema
-        // that changes file name leaves a test behind otherwise, and
-        // that test still references the class under its old name — so
-        // the regenerated package no longer analyzes.
-        //
-        // Only when we are the ones writing them. `test/` is where a
-        // consumer's own tests live by Dart convention, so with
-        // [GeneratorConfig.generateTests] off these directories are not
-        // ours to delete — clearing them there would destroy files this
-        // run never produces.
-        if (config.generateTests) ...[
-          p.join('test', 'model'),
-          p.join('test', 'models'),
-          p.join('test', 'messages'),
-        ],
-      };
-      for (final dirName in dirs) {
-        final path = p.join(fileWriter.outDir.path, dirName);
-        final dir = fileWriter.fs.directory(path);
-        if (dir.existsSync()) {
-          dir.deleteSync(recursive: true);
-        }
-      }
+      _clearOutDir();
     }
     // Collect all the Apis and Model Schemas.
     // Do we walk through each endpoint and ask which class to put it on?

--- a/test/render/file_renderer_test.dart
+++ b/test/render/file_renderer_test.dart
@@ -127,6 +127,7 @@ void main() {
       Directory? outDir,
       Logger? logger,
       bool generateTests = true,
+      bool clearDirectory = true,
     }) async {
       final out = outDir ?? MemoryFileSystem.test().directory('spacetraders');
       final fs = out.fileSystem;
@@ -144,6 +145,7 @@ void main() {
             runProcess: runProcess,
             logSchemas: false,
             generateTests: generateTests,
+            clearDirectory: clearDirectory,
           ),
         ),
       );
@@ -182,9 +184,81 @@ void main() {
       await renderToDirectory(spec: spec, outDir: out, logger: logger);
       expect(extraApiFile.existsSync(), isFalse);
       expect(extraModelFile.existsSync(), isFalse);
-      expect(extraRootFile.existsSync(), isTrue); // Only delete dirs we make.
+      // Everything, not just the directories we happen to write to:
+      // with clearing on, the output directory is ours.
+      expect(extraRootFile.existsSync(), isFalse);
       expect(out.childFile('lib/api.dart'), exists);
       expect(out.childFile('lib/api_client.dart'), exists);
+    });
+
+    test('clearing preserves build artifacts', () async {
+      // Reproducible, but re-resolving dependencies on every run is
+      // slow, and `.git` would take a repository with it.
+      final out = MemoryFileSystem.test().directory('spacetraders');
+      final spec = {
+        'openapi': '3.1.0',
+        'info': {'title': 'Space Traders API', 'version': '1.0.0'},
+        'servers': [
+          {'url': 'https://api.spacetraders.io/v2'},
+        ],
+        'paths': <String, dynamic>{},
+        'components': <String, dynamic>{},
+      };
+      final preserved = {
+        '.dart_tool/package_config.json': '{}',
+        'pubspec.lock': '# lock',
+        '.git/HEAD': 'ref: refs/heads/main',
+      };
+      for (final entry in preserved.entries) {
+        out.childFile(entry.key)
+          ..createSync(recursive: true)
+          ..writeAsStringSync(entry.value);
+      }
+
+      await renderToDirectory(spec: spec, outDir: out);
+      for (final entry in preserved.entries) {
+        final file = out.childFile(entry.key);
+        expect(file.existsSync(), isTrue, reason: '${entry.key} was deleted');
+        expect(file.readAsStringSync(), entry.value);
+      }
+    });
+
+    test('clearDirectory off leaves the package alone', () async {
+      // The escape hatch for generating into a package that also holds
+      // hand-written code: we write our files and delete nothing, so
+      // removing stale output becomes the consumer's job.
+      final out = MemoryFileSystem.test().directory('spacetraders');
+      final spec = {
+        'openapi': '3.1.0',
+        'info': {'title': 'Space Traders API', 'version': '1.0.0'},
+        'servers': [
+          {'url': 'https://api.spacetraders.io/v2'},
+        ],
+        'paths': <String, dynamic>{},
+        'components': <String, dynamic>{},
+      };
+      final handWritten = {
+        'lib/extensions/thing_x.dart': '// extension',
+        'test/src/my_own_test.dart': '// mine',
+        'README.md': '// readme',
+      };
+      for (final entry in handWritten.entries) {
+        out.childFile(entry.key)
+          ..createSync(recursive: true)
+          ..writeAsStringSync(entry.value);
+      }
+
+      await renderToDirectory(spec: spec, outDir: out, clearDirectory: false);
+      for (final entry in handWritten.entries) {
+        final file = out.childFile(entry.key);
+        expect(file.existsSync(), isTrue, reason: '${entry.key} was deleted');
+        expect(file.readAsStringSync(), entry.value);
+      }
+      expect(
+        out.childFile('lib/api_client.dart').existsSync(),
+        isTrue,
+        reason: 'sanity: we still generated',
+      );
     });
 
     test('empty spec throws format exception', () async {
@@ -2348,67 +2422,6 @@ void main() {
         isFalse,
         reason: "the previous name's test must not survive the regen",
       );
-    });
-
-    test('regen leaves test/ alone when not generating tests', () async {
-      // `test/` is where a consumer's own tests live by Dart
-      // convention. With generateTests off we write nothing there, so
-      // clearing it would delete files this run never produces — worse
-      // than the stale-file problem the clearing exists to fix.
-      final out = MemoryFileSystem.test().directory('spacetraders');
-      final spec = {
-        'openapi': '3.1.0',
-        'info': {'title': 'Space Traders API', 'version': '1.0.0'},
-        'servers': [
-          {'url': 'https://api.spacetraders.io/v2'},
-        ],
-        'paths': {
-          '/thing': {
-            'get': {
-              'operationId': 'getThing',
-              'responses': {
-                '200': {
-                  'description': 'ok',
-                  'content': {
-                    'application/json': {
-                      'schema': {r'$ref': '#/components/schemas/Thing'},
-                    },
-                  },
-                },
-              },
-            },
-          },
-        },
-        'components': {
-          'schemas': {
-            'Thing': {
-              'type': 'object',
-              'properties': {
-                'id': {'type': 'string'},
-              },
-            },
-          },
-        },
-      };
-
-      await renderToDirectory(
-        spec: spec,
-        outDir: out,
-        generateTests: false,
-      );
-      // A hand-written test, in the layout a consumer would naturally
-      // mirror from lib/.
-      final handWritten = out.childFile('test/models/my_own_test.dart')
-        ..createSync(recursive: true)
-        ..writeAsStringSync('// mine');
-
-      await renderToDirectory(
-        spec: spec,
-        outDir: out,
-        generateTests: false,
-      );
-      expect(handWritten.existsSync(), isTrue);
-      expect(handWritten.readAsStringSync(), '// mine');
     });
 
     test('colliding names are renamed', () async {


### PR DESCRIPTION
## Summary

The output directory now belongs to the generator: with clearing on it is
emptied before each run, keeping only `.dart_tool/`, `pubspec.lock`, and
`.git/`. `clearDirectory` becomes a real, reachable option — on
`GeneratorConfig` and as `--no-clear` — for generating into a package that
holds hand-written code.

## Why

Stale output was removed by deleting a hardcoded list of directories:
`lib/{api,model,models,messages}`, plus `test/` mirrors when generating tests.
That list failed in both directions.

**It cleaned too little.** The list only described the default layout, but
layout is a subclass hook. `shorebird_code_push_protocol` overrides `modelPath`
to `lib/src/models/` and `testPath` to `test/generated/`, so none of its output
was named and it got no stale-file cleanup at all. Rename a schema in the
Shorebird spec and the old model and its old test both linger indefinitely.

**It cleaned too much.** Generated tests mirrored the `lib/` layout into
`test/models/`, and `test/` is where all of a package's tests live by Dart
convention, so a consumer writing `test/models/my_thing_test.dart` had it
deleted on the next regen (#302). #300 contained that by skipping `test/` when
not generating tests, which in turn stranded previously-generated tests
permanently.

Both are the same mistake: trying to infer which paths are ours. Nothing
reliable supports that inference, because the layout hooks mean any fixed set of
paths is wrong for whoever uses them. So the contract is blunt instead — you
name the directory, we own it — and the case it cannot serve gets an explicit
opt-out rather than a guess.

`clearDirectory` already existed as a parameter on `render()`, but nothing
plumbed it through, so a `runCli` consumer like Shorebird could not opt out at
all. That is the gap this fills.

## Alternatives considered

Earlier revisions of this PR tried three narrower rules before settling here.
Recording them since they all look reasonable until you check them against a
real consumer:

- **Generated tests under `test/gen/`.** Fixes the collision, but moves 2536
  fixture files and does nothing for Shorebird, which already overrides
  `testPath` to escape the same collision.
- **A marker comment in each generated file.** Cannot go stale, but makes the
  sweep open files to decide ownership — including files that aren't ours.
- **Deriving the swept directories from the paths written that run.** Follows
  any subclass layout, but needs a list of directories Dart convention makes
  shared (`lib/`, `test/`, the package root), plus recursion from a "generated
  root" to catch directories that empty out. Correct, and about 50 lines of
  rules to explain. The blunt contract is fewer lines than the code it replaces.

## Behavior changes

- Files in the output directory that space_gen did not write are now deleted
  when clearing is on. Previously anything outside the hardcoded directories
  survived.
- `--no-clear` / `GeneratorConfig.clearDirectory: false` is the supported way to
  generate into a shared package.

Shorebird should move to `--no-clear` in its `tool/gen.dart`. That is a
status-quo hold for it — the hardcoded list never matched its layout, so it has
never had automatic cleanup — but it must land before its next regeneration, or
clearing will remove its hand-written `lib/extensions/`, barrel, `test/src/`,
pubspec, and README.

## Testing

- 744 unit tests, `dart analyze`, `dart format`, cspell clean.
- New coverage: build artifacts survive clearing; `clearDirectory: false` leaves
  hand-written `lib/extensions/`, `test/src/`, and `README.md` untouched while
  still generating; the existing "deletes existing output directory" test now
  pins that a stray root file is removed.
- Fixture output byte-identical; regen wall-clock unchanged (preserving
  `.dart_tool/` and `pubspec.lock` keeps dependency resolution warm).
- Net change to `file_renderer.dart` is 6 fewer lines than it replaces.

Closes #302.
