### PR TITLE
feat: support apiKey security schemes with in: cookie

### DIFF
--- a/gen_tests/multipart/lib/auth.dart
+++ b/gen_tests/multipart/lib/auth.dart
@@ -22,10 +22,15 @@ class MissingSecretsException implements Exception {
 @immutable
 class ResolvedAuth {
   /// Create a new [ResolvedAuth].
-  const ResolvedAuth({required this.headers, required this.params});
+  const ResolvedAuth({
+    required this.headers,
+    required this.params,
+    required this.cookies,
+  });
 
   /// Create a new [ResolvedAuth] with no headers or parameters.
-  const ResolvedAuth.noAuth() : this(headers: const {}, params: const {});
+  const ResolvedAuth.noAuth()
+    : this(headers: const {}, params: const {}, cookies: const {});
 
   /// The headers of the resolved auth.
   final Map<String, String> headers;
@@ -33,9 +38,21 @@ class ResolvedAuth {
   /// The parameters of the resolved auth.
   final Map<String, String> params;
 
+  /// The cookies of the resolved auth, keyed by cookie name.
+  ///
+  /// Kept separate from [headers] because every cookie shares the single
+  /// `Cookie` header: merging two cookie-bearing auths has to concatenate
+  /// them rather than let the later one replace the earlier.
+  final Map<String, String> cookies;
+
   /// Apply the resolved auth to the given headers.
   void applyToHeaders(Map<String, String> headers) {
     headers.addAll(this.headers);
+    if (cookies.isNotEmpty) {
+      headers['Cookie'] = cookies.entries
+          .map((e) => '${e.key}=${e.value}')
+          .join('; ');
+    }
   }
 
   /// Apply the resolved auth to the given parameters. The generated
@@ -55,6 +72,7 @@ class ResolvedAuth {
     return ResolvedAuth(
       headers: {...headers, ...other.headers},
       params: {...params, ...other.params},
+      cookies: {...cookies, ...other.cookies},
     );
   }
 }
@@ -173,12 +191,13 @@ class HttpAuth extends SecretAuth {
     return ResolvedAuth(
       headers: {'Authorization': '$scheme $secret'},
       params: const {},
+      cookies: const {},
     );
   }
 }
 
-// Cookie is not yet supported.
-enum ApiKeyLocation { query, header }
+/// Where an API key is sent on the request.
+enum ApiKeyLocation { query, header, cookie }
 
 /// An API key authentication scheme.
 @immutable
@@ -205,10 +224,17 @@ class ApiKeyAuth extends SecretAuth {
       ApiKeyLocation.header => ResolvedAuth(
         headers: {name: secret},
         params: const {},
+        cookies: const {},
       ),
       ApiKeyLocation.query => ResolvedAuth(
         headers: const {},
         params: {name: secret},
+        cookies: const {},
+      ),
+      ApiKeyLocation.cookie => ResolvedAuth(
+        headers: const {},
+        params: const {},
+        cookies: {name: secret},
       ),
     };
   }

--- a/gen_tests/security.json
+++ b/gen_tests/security.json
@@ -3,7 +3,7 @@
     "info": {
         "title": "Security",
         "version": "1.0.0",
-        "description": "Exercises global + per-operation security. Covers the Shorebird-shaped case: globally-required bearer auth with a public endpoint that opts out via `security: []`, plus a scheme swap to apiKey."
+        "description": "Exercises global + per-operation security. Covers the Shorebird-shaped case: globally-required bearer auth with a public endpoint that opts out via `security: []`, plus a scheme swap to apiKey, in both its header and cookie locations."
     },
     "servers": [
         {
@@ -61,6 +61,22 @@
                     }
                 }
             }
+        },
+        "/session": {
+            "get": {
+                "operationId": "getSession",
+                "summary": "Uses a cookie-borne API key.",
+                "security": [
+                    {
+                        "cookieAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
         }
     },
     "components": {
@@ -69,6 +85,11 @@
                 "type": "http",
                 "scheme": "bearer",
                 "bearerFormat": "JWT"
+            },
+            "cookieAuth": {
+                "type": "apiKey",
+                "name": "session",
+                "in": "cookie"
             },
             "apiKeyAuth": {
                 "type": "apiKey",

--- a/gen_tests/security/lib/api/default_api.dart
+++ b/gen_tests/security/lib/api/default_api.dart
@@ -58,4 +58,21 @@ class DefaultApi {
       throw ApiException<Object?>(response.statusCode, response.body);
     }
   }
+
+  /// Uses a cookie-borne API key.
+  Future<void> getSession() async {
+    final response = await client.invokeApi(
+      method: Method.get,
+      path: '/session',
+      authRequest: const ApiKeyAuth(
+        name: 'session',
+        secretName: 'cookieAuth',
+        sendIn: ApiKeyLocation.cookie,
+      ),
+    );
+
+    if (response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException<Object?>(response.statusCode, response.body);
+    }
+  }
 }

--- a/gen_tests/security/lib/auth.dart
+++ b/gen_tests/security/lib/auth.dart
@@ -22,10 +22,15 @@ class MissingSecretsException implements Exception {
 @immutable
 class ResolvedAuth {
   /// Create a new [ResolvedAuth].
-  const ResolvedAuth({required this.headers, required this.params});
+  const ResolvedAuth({
+    required this.headers,
+    required this.params,
+    required this.cookies,
+  });
 
   /// Create a new [ResolvedAuth] with no headers or parameters.
-  const ResolvedAuth.noAuth() : this(headers: const {}, params: const {});
+  const ResolvedAuth.noAuth()
+    : this(headers: const {}, params: const {}, cookies: const {});
 
   /// The headers of the resolved auth.
   final Map<String, String> headers;
@@ -33,9 +38,21 @@ class ResolvedAuth {
   /// The parameters of the resolved auth.
   final Map<String, String> params;
 
+  /// The cookies of the resolved auth, keyed by cookie name.
+  ///
+  /// Kept separate from [headers] because every cookie shares the single
+  /// `Cookie` header: merging two cookie-bearing auths has to concatenate
+  /// them rather than let the later one replace the earlier.
+  final Map<String, String> cookies;
+
   /// Apply the resolved auth to the given headers.
   void applyToHeaders(Map<String, String> headers) {
     headers.addAll(this.headers);
+    if (cookies.isNotEmpty) {
+      headers['Cookie'] = cookies.entries
+          .map((e) => '${e.key}=${e.value}')
+          .join('; ');
+    }
   }
 
   /// Apply the resolved auth to the given parameters. The generated
@@ -55,6 +72,7 @@ class ResolvedAuth {
     return ResolvedAuth(
       headers: {...headers, ...other.headers},
       params: {...params, ...other.params},
+      cookies: {...cookies, ...other.cookies},
     );
   }
 }
@@ -173,12 +191,13 @@ class HttpAuth extends SecretAuth {
     return ResolvedAuth(
       headers: {'Authorization': '$scheme $secret'},
       params: const {},
+      cookies: const {},
     );
   }
 }
 
-// Cookie is not yet supported.
-enum ApiKeyLocation { query, header }
+/// Where an API key is sent on the request.
+enum ApiKeyLocation { query, header, cookie }
 
 /// An API key authentication scheme.
 @immutable
@@ -205,10 +224,17 @@ class ApiKeyAuth extends SecretAuth {
       ApiKeyLocation.header => ResolvedAuth(
         headers: {name: secret},
         params: const {},
+        cookies: const {},
       ),
       ApiKeyLocation.query => ResolvedAuth(
         headers: const {},
         params: {name: secret},
+        cookies: const {},
+      ),
+      ApiKeyLocation.cookie => ResolvedAuth(
+        headers: const {},
+        params: const {},
+        cookies: {name: secret},
       ),
     };
   }

--- a/gen_tests/third_party/backstage/lib/auth.dart
+++ b/gen_tests/third_party/backstage/lib/auth.dart
@@ -22,10 +22,15 @@ class MissingSecretsException implements Exception {
 @immutable
 class ResolvedAuth {
   /// Create a new [ResolvedAuth].
-  const ResolvedAuth({required this.headers, required this.params});
+  const ResolvedAuth({
+    required this.headers,
+    required this.params,
+    required this.cookies,
+  });
 
   /// Create a new [ResolvedAuth] with no headers or parameters.
-  const ResolvedAuth.noAuth() : this(headers: const {}, params: const {});
+  const ResolvedAuth.noAuth()
+    : this(headers: const {}, params: const {}, cookies: const {});
 
   /// The headers of the resolved auth.
   final Map<String, String> headers;
@@ -33,9 +38,21 @@ class ResolvedAuth {
   /// The parameters of the resolved auth.
   final Map<String, String> params;
 
+  /// The cookies of the resolved auth, keyed by cookie name.
+  ///
+  /// Kept separate from [headers] because every cookie shares the single
+  /// `Cookie` header: merging two cookie-bearing auths has to concatenate
+  /// them rather than let the later one replace the earlier.
+  final Map<String, String> cookies;
+
   /// Apply the resolved auth to the given headers.
   void applyToHeaders(Map<String, String> headers) {
     headers.addAll(this.headers);
+    if (cookies.isNotEmpty) {
+      headers['Cookie'] = cookies.entries
+          .map((e) => '${e.key}=${e.value}')
+          .join('; ');
+    }
   }
 
   /// Apply the resolved auth to the given parameters. The generated
@@ -55,6 +72,7 @@ class ResolvedAuth {
     return ResolvedAuth(
       headers: {...headers, ...other.headers},
       params: {...params, ...other.params},
+      cookies: {...cookies, ...other.cookies},
     );
   }
 }
@@ -173,12 +191,13 @@ class HttpAuth extends SecretAuth {
     return ResolvedAuth(
       headers: {'Authorization': '$scheme $secret'},
       params: const {},
+      cookies: const {},
     );
   }
 }
 
-// Cookie is not yet supported.
-enum ApiKeyLocation { query, header }
+/// Where an API key is sent on the request.
+enum ApiKeyLocation { query, header, cookie }
 
 /// An API key authentication scheme.
 @immutable
@@ -205,10 +224,17 @@ class ApiKeyAuth extends SecretAuth {
       ApiKeyLocation.header => ResolvedAuth(
         headers: {name: secret},
         params: const {},
+        cookies: const {},
       ),
       ApiKeyLocation.query => ResolvedAuth(
         headers: const {},
         params: {name: secret},
+        cookies: const {},
+      ),
+      ApiKeyLocation.cookie => ResolvedAuth(
+        headers: const {},
+        params: const {},
+        cookies: {name: secret},
       ),
     };
   }

--- a/gen_tests/third_party/discord/lib/auth.dart
+++ b/gen_tests/third_party/discord/lib/auth.dart
@@ -22,10 +22,15 @@ class MissingSecretsException implements Exception {
 @immutable
 class ResolvedAuth {
   /// Create a new [ResolvedAuth].
-  const ResolvedAuth({required this.headers, required this.params});
+  const ResolvedAuth({
+    required this.headers,
+    required this.params,
+    required this.cookies,
+  });
 
   /// Create a new [ResolvedAuth] with no headers or parameters.
-  const ResolvedAuth.noAuth() : this(headers: const {}, params: const {});
+  const ResolvedAuth.noAuth()
+    : this(headers: const {}, params: const {}, cookies: const {});
 
   /// The headers of the resolved auth.
   final Map<String, String> headers;
@@ -33,9 +38,21 @@ class ResolvedAuth {
   /// The parameters of the resolved auth.
   final Map<String, String> params;
 
+  /// The cookies of the resolved auth, keyed by cookie name.
+  ///
+  /// Kept separate from [headers] because every cookie shares the single
+  /// `Cookie` header: merging two cookie-bearing auths has to concatenate
+  /// them rather than let the later one replace the earlier.
+  final Map<String, String> cookies;
+
   /// Apply the resolved auth to the given headers.
   void applyToHeaders(Map<String, String> headers) {
     headers.addAll(this.headers);
+    if (cookies.isNotEmpty) {
+      headers['Cookie'] = cookies.entries
+          .map((e) => '${e.key}=${e.value}')
+          .join('; ');
+    }
   }
 
   /// Apply the resolved auth to the given parameters. The generated
@@ -55,6 +72,7 @@ class ResolvedAuth {
     return ResolvedAuth(
       headers: {...headers, ...other.headers},
       params: {...params, ...other.params},
+      cookies: {...cookies, ...other.cookies},
     );
   }
 }
@@ -173,12 +191,13 @@ class HttpAuth extends SecretAuth {
     return ResolvedAuth(
       headers: {'Authorization': '$scheme $secret'},
       params: const {},
+      cookies: const {},
     );
   }
 }
 
-// Cookie is not yet supported.
-enum ApiKeyLocation { query, header }
+/// Where an API key is sent on the request.
+enum ApiKeyLocation { query, header, cookie }
 
 /// An API key authentication scheme.
 @immutable
@@ -205,10 +224,17 @@ class ApiKeyAuth extends SecretAuth {
       ApiKeyLocation.header => ResolvedAuth(
         headers: {name: secret},
         params: const {},
+        cookies: const {},
       ),
       ApiKeyLocation.query => ResolvedAuth(
         headers: const {},
         params: {name: secret},
+        cookies: const {},
+      ),
+      ApiKeyLocation.cookie => ResolvedAuth(
+        headers: const {},
+        params: const {},
+        cookies: {name: secret},
       ),
     };
   }

--- a/gen_tests/third_party/github/lib/auth.dart
+++ b/gen_tests/third_party/github/lib/auth.dart
@@ -22,10 +22,15 @@ class MissingSecretsException implements Exception {
 @immutable
 class ResolvedAuth {
   /// Create a new [ResolvedAuth].
-  const ResolvedAuth({required this.headers, required this.params});
+  const ResolvedAuth({
+    required this.headers,
+    required this.params,
+    required this.cookies,
+  });
 
   /// Create a new [ResolvedAuth] with no headers or parameters.
-  const ResolvedAuth.noAuth() : this(headers: const {}, params: const {});
+  const ResolvedAuth.noAuth()
+    : this(headers: const {}, params: const {}, cookies: const {});
 
   /// The headers of the resolved auth.
   final Map<String, String> headers;
@@ -33,9 +38,21 @@ class ResolvedAuth {
   /// The parameters of the resolved auth.
   final Map<String, String> params;
 
+  /// The cookies of the resolved auth, keyed by cookie name.
+  ///
+  /// Kept separate from [headers] because every cookie shares the single
+  /// `Cookie` header: merging two cookie-bearing auths has to concatenate
+  /// them rather than let the later one replace the earlier.
+  final Map<String, String> cookies;
+
   /// Apply the resolved auth to the given headers.
   void applyToHeaders(Map<String, String> headers) {
     headers.addAll(this.headers);
+    if (cookies.isNotEmpty) {
+      headers['Cookie'] = cookies.entries
+          .map((e) => '${e.key}=${e.value}')
+          .join('; ');
+    }
   }
 
   /// Apply the resolved auth to the given parameters. The generated
@@ -55,6 +72,7 @@ class ResolvedAuth {
     return ResolvedAuth(
       headers: {...headers, ...other.headers},
       params: {...params, ...other.params},
+      cookies: {...cookies, ...other.cookies},
     );
   }
 }
@@ -173,12 +191,13 @@ class HttpAuth extends SecretAuth {
     return ResolvedAuth(
       headers: {'Authorization': '$scheme $secret'},
       params: const {},
+      cookies: const {},
     );
   }
 }
 
-// Cookie is not yet supported.
-enum ApiKeyLocation { query, header }
+/// Where an API key is sent on the request.
+enum ApiKeyLocation { query, header, cookie }
 
 /// An API key authentication scheme.
 @immutable
@@ -205,10 +224,17 @@ class ApiKeyAuth extends SecretAuth {
       ApiKeyLocation.header => ResolvedAuth(
         headers: {name: secret},
         params: const {},
+        cookies: const {},
       ),
       ApiKeyLocation.query => ResolvedAuth(
         headers: const {},
         params: {name: secret},
+        cookies: const {},
+      ),
+      ApiKeyLocation.cookie => ResolvedAuth(
+        headers: const {},
+        params: const {},
+        cookies: {name: secret},
       ),
     };
   }

--- a/gen_tests/third_party/petstore/lib/auth.dart
+++ b/gen_tests/third_party/petstore/lib/auth.dart
@@ -22,10 +22,15 @@ class MissingSecretsException implements Exception {
 @immutable
 class ResolvedAuth {
   /// Create a new [ResolvedAuth].
-  const ResolvedAuth({required this.headers, required this.params});
+  const ResolvedAuth({
+    required this.headers,
+    required this.params,
+    required this.cookies,
+  });
 
   /// Create a new [ResolvedAuth] with no headers or parameters.
-  const ResolvedAuth.noAuth() : this(headers: const {}, params: const {});
+  const ResolvedAuth.noAuth()
+    : this(headers: const {}, params: const {}, cookies: const {});
 
   /// The headers of the resolved auth.
   final Map<String, String> headers;
@@ -33,9 +38,21 @@ class ResolvedAuth {
   /// The parameters of the resolved auth.
   final Map<String, String> params;
 
+  /// The cookies of the resolved auth, keyed by cookie name.
+  ///
+  /// Kept separate from [headers] because every cookie shares the single
+  /// `Cookie` header: merging two cookie-bearing auths has to concatenate
+  /// them rather than let the later one replace the earlier.
+  final Map<String, String> cookies;
+
   /// Apply the resolved auth to the given headers.
   void applyToHeaders(Map<String, String> headers) {
     headers.addAll(this.headers);
+    if (cookies.isNotEmpty) {
+      headers['Cookie'] = cookies.entries
+          .map((e) => '${e.key}=${e.value}')
+          .join('; ');
+    }
   }
 
   /// Apply the resolved auth to the given parameters. The generated
@@ -55,6 +72,7 @@ class ResolvedAuth {
     return ResolvedAuth(
       headers: {...headers, ...other.headers},
       params: {...params, ...other.params},
+      cookies: {...cookies, ...other.cookies},
     );
   }
 }
@@ -173,12 +191,13 @@ class HttpAuth extends SecretAuth {
     return ResolvedAuth(
       headers: {'Authorization': '$scheme $secret'},
       params: const {},
+      cookies: const {},
     );
   }
 }
 
-// Cookie is not yet supported.
-enum ApiKeyLocation { query, header }
+/// Where an API key is sent on the request.
+enum ApiKeyLocation { query, header, cookie }
 
 /// An API key authentication scheme.
 @immutable
@@ -205,10 +224,17 @@ class ApiKeyAuth extends SecretAuth {
       ApiKeyLocation.header => ResolvedAuth(
         headers: {name: secret},
         params: const {},
+        cookies: const {},
       ),
       ApiKeyLocation.query => ResolvedAuth(
         headers: const {},
         params: {name: secret},
+        cookies: const {},
+      ),
+      ApiKeyLocation.cookie => ResolvedAuth(
+        headers: const {},
+        params: const {},
+        cookies: {name: secret},
       ),
     };
   }

--- a/gen_tests/third_party/spacetraders/lib/auth.dart
+++ b/gen_tests/third_party/spacetraders/lib/auth.dart
@@ -22,10 +22,15 @@ class MissingSecretsException implements Exception {
 @immutable
 class ResolvedAuth {
   /// Create a new [ResolvedAuth].
-  const ResolvedAuth({required this.headers, required this.params});
+  const ResolvedAuth({
+    required this.headers,
+    required this.params,
+    required this.cookies,
+  });
 
   /// Create a new [ResolvedAuth] with no headers or parameters.
-  const ResolvedAuth.noAuth() : this(headers: const {}, params: const {});
+  const ResolvedAuth.noAuth()
+    : this(headers: const {}, params: const {}, cookies: const {});
 
   /// The headers of the resolved auth.
   final Map<String, String> headers;
@@ -33,9 +38,21 @@ class ResolvedAuth {
   /// The parameters of the resolved auth.
   final Map<String, String> params;
 
+  /// The cookies of the resolved auth, keyed by cookie name.
+  ///
+  /// Kept separate from [headers] because every cookie shares the single
+  /// `Cookie` header: merging two cookie-bearing auths has to concatenate
+  /// them rather than let the later one replace the earlier.
+  final Map<String, String> cookies;
+
   /// Apply the resolved auth to the given headers.
   void applyToHeaders(Map<String, String> headers) {
     headers.addAll(this.headers);
+    if (cookies.isNotEmpty) {
+      headers['Cookie'] = cookies.entries
+          .map((e) => '${e.key}=${e.value}')
+          .join('; ');
+    }
   }
 
   /// Apply the resolved auth to the given parameters. The generated
@@ -55,6 +72,7 @@ class ResolvedAuth {
     return ResolvedAuth(
       headers: {...headers, ...other.headers},
       params: {...params, ...other.params},
+      cookies: {...cookies, ...other.cookies},
     );
   }
 }
@@ -173,12 +191,13 @@ class HttpAuth extends SecretAuth {
     return ResolvedAuth(
       headers: {'Authorization': '$scheme $secret'},
       params: const {},
+      cookies: const {},
     );
   }
 }
 
-// Cookie is not yet supported.
-enum ApiKeyLocation { query, header }
+/// Where an API key is sent on the request.
+enum ApiKeyLocation { query, header, cookie }
 
 /// An API key authentication scheme.
 @immutable
@@ -205,10 +224,17 @@ class ApiKeyAuth extends SecretAuth {
       ApiKeyLocation.header => ResolvedAuth(
         headers: {name: secret},
         params: const {},
+        cookies: const {},
       ),
       ApiKeyLocation.query => ResolvedAuth(
         headers: const {},
         params: {name: secret},
+        cookies: const {},
+      ),
+      ApiKeyLocation.cookie => ResolvedAuth(
+        headers: const {},
+        params: const {},
+        cookies: {name: secret},
       ),
     };
   }

--- a/gen_tests/third_party/train_travel/lib/auth.dart
+++ b/gen_tests/third_party/train_travel/lib/auth.dart
@@ -22,10 +22,15 @@ class MissingSecretsException implements Exception {
 @immutable
 class ResolvedAuth {
   /// Create a new [ResolvedAuth].
-  const ResolvedAuth({required this.headers, required this.params});
+  const ResolvedAuth({
+    required this.headers,
+    required this.params,
+    required this.cookies,
+  });
 
   /// Create a new [ResolvedAuth] with no headers or parameters.
-  const ResolvedAuth.noAuth() : this(headers: const {}, params: const {});
+  const ResolvedAuth.noAuth()
+    : this(headers: const {}, params: const {}, cookies: const {});
 
   /// The headers of the resolved auth.
   final Map<String, String> headers;
@@ -33,9 +38,21 @@ class ResolvedAuth {
   /// The parameters of the resolved auth.
   final Map<String, String> params;
 
+  /// The cookies of the resolved auth, keyed by cookie name.
+  ///
+  /// Kept separate from [headers] because every cookie shares the single
+  /// `Cookie` header: merging two cookie-bearing auths has to concatenate
+  /// them rather than let the later one replace the earlier.
+  final Map<String, String> cookies;
+
   /// Apply the resolved auth to the given headers.
   void applyToHeaders(Map<String, String> headers) {
     headers.addAll(this.headers);
+    if (cookies.isNotEmpty) {
+      headers['Cookie'] = cookies.entries
+          .map((e) => '${e.key}=${e.value}')
+          .join('; ');
+    }
   }
 
   /// Apply the resolved auth to the given parameters. The generated
@@ -55,6 +72,7 @@ class ResolvedAuth {
     return ResolvedAuth(
       headers: {...headers, ...other.headers},
       params: {...params, ...other.params},
+      cookies: {...cookies, ...other.cookies},
     );
   }
 }
@@ -173,12 +191,13 @@ class HttpAuth extends SecretAuth {
     return ResolvedAuth(
       headers: {'Authorization': '$scheme $secret'},
       params: const {},
+      cookies: const {},
     );
   }
 }
 
-// Cookie is not yet supported.
-enum ApiKeyLocation { query, header }
+/// Where an API key is sent on the request.
+enum ApiKeyLocation { query, header, cookie }
 
 /// An API key authentication scheme.
 @immutable
@@ -205,10 +224,17 @@ class ApiKeyAuth extends SecretAuth {
       ApiKeyLocation.header => ResolvedAuth(
         headers: {name: secret},
         params: const {},
+        cookies: const {},
       ),
       ApiKeyLocation.query => ResolvedAuth(
         headers: const {},
         params: {name: secret},
+        cookies: const {},
+      ),
+      ApiKeyLocation.cookie => ResolvedAuth(
+        headers: const {},
+        params: const {},
+        cookies: {name: secret},
       ),
     };
   }

--- a/gen_tests/types/lib/auth.dart
+++ b/gen_tests/types/lib/auth.dart
@@ -22,10 +22,15 @@ class MissingSecretsException implements Exception {
 @immutable
 class ResolvedAuth {
   /// Create a new [ResolvedAuth].
-  const ResolvedAuth({required this.headers, required this.params});
+  const ResolvedAuth({
+    required this.headers,
+    required this.params,
+    required this.cookies,
+  });
 
   /// Create a new [ResolvedAuth] with no headers or parameters.
-  const ResolvedAuth.noAuth() : this(headers: const {}, params: const {});
+  const ResolvedAuth.noAuth()
+    : this(headers: const {}, params: const {}, cookies: const {});
 
   /// The headers of the resolved auth.
   final Map<String, String> headers;
@@ -33,9 +38,21 @@ class ResolvedAuth {
   /// The parameters of the resolved auth.
   final Map<String, String> params;
 
+  /// The cookies of the resolved auth, keyed by cookie name.
+  ///
+  /// Kept separate from [headers] because every cookie shares the single
+  /// `Cookie` header: merging two cookie-bearing auths has to concatenate
+  /// them rather than let the later one replace the earlier.
+  final Map<String, String> cookies;
+
   /// Apply the resolved auth to the given headers.
   void applyToHeaders(Map<String, String> headers) {
     headers.addAll(this.headers);
+    if (cookies.isNotEmpty) {
+      headers['Cookie'] = cookies.entries
+          .map((e) => '${e.key}=${e.value}')
+          .join('; ');
+    }
   }
 
   /// Apply the resolved auth to the given parameters. The generated
@@ -55,6 +72,7 @@ class ResolvedAuth {
     return ResolvedAuth(
       headers: {...headers, ...other.headers},
       params: {...params, ...other.params},
+      cookies: {...cookies, ...other.cookies},
     );
   }
 }
@@ -173,12 +191,13 @@ class HttpAuth extends SecretAuth {
     return ResolvedAuth(
       headers: {'Authorization': '$scheme $secret'},
       params: const {},
+      cookies: const {},
     );
   }
 }
 
-// Cookie is not yet supported.
-enum ApiKeyLocation { query, header }
+/// Where an API key is sent on the request.
+enum ApiKeyLocation { query, header, cookie }
 
 /// An API key authentication scheme.
 @immutable
@@ -205,10 +224,17 @@ class ApiKeyAuth extends SecretAuth {
       ApiKeyLocation.header => ResolvedAuth(
         headers: {name: secret},
         params: const {},
+        cookies: const {},
       ),
       ApiKeyLocation.query => ResolvedAuth(
         headers: const {},
         params: {name: secret},
+        cookies: const {},
+      ),
+      ApiKeyLocation.cookie => ResolvedAuth(
+        headers: const {},
+        params: const {},
+        cookies: {name: secret},
       ),
     };
   }

--- a/gen_tests/unsupported_auth/lib/auth.dart
+++ b/gen_tests/unsupported_auth/lib/auth.dart
@@ -22,10 +22,15 @@ class MissingSecretsException implements Exception {
 @immutable
 class ResolvedAuth {
   /// Create a new [ResolvedAuth].
-  const ResolvedAuth({required this.headers, required this.params});
+  const ResolvedAuth({
+    required this.headers,
+    required this.params,
+    required this.cookies,
+  });
 
   /// Create a new [ResolvedAuth] with no headers or parameters.
-  const ResolvedAuth.noAuth() : this(headers: const {}, params: const {});
+  const ResolvedAuth.noAuth()
+    : this(headers: const {}, params: const {}, cookies: const {});
 
   /// The headers of the resolved auth.
   final Map<String, String> headers;
@@ -33,9 +38,21 @@ class ResolvedAuth {
   /// The parameters of the resolved auth.
   final Map<String, String> params;
 
+  /// The cookies of the resolved auth, keyed by cookie name.
+  ///
+  /// Kept separate from [headers] because every cookie shares the single
+  /// `Cookie` header: merging two cookie-bearing auths has to concatenate
+  /// them rather than let the later one replace the earlier.
+  final Map<String, String> cookies;
+
   /// Apply the resolved auth to the given headers.
   void applyToHeaders(Map<String, String> headers) {
     headers.addAll(this.headers);
+    if (cookies.isNotEmpty) {
+      headers['Cookie'] = cookies.entries
+          .map((e) => '${e.key}=${e.value}')
+          .join('; ');
+    }
   }
 
   /// Apply the resolved auth to the given parameters. The generated
@@ -55,6 +72,7 @@ class ResolvedAuth {
     return ResolvedAuth(
       headers: {...headers, ...other.headers},
       params: {...params, ...other.params},
+      cookies: {...cookies, ...other.cookies},
     );
   }
 }
@@ -173,12 +191,13 @@ class HttpAuth extends SecretAuth {
     return ResolvedAuth(
       headers: {'Authorization': '$scheme $secret'},
       params: const {},
+      cookies: const {},
     );
   }
 }
 
-// Cookie is not yet supported.
-enum ApiKeyLocation { query, header }
+/// Where an API key is sent on the request.
+enum ApiKeyLocation { query, header, cookie }
 
 /// An API key authentication scheme.
 @immutable
@@ -205,10 +224,17 @@ class ApiKeyAuth extends SecretAuth {
       ApiKeyLocation.header => ResolvedAuth(
         headers: {name: secret},
         params: const {},
+        cookies: const {},
       ),
       ApiKeyLocation.query => ResolvedAuth(
         headers: const {},
         params: {name: secret},
+        cookies: const {},
+      ),
+      ApiKeyLocation.cookie => ResolvedAuth(
+        headers: const {},
+        params: const {},
+        cookies: {name: secret},
       ),
     };
   }

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -1870,10 +1870,7 @@ ApiKeyLocation _parseApiKeyLocation(MapContext context, String location) {
     case 'query':
       return ApiKeyLocation.query;
     case 'cookie':
-      _unimplemented(
-        context,
-        'cookie parameters are not yet supported for API key authentication',
-      );
+      return ApiKeyLocation.cookie;
     default:
       _error(context, 'Unknown API key location: $location');
   }

--- a/lib/templates/auth.dart
+++ b/lib/templates/auth.dart
@@ -22,10 +22,15 @@ class MissingSecretsException implements Exception {
 @immutable
 class ResolvedAuth {
   /// Create a new [ResolvedAuth].
-  const ResolvedAuth({required this.headers, required this.params});
+  const ResolvedAuth({
+    required this.headers,
+    required this.params,
+    required this.cookies,
+  });
 
   /// Create a new [ResolvedAuth] with no headers or parameters.
-  const ResolvedAuth.noAuth() : this(headers: const {}, params: const {});
+  const ResolvedAuth.noAuth()
+    : this(headers: const {}, params: const {}, cookies: const {});
 
   /// The headers of the resolved auth.
   final Map<String, String> headers;
@@ -33,9 +38,21 @@ class ResolvedAuth {
   /// The parameters of the resolved auth.
   final Map<String, String> params;
 
+  /// The cookies of the resolved auth, keyed by cookie name.
+  ///
+  /// Kept separate from [headers] because every cookie shares the single
+  /// `Cookie` header: merging two cookie-bearing auths has to concatenate
+  /// them rather than let the later one replace the earlier.
+  final Map<String, String> cookies;
+
   /// Apply the resolved auth to the given headers.
   void applyToHeaders(Map<String, String> headers) {
     headers.addAll(this.headers);
+    if (cookies.isNotEmpty) {
+      headers['Cookie'] = cookies.entries
+          .map((e) => '${e.key}=${e.value}')
+          .join('; ');
+    }
   }
 
   /// Apply the resolved auth to the given parameters. The generated
@@ -55,6 +72,7 @@ class ResolvedAuth {
     return ResolvedAuth(
       headers: {...headers, ...other.headers},
       params: {...params, ...other.params},
+      cookies: {...cookies, ...other.cookies},
     );
   }
 }
@@ -173,12 +191,13 @@ class HttpAuth extends SecretAuth {
     return ResolvedAuth(
       headers: {'Authorization': '$scheme $secret'},
       params: const {},
+      cookies: const {},
     );
   }
 }
 
-// Cookie is not yet supported.
-enum ApiKeyLocation { query, header }
+/// Where an API key is sent on the request.
+enum ApiKeyLocation { query, header, cookie }
 
 /// An API key authentication scheme.
 @immutable
@@ -205,10 +224,17 @@ class ApiKeyAuth extends SecretAuth {
       ApiKeyLocation.header => ResolvedAuth(
         headers: {name: secret},
         params: const {},
+        cookies: const {},
       ),
       ApiKeyLocation.query => ResolvedAuth(
         headers: const {},
         params: {name: secret},
+        cookies: const {},
+      ),
+      ApiKeyLocation.cookie => ResolvedAuth(
+        headers: const {},
+        params: const {},
+        cookies: {name: secret},
       ),
     };
   }

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -2784,11 +2784,14 @@ void main() {
       });
     });
     group('security scheme', () {
-      test('cookie not supported', () {
-        final json = {'type': 'apiKey', 'name': 'apiKey', 'in': 'cookie'};
+      test('cookie location', () {
+        final json = {'type': 'apiKey', 'name': 'session', 'in': 'cookie'};
+        final scheme = parseSecurityScheme('name', MapContext.initial(json));
         expect(
-          () => parseSecurityScheme('name', MapContext.initial(json)),
-          throwsA(isA<UnimplementedError>()),
+          scheme,
+          isA<ApiKeySecurityScheme>()
+              .having((s) => s.keyName, 'keyName', 'session')
+              .having((s) => s.inLocation, 'inLocation', ApiKeyLocation.cookie),
         );
       });
       test('unknown location', () {

--- a/test/templates/auth_test.dart
+++ b/test/templates/auth_test.dart
@@ -1,0 +1,61 @@
+import 'package:space_gen/templates/auth.dart';
+import 'package:test/test.dart';
+
+String? Function(String) _secrets(Map<String, String> values) =>
+    (name) => values[name];
+
+void main() {
+  group('ApiKeyAuth', () {
+    test('sendIn: cookie resolves into a Cookie header', () {
+      const auth = ApiKeyAuth(
+        name: 'session',
+        sendIn: ApiKeyLocation.cookie,
+        secretName: 'Session',
+      );
+      final resolved = auth.resolve(_secrets({'Session': 'abc123'}));
+      expect(resolved.cookies, {'session': 'abc123'});
+      expect(resolved.headers, isEmpty);
+      expect(resolved.params, isEmpty);
+
+      final headers = <String, String>{};
+      resolved.applyToHeaders(headers);
+      expect(headers, {'Cookie': 'session=abc123'});
+    });
+
+    test('no Cookie header when there are no cookies', () {
+      const auth = ApiKeyAuth(
+        name: 'X-Api-Key',
+        sendIn: ApiKeyLocation.header,
+        secretName: 'ApiKey',
+      );
+      final headers = <String, String>{};
+      auth.resolve(_secrets({'ApiKey': 'abc123'})).applyToHeaders(headers);
+      expect(headers, {'X-Api-Key': 'abc123'});
+    });
+  });
+
+  group('ResolvedAuth', () {
+    test('merging two cookie auths keeps both cookies', () {
+      // Both cookies share the single `Cookie` header, so merge has to
+      // concatenate rather than let the later auth replace the earlier.
+      const first = ApiKeyAuth(
+        name: 'session',
+        sendIn: ApiKeyLocation.cookie,
+        secretName: 'Session',
+      );
+      const second = ApiKeyAuth(
+        name: 'csrf',
+        sendIn: ApiKeyLocation.cookie,
+        secretName: 'Csrf',
+      );
+      const auth = AllOfAuth([first, second]);
+      final resolved = auth.resolve(
+        _secrets({'Session': 'abc123', 'Csrf': 'xyz789'}),
+      );
+
+      final headers = <String, String>{};
+      resolved.applyToHeaders(headers);
+      expect(headers, {'Cookie': 'session=abc123; csrf=xyz789'});
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Support `apiKey` security schemes with `in: cookie`. They previously threw `UnimplementedError` at parse time; `in: header` and `in: query` were already handled. The generated client now sends the key as a `Cookie:` header.

## Details

- `_parseApiKeyLocation` returns `ApiKeyLocation.cookie` instead of bailing out. The render side already forwarded `inLocation.name` verbatim, so no renderer change was needed.
- `lib/templates/auth.dart` gains `ApiKeyLocation.cookie` and a `cookies` map on `ResolvedAuth`.

Cookies get their own map rather than going straight into `headers` because every cookie shares the single `Cookie` header. `ResolvedAuth.merge` is a spread (`{...headers, ...other.headers}`), so two cookie-bearing auths combined under an `AllOfAuth` would have silently dropped the first credential. Keeping them separate lets `merge` accumulate and `applyToHeaders` join them into one `Cookie: a=1; b=2` header.

## Validation

The issue's target spec (openfoodfacts `#/components/securitySchemes/cookieAuth`) now parses past the scheme. It hits a separate, unrelated blocker further on — external `$ref`s into documents with no `components:` section — which I filed separately as a follow-up.

## Tests

- `test/templates/auth_test.dart` (new): cookie resolution, no stray `Cookie` header when there are no cookies, and the `AllOfAuth` two-cookie merge.
- `test/parser_test.dart`: the `cookie not supported` test becomes a positive assertion on `ApiKeyLocation.cookie`.
- `gen_tests/security.json` gains a `cookieAuth` scheme and a `/session` operation for end-to-end coverage.
