### PR TITLE
fix: don't suppress comment_references for non-reference brackets

### DIFF
--- a/gen_tests/third_party/github/lib/api/actions_api.dart
+++ b/gen_tests/third_party/github/lib/api/actions_api.dart
@@ -2,12 +2,6 @@
 // enough that `dart format` can't keep imports and call sites under
 // 80 cols as bare identifiers.
 // ignore_for_file: lines_longer_than_80_chars
-// Spec descriptions copy prose verbatim into dartdoc, where `[x]`
-// inside a sentence (placeholder text, ALL_CAPS tokens, license
-// templates) is parsed as a symbol reference even when no such
-// symbol exists. Suppress file-locally so the lint stays live
-// elsewhere; spec authors do not always escape brackets.
-// ignore_for_file: comment_references
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/gen_tests/third_party/github/lib/api/activity_api.dart
+++ b/gen_tests/third_party/github/lib/api/activity_api.dart
@@ -2,12 +2,6 @@
 // enough that `dart format` can't keep imports and call sites under
 // 80 cols as bare identifiers.
 // ignore_for_file: lines_longer_than_80_chars
-// Spec descriptions copy prose verbatim into dartdoc, where `[x]`
-// inside a sentence (placeholder text, ALL_CAPS tokens, license
-// templates) is parsed as a symbol reference even when no such
-// symbol exists. Suppress file-locally so the lint stays live
-// elsewhere; spec authors do not always escape brackets.
-// ignore_for_file: comment_references
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/gen_tests/third_party/github/lib/api/code_scanning_api.dart
+++ b/gen_tests/third_party/github/lib/api/code_scanning_api.dart
@@ -2,12 +2,6 @@
 // enough that `dart format` can't keep imports and call sites under
 // 80 cols as bare identifiers.
 // ignore_for_file: lines_longer_than_80_chars
-// Spec descriptions copy prose verbatim into dartdoc, where `[x]`
-// inside a sentence (placeholder text, ALL_CAPS tokens, license
-// templates) is parsed as a symbol reference even when no such
-// symbol exists. Suppress file-locally so the lint stays live
-// elsewhere; spec authors do not always escape brackets.
-// ignore_for_file: comment_references
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/gen_tests/third_party/github/lib/api/copilot_api.dart
+++ b/gen_tests/third_party/github/lib/api/copilot_api.dart
@@ -2,12 +2,6 @@
 // enough that `dart format` can't keep imports and call sites under
 // 80 cols as bare identifiers.
 // ignore_for_file: lines_longer_than_80_chars
-// Spec descriptions copy prose verbatim into dartdoc, where `[x]`
-// inside a sentence (placeholder text, ALL_CAPS tokens, license
-// templates) is parsed as a symbol reference even when no such
-// symbol exists. Suppress file-locally so the lint stays live
-// elsewhere; spec authors do not always escape brackets.
-// ignore_for_file: comment_references
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/gen_tests/third_party/github/lib/api/credentials_api.dart
+++ b/gen_tests/third_party/github/lib/api/credentials_api.dart
@@ -1,9 +1,3 @@
-// Spec descriptions copy prose verbatim into dartdoc, where `[x]`
-// inside a sentence (placeholder text, ALL_CAPS tokens, license
-// templates) is parsed as a symbol reference even when no such
-// symbol exists. Suppress file-locally so the lint stays live
-// elsewhere; spec authors do not always escape brackets.
-// ignore_for_file: comment_references
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/gen_tests/third_party/github/lib/api/dependabot_api.dart
+++ b/gen_tests/third_party/github/lib/api/dependabot_api.dart
@@ -2,12 +2,6 @@
 // enough that `dart format` can't keep imports and call sites under
 // 80 cols as bare identifiers.
 // ignore_for_file: lines_longer_than_80_chars
-// Spec descriptions copy prose verbatim into dartdoc, where `[x]`
-// inside a sentence (placeholder text, ALL_CAPS tokens, license
-// templates) is parsed as a symbol reference even when no such
-// symbol exists. Suppress file-locally so the lint stays live
-// elsewhere; spec authors do not always escape brackets.
-// ignore_for_file: comment_references
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/gen_tests/third_party/github/lib/api/gists_api.dart
+++ b/gen_tests/third_party/github/lib/api/gists_api.dart
@@ -2,12 +2,6 @@
 // enough that `dart format` can't keep imports and call sites under
 // 80 cols as bare identifiers.
 // ignore_for_file: lines_longer_than_80_chars
-// Spec descriptions copy prose verbatim into dartdoc, where `[x]`
-// inside a sentence (placeholder text, ALL_CAPS tokens, license
-// templates) is parsed as a symbol reference even when no such
-// symbol exists. Suppress file-locally so the lint stays live
-// elsewhere; spec authors do not always escape brackets.
-// ignore_for_file: comment_references
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/gen_tests/third_party/github/lib/api/issues_api.dart
+++ b/gen_tests/third_party/github/lib/api/issues_api.dart
@@ -2,12 +2,6 @@
 // enough that `dart format` can't keep imports and call sites under
 // 80 cols as bare identifiers.
 // ignore_for_file: lines_longer_than_80_chars
-// Spec descriptions copy prose verbatim into dartdoc, where `[x]`
-// inside a sentence (placeholder text, ALL_CAPS tokens, license
-// templates) is parsed as a symbol reference even when no such
-// symbol exists. Suppress file-locally so the lint stays live
-// elsewhere; spec authors do not always escape brackets.
-// ignore_for_file: comment_references
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/gen_tests/third_party/github/lib/api/meta_api.dart
+++ b/gen_tests/third_party/github/lib/api/meta_api.dart
@@ -2,12 +2,6 @@
 // enough that `dart format` can't keep imports and call sites under
 // 80 cols as bare identifiers.
 // ignore_for_file: lines_longer_than_80_chars
-// Spec descriptions copy prose verbatim into dartdoc, where `[x]`
-// inside a sentence (placeholder text, ALL_CAPS tokens, license
-// templates) is parsed as a symbol reference even when no such
-// symbol exists. Suppress file-locally so the lint stays live
-// elsewhere; spec authors do not always escape brackets.
-// ignore_for_file: comment_references
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/gen_tests/third_party/github/lib/api/migrations_api.dart
+++ b/gen_tests/third_party/github/lib/api/migrations_api.dart
@@ -2,12 +2,6 @@
 // enough that `dart format` can't keep imports and call sites under
 // 80 cols as bare identifiers.
 // ignore_for_file: lines_longer_than_80_chars
-// Spec descriptions copy prose verbatim into dartdoc, where `[x]`
-// inside a sentence (placeholder text, ALL_CAPS tokens, license
-// templates) is parsed as a symbol reference even when no such
-// symbol exists. Suppress file-locally so the lint stays live
-// elsewhere; spec authors do not always escape brackets.
-// ignore_for_file: comment_references
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/gen_tests/third_party/github/lib/api/orgs_api.dart
+++ b/gen_tests/third_party/github/lib/api/orgs_api.dart
@@ -2,12 +2,6 @@
 // enough that `dart format` can't keep imports and call sites under
 // 80 cols as bare identifiers.
 // ignore_for_file: lines_longer_than_80_chars
-// Spec descriptions copy prose verbatim into dartdoc, where `[x]`
-// inside a sentence (placeholder text, ALL_CAPS tokens, license
-// templates) is parsed as a symbol reference even when no such
-// symbol exists. Suppress file-locally so the lint stays live
-// elsewhere; spec authors do not always escape brackets.
-// ignore_for_file: comment_references
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/gen_tests/third_party/github/lib/api/projects_api.dart
+++ b/gen_tests/third_party/github/lib/api/projects_api.dart
@@ -2,12 +2,6 @@
 // enough that `dart format` can't keep imports and call sites under
 // 80 cols as bare identifiers.
 // ignore_for_file: lines_longer_than_80_chars
-// Spec descriptions copy prose verbatim into dartdoc, where `[x]`
-// inside a sentence (placeholder text, ALL_CAPS tokens, license
-// templates) is parsed as a symbol reference even when no such
-// symbol exists. Suppress file-locally so the lint stays live
-// elsewhere; spec authors do not always escape brackets.
-// ignore_for_file: comment_references
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/gen_tests/third_party/github/lib/api/pulls_api.dart
+++ b/gen_tests/third_party/github/lib/api/pulls_api.dart
@@ -2,12 +2,6 @@
 // enough that `dart format` can't keep imports and call sites under
 // 80 cols as bare identifiers.
 // ignore_for_file: lines_longer_than_80_chars
-// Spec descriptions copy prose verbatim into dartdoc, where `[x]`
-// inside a sentence (placeholder text, ALL_CAPS tokens, license
-// templates) is parsed as a symbol reference even when no such
-// symbol exists. Suppress file-locally so the lint stays live
-// elsewhere; spec authors do not always escape brackets.
-// ignore_for_file: comment_references
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/gen_tests/third_party/github/lib/api/rate_limit_api.dart
+++ b/gen_tests/third_party/github/lib/api/rate_limit_api.dart
@@ -2,12 +2,6 @@
 // enough that `dart format` can't keep imports and call sites under
 // 80 cols as bare identifiers.
 // ignore_for_file: lines_longer_than_80_chars
-// Spec descriptions copy prose verbatim into dartdoc, where `[x]`
-// inside a sentence (placeholder text, ALL_CAPS tokens, license
-// templates) is parsed as a symbol reference even when no such
-// symbol exists. Suppress file-locally so the lint stays live
-// elsewhere; spec authors do not always escape brackets.
-// ignore_for_file: comment_references
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/gen_tests/third_party/github/lib/api/reactions_api.dart
+++ b/gen_tests/third_party/github/lib/api/reactions_api.dart
@@ -2,12 +2,6 @@
 // enough that `dart format` can't keep imports and call sites under
 // 80 cols as bare identifiers.
 // ignore_for_file: lines_longer_than_80_chars
-// Spec descriptions copy prose verbatim into dartdoc, where `[x]`
-// inside a sentence (placeholder text, ALL_CAPS tokens, license
-// templates) is parsed as a symbol reference even when no such
-// symbol exists. Suppress file-locally so the lint stays live
-// elsewhere; spec authors do not always escape brackets.
-// ignore_for_file: comment_references
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/gen_tests/third_party/github/lib/api/repos_api.dart
+++ b/gen_tests/third_party/github/lib/api/repos_api.dart
@@ -2,12 +2,6 @@
 // enough that `dart format` can't keep imports and call sites under
 // 80 cols as bare identifiers.
 // ignore_for_file: lines_longer_than_80_chars
-// Spec descriptions copy prose verbatim into dartdoc, where `[x]`
-// inside a sentence (placeholder text, ALL_CAPS tokens, license
-// templates) is parsed as a symbol reference even when no such
-// symbol exists. Suppress file-locally so the lint stays live
-// elsewhere; spec authors do not always escape brackets.
-// ignore_for_file: comment_references
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/gen_tests/third_party/github/lib/api/search_api.dart
+++ b/gen_tests/third_party/github/lib/api/search_api.dart
@@ -2,12 +2,6 @@
 // enough that `dart format` can't keep imports and call sites under
 // 80 cols as bare identifiers.
 // ignore_for_file: lines_longer_than_80_chars
-// Spec descriptions copy prose verbatim into dartdoc, where `[x]`
-// inside a sentence (placeholder text, ALL_CAPS tokens, license
-// templates) is parsed as a symbol reference even when no such
-// symbol exists. Suppress file-locally so the lint stays live
-// elsewhere; spec authors do not always escape brackets.
-// ignore_for_file: comment_references
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/gen_tests/third_party/github/lib/api/security_advisories_api.dart
+++ b/gen_tests/third_party/github/lib/api/security_advisories_api.dart
@@ -2,12 +2,6 @@
 // enough that `dart format` can't keep imports and call sites under
 // 80 cols as bare identifiers.
 // ignore_for_file: lines_longer_than_80_chars
-// Spec descriptions copy prose verbatim into dartdoc, where `[x]`
-// inside a sentence (placeholder text, ALL_CAPS tokens, license
-// templates) is parsed as a symbol reference even when no such
-// symbol exists. Suppress file-locally so the lint stays live
-// elsewhere; spec authors do not always escape brackets.
-// ignore_for_file: comment_references
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/gen_tests/third_party/github/lib/api/teams_api.dart
+++ b/gen_tests/third_party/github/lib/api/teams_api.dart
@@ -2,12 +2,6 @@
 // enough that `dart format` can't keep imports and call sites under
 // 80 cols as bare identifiers.
 // ignore_for_file: lines_longer_than_80_chars
-// Spec descriptions copy prose verbatim into dartdoc, where `[x]`
-// inside a sentence (placeholder text, ALL_CAPS tokens, license
-// templates) is parsed as a symbol reference even when no such
-// symbol exists. Suppress file-locally so the lint stays live
-// elsewhere; spec authors do not always escape brackets.
-// ignore_for_file: comment_references
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/gen_tests/third_party/github/lib/messages/orgs_create_webhook_request.dart
+++ b/gen_tests/third_party/github/lib/messages/orgs_create_webhook_request.dart
@@ -1,9 +1,3 @@
-// Spec descriptions copy prose verbatim into dartdoc, where `[x]`
-// inside a sentence (placeholder text, ALL_CAPS tokens, license
-// templates) is parsed as a symbol reference even when no such
-// symbol exists. Suppress file-locally so the lint stays live
-// elsewhere; spec authors do not always escape brackets.
-// ignore_for_file: comment_references
 import 'package:github/model_helpers.dart';
 import 'package:github/models/orgs_create_webhook_request_config.dart';
 import 'package:meta/meta.dart';

--- a/gen_tests/third_party/github/lib/messages/repos_create_deployment_status_request.dart
+++ b/gen_tests/third_party/github/lib/messages/repos_create_deployment_status_request.dart
@@ -1,9 +1,3 @@
-// Spec descriptions copy prose verbatim into dartdoc, where `[x]`
-// inside a sentence (placeholder text, ALL_CAPS tokens, license
-// templates) is parsed as a symbol reference even when no such
-// symbol exists. Suppress file-locally so the lint stays live
-// elsewhere; spec authors do not always escape brackets.
-// ignore_for_file: comment_references
 import 'package:github/model_helpers.dart';
 import 'package:github/models/repos_create_deployment_status_request_state.dart';
 import 'package:meta/meta.dart';

--- a/gen_tests/third_party/github/lib/models/dependabot_alert_dependency.dart
+++ b/gen_tests/third_party/github/lib/models/dependabot_alert_dependency.dart
@@ -1,9 +1,3 @@
-// Spec descriptions copy prose verbatim into dartdoc, where `[x]`
-// inside a sentence (placeholder text, ALL_CAPS tokens, license
-// templates) is parsed as a symbol reference even when no such
-// symbol exists. Suppress file-locally so the lint stays live
-// elsewhere; spec authors do not always escape brackets.
-// ignore_for_file: comment_references
 import 'package:github/model_helpers.dart';
 import 'package:github/models/dependabot_alert_dependency_relationship.dart';
 import 'package:github/models/dependabot_alert_dependency_scope.dart';

--- a/gen_tests/third_party/github/lib/models/dependabot_alert_dependency_relationship.dart
+++ b/gen_tests/third_party/github/lib/models/dependabot_alert_dependency_relationship.dart
@@ -1,9 +1,3 @@
-// Spec descriptions copy prose verbatim into dartdoc, where `[x]`
-// inside a sentence (placeholder text, ALL_CAPS tokens, license
-// templates) is parsed as a symbol reference even when no such
-// symbol exists. Suppress file-locally so the lint stays live
-// elsewhere; spec authors do not always escape brackets.
-// ignore_for_file: comment_references
 /// The vulnerable dependency's relationship to your project.
 ///
 /// > [!NOTE]

--- a/gen_tests/third_party/github/lib/models/dependabot_alert_with_repository_dependency.dart
+++ b/gen_tests/third_party/github/lib/models/dependabot_alert_with_repository_dependency.dart
@@ -1,9 +1,3 @@
-// Spec descriptions copy prose verbatim into dartdoc, where `[x]`
-// inside a sentence (placeholder text, ALL_CAPS tokens, license
-// templates) is parsed as a symbol reference even when no such
-// symbol exists. Suppress file-locally so the lint stays live
-// elsewhere; spec authors do not always escape brackets.
-// ignore_for_file: comment_references
 import 'package:github/model_helpers.dart';
 import 'package:github/models/dependabot_alert_package.dart';
 import 'package:github/models/dependabot_alert_with_repository_dependency_relationship.dart';

--- a/gen_tests/third_party/github/lib/models/dependabot_alert_with_repository_dependency_relationship.dart
+++ b/gen_tests/third_party/github/lib/models/dependabot_alert_with_repository_dependency_relationship.dart
@@ -2,12 +2,6 @@
 // enough that `dart format` can't keep imports and call sites under
 // 80 cols as bare identifiers.
 // ignore_for_file: lines_longer_than_80_chars
-// Spec descriptions copy prose verbatim into dartdoc, where `[x]`
-// inside a sentence (placeholder text, ALL_CAPS tokens, license
-// templates) is parsed as a symbol reference even when no such
-// symbol exists. Suppress file-locally so the lint stays live
-// elsewhere; spec authors do not always escape brackets.
-// ignore_for_file: comment_references
 /// The vulnerable dependency's relationship to your project.
 ///
 /// > [!NOTE]

--- a/gen_tests/third_party/github/lib/models/hook.dart
+++ b/gen_tests/third_party/github/lib/models/hook.dart
@@ -1,9 +1,3 @@
-// Spec descriptions copy prose verbatim into dartdoc, where `[x]`
-// inside a sentence (placeholder text, ALL_CAPS tokens, license
-// templates) is parsed as a symbol reference even when no such
-// symbol exists. Suppress file-locally so the lint stays live
-// elsewhere; spec authors do not always escape brackets.
-// ignore_for_file: comment_references
 import 'package:github/messages/hook_response.dart';
 import 'package:github/model_helpers.dart';
 import 'package:github/models/webhook_config.dart';

--- a/gen_tests/third_party/github/lib/models/selected_actions.dart
+++ b/gen_tests/third_party/github/lib/models/selected_actions.dart
@@ -1,9 +1,3 @@
-// Spec descriptions copy prose verbatim into dartdoc, where `[x]`
-// inside a sentence (placeholder text, ALL_CAPS tokens, license
-// templates) is parsed as a symbol reference even when no such
-// symbol exists. Suppress file-locally so the lint stays live
-// elsewhere; spec authors do not always escape brackets.
-// ignore_for_file: comment_references
 import 'package:github/model_helpers.dart';
 import 'package:meta/meta.dart';
 

--- a/lib/src/render/formatting.dart
+++ b/lib/src/render/formatting.dart
@@ -175,12 +175,17 @@ bool _dartdocHasHtmlTag(String content) {
 /// reference in their docs doesn't get silently suppressed when it
 /// should be fixed at the source.
 ///
+/// A token counts only if it is a real comment reference in the first
+/// place — [_bracketedDartdocTokens] drops Markdown-alert and literal
+/// noise the lint never fires on.
+///
 /// "In scope" today means *declared in the same file* — top-level
 /// types ([_topLevelDeclarations]) plus same-file field declarations
 /// (so e.g. shorebird's `/// The signature of the [hash].` resolves
-/// against `final String hash;`). Imported names aren't tracked yet
-/// — see #142 — so a `[Foo]` ref to an imported type still triggers
-/// the directive even when it would resolve.
+/// against `final String hash;`). Names reachable another way aren't
+/// tracked yet — see #142 — so a `[Foo]` ref to an imported type, or a
+/// `[param]` ref to a method parameter, still triggers the directive
+/// even when the analyzer would resolve it.
 @visibleForTesting
 String maybeAddCommentReferencesIgnore(String content) {
   final tokens = _bracketedDartdocTokens(content);
@@ -206,7 +211,20 @@ String maybeAddIgnoreDirectives(String content) => maybeAddLongLineIgnore(
 );
 
 /// Collects every `[token]` bracketed reference inside a `///` doc
-/// comment, ignoring `[Foo](url)` markdown links (the `(?!\()` guard).
+/// comment that `comment_references` could actually fire on, ignoring
+/// `[Foo](url)` markdown links (the `(?!\()` guard).
+///
+/// Only tokens shaped like a Dart comment reference are kept — an
+/// identifier or a dotted chain of them ([_commentReferenceRe]). The
+/// analyzer parses `[x]` as a comment reference (and so can complain it
+/// doesn't resolve) *only* when `x` is such a chain; anything else it
+/// leaves as plain text. github's spec prose is full of the "anything
+/// else" case — GitHub-flavored-Markdown alerts (`[!NOTE]`,
+/// `[!WARNING]`), quoted literals (`["push"]`), and bare numbers
+/// (`[789]`) — none of which the lint touches. Collecting them anyway
+/// made the file look like it needed the directive when it did not:
+/// across github those non-references alone accounted for the directive
+/// on 27 of 43 annotated files.
 Set<String> _bracketedDartdocTokens(String content) {
   final tokenRe = RegExp(r'\[([^\]\s]+)\](?!\()');
   final tokens = <String>{};
@@ -214,11 +232,22 @@ Set<String> _bracketedDartdocTokens(String content) {
     final stripped = line.trimLeft();
     if (!stripped.startsWith('///')) continue;
     for (final m in tokenRe.allMatches(stripped)) {
-      tokens.add(m.group(1)!);
+      final token = m.group(1)!;
+      if (_commentReferenceRe.hasMatch(token)) tokens.add(token);
     }
   }
   return tokens;
 }
+
+/// A bracketed dartdoc token the analyzer treats as a comment
+/// reference: a Dart identifier, optionally a dotted chain (`Foo`,
+/// `Foo.bar`, `Foo.bar.baz`). Operator references (`[==]`) are not
+/// matched — the generator never emits them in prose — so, like the
+/// rest of this file's regex-based scan, this is a pragmatic
+/// approximation of the parser rather than the parser itself.
+final _commentReferenceRe = RegExp(
+  r'^[A-Za-z_$][A-Za-z0-9_$]*(?:\.[A-Za-z_$][A-Za-z0-9_$]*)*$',
+);
 
 /// Collects the names of declarations the analyzer would resolve a
 /// `[token]` bracketed dartdoc reference against. Two regexes:

--- a/test/render/formatting_test.dart
+++ b/test/render/formatting_test.dart
@@ -236,6 +236,44 @@ void main() {
           '}\n';
       expect(maybeAddCommentReferencesIgnore(content), content);
     });
+
+    test('passes through GitHub Markdown alert markers', () {
+      // github spec prose copies GitHub-flavored-Markdown alerts
+      // verbatim: `> [!NOTE]`, `> [!WARNING]`. `!NOTE` is not a valid
+      // Dart identifier, so `comment_references` never parses it as a
+      // reference — these were the single biggest false trigger, the
+      // sole reason for the directive on 27 of github's 43 annotated
+      // files (#142).
+      const content =
+          '/// [!NOTE]\n'
+          '/// [!WARNING] this endpoint is rate limited.\n'
+          'class Repo {}\n';
+      expect(maybeAddCommentReferencesIgnore(content), content);
+    });
+
+    test('passes through bracketed literals and numbers', () {
+      // Quoted enum-value prose (`["push"]`, `['pull']`) and bare
+      // numbers (`[789]`) are not identifiers, so the lint leaves them
+      // as plain text. Collecting them made the file look like it
+      // needed suppression.
+      const content =
+          '/// One of [\'push\'], ["pull"], or the id [789].\n'
+          'class Event {}\n';
+      expect(maybeAddCommentReferencesIgnore(content), content);
+    });
+
+    test('a real ref among alert markers still needs the directive', () {
+      // Dropping the noise must not drop a genuine unresolved reference
+      // sharing the same doc comment.
+      const content =
+          '/// [!NOTE]\n'
+          '/// See [ImportedThing] for details.\n'
+          'class Repo {}\n';
+      expect(
+        maybeAddCommentReferencesIgnore(content),
+        startsWith('$commentReferencesIgnoreBlock\n'),
+      );
+    });
   });
 
   group('maybeAddUnintendedHtmlIgnore', () {


### PR DESCRIPTION
## Summary

The `comment_references` gate added its file-wide `ignore_for_file` directive
whenever a `///` doc comment held a bracketed token that didn't resolve against
a same-file declaration — but it counted *any* bracketed token, including ones
the analyzer never treats as a comment reference. Files were annotated for
tokens the lint would never fire on.

Measured against github: of the 43 annotated files, **27 were annotated solely
because of non-reference brackets**. The dominant case is GitHub-flavored-Markdown
alerts copied verbatim from spec prose — `[!NOTE]` (122 occurrences),
`[!WARNING]` (81) — plus quoted enum values (`["push"]`, `['pull']`) and bare
numbers (`[789]`). None are Dart identifiers, so the analyzer leaves them as
plain text and `comment_references` never mentions them.

`_bracketedDartdocTokens` now keeps only tokens shaped like a real comment
reference — an identifier or a dotted chain (`Foo`, `Foo.bar`) — via the new
`_commentReferenceRe`. Operator references (`[==]`) aren't matched; the
generator never emits them in prose, consistent with the rest of this file's
pragmatic regex scan.

github goes **43 → 16** annotated files. The 16 that remain are genuine:
license/code-of-conduct placeholders (`[year]`, `[fullname]`, `[EMAIL]`), plus
`[entries]` map-field and `[installationId]`-style method-parameter refs that
the analyzer *does* resolve but the same-file declaration scan doesn't see yet
— those stay tracked under the narrowed #142.

### Note on #142's framing

The issue was filed assuming the remaining over-triggers were refs to *imported
types* and proposed "track imports" as the fix. The data says otherwise: zero
imported-type tokens appear in the actual over-trigger population. The real
causes are non-identifier Markdown noise (this PR), same-file `Map<...>` fields,
and method parameters. Updating #142 to reflect that.

## Test plan

- New unit tests: `[!NOTE]`/`[!WARNING]` alerts and bracketed literals/numbers
  pass through without the directive; a genuine unresolved ref sharing a doc
  comment with alert markers still gets it.
- Regenerated github before/after, normalized package name + the
  length-sensitive long-line header, diffed: the **only** change is the 6-line
  directive block removed from exactly 27 files — zero other content differs.
- Regenerated output stays `dart analyze`-clean (the 27 freed files never
  needed the directive — no missed lint).
- discord / backstage / petstore / spacetraders all still analyze-clean.
- Full suite (743), `dart analyze`, `dart format` clean.

Updates #142.
