### PR TITLE
fix: warn and drop an invalid enum default instead of crashing

### DIFF
--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -943,14 +943,24 @@ SchemaMap _mapSchema(
   );
 }
 
-/// Some specs wrap a scalar enum `default` in a single-element list
-/// (OpenAI: `default: [auto]` on `enum: [auto]`). Enum values are always
-/// scalars, so a one-element list default is an unambiguous author typo —
-/// treat it as the scalar it plainly means. Any other value is returned
-/// untouched.
-dynamic _unwrapSingletonDefault(dynamic value) {
+/// Unwraps a scalar enum `default` that a spec wrapped in a single-element
+/// list — e.g. OpenAI's `default: [auto]` on `enum: [auto]`.
+///
+/// **This is a real-world leniency, not part of the OpenAPI / JSON Schema
+/// spec.** There, an enum `default` is a bare value, and for a scalar enum
+/// that means a scalar — never a list. But some spec-authoring tools emit
+/// the value wrapped in a one-element list; since enum values are always
+/// scalars, a one-item list is an unambiguous typo, so we reinterpret it as
+/// the scalar it plainly means and log the accommodation at `-v`. Any other
+/// value is returned untouched.
+dynamic _unwrapSingletonDefault(MapContext json, dynamic value) {
   if (value is List && value.length == 1) {
-    return value.first;
+    final unwrapped = value.first;
+    logger.detail(
+      'Unwrapping single-element list default $value to $unwrapped '
+      '(not spec-conformant; seen in real-world specs) in ${json.pointer}',
+    );
+    return unwrapped;
   }
   return value;
 }
@@ -1039,7 +1049,7 @@ SchemaEnum<Object>? _handleEnum({
     final typedEnumValues = nonNullValues.cast<int>();
     int? typedDefaultValue;
     if (defaultValue != null) {
-      final candidate = _unwrapSingletonDefault(defaultValue);
+      final candidate = _unwrapSingletonDefault(json, defaultValue);
       if (candidate is int && nonNullValues.contains(candidate)) {
         typedDefaultValue = candidate;
       } else {
@@ -1066,7 +1076,7 @@ SchemaEnum<Object>? _handleEnum({
   final typedEnumValues = nonNullValues.cast<String>();
   String? typedDefaultValue;
   if (defaultValue != null) {
-    final candidate = _unwrapSingletonDefault(defaultValue);
+    final candidate = _unwrapSingletonDefault(json, defaultValue);
     if (nonNullValues.contains(candidate)) {
       typedDefaultValue = candidate as String;
     } else if (nonNullValues.contains(candidate.toString())) {

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -943,6 +943,18 @@ SchemaMap _mapSchema(
   );
 }
 
+/// Some specs wrap a scalar enum `default` in a single-element list
+/// (OpenAI: `default: [auto]` on `enum: [auto]`). Enum values are always
+/// scalars, so a one-element list default is an unambiguous author typo —
+/// treat it as the scalar it plainly means. Any other value is returned
+/// untouched.
+dynamic _unwrapSingletonDefault(dynamic value) {
+  if (value is List && value.length == 1) {
+    return value.first;
+  }
+  return value;
+}
+
 SchemaEnum<Object>? _handleEnum({
   required MapContext json,
   required TypeAndFormat typeAndFormat,
@@ -1027,13 +1039,16 @@ SchemaEnum<Object>? _handleEnum({
     final typedEnumValues = nonNullValues.cast<int>();
     int? typedDefaultValue;
     if (defaultValue != null) {
-      if (!nonNullValues.contains(defaultValue)) {
-        _error(
+      final candidate = _unwrapSingletonDefault(defaultValue);
+      if (candidate is int && nonNullValues.contains(candidate)) {
+        typedDefaultValue = candidate;
+      } else {
+        _warn(
           json,
-          'defaultValue must be one of the enum values: $defaultValue',
+          'Ignoring default=$defaultValue: not one of the enum values '
+          '$nonNullValues',
         );
       }
-      typedDefaultValue = defaultValue as int;
     }
     return SchemaIntEnum(
       common: common,
@@ -1051,20 +1066,20 @@ SchemaEnum<Object>? _handleEnum({
   final typedEnumValues = nonNullValues.cast<String>();
   String? typedDefaultValue;
   if (defaultValue != null) {
-    if (!nonNullValues.contains(defaultValue)) {
-      // Try converting to a string and looking again.
+    final candidate = _unwrapSingletonDefault(defaultValue);
+    if (nonNullValues.contains(candidate)) {
+      typedDefaultValue = candidate as String;
+    } else if (nonNullValues.contains(candidate.toString())) {
       // In GitHub spec, they have a defaultValue of true (boolean) despite the
       // enum being strings (with 'true' as a valid value), so we convert the
       // default value to the enum type before checking if it's valid.
-      typedDefaultValue = defaultValue.toString();
-      if (!nonNullValues.contains(typedDefaultValue)) {
-        _error(
-          json,
-          'defaultValue must be one of the enum values: $defaultValue',
-        );
-      }
+      typedDefaultValue = candidate.toString();
     } else {
-      typedDefaultValue = defaultValue as String?;
+      _warn(
+        json,
+        'Ignoring default=$defaultValue: not one of the enum values '
+        '$nonNullValues',
+      );
     }
   }
   return SchemaStringEnum(

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -2232,22 +2232,36 @@ void main() {
         }
         expect(schema.defaultValue, equals(11));
       });
-      test('integer enum default value not in enum is a spec error', () {
+      test(
+        'integer enum default value not in enum is dropped with a warning',
+        () {
+          final json = {
+            'type': 'integer',
+            'enum': [1, 2, 11],
+            'default': 99,
+          };
+          final logger = _MockLogger();
+          final schema = runWithLogger(logger, () => parseTestSchema(json));
+          if (schema is! SchemaIntEnum) {
+            fail('Expected SchemaIntEnum, got ${schema.runtimeType}');
+          }
+          expect(schema.defaultValue, isNull);
+          verify(
+            () => logger.warn(any(that: contains('Ignoring default=99'))),
+          ).called(1);
+        },
+      );
+      test('integer enum default wrapped in a single-element list unwraps', () {
         final json = {
           'type': 'integer',
           'enum': [1, 2, 11],
-          'default': 99,
+          'default': [11],
         };
-        expect(
-          () => parseTestSchema(json),
-          throwsA(
-            isA<FormatException>().having(
-              (e) => e.message,
-              'message',
-              contains('defaultValue must be one of the enum values: 99'),
-            ),
-          ),
-        );
+        final schema = parseTestSchema(json);
+        if (schema is! SchemaIntEnum) {
+          fail('Expected SchemaIntEnum, got ${schema.runtimeType}');
+        }
+        expect(schema.defaultValue, 11);
       });
       test('integer const parses as a single-value SchemaIntEnum', () {
         // OpenAPI 3.1 / JSON Schema 2020-12: `const: N` is the single-
@@ -2523,22 +2537,36 @@ void main() {
         );
       });
 
-      test('defaultValue must be a valid enum value', () {
+      test('string enum default not in enum is dropped with a warning', () {
         final json = {
           'type': 'string',
           'enum': ['success', 'failure'],
           'default': 'neutral',
         };
-        expect(
-          () => parseTestSchema(json),
-          throwsA(
-            isA<FormatException>().having(
-              (e) => e.message,
-              'message',
-              contains('defaultValue must be one of the enum values: neutral'),
-            ),
-          ),
-        );
+        final logger = _MockLogger();
+        final schema = runWithLogger(logger, () => parseTestSchema(json));
+        if (schema is! SchemaStringEnum) {
+          fail('Expected SchemaStringEnum, got ${schema.runtimeType}');
+        }
+        expect(schema.defaultValue, isNull);
+        verify(
+          () => logger.warn(any(that: contains('Ignoring default=neutral'))),
+        ).called(1);
+      });
+      test('string enum default wrapped in a single-element list unwraps', () {
+        // OpenAI's `TranscriptionChunkingStrategy`: `default: [auto]` on
+        // `enum: [auto]` — a scalar default the author wrote as a one-item
+        // list.
+        final json = {
+          'type': 'string',
+          'enum': ['auto'],
+          'default': ['auto'],
+        };
+        final schema = parseTestSchema(json);
+        if (schema is! SchemaStringEnum) {
+          fail('Expected SchemaStringEnum, got ${schema.runtimeType}');
+        }
+        expect(schema.defaultValue, 'auto');
       });
     });
 

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -2257,11 +2257,15 @@ void main() {
           'enum': [1, 2, 11],
           'default': [11],
         };
-        final schema = parseTestSchema(json);
+        final logger = _MockLogger();
+        final schema = runWithLogger(logger, () => parseTestSchema(json));
         if (schema is! SchemaIntEnum) {
           fail('Expected SchemaIntEnum, got ${schema.runtimeType}');
         }
         expect(schema.defaultValue, 11);
+        verify(
+          () => logger.detail(any(that: contains('not spec-conformant'))),
+        ).called(1);
       });
       test('integer const parses as a single-value SchemaIntEnum', () {
         // OpenAPI 3.1 / JSON Schema 2020-12: `const: N` is the single-
@@ -2556,17 +2560,21 @@ void main() {
       test('string enum default wrapped in a single-element list unwraps', () {
         // OpenAI's `TranscriptionChunkingStrategy`: `default: [auto]` on
         // `enum: [auto]` — a scalar default the author wrote as a one-item
-        // list.
+        // list. Not spec-conformant, so the accommodation is logged.
         final json = {
           'type': 'string',
           'enum': ['auto'],
           'default': ['auto'],
         };
-        final schema = parseTestSchema(json);
+        final logger = _MockLogger();
+        final schema = runWithLogger(logger, () => parseTestSchema(json));
         if (schema is! SchemaStringEnum) {
           fail('Expected SchemaStringEnum, got ${schema.runtimeType}');
         }
         expect(schema.defaultValue, 'auto');
+        verify(
+          () => logger.detail(any(that: contains('not spec-conformant'))),
+        ).called(1);
       });
     });
 


### PR DESCRIPTION
## Summary

An enum whose `default` didn't match any enum value threw a
`FormatException` that aborted the entire run. OpenAI trips this: its
`TranscriptionChunkingStrategy` writes `default: [auto]` — a one-element
*list* where a string-enum default should be the scalar `auto` — so the
value `["auto"]` failed the membership check and crashed generation.

Two changes to `_handleEnum`, applied to both the int- and string-enum
paths:

- **Unwrap a single-element list default** (`[auto]` → `auto`). Enum
  values are always scalars, so a one-item list is an unambiguous author
  typo; unwrap it to the scalar it plainly means.
- **Downgrade the "not a valid enum value" hard error to a warn + drop.**
  A malformed default is a nicety gone wrong; best-effort generation with
  a visible warning beats crashing the whole spec. The github
  boolean-default-on-string-enum tolerance (`true` → `'true'`) is
  preserved.

Closes #351. Surfaced while scouting OpenAI as a corpus target (next
blocker after #345 and #350).

## Test plan

- Updated the two tests that asserted the old hard error to assert
  warn + drop; added unwrap tests for both int and string enums.
- `dart test` green; analyze/format clean; `tool/gen_tests.dart`
  regenerates the corpus byte-identically (affected path previously
  crashed).