### PR TITLE
fix: accept OpenAPI 3.0 boolean exclusiveMinimum/exclusiveMaximum

### DIFF
--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -88,6 +88,35 @@ int? _optionalInt(MapContext parent, String key) {
   return null;
 }
 
+/// Resolves an inclusive/exclusive numeric bound pair, tolerating both
+/// OpenAPI spellings of `exclusiveMinimum` / `exclusiveMaximum`:
+///
+/// - **OpenAPI 3.1 / JSON Schema 2020-12** — a *number* that is itself the
+///   exclusive bound (`exclusiveMinimum: 5` ⇒ value > 5). Passed through.
+/// - **OpenAPI 3.0** — a *boolean* modifier on the sibling inclusive bound
+///   (`minimum: 5` + `exclusiveMinimum: true` ⇒ value > 5). Folded into the
+///   3.1 shape the rest of the pipeline already understands by promoting the
+///   inclusive value into the exclusive slot; `false` leaves it inclusive.
+///
+/// At most one of the returned bounds is non-null.
+({T? inclusive, T? exclusive}) _resolveBound<T extends num>(
+  MapContext json, {
+  required String inclusiveKey,
+  required String exclusiveKey,
+  required T? Function(MapContext, String) readNumber,
+}) {
+  final inclusive = readNumber(json, inclusiveKey);
+  // Reading via `[]` marks the key used; branch before `readNumber` so the
+  // 3.0 boolean never reaches the `num` type check.
+  final exclusiveRaw = json[exclusiveKey];
+  if (exclusiveRaw is bool) {
+    return exclusiveRaw
+        ? (inclusive: null, exclusive: inclusive)
+        : (inclusive: inclusive, exclusive: null);
+  }
+  return (inclusive: inclusive, exclusive: readNumber(json, exclusiveKey));
+}
+
 List<T> _expectList<T>(MapContext parent, String key, dynamic value) {
   if (value is! List || !value.every((e) => e is T)) {
     _error(parent, "'$key' is not a list of $T: $value");
@@ -1053,24 +1082,48 @@ Schema? _handleNumberTypes(
   required CommonProperties common,
 }) {
   if (type == 'integer') {
+    final min = _resolveBound<int>(
+      json,
+      inclusiveKey: 'minimum',
+      exclusiveKey: 'exclusiveMinimum',
+      readNumber: _optionalInt,
+    );
+    final max = _resolveBound<int>(
+      json,
+      inclusiveKey: 'maximum',
+      exclusiveKey: 'exclusiveMaximum',
+      readNumber: _optionalInt,
+    );
     return SchemaInteger(
       common: common,
       defaultValue: _optionalInt(json, 'default'),
-      minimum: _optionalInt(json, 'minimum'),
-      maximum: _optionalInt(json, 'maximum'),
-      exclusiveMinimum: _optionalInt(json, 'exclusiveMinimum'),
-      exclusiveMaximum: _optionalInt(json, 'exclusiveMaximum'),
+      minimum: min.inclusive,
+      maximum: max.inclusive,
+      exclusiveMinimum: min.exclusive,
+      exclusiveMaximum: max.exclusive,
       multipleOf: _optionalInt(json, 'multipleOf'),
     );
   }
   if (type == 'number') {
+    final min = _resolveBound<double>(
+      json,
+      inclusiveKey: 'minimum',
+      exclusiveKey: 'exclusiveMinimum',
+      readNumber: _optionalDouble,
+    );
+    final max = _resolveBound<double>(
+      json,
+      inclusiveKey: 'maximum',
+      exclusiveKey: 'exclusiveMaximum',
+      readNumber: _optionalDouble,
+    );
     return SchemaNumber(
       common: common,
       defaultValue: _optionalDouble(json, 'default'),
-      minimum: _optionalDouble(json, 'minimum'),
-      maximum: _optionalDouble(json, 'maximum'),
-      exclusiveMinimum: _optionalDouble(json, 'exclusiveMinimum'),
-      exclusiveMaximum: _optionalDouble(json, 'exclusiveMaximum'),
+      minimum: min.inclusive,
+      maximum: max.inclusive,
+      exclusiveMinimum: min.exclusive,
+      exclusiveMaximum: max.exclusive,
       multipleOf: _optionalDouble(json, 'multipleOf'),
     );
   }

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -2616,6 +2616,60 @@ void main() {
       },
     );
 
+    group('numeric bounds', () {
+      test('number: 3.1 numeric exclusiveMinimum passes through', () {
+        final json = {'type': 'number', 'exclusiveMinimum': 5};
+        final schema = parseTestSchema(json);
+        if (schema is! SchemaNumber) {
+          fail('Expected SchemaNumber, got ${schema.runtimeType}');
+        }
+        expect(schema.minimum, isNull);
+        expect(schema.exclusiveMinimum, 5.0);
+      });
+      test('number: 3.0 boolean exclusiveMinimum promotes minimum', () {
+        // OpenAI's `learning_rate_multiplier` uses the 3.0 boolean form:
+        // `minimum: 0` + `exclusiveMinimum: true` means value > 0. Fold it
+        // into the numeric `exclusiveMinimum` slot the renderer emits.
+        final json = {
+          'type': 'number',
+          'minimum': 0,
+          'exclusiveMinimum': true,
+        };
+        final schema = parseTestSchema(json);
+        if (schema is! SchemaNumber) {
+          fail('Expected SchemaNumber, got ${schema.runtimeType}');
+        }
+        expect(schema.minimum, isNull);
+        expect(schema.exclusiveMinimum, 0.0);
+      });
+      test('integer: 3.0 boolean exclusiveMaximum promotes maximum', () {
+        final json = {
+          'type': 'integer',
+          'maximum': 10,
+          'exclusiveMaximum': true,
+        };
+        final schema = parseTestSchema(json);
+        if (schema is! SchemaInteger) {
+          fail('Expected SchemaInteger, got ${schema.runtimeType}');
+        }
+        expect(schema.maximum, isNull);
+        expect(schema.exclusiveMaximum, 10);
+      });
+      test('3.0 boolean exclusive=false leaves the bound inclusive', () {
+        final json = {
+          'type': 'integer',
+          'minimum': 1,
+          'exclusiveMinimum': false,
+        };
+        final schema = parseTestSchema(json);
+        if (schema is! SchemaInteger) {
+          fail('Expected SchemaInteger, got ${schema.runtimeType}');
+        }
+        expect(schema.minimum, 1);
+        expect(schema.exclusiveMinimum, isNull);
+      });
+    });
+
     group('nullable', () {
       test('string', () {
         final json = {'type': 'string', 'nullable': true};


### PR DESCRIPTION
## Summary

`exclusiveMinimum` / `exclusiveMaximum` were read as numbers — the
OpenAPI 3.1 / JSON-Schema-2020-12 form, where the keyword *is* the
exclusive bound (`exclusiveMinimum: 5` ⇒ value > 5). In OpenAPI 3.0 they
are instead *booleans* that modify the sibling `minimum` / `maximum`
(`minimum: 5` + `exclusiveMinimum: true` ⇒ value > 5). A 3.0 spec using
them crashed the parse:

```
FormatException: 'exclusiveMinimum' is not of type num?: true
```

A new `_resolveBound` reads each inclusive/exclusive pair together and
folds the 3.0 boolean form into the numeric representation the render
layer already emits: `true` promotes the inclusive value into the
exclusive slot, `false` leaves it inclusive. The 3.1 numeric form is
unchanged.

Closes #346. Surfaced while scouting OpenAI as a corpus target (next
blocker after #345).

## Test plan

- New `numeric bounds` unit tests: 3.1 numeric passthrough; 3.0 boolean
  `true` promotes min/max to the exclusive slot (int + number); `false`
  leaves it inclusive.
- Verified end-to-end: `minimum: 0` + `exclusiveMinimum: true` renders
  `validate(exclusiveMin: 0.0)`, not `validate(min: 0)`.
- `dart test` green; analyze/format clean; `tool/gen_tests.dart`
  regenerates the corpus byte-identically (affected path previously
  crashed).