### PR TITLE
feat: transliterate known symbols/letters to ASCII in identifier names

### DIFF
--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -71,11 +71,16 @@ String variableSafeName(
       // Replace any remaining skewers with underscores.
       .replaceAll('-', '_')
       // ' is most commonly used as an apostrophe so just stripping it.
-      .replaceAll("'", '')
-      // Since jsonName is a raw string, it could have non-legal characters.
-      // We need to escape them.
-      // TODO(eseidel): Tweak this to make nicer names.
-      .replaceAll(RegExp('[^a-zA-Z0-9_]'), '_');
+      .replaceAll("'", '');
+  // Give known symbols and letters a real ASCII spelling (`µg` -> `mug`,
+  // `%` -> `percent`, `café` -> `cafe`) before the catch-all below turns
+  // every other non-identifier character into `_`. This keeps distinct
+  // values from collapsing to the same name (which the enum-dedup pass
+  // would then have to disambiguate as `g`/`g2`).
+  escapedName = transliterateToAscii(escapedName);
+  // Since jsonName is a raw string, it could have non-legal characters.
+  // We need to escape them.
+  escapedName = escapedName.replaceAll(RegExp('[^a-zA-Z0-9_]'), '_');
 
   if (!preserveCase) {
     // Dart style uses camelCase.

--- a/lib/src/string.dart
+++ b/lib/src/string.dart
@@ -67,6 +67,76 @@ String toSnakeCase(String unknown) {
 /// Convert kebab-case to snake_case.
 String snakeFromKebab(String kebab) => kebab.replaceAll('-', '_');
 
+/// Characters that carry a conventional ASCII spelling, mapped to it so
+/// identifier sanitization yields a readable name instead of dropping the
+/// character (which leaves collisions for the enum-dedup pass to paper over
+/// with numeric suffixes: `g` and `mug` beat `g` and `g2`).
+///
+/// Dart identifiers are ASCII-only — a raw `μg` is `illegal_character`, not
+/// a valid name (https://github.com/dart-lang/language/issues/1283) — so
+/// some ASCII rewrite is mandatory; this just makes it a meaningful one.
+///
+/// Keyed by the character's *name*, not a domain reading — Greek `μ`
+/// (mu) becomes `mu`, never the units interpretation `micro`, so one table
+/// serves every spec. Only word- and unit-forming characters belong here:
+/// separators like `&`/`@`/`#` are deliberately left to the `_` catch-all
+/// in `variableSafeName`, since spelling them out in place would run
+/// together the words they divide.
+///
+/// Each replacement mirrors the source character's case — lowercase `μ` ->
+/// `mu`, uppercase `Δ` -> `Delta`, symbols with no case (`°`, `%`) go
+/// lowercase.
+/// Case is preserved rather than lowercased because `variableSafeName` has
+/// a `preserveCase` mode (the SCREAMING_CAPS-enum quirk) where casing is
+/// meaningful: a spec may use `Δ` and `δ` as distinct enum values, and
+/// collapsing both to `delta` would fabricate a collision.
+///
+/// Greek mu (U+03BC) and the micro sign (U+00B5) look identical but are
+/// distinct code points; both are listed, tagged with their Unicode name.
+const Map<String, String> asciiTransliterations = {
+  // Greek letters, by letter name.
+  'α': 'alpha', 'β': 'beta', 'γ': 'gamma', 'δ': 'delta',
+  'ε': 'epsilon', 'ζ': 'zeta', 'η': 'eta', 'θ': 'theta',
+  'ι': 'iota', 'κ': 'kappa', 'λ': 'lambda',
+  'μ': 'mu', // GREEK SMALL LETTER MU
+  'ν': 'nu', 'ξ': 'xi', 'ο': 'omicron', 'π': 'pi',
+  'ρ': 'rho', 'σ': 'sigma', 'ς': 'sigma', 'τ': 'tau',
+  'υ': 'upsilon', 'φ': 'phi', 'χ': 'chi', 'ψ': 'psi',
+  'ω': 'omega',
+  'Δ': 'Delta', 'Σ': 'Sigma', 'Π': 'Pi', 'Ω': 'Omega',
+  'Φ': 'Phi', 'Θ': 'Theta', 'Λ': 'Lambda', 'Ξ': 'Xi',
+  'Ψ': 'Psi', 'Γ': 'Gamma',
+  // Unit symbols, by name.
+  'µ': 'mu', // MICRO SIGN (looks like Greek mu; same spelling)
+  '°': 'degree', // DEGREE SIGN
+  '%': 'percent',
+  // Accented Latin (Latin-1 Supplement) folded to the base letter.
+  'à': 'a', 'á': 'a', 'â': 'a', 'ã': 'a', 'ä': 'a',
+  'å': 'a', 'æ': 'ae', 'ç': 'c', 'è': 'e', 'é': 'e',
+  'ê': 'e', 'ë': 'e', 'ì': 'i', 'í': 'i', 'î': 'i',
+  'ï': 'i', 'ñ': 'n', 'ò': 'o', 'ó': 'o', 'ô': 'o',
+  'õ': 'o', 'ö': 'o', 'ø': 'o', 'ù': 'u', 'ú': 'u',
+  'û': 'u', 'ü': 'u', 'ý': 'y', 'ÿ': 'y', 'ß': 'ss',
+  'À': 'A', 'Á': 'A', 'Â': 'A', 'Ã': 'A', 'Ä': 'A',
+  'Å': 'A', 'Æ': 'AE', 'Ç': 'C', 'È': 'E', 'É': 'E',
+  'Ê': 'E', 'Ë': 'E', 'Ì': 'I', 'Í': 'I', 'Î': 'I',
+  'Ï': 'I', 'Ñ': 'N', 'Ò': 'O', 'Ó': 'O', 'Ô': 'O',
+  'Õ': 'O', 'Ö': 'O', 'Ø': 'O', 'Ù': 'U', 'Ú': 'U',
+  'Û': 'U', 'Ü': 'U', 'Ý': 'Y',
+};
+
+/// Replace each character in [value] that has a conventional ASCII spelling
+/// (see [asciiTransliterations]) with that spelling, leaving every other
+/// character untouched. `µg` -> `mug`, `café` -> `cafe`.
+String transliterateToAscii(String value) {
+  final buffer = StringBuffer();
+  for (final rune in value.runes) {
+    final ch = String.fromCharCode(rune);
+    buffer.write(asciiTransliterations[ch] ?? ch);
+  }
+  return buffer.toString();
+}
+
 /// Converts from SCREAMING_CAPS, snake_case or kebab-case to camelCase.
 String toLowerCamelCase(String caps) {
   // Our SCREAMING_CAPS logic is not safe for camelCase input,

--- a/test/render/render_tree_test.dart
+++ b/test/render/render_tree_test.dart
@@ -74,6 +74,22 @@ void main() {
       ]);
     });
 
+    test('enum names transliterate symbols instead of collapsing them', () {
+      // openfoodfacts' NutrientUnit: `μg` used to drop its non-ASCII `μ` and
+      // collide with `g`; transliterating it to `mug` keeps every member
+      // both readable and distinct, so no numeric-suffix dedup is needed.
+      const quirks = Quirks();
+      final names = RenderEnum.variableNamesFor(quirks, [
+        'g',
+        'mg',
+        'μg',
+        'ml',
+        '% vol',
+        '%',
+      ]);
+      expect(names, ['g', 'mg', 'mug', 'ml', 'percentVol', 'percent']);
+    });
+
     test('parameter names', () {
       const quirks = Quirks();
       expect(quirks.screamingCapsEnums, isFalse);

--- a/test/string_test.dart
+++ b/test/string_test.dart
@@ -107,4 +107,26 @@ void main() {
     expect(isReservedWord('string'), false);
     expect(isReservedWord('foo'), false);
   });
+
+  test('transliterateToAscii', () {
+    // Greek mu and the identical-looking micro sign both spell out to `mu`,
+    // so `μg`/`µg` become `mug` instead of collapsing to a bare `g`.
+    expect(transliterateToAscii('μg'), 'mug'); // GREEK SMALL LETTER MU
+    expect(transliterateToAscii('µg'), 'mug'); // MICRO SIGN
+    // Unit symbols spell out by name.
+    expect(transliterateToAscii('%'), 'percent');
+    expect(transliterateToAscii('% vol'), 'percent vol');
+    expect(transliterateToAscii('°C'), 'degreeC'); // DEGREE SIGN
+    // Accented Latin folds to the base letter.
+    expect(transliterateToAscii('café'), 'cafe'); // e-acute
+    expect(transliterateToAscii('naïve'), 'naive'); // i-diaeresis
+    // Case mirrors the source, so distinct-cased values stay distinct
+    // (rather than both folding to `delta` and colliding).
+    expect(transliterateToAscii('Δ'), 'Delta'); // GREEK CAPITAL DELTA
+    expect(transliterateToAscii('δ'), 'delta'); // greek small delta
+    // Untouched characters pass through unchanged.
+    expect(transliterateToAscii('plain_name'), 'plain_name');
+    // Separator-like symbols are left alone (handled by the catch-all).
+    expect(transliterateToAscii('a&b'), 'a&b');
+  });
 }


### PR DESCRIPTION
## Summary

Transliterate known non-ASCII symbols and letters to a meaningful ASCII
spelling when building identifiers, instead of dropping them.

Dart identifiers are ASCII-only — a raw `μg` is `illegal_character`, not a
valid name ([dart-lang/language#1283](https://github.com/dart-lang/language/issues/1283))
— so `variableSafeName` must rewrite non-ASCII characters. It did so by
replacing them with `_`, so `μg` lost its `μ` and collapsed to a bare `g`,
colliding with the real `g` in openfoodfacts' `NutrientUnit`. That's the
collision the enum-dedup pass papers over as `g`/`g2` — correct, but
meaningless.

This adds a transliteration table (`lib/src/string.dart`) mapping the
characters that carry a conventional ASCII spelling — Greek letters by name
(`μ` → `mu`), the micro and degree signs, `%`, and accented Latin folded to
its base letter — to that spelling, applied before the `_` catch-all. So
`μg` → `mug`, `% vol` → `percentVol`, `café` → `cafe`. Distinct values stay
distinct *and* readable, and the dedup pass no longer fires for them.

## Design notes

- **Keyed by the character's name, not a domain reading** (`μ` → `mu`, never
  the units `micro`) so one table serves every spec.
- **Case mirrors the source** (`Δ` → `Delta`, `δ` → `delta`) because
  `variableSafeName`'s `preserveCase` mode makes casing meaningful — a spec
  may use `Δ` and `δ` as two distinct enum values, and lowercasing both
  would fabricate a collision.
- **Separators left alone.** `&`/`@`/`#` stay with the `_` catch-all;
  spelling them out in place would run the words they divide together
  (`a&b` → `aandb`).

## Validation

- `transliterateToAscii` unit tests (Greek, micro/degree/`%`, accents,
  case-mirroring, pass-through, separator exclusion).
- End-to-end `variableNamesFor` test: openfoodfacts' `NutrientUnit`
  (`g`, `mg`, `μg`, `ml`, `% vol`, `%`) → `g, mg, mug, ml, percentVol,
  percent` — readable, no dedup suffix.
- Corpus regen **byte-identical** (no vendored spec has non-ASCII
  identifiers), `dart analyze` + `dart format` + cspell clean.

Complements the enum-dedup pass (still the floor for genuine collisions).
Part of the openfoodfacts split-spec import chain (#324).
