### PR TITLE
refactor: drop RenderSchema Equatable, dedup by pointer (#187)

### DIFF
--- a/lib/src/render/file_renderer.dart
+++ b/lib/src/render/file_renderer.dart
@@ -13,16 +13,23 @@ import 'package:space_gen/src/render/schema_renderer.dart';
 import 'package:space_gen/src/render/templates.dart';
 import 'package:space_gen/src/render/tree_visitor.dart';
 import 'package:space_gen/src/string.dart';
+import 'package:space_gen/src/types.dart';
 
 export 'package:space_gen/src/render/formatting.dart'
     show Formatter, RunProcess;
 
 class _ModelCollector extends RenderTreeVisitor {
-  final Set<RenderSchema> schemas = {};
+  // Keyed by pointer (a schema's identity, per RenderSchema's doc): the
+  // walk reaches one definition through many paths, and per `$ref` site as
+  // a distinct instance, so without deduping the same
+  // `lib/models/<name>.dart` would be written more than once.
+  final Map<JsonPointer, RenderSchema> _byPointer = {};
+
+  List<RenderSchema> get schemas => _byPointer.values.toList();
 
   @override
   void visitSchema(RenderSchema schema) {
-    schemas.add(schema);
+    _byPointer.putIfAbsent(schema.pointer, () => schema);
   }
 }
 
@@ -126,7 +133,7 @@ String sortDartImports(String source) {
   ].join('\n');
 }
 
-Set<RenderSchema> collectAllSchemas(RenderSpec spec) {
+List<RenderSchema> collectAllSchemas(RenderSpec spec) {
   final collector = _ModelCollector();
   RenderTreeWalker(visitor: collector).walkRoot(spec);
   return collector.schemas;

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -983,8 +983,9 @@ class SpecResolver {
       return SingleSchemaReturn(toRenderSchema(successfulContent.first));
     }
     final renderSchemas = successfulContent.map(toRenderSchema).toList();
-    // We don't implement hashCode/equals but rather equalsIgnoringName.
-    final distinctSchemas = <RenderSchema>{};
+    // These come from different response bodies, so structural sameness
+    // (not identity) is the question — dedup by equalsIgnoringName.
+    final distinctSchemas = <RenderSchema>[];
     for (final schema in renderSchemas) {
       if (!distinctSchemas.any((e) => e.equalsIgnoringName(schema))) {
         distinctSchemas.add(schema);
@@ -2843,7 +2844,21 @@ class RenderDefaultResponse {
 /// it post-generation).
 String _equalsReceiver(String name) => name == 'other' ? 'this.$name' : name;
 
-abstract class RenderSchema extends Equatable implements ToTemplateContext {
+/// Equality is identity — the default. A [RenderSchema] is a node in the
+/// render graph, not a value, so `==` means "the same node."
+///
+/// A schema's identity for deduplication is its [pointer] — its location,
+/// which is also what the rest of the pipeline keys on (the resolver's
+/// recursion stack, the naming pass). `toRenderSchema` builds a fresh
+/// instance per `$ref` site, so the two collectors that must collapse
+/// those — file collection and the per-file name walkers — dedup on
+/// [pointer] explicitly, at the call site, rather than through a stand-in
+/// `==`/`hashCode` that would compare neither identity nor value.
+///
+/// Structural sameness across *different* locations (needed to collapse
+/// distinct-but-equivalent response bodies) is a separate question
+/// answered by [equalsIgnoringName].
+abstract class RenderSchema implements ToTemplateContext {
   const RenderSchema({
     required this.common,
     required this.createsNewType,
@@ -3002,9 +3017,6 @@ abstract class RenderSchema extends Equatable implements ToTemplateContext {
   /// compose their entry/element conversion expressions through the
   /// inner schema's [fromJsonExpression] / [toJsonExpression].
   _VariantConversion? _variantConversion(SchemaRenderer context) => null;
-
-  @override
-  List<Object?> get props => [snakeName, pointer];
 
   /// [expression], with this schema's default substituted when the JSON
   /// value can be null but the value the expression produces still has to
@@ -3378,9 +3390,6 @@ class RenderPod extends RenderSchema {
     };
   }
 
-  @override
-  List<Object?> get props => [super.props, type, defaultValue];
-
   /// The Dart type this pod represents at the use site (when inline) or that
   /// the newtype wraps (when a newtype). The source of truth for [dartType]
   /// and [dartTypeName].
@@ -3677,9 +3686,6 @@ class RenderString extends RenderSchema {
   final String? pattern;
 
   @override
-  List<Object?> get props => [super.props, defaultValue, maxLength, minLength];
-
-  @override
   DartType get dartType =>
       createsNewType ? DartType(_requireAssignedName()) : DartType.string;
 
@@ -3926,17 +3932,6 @@ abstract class RenderNumeric<T extends num> extends RenderSchema {
 
   /// The multiple of value of the number.
   final T? multipleOf;
-
-  @override
-  List<Object?> get props => [
-    super.props,
-    defaultValue,
-    maximum,
-    minimum,
-    exclusiveMaximum,
-    exclusiveMinimum,
-    multipleOf,
-  ];
 
   @override
   DartExpression? defaultValueExpression(SchemaRenderer context) {
@@ -4295,15 +4290,6 @@ class RenderObject extends RenderNewType {
   @override
   _VariantConversion? _variantConversion(SchemaRenderer context) =>
       _newtypeConversion(typeName);
-
-  @override
-  List<Object?> get props => [
-    super.props,
-    properties,
-    additionalProperties,
-    requiredProperties,
-    constProperties,
-  ];
 
   @override
   dynamic get defaultValue => null;
@@ -5066,16 +5052,6 @@ class RenderArray extends RenderSchema {
   ]);
 
   @override
-  List<Object?> get props => [
-    super.props,
-    items,
-    defaultValue,
-    maxItems,
-    minItems,
-    uniqueItems,
-  ];
-
-  @override
   bool get shouldCallToJson => items.shouldCallToJson;
 
   // Inline arrays show up as a oneOf variant; the shape-dispatch
@@ -5303,14 +5279,6 @@ class RenderMap extends RenderSchema {
 
   @override
   final dynamic defaultValue;
-
-  @override
-  List<Object?> get props => [
-    super.props,
-    valueSchema,
-    keySchema,
-    defaultValue,
-  ];
 
   // Map shape — `Map<String, dynamic>` on the wire. Inline maps
   // (additionalProperties on a parent, or `additionalProperties: true`
@@ -5597,15 +5565,6 @@ abstract class RenderEnum<T extends Object> extends RenderNewType {
   _VariantConversion? _variantConversion(SchemaRenderer context) =>
       _newtypeConversion(typeName);
 
-  @override
-  List<Object?> get props => [
-    super.props,
-    values,
-    names,
-    defaultValue,
-    descriptions,
-  ];
-
   /// Template context for an enum schema.
   @override
   Map<String, dynamic> toTemplateContext(SchemaRenderer context) {
@@ -5791,9 +5750,6 @@ class RenderIntNewtype extends RenderInteger {
   /// Rendered as a `value.validate(enumValues: [...])` membership check.
   final List<int> allowedValues;
 
-  @override
-  List<Object?> get props => [super.props, allowedValues];
-
   // A dedicated membership check rather than the multi-bound `validate(...)`
   // sugar: an int enum never carries min/max/multipleOf (the parser routes
   // `enum` away from the bounded-numeric path), so membership is the sole
@@ -5891,9 +5847,6 @@ class RenderOneOf extends RenderNewType {
 
   @override
   Iterable<RenderSchema> get children => schemas;
-
-  @override
-  List<Object?> get props => [super.props, schemas, discriminator];
 
   @override
   bool equalsIgnoringName(RenderSchema other) {
@@ -7328,9 +7281,6 @@ class RenderDate extends RenderSchema {
   final String? defaultValue;
 
   @override
-  List<Object?> get props => [super.props, defaultValue];
-
-  @override
   DartType get dartType => _dateType;
 
   @override
@@ -7536,7 +7486,4 @@ class RenderRecursiveRef extends RenderSchema {
   /// schema opts out of test generation.
   @override
   DartExpression? exampleValue(SchemaRenderer context) => null;
-
-  @override
-  List<Object?> get props => [super.props, targetPointer];
 }

--- a/lib/src/render/tree_visitor.dart
+++ b/lib/src/render/tree_visitor.dart
@@ -1,4 +1,5 @@
 import 'package:space_gen/src/render/render_tree.dart';
+import 'package:space_gen/src/types.dart';
 
 class RenderTreeVisitor {
   void visitSchema(RenderSchema schema) {}
@@ -115,15 +116,16 @@ class NamedSchemas {
   const NamedSchemas({required this.imported, required this.inline});
 
   /// Newtypes the body names. Each renders to its own file, so each
-  /// needs an import at this use site.
-  final Set<RenderSchema> imported;
+  /// needs an import at this use site. Deduplicated by pointer (see
+  /// [_NamedSchemaCollector]).
+  final List<RenderSchema> imported;
 
   /// Schemas whose code this file renders itself: inline structure
   /// (arrays, maps, non-newtype objects) and smooshed variants, which
   /// a sealed parent emits into its own library. Named without an
   /// import, but they can still contribute library imports of their
-  /// own (see `RenderSchema.additionalImports`).
-  final Set<RenderSchema> inline;
+  /// own (see `RenderSchema.additionalImports`). Deduplicated by pointer.
+  final List<RenderSchema> inline;
 }
 
 /// Collects the schemas named by the file rendered for [root].
@@ -179,10 +181,17 @@ NamedSchemas schemasNamedByApi(Api api) {
 }
 
 class _NamedSchemaCollector {
-  final Set<RenderSchema> imported = {};
-  final Set<RenderSchema> inline = {};
+  // Keyed by pointer (a schema's identity): a schema is reached repeatedly
+  // (endpoints share structure; `$ref` sites produce distinct instances
+  // of one definition). First instance per pointer wins, matching
+  // insertion order.
+  final Map<JsonPointer, RenderSchema> _imported = {};
+  final Map<JsonPointer, RenderSchema> _inline = {};
 
-  NamedSchemas get result => NamedSchemas(imported: imported, inline: inline);
+  NamedSchemas get result => NamedSchemas(
+    imported: _imported.values.toList(),
+    inline: _inline.values.toList(),
+  );
 
   /// Collects from [schema] itself, which this file renders — so it is
   /// never its own import.
@@ -197,13 +206,14 @@ class _NamedSchemaCollector {
       // its sealed parent renders it — so it resolves locally, and this
       // file goes on to name whatever the variant names.
       if (schema.createsNewType && !schema.isSmooshed) {
-        imported.add(schema);
+        _imported.putIfAbsent(schema.pointer, () => schema);
         return;
       }
       // Descend each inline schema once. An api file's endpoints share
       // structure freely, so without this the same subtree is re-walked
       // per endpoint that reaches it.
-      if (!inline.add(schema)) return;
+      if (_inline.containsKey(schema.pointer)) return;
+      _inline[schema.pointer] = schema;
     }
     // A oneOf with no dispatch emits an `UnimplementedError` stub that
     // names no variant, so this file imports none of them. Asking the

--- a/test/render/render_tree_test.dart
+++ b/test/render/render_tree_test.dart
@@ -1148,91 +1148,12 @@ void main() {
       expect(collector.visited.whereType<RenderObject>().length, 1);
       expect(collector.visited.whereType<RenderRecursiveRef>().length, 1);
     });
-
-    test('equality is based on pointer + snakeName + targetPointer', () {
-      const a = RenderRecursiveRef(
-        common: CommonProperties.test(
-          snakeName: 'node',
-          pointer: JsonPointer.empty(),
-        ),
-        targetPointer: JsonPointer.empty(),
-      );
-      const b = RenderRecursiveRef(
-        common: CommonProperties.test(
-          snakeName: 'node',
-          pointer: JsonPointer.empty(),
-        ),
-        targetPointer: JsonPointer.empty(),
-      );
-      final differentTarget = RenderRecursiveRef(
-        common: const CommonProperties.test(
-          snakeName: 'node',
-          pointer: JsonPointer.empty(),
-        ),
-        targetPointer: JsonPointer.parse('#/components/schemas/Node'),
-      );
-      expect(a, equals(b));
-      expect(a, isNot(equals(differentTarget)));
-    });
   });
 
-  group('RenderSchema equality (load-bearing)', () {
-    // _ModelCollector in file_renderer.dart accumulates a
-    // `Set<RenderSchema>` while walking the render tree and relies on
-    // `==` / `hashCode` to dedup duplicate-pointer instances.
-    // `toRenderSchema` produces a fresh instance per `$ref` site (no
-    // instance caching), so without dedup we'd try to emit the same
-    // `lib/models/<name>.dart` file twice and `writeFile` would throw.
-    // These tests document that invariant — if someone removes the
-    // equality contract from `RenderSchema`, the github regen will
-    // crash with "File already written" and these tests will surface
-    // the cause earlier.
-
-    test('two RenderObject instances with the same pointer compare equal', () {
-      const a = RenderObject(
-        common: CommonProperties.test(
-          snakeName: 'user',
-          pointer: JsonPointer.empty(),
-        ),
-        properties: <String, RenderSchema>{},
-        assignedName: 'User',
-        assignedSnakeName: 'user',
-      );
-      const b = RenderObject(
-        common: CommonProperties.test(
-          snakeName: 'user',
-          pointer: JsonPointer.empty(),
-        ),
-        properties: <String, RenderSchema>{},
-        assignedName: 'User',
-        assignedSnakeName: 'user',
-      );
-      expect(a, equals(b));
-      expect(a.hashCode, equals(b.hashCode));
-    });
-
-    test('two RenderObjects with different pointers do NOT compare equal', () {
-      const a = RenderObject(
-        common: CommonProperties.test(
-          snakeName: 'user',
-          pointer: JsonPointer.empty(),
-        ),
-        properties: <String, RenderSchema>{},
-        assignedName: 'User',
-        assignedSnakeName: 'user',
-      );
-      final b = RenderObject(
-        common: CommonProperties.test(
-          snakeName: 'user',
-          pointer: JsonPointer.parse('#/components/schemas/User'),
-        ),
-        properties: const <String, RenderSchema>{},
-        assignedName: 'User',
-        assignedSnakeName: 'user',
-      );
-      expect(a, isNot(equals(b)));
-    });
-  });
+  // RenderSchema equality is plain identity; the duplicate-pointer dedup
+  // it used to back now lives explicitly in the collectors, tested by
+  // `schemasNamedBy collapses distinct instances that share a pointer`
+  // in tree_visitor_test.dart.
 
   group('Import equality (load-bearing)', () {
     // _ImportCollector in file_renderer.dart accumulates a
@@ -2259,12 +2180,7 @@ void main() {
       expect(date.defaultValueExpression(context), isNull);
     });
 
-    test('equality includes the default; toTemplateContext throws', () {
-      expect(date, const RenderDate(common: common, defaultValue: null));
-      expect(
-        date,
-        isNot(const RenderDate(common: common, defaultValue: '2020-01-01')),
-      );
+    test('toTemplateContext throws', () {
       expect(() => date.toTemplateContext(context), throwsUnimplementedError);
     });
   });

--- a/test/render/tree_visitor_test.dart
+++ b/test/render/tree_visitor_test.dart
@@ -36,6 +36,22 @@ void main() {
       expect(named.imported, isNot(contains(outer)));
     });
 
+    test('collapses distinct instances that share a pointer', () {
+      // `toRenderSchema` builds a fresh instance per `$ref` site, so one
+      // definition reached through two fields arrives as two instances
+      // with the same pointer. They must collapse — the file, and the
+      // import naming it, is one. This is the dedup RenderSchema equality
+      // used to back; it now lives here, keyed on pointer.
+      final first = _object('Nested');
+      final second = _object('Nested');
+      expect(identical(first, second), isFalse);
+      expect(first.pointer, second.pointer);
+      final outer = _object('Outer', properties: {'a': first, 'b': second});
+
+      final imported = schemasNamedBy(outer).imported;
+      expect(imported.where((s) => s.pointer == first.pointer), hasLength(1));
+    });
+
     test('descends through inline structure to the newtype inside', () {
       // `List<Deep>` names Deep even though the array itself is inline.
       final deep = _object('Deep');


### PR DESCRIPTION
## Summary

Drop `Equatable` from `RenderSchema` and make its duplicate-instance
dedup an explicit pointer key at the collectors (#187).

`RenderSchema` extended `Equatable` only to back the `Set<RenderSchema>`
dedup that collapses the duplicate instances `toRenderSchema` builds per
`$ref` site, so a definition reached many ways writes one file. That cost
two things: every schema-field PR paid a tax threading the new field into
a `props` list (this PR removes eleven such overrides, and #352 had just
added another), and the resulting `==` compared **neither identity nor
value** — it meant "same `[snakeName, pointer]`", a surprising equality
for a node in the render graph.

Now `RenderSchema` uses the default identity `==`, and the two collect
sites key on `pointer` directly:

- `_ModelCollector` / `collectAllSchemas` → `Map<JsonPointer, RenderSchema>`.
- `_NamedSchemaCollector` keys `imported` / `inline` on `pointer`;
  `NamedSchemas.imported` / `inline` become deduped lists.

A schema's location is its identity, and pointer is exactly what the rest
of the pipeline already keys on — the resolver's recursion stack
(`Set<JsonPointer>`) and the naming pass (`Map<JsonPointer, String>`, so a
schema's name is itself a function of its pointer, which is why `snakeName`
would be redundant in the key).

## Verification

- **Byte-identical regen** across github, discord, petstore,
  spacetraders, backstage.
- The obsolete `RenderSchema equality (load-bearing)` unit group (which
  only passed via `const` canonicalization once `==` was identity) is
  replaced by a test exercising the real invariant where it now lives:
  two distinct instances that share a pointer collapse to a single import
  (`tree_visitor_test.dart`).
- Full suite green.

## Not addressed here

Two documents both defining `#/components/schemas/Foo` collide (pointers
from an external components-library are document-relative, not globally
unique). This is pre-existing — the pipeline keys on `pointer` everywhere
and already warns — and unchanged in behavior on every tracked spec. Filed
as #358; the fix belongs in `assemble.dart` (namespace those pointers by
document, as split-spec targets already are).

## Scope

Render layer only. Parser has no `Equatable`. The resolver's
`ResolvedSchema` `Equatable` **stays** — it genuinely value-compares via
`_CollectionStructure`, the `_collectionCache` key that shares identical
`oneOf` / `anyOf` collections.
