### PR TITLE
feat: suppress flutter_style_todos on spec-derived doc comments

### DIFF
--- a/lib/src/render/formatting.dart
+++ b/lib/src/render/formatting.dart
@@ -167,6 +167,46 @@ bool _dartdocHasHtmlTag(String content) {
   return false;
 }
 
+/// Block prepended to generated `.dart` files whose dartdoc copies a
+/// spec description containing a bare `TODO` (e.g. openfoodfacts'
+/// `element` schema documents "TODO: add Map type"). Exposed for tests.
+@visibleForTesting
+const flutterStyleTodosIgnoreBlock =
+    '// Spec descriptions copy prose verbatim into dartdoc, where a bare\n'
+    '// `TODO` in the text (written by the spec author, not us) reads as\n'
+    '// an unformatted to-do. Suppress file-locally so the lint stays live\n'
+    '// elsewhere; spec authors do not write to-dos in Flutter style.\n'
+    '// ignore_for_file: flutter_style_todos';
+
+/// Returns [content] with [flutterStyleTodosIgnoreBlock] prepended if any
+/// `///` doc comment carries a `TODO` token not in Flutter's
+/// `TODO(user): message` form. Threaded through [maybeAddIgnoreDirectives]
+/// at file-emit time on every space_gen-emitted file — hand-written
+/// templates skip the call, so a real to-do in their docs still gets
+/// flagged rather than silently suppressed.
+@visibleForTesting
+String maybeAddFlutterStyleTodosIgnore(String content) {
+  const marker = '// ignore_for_file: flutter_style_todos';
+  if (content.contains(marker)) return content;
+  if (!_dartdocHasUnformattedTodo(content)) return content;
+  return '$flutterStyleTodosIgnoreBlock\n$content';
+}
+
+/// Whether any `///` doc comment line carries a `TODO` token that
+/// `flutter_style_todos` would flag — a bare `TODO` (as spec prose writes
+/// it) rather than the `TODO(user):` form the lint accepts. Restricted to
+/// `///` lines because only doc comments carry copied spec prose; the
+/// generator's own `//` comments are already Flutter-style.
+bool _dartdocHasUnformattedTodo(String content) {
+  final todoRe = RegExp(r'\bTODO\b(?!\s*\()');
+  for (final line in content.split('\n')) {
+    final stripped = line.trimLeft();
+    if (!stripped.startsWith('///')) continue;
+    if (todoRe.hasMatch(stripped.substring(3))) return true;
+  }
+  return false;
+}
+
 /// Returns [content] with [commentReferencesIgnoreBlock] prepended if
 /// any `///` doc comment carries a bracketed token that wouldn't
 /// resolve in scope. Threaded through [maybeAddIgnoreDirectives] at
@@ -207,7 +247,9 @@ String maybeAddCommentReferencesIgnore(String content) {
 /// Hand-written templates use `_renderTemplate` instead and bypass
 /// this entirely (see #138's design rationale).
 String maybeAddIgnoreDirectives(String content) => maybeAddLongLineIgnore(
-  maybeAddCommentReferencesIgnore(maybeAddUnintendedHtmlIgnore(content)),
+  maybeAddCommentReferencesIgnore(
+    maybeAddUnintendedHtmlIgnore(maybeAddFlutterStyleTodosIgnore(content)),
+  ),
 );
 
 /// Collects every `[token]` bracketed reference inside a `///` doc

--- a/test/render/formatting_test.dart
+++ b/test/render/formatting_test.dart
@@ -593,4 +593,62 @@ void main() {
       expect(config.trailingCommas, isNull);
     });
   });
+
+  group('maybeAddFlutterStyleTodosIgnore', () {
+    test('passes through content with no TODO in dartdoc', () {
+      const content = '/// A perfectly ordinary description.\nclass Foo {}\n';
+      expect(maybeAddFlutterStyleTodosIgnore(content), content);
+    });
+
+    test('prepends directive when dartdoc has a bare `TODO`', () {
+      // Mirrors openfoodfacts' `element` schema, whose description ends
+      // with a literal "TODO: add Map type".
+      const content =
+          '/// The element type.\n/// TODO: add Map type\nenum E {}\n';
+      expect(
+        maybeAddFlutterStyleTodosIgnore(content),
+        startsWith('$flutterStyleTodosIgnoreBlock\n'),
+      );
+    });
+
+    test('does not fire on a Flutter-style `TODO(user):` reference', () {
+      // If spec prose already used the accepted form, the lint would not
+      // fire, so neither should the directive (else `unnecessary_ignore`).
+      const content = '/// See TODO(alice): finish this later.\nclass Foo {}\n';
+      expect(maybeAddFlutterStyleTodosIgnore(content), content);
+    });
+
+    test('does not match a `//` line comment, only `///` doc', () {
+      // The generator writes its own `//` TODOs in Flutter style; only
+      // copied spec prose in `///` docs should trigger suppression.
+      const content = '// TODO: internal note\nclass Foo {}\n';
+      expect(maybeAddFlutterStyleTodosIgnore(content), content);
+    });
+
+    test('does not fire on `TODO` embedded in a larger word', () {
+      const content = '/// The MASTODON integration endpoint.\nclass Foo {}\n';
+      expect(maybeAddFlutterStyleTodosIgnore(content), content);
+    });
+
+    test('idempotent: does not double-prepend if marker already present', () {
+      const content =
+          '$flutterStyleTodosIgnoreBlock\n'
+          '/// TODO: add Map type\nenum E {}\n';
+      expect(flutterStyleTodosIgnoreBlock.allMatches(content).length, 1);
+      final result = maybeAddFlutterStyleTodosIgnore(content);
+      expect(flutterStyleTodosIgnoreBlock.allMatches(result).length, 1);
+    });
+
+    test('indented `///` member docs still count', () {
+      const content =
+          'class Foo {\n'
+          '  /// TODO: revisit this field\n'
+          '  final int x;\n'
+          '}\n';
+      expect(
+        maybeAddFlutterStyleTodosIgnore(content),
+        startsWith('$flutterStyleTodosIgnoreBlock\n'),
+      );
+    });
+  });
 }


### PR DESCRIPTION
## Summary

Suppress `flutter_style_todos` on generated files whose dartdoc copies a
spec description containing a bare `TODO`.

openfoodfacts' `element` schema documents "TODO: add Map type", which the
generator faithfully copies into a `///` doc comment — and
`flutter_style_todos` then fires on generated code for a to-do the *spec
author* wrote, not us.

This adds `maybeAddFlutterStyleTodosIgnore` to the existing emit-time
per-file-ignore pipeline (alongside the long-line, comment-references, and
unintended-html suppressors it sits next to in `formatting.dart`): when a
`///` doc line carries a `TODO` not in the accepted `TODO(user):` form,
prepend a file-local `// ignore_for_file: flutter_style_todos` with a
justification comment. File-local, so the lint stays live for consumers who
don't use our `analysis_options` and catches future template regressions.

Matching is `///`-only, word-boundary, and not-followed-by-`(`, so it never
fires on the generator's own Flutter-style `//` to-dos or on `TODO` inside a
larger word (`MASTODON`).

## Validation

- New `maybeAddFlutterStyleTodosIgnore` test group (bare TODO fires;
  `TODO(user):`, `//` line comments, and `MASTODON` don't; idempotent;
  indented member docs).
- openfoodfacts regen: the two `flutter_style_todos` infos are gone (9 → 7
  analyzer issues; the remaining 7 are the array-newtype and map-key
  blockers, tracked separately).
- Corpus regen **byte-identical** (no vendored spec has a TODO description);
  `dart analyze` + `dart format` + cspell clean.

Part of the openfoodfacts split-spec import chain (#324).
