### PR TITLE
fix: tolerate integer schema bounds that overflow a 64-bit int

### DIFF
--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -56,6 +56,38 @@ double? _optionalDouble(MapContext parent, String key) {
   return _expectType<num?>(parent, key, value)?.toDouble();
 }
 
+// Read an integer-typed field (an `integer` schema's `minimum`,
+// `maximum`, `default`, etc.) tolerantly as a `num`. A JSON/YAML integer
+// literal too large for a signed 64-bit int is handed back as a double
+// (e.g. OpenAI's `maximum: 9223372036854775807` — int64 max serialized
+// through float64 as 9223372036854776000), which `_optional<int>` would
+// reject outright. Such a bound is unrepresentable as a Dart `int`
+// literal *and* vacuous for a 64-bit `int` value, so we drop it with a
+// warning rather than crash or emit uncompilable code. A double that is
+// an exact, small-enough integer (`5.0`) is still accepted.
+int? _optionalInt(MapContext parent, String key) {
+  final value = parent[key];
+  if (value == null) {
+    return null;
+  }
+  final number = _expectType<num>(parent, key, value);
+  if (number is int) {
+    return number;
+  }
+  // The value arrived as a double. Only trust the conversion within
+  // ±2^53, the largest magnitude where a double represents every integer
+  // exactly; beyond it `toInt()` silently saturates, so a round-trip
+  // check would falsely accept an out-of-range value. Real specs only
+  // exceed this with int64-boundary sentinels, which are vacuous bounds
+  // for a Dart `int` anyway.
+  const maxExactInt = 0x20000000000000; // 2^53
+  if (number.abs() <= maxExactInt && number == number.roundToDouble()) {
+    return number.toInt();
+  }
+  _warn(parent, "Ignoring '$key'=$number: not representable as a 64-bit int");
+  return null;
+}
+
 List<T> _expectList<T>(MapContext parent, String key, dynamic value) {
   if (value is! List || !value.every((e) => e is T)) {
     _error(parent, "'$key' is not a list of $T: $value");
@@ -1023,12 +1055,12 @@ Schema? _handleNumberTypes(
   if (type == 'integer') {
     return SchemaInteger(
       common: common,
-      defaultValue: _optional<int>(json, 'default'),
-      minimum: _optional<int>(json, 'minimum'),
-      maximum: _optional<int>(json, 'maximum'),
-      exclusiveMinimum: _optional<int>(json, 'exclusiveMinimum'),
-      exclusiveMaximum: _optional<int>(json, 'exclusiveMaximum'),
-      multipleOf: _optional<int>(json, 'multipleOf'),
+      defaultValue: _optionalInt(json, 'default'),
+      minimum: _optionalInt(json, 'minimum'),
+      maximum: _optionalInt(json, 'maximum'),
+      exclusiveMinimum: _optionalInt(json, 'exclusiveMinimum'),
+      exclusiveMaximum: _optionalInt(json, 'exclusiveMaximum'),
+      multipleOf: _optionalInt(json, 'multipleOf'),
     );
   }
   if (type == 'number') {

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -2261,6 +2261,47 @@ void main() {
         }
         expect(schema.enumValues, equals([7]));
       });
+      test('integer bounds parse, tolerating an int written as a double', () {
+        // A JSON/YAML integer bound may arrive as a double (`5.0`); it
+        // still round-trips exactly to an int, so it is accepted.
+        final json = {
+          'type': 'integer',
+          'minimum': -5,
+          'maximum': 5.0,
+        };
+        final schema = parseTestSchema(json);
+        if (schema is! SchemaInteger) {
+          fail('Expected SchemaInteger, got ${schema.runtimeType}');
+        }
+        expect(schema.minimum, -5);
+        expect(schema.maximum, 5);
+      });
+      test('integer bound outside 64-bit range is dropped with a warning', () {
+        // OpenAI's `CreateChatCompletionRequest.seed` declares
+        // `minimum: -9223372036854775808 / maximum: 9223372036854775807`
+        // (int64 bounds), but the spec serialized them through float64,
+        // yielding `±9223372036854776000` — beyond Dart's int range, so
+        // the YAML parser hands them back as doubles. Such a bound is
+        // both unrepresentable as a Dart `int` literal and vacuous for a
+        // 64-bit `int`, so it is dropped rather than crashing the parse.
+        final json = {
+          'type': 'integer',
+          'minimum': -9223372036854776000.0,
+          'maximum': 9223372036854776000.0,
+        };
+        final logger = _MockLogger();
+        final schema = runWithLogger(logger, () => parseTestSchema(json));
+        if (schema is! SchemaInteger) {
+          fail('Expected SchemaInteger, got ${schema.runtimeType}');
+        }
+        expect(schema.minimum, isNull);
+        expect(schema.maximum, isNull);
+        verify(
+          () => logger.warn(
+            any(that: contains('not representable as a 64-bit int')),
+          ),
+        ).called(2);
+      });
       test('string const parses as a single-value SchemaStringEnum', () {
         // Discord's `match_all` discriminator value uses `const`.
         final json = {'type': 'string', 'const': 'match_all'};


### PR DESCRIPTION
## Summary

The parser read an `integer` schema's `minimum` / `maximum` / `default`
(and the other numeric constraints) with `_optional<int>`, which throws
when the value isn't already a Dart `int`. Real specs trip this: OpenAI's
`CreateChatCompletionRequest.seed` declares int64 bounds
(`±9223372036854775807`) that were serialized through float64, arriving
as `±9223372036854776000` — beyond Dart's `int` range, so the YAML parser
hands them back as doubles. Generation crashed with
`FormatException: 'minimum' is not of type int?`.

A new `_optionalInt` reads the value as a `num` and accepts any exact
integer within ±2^53 (including one written as a double, `5.0`). Beyond
that magnitude a `double` can no longer represent every integer, and such
a bound is vacuous for a 64-bit `int` anyway, so it is dropped with a
warning rather than crashing or emitting an uncompilable literal.

Surfaced while scouting OpenAI's spec as a candidate corpus target. No
fixture output changes — the affected path previously crashed, so no
corpus spec exercised it.

## Test plan

- New unit tests: an integer bound written as a double round-trips; an
  out-of-int64-range bound is dropped with a warning.
- `dart test` green; `dart analyze` / `dart format` clean.
- `dart run tool/gen_tests.dart` regenerates the corpus byte-identically.