### PR TITLE
feat: flatten a nested allOf member instead of crashing (#320)

### DIFF
--- a/lib/src/resolver.dart
+++ b/lib/src/resolver.dart
@@ -456,13 +456,15 @@ ResolvedSchema _resolveSchemaFully(
       // allOf members must be object-shaped. Besides plain objects, admit an
       // open map member (e.g. a `JsonObject`: `type: object` with only
       // `additionalProperties`, which resolves to `ResolvedMap`) — it
-      // contributes an arbitrary-key overflow to the merged object — and an
-      // empty object member, which contributes nothing. Both are folded into
-      // the merged `RenderObject` at render time (see `case ResolvedAllOf` in
-      // `render_tree.dart`).
+      // contributes an arbitrary-key overflow to the merged object — an
+      // empty object member, which contributes nothing, and a nested
+      // `allOf` member, which is itself an object composition: its own
+      // merge (recursively) is a `RenderObject` whose properties fold in.
+      // All are handled by `case ResolvedAllOf` in `render_tree.dart`.
       if (schema is ResolvedObject ||
           schema is ResolvedMap ||
-          schema is ResolvedEmptyObject) {
+          schema is ResolvedEmptyObject ||
+          schema is ResolvedAllOf) {
         continue;
       }
       _error('allOf only supports objects: $schema', allOf.pointer);

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -793,6 +793,45 @@ void main() {
       expect(result, contains('final int bar;'));
     });
 
+    test('allOf flattens a nested allOf member into one object', () {
+      // An `allOf` member that is itself an `allOf` (issue #320) merges
+      // recursively: the outer object collects the inner composition's
+      // properties alongside its own, producing one flat class.
+      final schema = {
+        'allOf': [
+          {
+            'allOf': [
+              {
+                'type': 'object',
+                'required': ['a'],
+                'properties': {
+                  'a': {'type': 'string'},
+                },
+              },
+              {
+                'type': 'object',
+                'properties': {
+                  'b': {'type': 'integer'},
+                },
+              },
+            ],
+          },
+          {
+            'type': 'object',
+            'properties': {
+              'c': {'type': 'boolean'},
+            },
+          },
+        ],
+      };
+      final result = renderTestSchema(schema);
+      expect(result, contains('final String a;'));
+      expect(result, contains('final int? b;'));
+      expect(result, contains('final bool? c;'));
+      // The inner member's `required` survives the flatten.
+      expect(result, contains('required this.a'));
+    });
+
     test('allOf with an open map member gets an overflow map', () {
       // Backstage's `RecursivePartialEntityMeta` shape: an open member
       // (`{type: object, additionalProperties: true}`, i.e. a `JsonObject`)

--- a/test/resolver_test.dart
+++ b/test/resolver_test.dart
@@ -586,6 +586,48 @@ void main() {
       );
     });
 
+    test('allOf admits a nested allOf member', () {
+      // An `allOf` whose member is itself an `allOf` (issue #320). The
+      // nested composition is object-shaped — its own merge is a
+      // `RenderObject` whose properties fold into the parent — so it is
+      // admitted rather than crashing with "allOf only supports objects".
+      final json = {
+        'allOf': [
+          {
+            'allOf': [
+              {
+                'type': 'object',
+                'properties': {
+                  'a': {'type': 'string'},
+                },
+              },
+              {
+                'type': 'object',
+                'properties': {
+                  'b': {'type': 'integer'},
+                },
+              },
+            ],
+          },
+          {
+            'type': 'object',
+            'properties': {
+              'c': {'type': 'boolean'},
+            },
+          },
+        ],
+      };
+      final logger = _MockLogger();
+      final schema = runWithLogger(
+        logger,
+        () => parseAndResolveTestSchema(json),
+      );
+      expect(schema, isA<ResolvedAllOf>());
+      final outer = schema as ResolvedAllOf;
+      expect(outer.schemas.length, 2);
+      expect(outer.schemas.first, isA<ResolvedAllOf>());
+    });
+
     test('resolve anyOf', () {
       final json = {
         'anyOf': [


### PR DESCRIPTION
## Summary

An `allOf` whose member is itself an `allOf` — a common composition shape
(`Outer: allOf[Inner, {…}]` where `Inner: allOf[A, B]`) — crashed the
resolver with `allOf only supports objects`. `_resolveAllOf` admitted only
`ResolvedObject`, `ResolvedMap`, and `ResolvedEmptyObject` members.

A nested `allOf` is object-shaped like the others: its own merge is a
`RenderObject`, and the render-side `allOf` handling already folds a member
that renders to a `RenderObject` into the parent (properties, required, and
open-map overflow all propagate). So the fix is to admit `ResolvedAllOf` as
a member; the existing recursive merge does the rest — `Outer` flattens to
one class carrying `A`'s, `B`'s, and its own fields. An intermediate
composition that is also referenced directly still renders its own class.

Purely additive: nested `allOf` previously threw, so no spec that generates
today exercises it, and every tracked fixture regenerates byte-identically.
Covered by resolver and render unit tests (the render test asserts the flat
merge, including a nested member's `required` surviving).

Surfaced by the openfoodfacts spec (`Nutriscore2021Data` composes
`Nutriscore2021InnerData`, itself an `allOf`) — the next blocker after the
split-spec external refs of #319.
