### PR TITLE
fix: treat OpenAPI `servers` as optional, defaulting the base URL to `/`

### DIFF
--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -2126,15 +2126,14 @@ SecurityRequirement parseSecurityRequirement(MapContext json) {
 /// mirror that — consumers override `baseUri` on the generated client, so `/`
 /// is a safe placeholder base rather than a parse failure.
 Uri _parseServerUrl(MapContext json) {
-  if (json['servers'] == null) {
-    return Uri.parse('/');
+  var url = '/';
+  if (json['servers'] != null) {
+    final servers = json.childAsList('servers');
+    if (servers.length > 0) {
+      url = _required<String>(servers.indexAsMap(0), 'url');
+    }
   }
-  final servers = json.childAsList('servers');
-  if (servers.length == 0) {
-    return Uri.parse('/');
-  }
-  final firstServer = servers.indexAsMap(0);
-  return Uri.parse(_required<String>(firstServer, 'url'));
+  return Uri.parse(url);
 }
 
 OpenApi parseOpenApi(Map<String, dynamic> openapiJson) {

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -28,14 +28,6 @@ MapContext _requiredMap(MapContext json, String key) {
   return json.childAsMap(key);
 }
 
-ListContext _requiredListOfMaps(MapContext json, String key) {
-  final value = json[key];
-  if (value == null) {
-    _error(json, 'Key $key is required');
-  }
-  return json.childAsList(key);
-}
-
 void _expect(bool condition, ParseContext json, String message) {
   if (!condition) {
     _error(json, message);
@@ -2126,6 +2118,25 @@ SecurityRequirement parseSecurityRequirement(MapContext json) {
   return SecurityRequirement(conditions: conditions, pointer: json.pointer);
 }
 
+/// The base URL for generated requests, taken from the first entry of the
+/// top-level `servers` list.
+///
+/// `servers` is optional in OpenAPI 3.x: when it's absent or an empty array,
+/// the spec defines the default as a single Server Object with url `/`. We
+/// mirror that — consumers override `baseUri` on the generated client, so `/`
+/// is a safe placeholder base rather than a parse failure.
+Uri _parseServerUrl(MapContext json) {
+  if (json['servers'] == null) {
+    return Uri.parse('/');
+  }
+  final servers = json.childAsList('servers');
+  if (servers.length == 0) {
+    return Uri.parse('/');
+  }
+  final firstServer = servers.indexAsMap(0);
+  return Uri.parse(_required<String>(firstServer, 'url'));
+}
+
 OpenApi parseOpenApi(Map<String, dynamic> openapiJson) {
   final json = MapContext.initial(openapiJson);
   _refNotExpected(json);
@@ -2141,9 +2152,7 @@ OpenApi parseOpenApi(Map<String, dynamic> openapiJson) {
 
   final info = parseInfo(_requiredMap(json, 'info'));
 
-  final servers = _requiredListOfMaps(json, 'servers');
-  final firstServer = servers.indexAsMap(0);
-  final serverUrl = _required<String>(firstServer, 'url');
+  final serverUrl = _parseServerUrl(json);
 
   final paths = parsePaths(_requiredMap(json, 'paths'));
   final components = parseComponents(_optionalMap(json, 'components'));
@@ -2161,7 +2170,7 @@ OpenApi parseOpenApi(Map<String, dynamic> openapiJson) {
   _ignored<dynamic>(json, 'externalDocs');
   _warnUnused(json);
   return OpenApi(
-    serverUrl: Uri.parse(serverUrl),
+    serverUrl: serverUrl,
     version: version,
     info: info,
     paths: paths,

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -206,6 +206,32 @@ void main() {
       expect(spec.serverUrl, Uri.parse('https://api.spacetraders.io/v2'));
       expect(spec.paths.keys.first, '/users');
     });
+    test('servers is optional, defaulting the base URL to /', () {
+      // OpenAPI 3.x: an absent or empty `servers` list defaults to a single
+      // Server Object with url `/`, rather than being a parse error.
+      Map<String, dynamic> specWith(Object? servers) => {
+        'openapi': '3.1.0',
+        'info': {'title': 'No Servers API', 'version': '1.0.0'},
+        if (servers != null) 'servers': servers,
+        'paths': {
+          '/users': {
+            'get': {
+              'responses': {
+                '200': {'description': 'OK'},
+              },
+            },
+          },
+        },
+      };
+      final logger = _MockLogger();
+      final absent = runWithLogger(logger, () => parseOpenApi(specWith(null)));
+      expect(absent.serverUrl, Uri.parse('/'));
+      final empty = runWithLogger(
+        logger,
+        () => parseOpenApi(specWith(<Object>[])),
+      );
+      expect(empty.serverUrl, Uri.parse('/'));
+    });
     test('allOf with multiple items', () {
       final json = {
         'allOf': [
@@ -1266,23 +1292,6 @@ void main() {
         ),
       );
     });
-    test('servers is required', () {
-      final json = {
-        'openapi': '3.1.0',
-        'info': {'title': 'Space Traders API', 'version': '1.0.0'},
-      };
-      expect(
-        () => parseOpenApi(json),
-        throwsA(
-          isA<FormatException>().having(
-            (e) => e.message,
-            'message',
-            equals('Key servers is required in #/'),
-          ),
-        ),
-      );
-    });
-
     test('path-item-level parameters are parsed', () {
       final json = {
         'openapi': '3.1.0',


### PR DESCRIPTION
## Summary

Treat the OpenAPI `servers` field as optional. In OpenAPI 3.x an absent or
empty `servers` array defaults to a single Server Object with url `/`; the
parser required it, so a valid spec that omitted `servers` crashed with an
uncaught `FormatException` (`Key servers is required in #/`) instead of
generating. We now default the base URL to `/` in that case — consumers
override `baseUri` on the generated client anyway.

## Details

- `_parseServerUrl` handles absent / empty `servers`, otherwise keeps the
  existing first-server behavior. The now-dead `_requiredListOfMaps` helper
  is removed.
- Unit test covers absent and empty `servers` both resolving to `/`; the old
  "servers is required" test (which encoded the bug) is dropped.
- No fixture churn — every corpus spec declares `servers`, verified by a full
  `tool/gen_tests.dart` regen with zero diff.

Closes #338
