### PR TITLE
fix: disambiguate enum member names that collide after sanitization

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -47,6 +47,7 @@ words:
   - pubignore
   - dartdoc
   - uncompilable
+  - codepoint
   - endtemplate
   - codepush
   - octocat

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -5410,7 +5410,34 @@ abstract class RenderEnum<T extends Object> extends RenderNewType {
       return dartName;
     }
 
-    return values.map(toShortVariableName).toList();
+    return _deduplicateNames(values.map(toShortVariableName).toList());
+  }
+
+  /// Disambiguate enum member names that collide after sanitization.
+  ///
+  /// Distinct wire values can sanitize to the same Dart identifier —
+  /// openfoodfacts' `NutrientUnit` has both `g` and `μg`, and stripping the
+  /// non-ASCII `μ` leaves two `g` members, which is a `duplicate_definition`
+  /// error. The first occurrence keeps the bare name; each later collision
+  /// gets the lowest free numeric suffix (`g`, `g2`, `g3`, …), mirroring how
+  /// the type [NameAllocator] resolves ties. The wire value is preserved
+  /// verbatim in the member's `._(<value>)`, so round-tripping is unaffected —
+  /// only the (rarely-referenced) member identifier changes.
+  static List<String> _deduplicateNames(List<String> names) {
+    final used = <String>{};
+    final result = <String>[];
+    for (final name in names) {
+      if (used.add(name)) {
+        result.add(name);
+        continue;
+      }
+      var suffix = 2;
+      while (!used.add('$name$suffix')) {
+        suffix++;
+      }
+      result.add('$name$suffix');
+    }
+    return result;
   }
 
   /// Variable names for an int-valued enum. Defaults to `value<N>`

--- a/test/render/render_tree_test.dart
+++ b/test/render/render_tree_test.dart
@@ -74,6 +74,21 @@ void main() {
       ]);
     });
 
+    test('enum names collide-free after sanitization', () {
+      const quirks = Quirks();
+      // openfoodfacts' `NutrientUnit` has both `g` and `μg`; stripping the
+      // non-ASCII `μ` leaves two `g` members. Distinct wire values must not
+      // sanitize to the same Dart identifier — the first keeps the bare name,
+      // later collisions take the lowest free numeric suffix.
+      final names = RenderEnum.variableNamesFor(quirks, [
+        'g',
+        'mg',
+        'μg',
+        'µg', // A second, distinct micro-sign codepoint — also strips to `g`.
+      ]);
+      expect(names, ['g', 'mg', 'g2', 'g3']);
+    });
+
     test('parameter names', () {
       const quirks = Quirks();
       expect(quirks.screamingCapsEnums, isFalse);


### PR DESCRIPTION
## Summary

Disambiguate enum member names that collide after identifier sanitization, so distinct wire values never produce a `duplicate_definition` error.

openfoodfacts' `NutrientUnit` declares both `g` and `μg`. The identifier sanitizer strips the non-ASCII `μ`, so both collapse to the Dart member `g` — two `g._(...)` entries in one enum, which doesn't compile:

```dart
enum NutrientUnit {
  g._('g'),
  g._('μg'),   // duplicate_definition
  ...
}
```

`variableNamesFor` mapped each value through the sanitizer with no collision check. This adds a dedup pass: the first occurrence keeps the bare name, each later collision takes the lowest free numeric suffix, mirroring how the type `NameAllocator` resolves ties:

```dart
enum NutrientUnit {
  g._('g'),
  g2._('μg'),  // wire value preserved verbatim
  ...
}
```

The wire value is preserved in `._(<value>)`, so `fromJson`/`toJson` round-tripping is unaffected — only the (rarely-referenced) member identifier changes.

## Validation

- New unit test in `render_tree_test.dart` (fails on the old code, passes now).
- Full suite green (791 tests); `dart analyze` + `dart format` clean.
- Byte-identical regen on github, discord, petstore, spacetraders, backstage, and train-travel — no corpus enum collides today, so this only affects previously-broken enums.

Found while probing the openfoodfacts split-spec (#324).
