### PR TITLE
fix: type constrained-string propertyNames as a validated newtype key

### DIFF
--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -876,13 +876,11 @@ class SpecResolver {
           wrapperNames: _wrapperNamesFor(schema),
         );
       case ResolvedMap():
-        final keyEnum = schema.keySchema;
+        final keySchema = schema.keySchema;
         return RenderMap(
           common: schema.common,
           valueSchema: toRenderSchema(schema.valueSchema),
-          keySchema: keyEnum == null
-              ? null
-              : toRenderSchema(keyEnum) as RenderStringEnum,
+          keySchema: keySchema == null ? null : toRenderSchema(keySchema),
         );
       case ResolvedEmptyObject():
         return RenderEmptyObject(
@@ -5290,9 +5288,11 @@ class RenderMap extends RenderSchema {
   final RenderSchema valueSchema;
 
   /// Optional typed key schema. JSON object keys are strings on the wire, so
-  /// only a string enum can type a key — its `fromJson`/`toJson` round-trip
-  /// each key directly. When null, the map has plain `String` keys.
-  final RenderStringEnum? keySchema;
+  /// a key can only be typed by a schema whose wire form is a string that
+  /// round-trips through `fromJson`/`toJson` — a string enum, or a constrained
+  /// string rendered as a validated newtype. When null, the map has plain
+  /// `String` keys.
+  final RenderSchema? keySchema;
 
   @override
   Iterable<RenderSchema> get children {

--- a/lib/src/resolver.dart
+++ b/lib/src/resolver.dart
@@ -20,6 +20,21 @@ Never _error(String message, JsonPointer pointer) {
   throw FormatException('$message in $pointer');
 }
 
+/// Whether a string used as a map key carries a validation constraint worth
+/// enforcing — in which case it becomes a newtype key rather than plain
+/// `String`. A bare `type: string` has nothing to validate.
+bool _stringKeyNeedsNewType(ResolvedString key) =>
+    key.maxLength != null || key.minLength != null || key.pattern != null;
+
+/// Re-mints a constrained inline string as a newtype so it can carry its
+/// constraint as a validated map-key type. Inline schemas don't create a
+/// newtype on their own (only top-level components do), and a map key has no
+/// enclosing object constructor to validate against (unlike an inline object
+/// property), so the newtype is the only home for the constraint. The
+/// pointer-derived `snakeName` names the emitted key type.
+ResolvedString _promoteStringKeyToNewType(ResolvedString key) =>
+    key.copyWith(createsNewType: true);
+
 class ResolveContext {
   ResolveContext({
     required this.specUrl,
@@ -536,24 +551,39 @@ ResolvedSchema _resolveSchemaFully(
     final resolvedKey = keyRef == null
         ? null
         : resolveSchemaRef(keyRef, context);
-    // Only a string enum can type a JSON map key: keys are strings on the
-    // wire, and a string enum's fromJson/toJson round-trip them directly.
-    ResolvedStringEnum? keySchema;
+    // JSON object keys are strings on the wire, so a `propertyNames` schema
+    // can type a map key only when its wire form is a string that round-trips
+    // through `fromJson`/`toJson`.
+    ResolvedSchema? keySchema;
     if (resolvedKey is ResolvedStringEnum) {
+      // A string enum types the key directly.
       keySchema = resolvedKey;
+    } else if (resolvedKey is ResolvedString) {
+      // A string types the key only when it is a distinct type: a named
+      // string component (already a newtype), or an inline constrained string
+      // (`maxLength` / `minLength` / `pattern`, as in OpenAI's
+      // `VectorStoreFileAttributes`) promoted to one so the constraint runs on
+      // every key. A bare inline `type: string` has nothing to validate and
+      // no distinct identity, so it stays plain `String` keys.
+      if (resolvedKey.createsNewType) {
+        keySchema = resolvedKey;
+      } else if (_stringKeyNeedsNewType(resolvedKey)) {
+        keySchema = _promoteStringKeyToNewType(resolvedKey);
+      }
     } else if (resolvedKey is ResolvedIntEnum) {
-      // An int enum renders as a value newtype, not an enum, and can't
-      // carry a string key; drop back to plain String keys.
+      // An int enum renders as a value newtype whose wire form is an int, not
+      // a string, so it can't type a JSON key; fall back to `String` keys.
       _warn(
         'propertyNames resolves to an integer enum, which cannot type a '
         'map key (JSON object keys are strings). Using String keys instead.',
         schema.pointer,
       );
     } else if (resolvedKey != null) {
-      _error(
-        'propertyNames must resolve to a string enum for a map-typed '
-        r'schema. Either use a $ref to a named string enum or an inline '
-        'string enum. Got: ${resolvedKey.runtimeType}',
+      // A non-string, non-enum `propertyNames` can't describe JSON keys
+      // (which are always strings); keep `String` keys.
+      _warn(
+        'Ignoring propertyNames (${resolvedKey.runtimeType}): map keys are '
+        'always String',
         schema.pointer,
       );
     }
@@ -1385,10 +1415,10 @@ class ResolvedString extends ResolvedSchema {
   final String? pattern;
 
   @override
-  ResolvedString copyWith({CommonProperties? common}) {
+  ResolvedString copyWith({CommonProperties? common, bool? createsNewType}) {
     return ResolvedString(
       common: common ?? this.common,
-      createsNewType: createsNewType,
+      createsNewType: createsNewType ?? this.createsNewType,
       defaultValue: defaultValue,
       maxLength: maxLength,
       minLength: minLength,
@@ -1890,10 +1920,13 @@ class ResolvedMap extends ResolvedSchema {
 
   final ResolvedSchema valueSchema;
 
-  /// Optional typed key schema. Must resolve to a string enum — JSON object
-  /// keys are strings, and only a string enum can round-trip them as a typed
-  /// key. Int enums render as value newtypes and fall back to `String` keys.
-  final ResolvedStringEnum? keySchema;
+  /// Optional typed key schema. JSON object keys are strings on the wire, so
+  /// a key can only be typed by a schema whose wire form is a string that
+  /// round-trips through `fromJson`/`toJson`: a string enum, or a constrained
+  /// string rendered as a validated newtype. When null, the map has plain
+  /// `String` keys. Int enums render as value newtypes (int wire form) and
+  /// fall back to `String` keys.
+  final ResolvedSchema? keySchema;
 
   @override
   ResolvedMap copyWith({CommonProperties? common}) {

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -256,7 +256,42 @@ void main() {
       expect(r, isNot(contains('NovaGroup')));
     });
 
-    test('propertyNames without an enum ref is a spec error', () {
+    test(
+      'constrained-string propertyNames renders a validated newtype key',
+      () {
+        // OpenAI's `VectorStoreFileAttributes`: `propertyNames: {type: string,
+        // maxLength: 64}` becomes a validated string newtype so the length
+        // constraint is enforced on every key.
+        final schemas = <String, Map<String, dynamic>>{
+          'R': {
+            'type': 'object',
+            'required': ['statuses'],
+            'properties': {
+              'statuses': {
+                'type': 'object',
+                'additionalProperties': {'type': 'string'},
+                'propertyNames': {'type': 'string', 'maxLength': 64},
+              },
+            },
+          },
+        };
+        final rendered = renderTestSchemas(
+          schemas,
+          specUrl: Uri.parse('file:///spec.yaml'),
+        );
+        // The key is a typed newtype (`RStatuses`), not plain `String`, and
+        // the parent bridges each key through its `fromJson`. The newtype's
+        // own `maxLength` validation is covered in resolver_test.
+        final r = rendered['R'];
+        expect(r, contains('Map<RStatuses, String> statuses;'));
+        expect(r, contains('RStatuses.fromJson(key)'));
+        expect(r, contains('MapEntry(key.toJson(), value)'));
+      },
+    );
+
+    test('bare-string propertyNames keeps String keys', () {
+      // No constraint to validate, so no newtype and no warning — keys stay
+      // plain `String`.
       final schema = {
         'type': 'object',
         'required': ['statuses'],
@@ -268,16 +303,13 @@ void main() {
           },
         },
       };
-      expect(
+      final logger = _MockLogger();
+      final result = runWithLogger(
+        logger,
         () => renderTestSchema(schema, asComponent: true),
-        throwsA(
-          isA<FormatException>().having(
-            (e) => e.message,
-            'message',
-            contains('must resolve to a string enum'),
-          ),
-        ),
       );
+      expect(result, contains('Map<String, String> statuses;'));
+      verifyNever(() => logger.warn(any()));
     });
 
     test(

--- a/test/resolver_test.dart
+++ b/test/resolver_test.dart
@@ -1463,6 +1463,113 @@ void main() {
       );
     });
 
+    group('propertyNames', () {
+      test('string enum propertyNames yields a typed map key', () {
+        final json = {
+          'type': 'object',
+          'propertyNames': {
+            'type': 'string',
+            'enum': ['a', 'b'],
+          },
+          'additionalProperties': {'type': 'string'},
+        };
+        final schema = parseAndResolveTestSchema(json);
+        if (schema is! ResolvedMap) {
+          fail('Expected ResolvedMap, got ${schema.runtimeType}');
+        }
+        expect(schema.keySchema, isA<ResolvedEnum>());
+      });
+
+      test('constrained-string propertyNames becomes a newtype key', () {
+        // OpenAI's `VectorStoreFileAttributes`: `propertyNames` is a plain
+        // `type: string` with `maxLength`. It's promoted to a validated
+        // string newtype so the constraint is enforced on every key.
+        final json = {
+          'type': 'object',
+          'propertyNames': {'type': 'string', 'maxLength': 64},
+          'additionalProperties': {'type': 'string'},
+        };
+        final schema = parseAndResolveTestSchema(json);
+        if (schema is! ResolvedMap) {
+          fail('Expected ResolvedMap, got ${schema.runtimeType}');
+        }
+        final key = schema.keySchema;
+        if (key is! ResolvedString) {
+          fail('Expected ResolvedString key, got ${key.runtimeType}');
+        }
+        expect(key.createsNewType, isTrue);
+        expect(key.maxLength, 64);
+      });
+
+      test('named string-component propertyNames types the key', () {
+        // A `$ref` to a top-level `type: string` component is already a
+        // distinct newtype, so it types the key even without a constraint.
+        final spec = parseAndResolveTestSpec({
+          'openapi': '3.1.0',
+          'info': {'title': 'T', 'version': '1.0.0'},
+          'servers': [
+            {'url': 'https://example.com'},
+          ],
+          'paths': {
+            '/a': {
+              'get': {
+                'responses': {
+                  '200': {
+                    'description': 'ok',
+                    'content': {
+                      'application/json': {
+                        'schema': {
+                          'type': 'object',
+                          'additionalProperties': {'type': 'string'},
+                          'propertyNames': {
+                            r'$ref': '#/components/schemas/UserId',
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          'components': {
+            'schemas': {
+              'UserId': {'type': 'string'},
+            },
+          },
+        });
+        final map = spec.paths.first.operations.first.responses.first.content;
+        if (map is! ResolvedMap) {
+          fail('Expected ResolvedMap, got ${map.runtimeType}');
+        }
+        final key = map.keySchema;
+        if (key is! ResolvedString) {
+          fail('Expected ResolvedString key, got ${key.runtimeType}');
+        }
+        expect(key.createsNewType, isTrue);
+        expect(key.snakeName, 'user_id');
+      });
+
+      test('bare-string propertyNames keeps plain String keys', () {
+        // No constraint to validate, so no newtype — keys stay `String`.
+        final json = {
+          'type': 'object',
+          'propertyNames': {'type': 'string'},
+          'additionalProperties': {'type': 'string'},
+        };
+        final logger = _MockLogger();
+        final schema = runWithLogger(
+          logger,
+          () => parseAndResolveTestSchema(json),
+        );
+        if (schema is! ResolvedMap) {
+          fail('Expected ResolvedMap, got ${schema.runtimeType}');
+        }
+        expect(schema.keySchema, isNull);
+        verifyNever(() => logger.warn(any()));
+      });
+    });
+
     group('request body content type selection', () {
       Map<String, dynamic> specWith(Map<String, dynamic> content) => {
         'openapi': '3.1.0',


### PR DESCRIPTION
## Summary

A map-typed schema whose `propertyNames` was a constrained string
(`type: string` with `maxLength`/`minLength`/`pattern`) threw a
`FormatException` that aborted the run — the resolver only accepted a
string *enum* as a typed key. OpenAI trips this: its
`VectorStoreFileAttributes` uses `propertyNames: {type: string,
maxLength: 64}`.

Rather than drop the constraint, the constrained key is now promoted to a
validated string newtype (the same `extension type` machinery a named
constrained string already uses), and the map is keyed by it:
`Map<VectorStoreFileAttributesAttributes, String>`, where the key type's
constructor runs `value.validate(maxLength: 64)`. Validation therefore
runs on every key construction and on `fromJson`. This mirrors the
existing string-enum-key path — both make the key a distinct type that
round-trips through a `String` `fromJson`/`toJson`.

Behavior by `propertyNames` shape:
- string enum → typed enum key (unchanged)
- **constrained string → validated newtype key (new)**
- bare `type: string` → plain `String` keys (nothing to validate)
- int enum → `String` keys + warning (int wire form can't key; from #357)
- other non-string → `String` keys + warning

`ResolvedMap.keySchema` / `RenderMap.keySchema` widen from `*StringEnum?`
to a string-wire schema; every method the map calls on the key
(`_fromJsonCall`, `dartType`, `toJson`, `exampleValue`) already lives on
the base schema, so the widening is a no-op for the enum path.

Closes #354. Surfaced while scouting OpenAI as a corpus target (rebased
onto #357).

## Test plan

- Resolver tests: constrained-string `propertyNames` promotes to a
  newtype key (`createsNewType`, `maxLength` preserved); bare-string keeps
  plain `String` keys with no warning.
- Render test: constrained-string key renders `Map<RStatuses, String>`
  with `RStatuses.fromJson(key)` / `key.toJson()` bridging.
- Verified end-to-end on a scratch spec mirroring OpenAI: emits
  `extension type VectorStoreFileAttributesAttributes(String value)` whose
  constructor validates `maxLength: 64`; the generated package analyzes
  clean.
- `dart test` green (842); analyze/format clean; corpus regenerates
  byte-identically.