### PR TITLE
refactor: share render-tree child enumeration (#289)

### DIFF
--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -2759,6 +2759,29 @@ abstract class RenderSchema extends Equatable implements ToTemplateContext {
   /// emit a wrapper / a separate file / a wrapping case-arm call.
   bool get isSmooshed => false;
 
+  /// The schemas structurally nested in this one: object properties and
+  /// the open member, array items, map value and key, oneOf variants.
+  ///
+  /// The render tree is enumerated by two traversals that each need a
+  /// node's children — `RenderTreeWalker` ("which schemas must exist, so
+  /// each gets a file") and the named-schema collector ("which schemas a
+  /// file names, so it imports them"). Routing both through this one
+  /// getter is what keeps them from drifting: they can no longer disagree
+  /// about a node's children, which for the collector meant a dropped
+  /// import (see #289). Each consumer keeps its own policy about what to
+  /// do with the children it gets; this only enumerates them.
+  ///
+  /// Defaults to none — only the container schemas ([RenderObject],
+  /// [RenderArray], [RenderMap], [RenderOneOf]) override it. A new subtype
+  /// with nested schemas must remember to override too, or it will be
+  /// treated as a leaf; that is the accepted cost of not enumerating every
+  /// leaf here.
+  ///
+  /// Order follows the traversals' historical visit order — collectors
+  /// fold these into ordered output (imports, exports), so the sequence
+  /// is load-bearing, not incidental.
+  Iterable<RenderSchema> get children => const [];
+
   /// The pointer of the resolved schema.
   JsonPointer get pointer => common.pointer;
 
@@ -4049,6 +4072,17 @@ class RenderObject extends RenderNewType {
   bool get isSmooshed => parentSealedTypeName != null;
 
   @override
+  Iterable<RenderSchema> get children {
+    // Local so the null-check promotes — `additionalProperties` is a
+    // public field, which flow analysis won't promote in place.
+    final additional = additionalProperties;
+    return [
+      ...properties.values,
+      if (additional != null) additional,
+    ];
+  }
+
+  @override
   String? get wrapperTag => typeName;
 
   @override
@@ -4643,6 +4677,9 @@ class RenderArray extends RenderSchema {
   final RenderSchema items;
 
   @override
+  Iterable<RenderSchema> get children => [items];
+
+  @override
   final dynamic defaultValue;
 
   /// The maximum number of items in the array.
@@ -4875,6 +4912,13 @@ class RenderMap extends RenderSchema {
   /// when non-null the generated Dart uses this enum as the map key and
   /// the enum's `fromJson`/`toJson` round-trips each key at the boundary.
   final RenderEnum? keySchema;
+
+  @override
+  Iterable<RenderSchema> get children {
+    // Local so the null-check promotes — `keySchema` is a public field.
+    final key = keySchema;
+    return [valueSchema, if (key != null) key];
+  }
 
   @override
   final dynamic defaultValue;
@@ -5352,6 +5396,9 @@ class RenderOneOf extends RenderNewType {
   /// owns their coverage.
   List<RenderObject> get smooshedVariants =>
       schemas.whereType<RenderObject>().where((v) => v.isSmooshed).toList();
+
+  @override
+  Iterable<RenderSchema> get children => schemas;
 
   @override
   List<Object?> get props => [super.props, schemas, discriminator];

--- a/lib/src/render/tree_visitor.dart
+++ b/lib/src/render/tree_visitor.dart
@@ -22,39 +22,13 @@ class RenderTreeWalker {
     }
   }
 
-  void maybeWalkSchema(RenderSchema? schema) {
-    if (schema != null) {
-      walkSchema(schema);
-    }
-  }
-
   void walkSchema(RenderSchema schema) {
     visitor.visitSchema(schema);
-    switch (schema) {
-      case RenderObject():
-        for (final property in schema.properties.values) {
-          walkSchema(property);
-        }
-        maybeWalkSchema(schema.additionalProperties);
-      case RenderArray():
-        maybeWalkSchema(schema.items);
-      case RenderOneOf():
-        for (final schema in schema.schemas) {
-          walkSchema(schema);
-        }
-      case RenderMap():
-        walkSchema(schema.valueSchema);
-        final keySchema = schema.keySchema;
-        if (keySchema != null) walkSchema(keySchema);
-      case RenderRecursiveRef():
-      case RenderEnum():
-      case RenderString():
-      case RenderInteger():
-      case RenderNumber():
-      case RenderPod():
-      case RenderUnknown():
-      case RenderVoid():
-        break;
+    // Every reachable schema, so each gets a file: descend through
+    // everything, newtypes included. Child enumeration lives on
+    // `RenderSchema.children` (see #289).
+    for (final child in schema.children) {
+      walkSchema(child);
     }
   }
 
@@ -231,41 +205,15 @@ class _NamedSchemaCollector {
       // per endpoint that reaches it.
       if (!inline.add(schema)) return;
     }
-    switch (schema) {
-      case RenderObject():
-        for (final property in schema.properties.values) {
-          _collect(property, isRoot: false);
-        }
-        final additional = schema.additionalProperties;
-        if (additional != null) _collect(additional, isRoot: false);
-      case RenderArray():
-        _collect(schema.items, isRoot: false);
-      case RenderOneOf():
-        // A oneOf with no dispatch emits an `UnimplementedError` stub
-        // that names no variant, so it imports none of them. Asking the
-        // oneOf rather than assuming keeps this in step with what the
-        // dispatch actually emits.
-        if (schema.emitsVariantDispatch) {
-          for (final variant in schema.schemas) {
-            _collect(variant, isRoot: false);
-          }
-        }
-      case RenderMap():
-        _collect(schema.valueSchema, isRoot: false);
-        final keySchema = schema.keySchema;
-        if (keySchema != null) _collect(keySchema, isRoot: false);
-      // Leaves: a recursive ref is handled above (it creates a type and
-      // points at the file that renders it), and the rest name nothing
-      // beyond themselves.
-      case RenderRecursiveRef():
-      case RenderEnum():
-      case RenderString():
-      case RenderInteger():
-      case RenderNumber():
-      case RenderPod():
-      case RenderUnknown():
-      case RenderVoid():
-        break;
+    // A oneOf with no dispatch emits an `UnimplementedError` stub that
+    // names no variant, so this file imports none of them. Asking the
+    // oneOf rather than assuming keeps this in step with what the
+    // dispatch actually emits. Every other schema names all its children,
+    // so the shared enumeration (`RenderSchema.children`, see #289)
+    // serves them directly.
+    if (schema is RenderOneOf && !schema.emitsVariantDispatch) return;
+    for (final child in schema.children) {
+      _collect(child, isRoot: false);
     }
   }
 }


### PR DESCRIPTION
## Summary

The render tree was walked by two independent traversals in
`tree_visitor.dart`, each with its own exhaustive `switch (schema)`
enumerating a node's children: `RenderTreeWalker` (which schemas must
exist, so each gets a file) and `_NamedSchemaCollector` (which schemas a
file names, so it imports them). Adding a `RenderSchema` subtype meant
updating both — and a miss in the collector silently drops an import,
the one direction this code must never fail in.

Move child enumeration onto an abstract `RenderSchema.children` getter
that every subtype implements, and route both traversals through it.
Each consumer keeps its own policy about what to do with the children
(the walker descends through newtypes; the collector stops at them and
gates a non-dispatching oneOf's variants). Because the getter is
abstract, a new subtype cannot compile without implementing it — so it
can never be silently dropped from one traversal but not the other.

Output is byte-identical across all fixtures (synthetic + third_party,
github and discord included).

Closes #289.