### PR TITLE
fix: don't fake an empty-list default on query-array params (#137)

### DIFF
--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -616,7 +616,19 @@ class SpecResolver {
     return toRenderSchema(schema);
   }
 
-  RenderSchema toRenderSchema(ResolvedSchema schema) {
+  /// [isParameterSchema] is set when [schema] is the top-level schema of a
+  /// parameter (query/path/header/cookie). The `allListsDefaultToEmpty` quirk
+  /// synthesizes an empty-list default for arrays to match openapi-generator's
+  /// *response model* behavior (list fields come back `[]`, never null) — but a
+  /// parameter is an input, where omitted and present-but-empty differ. Forcing
+  /// `= const []` there makes an optional array param non-optional in practice
+  /// and emits a no-op `if (x != null)` guard over the default. So the quirk
+  /// is suppressed for parameter schemas; they default to `null` like plain
+  /// output.
+  RenderSchema toRenderSchema(
+    ResolvedSchema schema, {
+    bool isParameterSchema = false,
+  }) {
     switch (schema) {
       case ResolvedRecursiveRef():
         // The recursive ref's type name is the target's class name —
@@ -721,9 +733,12 @@ class SpecResolver {
         );
       case ResolvedArray():
         var defaultValue = schema.defaultValue;
-        // I don't think this is quite right.  OpenAPI does not show this fake
-        // default in cases where the schema is being used as a parameter.
-        if (defaultValue == null && quirks.allListsDefaultToEmpty) {
+        // The `allListsDefaultToEmpty` quirk fakes an empty-list default so
+        // response-model list fields are non-null; a parameter is an input, so
+        // it keeps its real (usually null) default — see [isParameterSchema].
+        if (defaultValue == null &&
+            quirks.allListsDefaultToEmpty &&
+            !isParameterSchema) {
           defaultValue = List<dynamic>.empty();
         }
         return RenderArray(
@@ -876,7 +891,7 @@ class SpecResolver {
       inLocation: parameter.inLocation,
       isRequired: parameter.isRequired,
       isDeprecated: parameter.isDeprecated,
-      type: toRenderSchema(parameter.schema),
+      type: toRenderSchema(parameter.schema, isParameterSchema: true),
       example: parameter.example,
       examples: parameter.examples,
       queryEncoding: parameter.queryEncoding,

--- a/test/render/render_operation_test.dart
+++ b/test/render/render_operation_test.dart
@@ -1223,7 +1223,7 @@ void main() {
         '}\n',
       );
     });
-    test('openapi quirks all lists to empty default', () {
+    test('openapi list-default quirk does not apply to query params', () {
       final json = {
         'summary': 'Get user',
         'parameters': [
@@ -1254,9 +1254,10 @@ void main() {
       );
       expect(
         result,
-        // The `const []` default is an openapi-quirk artifact; foo should
-        // really default to null. Tracked separately — that quirk is
-        // out of scope for this query-array fix.
+        // `allListsDefaultToEmpty` fakes an empty-list default for
+        // response-model fields (never null); a query param is an input, so
+        // it keeps its real null default rather than a no-op `= const []`
+        // that the `if (foo != null)` guard would always pass. See #137.
         '/// Test API\n'
         'class DefaultApi {\n'
         '    DefaultApi(ApiClient? client) : client = client ?? ApiClient();\n'
@@ -1265,7 +1266,7 @@ void main() {
         '\n'
         '    /// Get user\n'
         '    Future<void> users(\n'
-        '        { List<String>? foo = const [], }\n'
+        '        { List<String>? foo, }\n'
         '    ) async {\n'
         '        final response = await client.invokeApi(\n'
         '            method: Method.post,\n'


### PR DESCRIPTION
## Summary

Suppress the `allListsDefaultToEmpty` quirk for parameter schemas so an optional array query parameter defaults to `null` instead of `const []`, matching the non-quirk output.

The quirk exists to mirror openapi-generator's *response model* behavior — list-typed fields come back `[]`, never null. A parameter is an input, where omitted and present-but-empty are distinct. Forcing `= const []` there made an optional array param non-optional in practice and emitted a no-op `if (x != null)` guard that always fired over the default:

```dart
Future<void> search({List<String>? tags = const []}) async {
  ... queryParameters: {if (tags != null) 'tags': tags},
```

now generates the clean form (identical to plain output):

```dart
Future<void> search({List<String>? tags}) async {
  ... queryParameters: {if (tags != null) 'tags': tags},
```

`toRenderSchema` gains an `isParameterSchema` flag, set only for the top-level schema of a parameter. Required params and params with a real spec `default:` are unaffected; response-model array properties still default to `const []`.

No golden-fixture churn — no existing corpus spec had an optional array query param under the quirk. Both branches of the new condition are covered: the existing object-with-array-properties test (quirk applies) and the updated render-operation test (quirk suppressed for the param).

Closes #137.