### PR TITLE
feat: render nameless integer enums as validated int newtypes (#352)

### DIFF
--- a/gen_tests/const_property/lib/api_exception.dart
+++ b/gen_tests/const_property/lib/api_exception.dart
@@ -70,6 +70,19 @@ extension ValidateNumber on num {
     if (multipleOf != null) validateMultipleOf(multipleOf);
   }
 
+  /// Validates that the value is one of [enumValues] — the members of a
+  /// nameless integer `enum`, which is generated as a newtype over `int`.
+  /// This is its own call rather than a [validate] argument: an int enum
+  /// never also carries range bounds, so membership is the only rule. Unlike
+  /// the range checks, an out-of-set value is a parse failure (the wire
+  /// carried a value the type does not name), so it throws [FormatException]
+  /// to match how a generated `fromJson` reports malformed input.
+  void validateEnumValues(List<num> enumValues) {
+    if (!enumValues.contains(this)) {
+      throw FormatException('$this is not one of $enumValues');
+    }
+  }
+
   void validateMinimum(num minimum) {
     if (this < minimum) {
       throw Exception('must be greater than or equal to $minimum');

--- a/gen_tests/form_urlencoded/lib/api_exception.dart
+++ b/gen_tests/form_urlencoded/lib/api_exception.dart
@@ -70,6 +70,19 @@ extension ValidateNumber on num {
     if (multipleOf != null) validateMultipleOf(multipleOf);
   }
 
+  /// Validates that the value is one of [enumValues] — the members of a
+  /// nameless integer `enum`, which is generated as a newtype over `int`.
+  /// This is its own call rather than a [validate] argument: an int enum
+  /// never also carries range bounds, so membership is the only rule. Unlike
+  /// the range checks, an out-of-set value is a parse failure (the wire
+  /// carried a value the type does not name), so it throws [FormatException]
+  /// to match how a generated `fromJson` reports malformed input.
+  void validateEnumValues(List<num> enumValues) {
+    if (!enumValues.contains(this)) {
+      throw FormatException('$this is not one of $enumValues');
+    }
+  }
+
   void validateMinimum(num minimum) {
     if (this < minimum) {
       throw Exception('must be greater than or equal to $minimum');

--- a/gen_tests/multipart/lib/api_exception.dart
+++ b/gen_tests/multipart/lib/api_exception.dart
@@ -70,6 +70,19 @@ extension ValidateNumber on num {
     if (multipleOf != null) validateMultipleOf(multipleOf);
   }
 
+  /// Validates that the value is one of [enumValues] — the members of a
+  /// nameless integer `enum`, which is generated as a newtype over `int`.
+  /// This is its own call rather than a [validate] argument: an int enum
+  /// never also carries range bounds, so membership is the only rule. Unlike
+  /// the range checks, an out-of-set value is a parse failure (the wire
+  /// carried a value the type does not name), so it throws [FormatException]
+  /// to match how a generated `fromJson` reports malformed input.
+  void validateEnumValues(List<num> enumValues) {
+    if (!enumValues.contains(this)) {
+      throw FormatException('$this is not one of $enumValues');
+    }
+  }
+
   void validateMinimum(num minimum) {
     if (this < minimum) {
       throw Exception('must be greater than or equal to $minimum');

--- a/gen_tests/security/lib/api_exception.dart
+++ b/gen_tests/security/lib/api_exception.dart
@@ -70,6 +70,19 @@ extension ValidateNumber on num {
     if (multipleOf != null) validateMultipleOf(multipleOf);
   }
 
+  /// Validates that the value is one of [enumValues] — the members of a
+  /// nameless integer `enum`, which is generated as a newtype over `int`.
+  /// This is its own call rather than a [validate] argument: an int enum
+  /// never also carries range bounds, so membership is the only rule. Unlike
+  /// the range checks, an out-of-set value is a parse failure (the wire
+  /// carried a value the type does not name), so it throws [FormatException]
+  /// to match how a generated `fromJson` reports malformed input.
+  void validateEnumValues(List<num> enumValues) {
+    if (!enumValues.contains(this)) {
+      throw FormatException('$this is not one of $enumValues');
+    }
+  }
+
   void validateMinimum(num minimum) {
     if (this < minimum) {
       throw Exception('must be greater than or equal to $minimum');

--- a/gen_tests/third_party/backstage/lib/api_exception.dart
+++ b/gen_tests/third_party/backstage/lib/api_exception.dart
@@ -70,6 +70,19 @@ extension ValidateNumber on num {
     if (multipleOf != null) validateMultipleOf(multipleOf);
   }
 
+  /// Validates that the value is one of [enumValues] — the members of a
+  /// nameless integer `enum`, which is generated as a newtype over `int`.
+  /// This is its own call rather than a [validate] argument: an int enum
+  /// never also carries range bounds, so membership is the only rule. Unlike
+  /// the range checks, an out-of-set value is a parse failure (the wire
+  /// carried a value the type does not name), so it throws [FormatException]
+  /// to match how a generated `fromJson` reports malformed input.
+  void validateEnumValues(List<num> enumValues) {
+    if (!enumValues.contains(this)) {
+      throw FormatException('$this is not one of $enumValues');
+    }
+  }
+
   void validateMinimum(num minimum) {
     if (this < minimum) {
       throw Exception('must be greater than or equal to $minimum');

--- a/gen_tests/third_party/discord/lib/api_exception.dart
+++ b/gen_tests/third_party/discord/lib/api_exception.dart
@@ -70,6 +70,19 @@ extension ValidateNumber on num {
     if (multipleOf != null) validateMultipleOf(multipleOf);
   }
 
+  /// Validates that the value is one of [enumValues] — the members of a
+  /// nameless integer `enum`, which is generated as a newtype over `int`.
+  /// This is its own call rather than a [validate] argument: an int enum
+  /// never also carries range bounds, so membership is the only rule. Unlike
+  /// the range checks, an out-of-set value is a parse failure (the wire
+  /// carried a value the type does not name), so it throws [FormatException]
+  /// to match how a generated `fromJson` reports malformed input.
+  void validateEnumValues(List<num> enumValues) {
+    if (!enumValues.contains(this)) {
+      throw FormatException('$this is not one of $enumValues');
+    }
+  }
+
   void validateMinimum(num minimum) {
     if (this < minimum) {
       throw Exception('must be greater than or equal to $minimum');

--- a/gen_tests/third_party/discord/lib/models/add_lobby_member_request_flags_one_of_1.dart
+++ b/gen_tests/third_party/discord/lib/models/add_lobby_member_request_flags_one_of_1.dart
@@ -1,19 +1,14 @@
-enum AddLobbyMemberRequestFlagsOneOf1 {
-  value1._(1);
+import 'package:discord/api_exception.dart';
 
-  const AddLobbyMemberRequestFlagsOneOf1._(this.value);
-
-  /// Creates a AddLobbyMemberRequestFlagsOneOf1 from a json value.
-  factory AddLobbyMemberRequestFlagsOneOf1.fromJson(int json) {
-    return AddLobbyMemberRequestFlagsOneOf1.values.firstWhere(
-      (value) => value.value == json,
-      orElse: () => throw FormatException(
-        'Unknown AddLobbyMemberRequestFlagsOneOf1 value: $json',
-      ),
-    );
+extension type const AddLobbyMemberRequestFlagsOneOf1._(int value) {
+  AddLobbyMemberRequestFlagsOneOf1(this.value) {
+    value.validateEnumValues([1]);
   }
 
-  /// Convenience to create a nullable type from a nullable json value.
+  factory AddLobbyMemberRequestFlagsOneOf1.fromJson(int json) =>
+      AddLobbyMemberRequestFlagsOneOf1(json);
+
+  /// Convenience to create a nullable type from a nullable json object.
   /// Useful when parsing optional fields.
   static AddLobbyMemberRequestFlagsOneOf1? maybeFromJson(int? json) {
     if (json == null) {
@@ -22,14 +17,5 @@ enum AddLobbyMemberRequestFlagsOneOf1 {
     return AddLobbyMemberRequestFlagsOneOf1.fromJson(json);
   }
 
-  /// The value of the enum.  This is the exact value
-  /// from the OpenAPI spec and will be used for network transport.
-  final int value;
-
-  /// Converts the enum to its json value.
   int toJson() => value;
-
-  /// Returns the string form of the enum.
-  @override
-  String toString() => value.toString();
 }

--- a/gen_tests/third_party/discord/lib/models/bulk_lobby_member_request_flags_one_of_1.dart
+++ b/gen_tests/third_party/discord/lib/models/bulk_lobby_member_request_flags_one_of_1.dart
@@ -1,19 +1,14 @@
-enum BulkLobbyMemberRequestFlagsOneOf1 {
-  value1._(1);
+import 'package:discord/api_exception.dart';
 
-  const BulkLobbyMemberRequestFlagsOneOf1._(this.value);
-
-  /// Creates a BulkLobbyMemberRequestFlagsOneOf1 from a json value.
-  factory BulkLobbyMemberRequestFlagsOneOf1.fromJson(int json) {
-    return BulkLobbyMemberRequestFlagsOneOf1.values.firstWhere(
-      (value) => value.value == json,
-      orElse: () => throw FormatException(
-        'Unknown BulkLobbyMemberRequestFlagsOneOf1 value: $json',
-      ),
-    );
+extension type const BulkLobbyMemberRequestFlagsOneOf1._(int value) {
+  BulkLobbyMemberRequestFlagsOneOf1(this.value) {
+    value.validateEnumValues([1]);
   }
 
-  /// Convenience to create a nullable type from a nullable json value.
+  factory BulkLobbyMemberRequestFlagsOneOf1.fromJson(int json) =>
+      BulkLobbyMemberRequestFlagsOneOf1(json);
+
+  /// Convenience to create a nullable type from a nullable json object.
   /// Useful when parsing optional fields.
   static BulkLobbyMemberRequestFlagsOneOf1? maybeFromJson(int? json) {
     if (json == null) {
@@ -22,14 +17,5 @@ enum BulkLobbyMemberRequestFlagsOneOf1 {
     return BulkLobbyMemberRequestFlagsOneOf1.fromJson(json);
   }
 
-  /// The value of the enum.  This is the exact value
-  /// from the OpenAPI spec and will be used for network transport.
-  final int value;
-
-  /// Converts the enum to its json value.
   int toJson() => value;
-
-  /// Returns the string form of the enum.
-  @override
-  String toString() => value.toString();
 }

--- a/gen_tests/third_party/discord/lib/models/create_lobby_request_flags_one_of_1.dart
+++ b/gen_tests/third_party/discord/lib/models/create_lobby_request_flags_one_of_1.dart
@@ -1,19 +1,14 @@
-enum CreateLobbyRequestFlagsOneOf1 {
-  value1._(1);
+import 'package:discord/api_exception.dart';
 
-  const CreateLobbyRequestFlagsOneOf1._(this.value);
-
-  /// Creates a CreateLobbyRequestFlagsOneOf1 from a json value.
-  factory CreateLobbyRequestFlagsOneOf1.fromJson(int json) {
-    return CreateLobbyRequestFlagsOneOf1.values.firstWhere(
-      (value) => value.value == json,
-      orElse: () => throw FormatException(
-        'Unknown CreateLobbyRequestFlagsOneOf1 value: $json',
-      ),
-    );
+extension type const CreateLobbyRequestFlagsOneOf1._(int value) {
+  CreateLobbyRequestFlagsOneOf1(this.value) {
+    value.validateEnumValues([1]);
   }
 
-  /// Convenience to create a nullable type from a nullable json value.
+  factory CreateLobbyRequestFlagsOneOf1.fromJson(int json) =>
+      CreateLobbyRequestFlagsOneOf1(json);
+
+  /// Convenience to create a nullable type from a nullable json object.
   /// Useful when parsing optional fields.
   static CreateLobbyRequestFlagsOneOf1? maybeFromJson(int? json) {
     if (json == null) {
@@ -22,14 +17,5 @@ enum CreateLobbyRequestFlagsOneOf1 {
     return CreateLobbyRequestFlagsOneOf1.fromJson(json);
   }
 
-  /// The value of the enum.  This is the exact value
-  /// from the OpenAPI spec and will be used for network transport.
-  final int value;
-
-  /// Converts the enum to its json value.
   int toJson() => value;
-
-  /// Returns the string form of the enum.
-  @override
-  String toString() => value.toString();
 }

--- a/gen_tests/third_party/discord/lib/models/create_or_join_lobby_request_flags_one_of_1.dart
+++ b/gen_tests/third_party/discord/lib/models/create_or_join_lobby_request_flags_one_of_1.dart
@@ -1,19 +1,14 @@
-enum CreateOrJoinLobbyRequestFlagsOneOf1 {
-  value1._(1);
+import 'package:discord/api_exception.dart';
 
-  const CreateOrJoinLobbyRequestFlagsOneOf1._(this.value);
-
-  /// Creates a CreateOrJoinLobbyRequestFlagsOneOf1 from a json value.
-  factory CreateOrJoinLobbyRequestFlagsOneOf1.fromJson(int json) {
-    return CreateOrJoinLobbyRequestFlagsOneOf1.values.firstWhere(
-      (value) => value.value == json,
-      orElse: () => throw FormatException(
-        'Unknown CreateOrJoinLobbyRequestFlagsOneOf1 value: $json',
-      ),
-    );
+extension type const CreateOrJoinLobbyRequestFlagsOneOf1._(int value) {
+  CreateOrJoinLobbyRequestFlagsOneOf1(this.value) {
+    value.validateEnumValues([1]);
   }
 
-  /// Convenience to create a nullable type from a nullable json value.
+  factory CreateOrJoinLobbyRequestFlagsOneOf1.fromJson(int json) =>
+      CreateOrJoinLobbyRequestFlagsOneOf1(json);
+
+  /// Convenience to create a nullable type from a nullable json object.
   /// Useful when parsing optional fields.
   static CreateOrJoinLobbyRequestFlagsOneOf1? maybeFromJson(int? json) {
     if (json == null) {
@@ -22,14 +17,5 @@ enum CreateOrJoinLobbyRequestFlagsOneOf1 {
     return CreateOrJoinLobbyRequestFlagsOneOf1.fromJson(json);
   }
 
-  /// The value of the enum.  This is the exact value
-  /// from the OpenAPI spec and will be used for network transport.
-  final int value;
-
-  /// Converts the enum to its json value.
   int toJson() => value;
-
-  /// Returns the string form of the enum.
-  @override
-  String toString() => value.toString();
 }

--- a/gen_tests/third_party/discord/lib/models/edit_lobby_request_flags_one_of_1.dart
+++ b/gen_tests/third_party/discord/lib/models/edit_lobby_request_flags_one_of_1.dart
@@ -1,19 +1,14 @@
-enum EditLobbyRequestFlagsOneOf1 {
-  value1._(1);
+import 'package:discord/api_exception.dart';
 
-  const EditLobbyRequestFlagsOneOf1._(this.value);
-
-  /// Creates a EditLobbyRequestFlagsOneOf1 from a json value.
-  factory EditLobbyRequestFlagsOneOf1.fromJson(int json) {
-    return EditLobbyRequestFlagsOneOf1.values.firstWhere(
-      (value) => value.value == json,
-      orElse: () => throw FormatException(
-        'Unknown EditLobbyRequestFlagsOneOf1 value: $json',
-      ),
-    );
+extension type const EditLobbyRequestFlagsOneOf1._(int value) {
+  EditLobbyRequestFlagsOneOf1(this.value) {
+    value.validateEnumValues([1]);
   }
 
-  /// Convenience to create a nullable type from a nullable json value.
+  factory EditLobbyRequestFlagsOneOf1.fromJson(int json) =>
+      EditLobbyRequestFlagsOneOf1(json);
+
+  /// Convenience to create a nullable type from a nullable json object.
   /// Useful when parsing optional fields.
   static EditLobbyRequestFlagsOneOf1? maybeFromJson(int? json) {
     if (json == null) {
@@ -22,14 +17,5 @@ enum EditLobbyRequestFlagsOneOf1 {
     return EditLobbyRequestFlagsOneOf1.fromJson(json);
   }
 
-  /// The value of the enum.  This is the exact value
-  /// from the OpenAPI spec and will be used for network transport.
-  final int value;
-
-  /// Converts the enum to its json value.
   int toJson() => value;
-
-  /// Returns the string form of the enum.
-  @override
-  String toString() => value.toString();
 }

--- a/gen_tests/third_party/discord/lib/models/lobby_member_request_flags_one_of_1.dart
+++ b/gen_tests/third_party/discord/lib/models/lobby_member_request_flags_one_of_1.dart
@@ -1,19 +1,14 @@
-enum LobbyMemberRequestFlagsOneOf1 {
-  value1._(1);
+import 'package:discord/api_exception.dart';
 
-  const LobbyMemberRequestFlagsOneOf1._(this.value);
-
-  /// Creates a LobbyMemberRequestFlagsOneOf1 from a json value.
-  factory LobbyMemberRequestFlagsOneOf1.fromJson(int json) {
-    return LobbyMemberRequestFlagsOneOf1.values.firstWhere(
-      (value) => value.value == json,
-      orElse: () => throw FormatException(
-        'Unknown LobbyMemberRequestFlagsOneOf1 value: $json',
-      ),
-    );
+extension type const LobbyMemberRequestFlagsOneOf1._(int value) {
+  LobbyMemberRequestFlagsOneOf1(this.value) {
+    value.validateEnumValues([1]);
   }
 
-  /// Convenience to create a nullable type from a nullable json value.
+  factory LobbyMemberRequestFlagsOneOf1.fromJson(int json) =>
+      LobbyMemberRequestFlagsOneOf1(json);
+
+  /// Convenience to create a nullable type from a nullable json object.
   /// Useful when parsing optional fields.
   static LobbyMemberRequestFlagsOneOf1? maybeFromJson(int? json) {
     if (json == null) {
@@ -22,14 +17,5 @@ enum LobbyMemberRequestFlagsOneOf1 {
     return LobbyMemberRequestFlagsOneOf1.fromJson(json);
   }
 
-  /// The value of the enum.  This is the exact value
-  /// from the OpenAPI spec and will be used for network transport.
-  final int value;
-
-  /// Converts the enum to its json value.
   int toJson() => value;
-
-  /// Returns the string form of the enum.
-  @override
-  String toString() => value.toString();
 }

--- a/gen_tests/third_party/discord/test/gen/models/add_lobby_member_request_flags_one_of_1_test.dart
+++ b/gen_tests/third_party/discord/test/gen/models/add_lobby_member_request_flags_one_of_1_test.dart
@@ -5,7 +5,7 @@ import 'package:test/test.dart';
 void main() {
   group('AddLobbyMemberRequestFlagsOneOf1', () {
     test('round-trips via maybeFromJson/toJson', () {
-      const instance = AddLobbyMemberRequestFlagsOneOf1.value1;
+      final instance = AddLobbyMemberRequestFlagsOneOf1(1);
       final parsed = AddLobbyMemberRequestFlagsOneOf1.maybeFromJson(
         instance.toJson(),
       )!;
@@ -22,21 +22,6 @@ void main() {
         () => AddLobbyMemberRequestFlagsOneOf1.maybeFromJson(-1),
         throwsFormatException,
       );
-    });
-
-    test('toString matches toJson for every value', () {
-      for (final value in AddLobbyMemberRequestFlagsOneOf1.values) {
-        expect(value.toString(), equals(value.toJson().toString()));
-      }
-    });
-
-    test('fromJson round-trips every value', () {
-      for (final value in AddLobbyMemberRequestFlagsOneOf1.values) {
-        expect(
-          AddLobbyMemberRequestFlagsOneOf1.fromJson(value.toJson()),
-          equals(value),
-        );
-      }
     });
   });
 }

--- a/gen_tests/third_party/discord/test/gen/models/bulk_lobby_member_request_flags_one_of_1_test.dart
+++ b/gen_tests/third_party/discord/test/gen/models/bulk_lobby_member_request_flags_one_of_1_test.dart
@@ -5,7 +5,7 @@ import 'package:test/test.dart';
 void main() {
   group('BulkLobbyMemberRequestFlagsOneOf1', () {
     test('round-trips via maybeFromJson/toJson', () {
-      const instance = BulkLobbyMemberRequestFlagsOneOf1.value1;
+      final instance = BulkLobbyMemberRequestFlagsOneOf1(1);
       final parsed = BulkLobbyMemberRequestFlagsOneOf1.maybeFromJson(
         instance.toJson(),
       )!;
@@ -22,21 +22,6 @@ void main() {
         () => BulkLobbyMemberRequestFlagsOneOf1.maybeFromJson(-1),
         throwsFormatException,
       );
-    });
-
-    test('toString matches toJson for every value', () {
-      for (final value in BulkLobbyMemberRequestFlagsOneOf1.values) {
-        expect(value.toString(), equals(value.toJson().toString()));
-      }
-    });
-
-    test('fromJson round-trips every value', () {
-      for (final value in BulkLobbyMemberRequestFlagsOneOf1.values) {
-        expect(
-          BulkLobbyMemberRequestFlagsOneOf1.fromJson(value.toJson()),
-          equals(value),
-        );
-      }
     });
   });
 }

--- a/gen_tests/third_party/discord/test/gen/models/create_lobby_request_flags_one_of_1_test.dart
+++ b/gen_tests/third_party/discord/test/gen/models/create_lobby_request_flags_one_of_1_test.dart
@@ -5,7 +5,7 @@ import 'package:test/test.dart';
 void main() {
   group('CreateLobbyRequestFlagsOneOf1', () {
     test('round-trips via maybeFromJson/toJson', () {
-      const instance = CreateLobbyRequestFlagsOneOf1.value1;
+      final instance = CreateLobbyRequestFlagsOneOf1(1);
       final parsed = CreateLobbyRequestFlagsOneOf1.maybeFromJson(
         instance.toJson(),
       )!;
@@ -22,21 +22,6 @@ void main() {
         () => CreateLobbyRequestFlagsOneOf1.maybeFromJson(-1),
         throwsFormatException,
       );
-    });
-
-    test('toString matches toJson for every value', () {
-      for (final value in CreateLobbyRequestFlagsOneOf1.values) {
-        expect(value.toString(), equals(value.toJson().toString()));
-      }
-    });
-
-    test('fromJson round-trips every value', () {
-      for (final value in CreateLobbyRequestFlagsOneOf1.values) {
-        expect(
-          CreateLobbyRequestFlagsOneOf1.fromJson(value.toJson()),
-          equals(value),
-        );
-      }
     });
   });
 }

--- a/gen_tests/third_party/discord/test/gen/models/create_or_join_lobby_request_flags_one_of_1_test.dart
+++ b/gen_tests/third_party/discord/test/gen/models/create_or_join_lobby_request_flags_one_of_1_test.dart
@@ -5,7 +5,7 @@ import 'package:test/test.dart';
 void main() {
   group('CreateOrJoinLobbyRequestFlagsOneOf1', () {
     test('round-trips via maybeFromJson/toJson', () {
-      const instance = CreateOrJoinLobbyRequestFlagsOneOf1.value1;
+      final instance = CreateOrJoinLobbyRequestFlagsOneOf1(1);
       final parsed = CreateOrJoinLobbyRequestFlagsOneOf1.maybeFromJson(
         instance.toJson(),
       )!;
@@ -22,21 +22,6 @@ void main() {
         () => CreateOrJoinLobbyRequestFlagsOneOf1.maybeFromJson(-1),
         throwsFormatException,
       );
-    });
-
-    test('toString matches toJson for every value', () {
-      for (final value in CreateOrJoinLobbyRequestFlagsOneOf1.values) {
-        expect(value.toString(), equals(value.toJson().toString()));
-      }
-    });
-
-    test('fromJson round-trips every value', () {
-      for (final value in CreateOrJoinLobbyRequestFlagsOneOf1.values) {
-        expect(
-          CreateOrJoinLobbyRequestFlagsOneOf1.fromJson(value.toJson()),
-          equals(value),
-        );
-      }
     });
   });
 }

--- a/gen_tests/third_party/discord/test/gen/models/edit_lobby_request_flags_one_of_1_test.dart
+++ b/gen_tests/third_party/discord/test/gen/models/edit_lobby_request_flags_one_of_1_test.dart
@@ -5,7 +5,7 @@ import 'package:test/test.dart';
 void main() {
   group('EditLobbyRequestFlagsOneOf1', () {
     test('round-trips via maybeFromJson/toJson', () {
-      const instance = EditLobbyRequestFlagsOneOf1.value1;
+      final instance = EditLobbyRequestFlagsOneOf1(1);
       final parsed = EditLobbyRequestFlagsOneOf1.maybeFromJson(
         instance.toJson(),
       )!;
@@ -22,21 +22,6 @@ void main() {
         () => EditLobbyRequestFlagsOneOf1.maybeFromJson(-1),
         throwsFormatException,
       );
-    });
-
-    test('toString matches toJson for every value', () {
-      for (final value in EditLobbyRequestFlagsOneOf1.values) {
-        expect(value.toString(), equals(value.toJson().toString()));
-      }
-    });
-
-    test('fromJson round-trips every value', () {
-      for (final value in EditLobbyRequestFlagsOneOf1.values) {
-        expect(
-          EditLobbyRequestFlagsOneOf1.fromJson(value.toJson()),
-          equals(value),
-        );
-      }
     });
   });
 }

--- a/gen_tests/third_party/discord/test/gen/models/lobby_member_request_flags_one_of_1_test.dart
+++ b/gen_tests/third_party/discord/test/gen/models/lobby_member_request_flags_one_of_1_test.dart
@@ -5,7 +5,7 @@ import 'package:test/test.dart';
 void main() {
   group('LobbyMemberRequestFlagsOneOf1', () {
     test('round-trips via maybeFromJson/toJson', () {
-      const instance = LobbyMemberRequestFlagsOneOf1.value1;
+      final instance = LobbyMemberRequestFlagsOneOf1(1);
       final parsed = LobbyMemberRequestFlagsOneOf1.maybeFromJson(
         instance.toJson(),
       )!;
@@ -22,21 +22,6 @@ void main() {
         () => LobbyMemberRequestFlagsOneOf1.maybeFromJson(-1),
         throwsFormatException,
       );
-    });
-
-    test('toString matches toJson for every value', () {
-      for (final value in LobbyMemberRequestFlagsOneOf1.values) {
-        expect(value.toString(), equals(value.toJson().toString()));
-      }
-    });
-
-    test('fromJson round-trips every value', () {
-      for (final value in LobbyMemberRequestFlagsOneOf1.values) {
-        expect(
-          LobbyMemberRequestFlagsOneOf1.fromJson(value.toJson()),
-          equals(value),
-        );
-      }
     });
   });
 }

--- a/gen_tests/third_party/github/lib/api_exception.dart
+++ b/gen_tests/third_party/github/lib/api_exception.dart
@@ -70,6 +70,19 @@ extension ValidateNumber on num {
     if (multipleOf != null) validateMultipleOf(multipleOf);
   }
 
+  /// Validates that the value is one of [enumValues] — the members of a
+  /// nameless integer `enum`, which is generated as a newtype over `int`.
+  /// This is its own call rather than a [validate] argument: an int enum
+  /// never also carries range bounds, so membership is the only rule. Unlike
+  /// the range checks, an out-of-set value is a parse failure (the wire
+  /// carried a value the type does not name), so it throws [FormatException]
+  /// to match how a generated `fromJson` reports malformed input.
+  void validateEnumValues(List<num> enumValues) {
+    if (!enumValues.contains(this)) {
+      throw FormatException('$this is not one of $enumValues');
+    }
+  }
+
   void validateMinimum(num minimum) {
     if (this < minimum) {
       throw Exception('must be greater than or equal to $minimum');

--- a/gen_tests/third_party/petstore/lib/api_exception.dart
+++ b/gen_tests/third_party/petstore/lib/api_exception.dart
@@ -70,6 +70,19 @@ extension ValidateNumber on num {
     if (multipleOf != null) validateMultipleOf(multipleOf);
   }
 
+  /// Validates that the value is one of [enumValues] — the members of a
+  /// nameless integer `enum`, which is generated as a newtype over `int`.
+  /// This is its own call rather than a [validate] argument: an int enum
+  /// never also carries range bounds, so membership is the only rule. Unlike
+  /// the range checks, an out-of-set value is a parse failure (the wire
+  /// carried a value the type does not name), so it throws [FormatException]
+  /// to match how a generated `fromJson` reports malformed input.
+  void validateEnumValues(List<num> enumValues) {
+    if (!enumValues.contains(this)) {
+      throw FormatException('$this is not one of $enumValues');
+    }
+  }
+
   void validateMinimum(num minimum) {
     if (this < minimum) {
       throw Exception('must be greater than or equal to $minimum');

--- a/gen_tests/third_party/spacetraders/lib/api_exception.dart
+++ b/gen_tests/third_party/spacetraders/lib/api_exception.dart
@@ -70,6 +70,19 @@ extension ValidateNumber on num {
     if (multipleOf != null) validateMultipleOf(multipleOf);
   }
 
+  /// Validates that the value is one of [enumValues] — the members of a
+  /// nameless integer `enum`, which is generated as a newtype over `int`.
+  /// This is its own call rather than a [validate] argument: an int enum
+  /// never also carries range bounds, so membership is the only rule. Unlike
+  /// the range checks, an out-of-set value is a parse failure (the wire
+  /// carried a value the type does not name), so it throws [FormatException]
+  /// to match how a generated `fromJson` reports malformed input.
+  void validateEnumValues(List<num> enumValues) {
+    if (!enumValues.contains(this)) {
+      throw FormatException('$this is not one of $enumValues');
+    }
+  }
+
   void validateMinimum(num minimum) {
     if (this < minimum) {
       throw Exception('must be greater than or equal to $minimum');

--- a/gen_tests/third_party/train_travel/lib/api_exception.dart
+++ b/gen_tests/third_party/train_travel/lib/api_exception.dart
@@ -70,6 +70,19 @@ extension ValidateNumber on num {
     if (multipleOf != null) validateMultipleOf(multipleOf);
   }
 
+  /// Validates that the value is one of [enumValues] — the members of a
+  /// nameless integer `enum`, which is generated as a newtype over `int`.
+  /// This is its own call rather than a [validate] argument: an int enum
+  /// never also carries range bounds, so membership is the only rule. Unlike
+  /// the range checks, an out-of-set value is a parse failure (the wire
+  /// carried a value the type does not name), so it throws [FormatException]
+  /// to match how a generated `fromJson` reports malformed input.
+  void validateEnumValues(List<num> enumValues) {
+    if (!enumValues.contains(this)) {
+      throw FormatException('$this is not one of $enumValues');
+    }
+  }
+
   void validateMinimum(num minimum) {
     if (this < minimum) {
       throw Exception('must be greater than or equal to $minimum');

--- a/gen_tests/types.json
+++ b/gen_tests/types.json
@@ -45,6 +45,9 @@
                                         },
                                         "stock": {
                                             "$ref": "#/components/schemas/StockStatus"
+                                        },
+                                        "priority": {
+                                            "$ref": "#/components/schemas/Priority"
                                         }
                                     },
                                     "required": [
@@ -90,6 +93,11 @@
                 "type": "string",
                 "description": "Values whose sanitized identifiers collide — `in stock` and `in-stock` both reduce to the same identifier. The generated enum must disambiguate rather than declare it twice.",
                 "enum": ["in stock", "in-stock", "out of stock"]
+            },
+            "Priority": {
+                "type": "integer",
+                "description": "An integer enum — a closed set of int values. Renders as a validated int newtype (not a Dart enum); the generated round-trip test also exercises the membership check throwing FormatException on an out-of-set value.",
+                "enum": [1, 2, 3]
             },
             "Widget": {
                 "type": "object",

--- a/gen_tests/types/lib/api.dart
+++ b/gen_tests/types/lib/api.dart
@@ -3,6 +3,7 @@ export 'package:types/api_client.dart';
 export 'package:types/api_exception.dart';
 export 'package:types/date.dart';
 export 'package:types/model/email_type.dart';
+export 'package:types/model/priority.dart';
 export 'package:types/model/status.dart';
 export 'package:types/model/stock_status.dart';
 export 'package:types/model/timestamp.dart';

--- a/gen_tests/types/lib/api_exception.dart
+++ b/gen_tests/types/lib/api_exception.dart
@@ -70,6 +70,19 @@ extension ValidateNumber on num {
     if (multipleOf != null) validateMultipleOf(multipleOf);
   }
 
+  /// Validates that the value is one of [enumValues] — the members of a
+  /// nameless integer `enum`, which is generated as a newtype over `int`.
+  /// This is its own call rather than a [validate] argument: an int enum
+  /// never also carries range bounds, so membership is the only rule. Unlike
+  /// the range checks, an out-of-set value is a parse failure (the wire
+  /// carried a value the type does not name), so it throws [FormatException]
+  /// to match how a generated `fromJson` reports malformed input.
+  void validateEnumValues(List<num> enumValues) {
+    if (!enumValues.contains(this)) {
+      throw FormatException('$this is not one of $enumValues');
+    }
+  }
+
   void validateMinimum(num minimum) {
     if (this < minimum) {
       throw Exception('must be greater than or equal to $minimum');

--- a/gen_tests/types/lib/model/priority.dart
+++ b/gen_tests/types/lib/model/priority.dart
@@ -1,0 +1,23 @@
+import 'package:types/api_exception.dart';
+
+/// An integer enum — a closed set of int values. Renders as a validated int
+/// newtype (not a Dart enum); the generated round-trip test also exercises the
+/// membership check throwing FormatException on an out-of-set value.
+extension type const Priority._(int value) {
+  Priority(this.value) {
+    value.validateEnumValues([1, 2, 3]);
+  }
+
+  factory Priority.fromJson(int json) => Priority(json);
+
+  /// Convenience to create a nullable type from a nullable json object.
+  /// Useful when parsing optional fields.
+  static Priority? maybeFromJson(int? json) {
+    if (json == null) {
+      return null;
+    }
+    return Priority.fromJson(json);
+  }
+
+  int toJson() => value;
+}

--- a/gen_tests/types/lib/model/types200_response.dart
+++ b/gen_tests/types/lib/model/types200_response.dart
@@ -1,5 +1,6 @@
 import 'package:types/date.dart';
 import 'package:types/model/email_type.dart';
+import 'package:types/model/priority.dart';
 import 'package:types/model/status.dart';
 import 'package:types/model/stock_status.dart';
 import 'package:types/model/timestamp.dart';
@@ -17,6 +18,7 @@ class Types200Response {
     required this.widget,
     required this.status,
     this.stock,
+    this.priority,
   });
 
   /// Converts a `Map<String, dynamic>` to a [Types200Response].
@@ -34,6 +36,7 @@ class Types200Response {
         widget: Widget.fromJson(json['widget'] as Map<String, dynamic>),
         status: Status.fromJson(json['status'] as String),
         stock: StockStatus.maybeFromJson(json['stock'] as String?),
+        priority: Priority.maybeFromJson(json['priority'] as int?),
       ),
     );
   }
@@ -63,6 +66,11 @@ class Types200Response {
   /// rather than declare it twice.
   StockStatus? stock;
 
+  /// An integer enum — a closed set of int values. Renders as a validated int
+  /// newtype (not a Dart enum); the generated round-trip test also exercises
+  /// the membership check throwing FormatException on an out-of-set value.
+  Priority? priority;
+
   /// Converts a [Types200Response] to a `Map<String, dynamic>`.
   Map<String, dynamic> toJson() {
     return {
@@ -74,6 +82,7 @@ class Types200Response {
       'widget': widget.toJson(),
       'status': status.toJson(),
       'stock': ?stock?.toJson(),
+      'priority': ?priority?.toJson(),
     };
   }
 
@@ -87,6 +96,7 @@ class Types200Response {
     widget,
     status,
     stock,
+    priority,
   ]);
 
   @override
@@ -100,6 +110,7 @@ class Types200Response {
         timestamp == other.timestamp &&
         widget == other.widget &&
         status == other.status &&
-        stock == other.stock;
+        stock == other.stock &&
+        priority == other.priority;
   }
 }

--- a/gen_tests/types/test/gen/model/priority_test.dart
+++ b/gen_tests/types/test/gen/model/priority_test.dart
@@ -1,0 +1,22 @@
+// GENERATED — do not hand-edit.
+import 'package:test/test.dart';
+import 'package:types/api.dart';
+
+void main() {
+  group('Priority', () {
+    test('round-trips via maybeFromJson/toJson', () {
+      final instance = Priority(1);
+      final parsed = Priority.maybeFromJson(instance.toJson())!;
+      expect(parsed, equals(instance));
+      expect(parsed.hashCode, equals(instance.hashCode));
+    });
+
+    test('maybeFromJson returns null on null input', () {
+      expect(Priority.maybeFromJson(null), isNull);
+    });
+
+    test('maybeFromJson throws FormatException on invalid input', () {
+      expect(() => Priority.maybeFromJson(-1), throwsFormatException);
+    });
+  });
+}

--- a/gen_tests/unsupported_auth/lib/api_exception.dart
+++ b/gen_tests/unsupported_auth/lib/api_exception.dart
@@ -70,6 +70,19 @@ extension ValidateNumber on num {
     if (multipleOf != null) validateMultipleOf(multipleOf);
   }
 
+  /// Validates that the value is one of [enumValues] — the members of a
+  /// nameless integer `enum`, which is generated as a newtype over `int`.
+  /// This is its own call rather than a [validate] argument: an int enum
+  /// never also carries range bounds, so membership is the only rule. Unlike
+  /// the range checks, an out-of-set value is a parse failure (the wire
+  /// carried a value the type does not name), so it throws [FormatException]
+  /// to match how a generated `fromJson` reports malformed input.
+  void validateEnumValues(List<num> enumValues) {
+    if (!enumValues.contains(this)) {
+      throw FormatException('$this is not one of $enumValues');
+    }
+  }
+
   void validateMinimum(num minimum) {
     if (this < minimum) {
       throw Exception('must be greater than or equal to $minimum');

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -656,16 +656,29 @@ class SpecResolver {
           assignedSnakeName: _snakeFor(schema.pointer),
         );
       case ResolvedIntEnum():
-        // An int enum has no value-derived name (`value1`); a spec `title:`
-        // rescues it (`blockMessage`).
         final intNames = schema.names;
-        return RenderIntEnum(
+        // The name split decides the representation. When the spec gives the
+        // members meaningful names — Discord's `oneOf` of `const`s with a
+        // `title:` (`BLOCK_MESSAGE` -> `blockMessage`) — a Dart enum earns
+        // its keep, exactly as for a string enum. When it doesn't, the only
+        // names available are synthetic `value<N>` that carry nothing the
+        // int doesn't, so a validated int newtype (an `extension type` over
+        // `int` whose constructor checks membership) reads better and matches
+        // the other validated-scalar newtypes. See #352.
+        if (intNames != null) {
+          return RenderIntEnum(
+            common: schema.common,
+            values: schema.values,
+            names: RenderEnum.variableNamesFor(quirks, intNames),
+            descriptions: schema.descriptions,
+            defaultValue: schema.defaultValue,
+            assignedName: _nameFor(schema.pointer),
+            assignedSnakeName: _snakeFor(schema.pointer),
+          );
+        }
+        return RenderIntNewtype(
           common: schema.common,
-          values: schema.values,
-          names: intNames != null
-              ? RenderEnum.variableNamesFor(quirks, intNames)
-              : RenderEnum.variableNamesForInts(schema.values),
-          descriptions: schema.descriptions,
+          allowedValues: schema.values,
           defaultValue: schema.defaultValue,
           assignedName: _nameFor(schema.pointer),
           assignedSnakeName: _snakeFor(schema.pointer),
@@ -869,7 +882,7 @@ class SpecResolver {
           valueSchema: toRenderSchema(schema.valueSchema),
           keySchema: keyEnum == null
               ? null
-              : toRenderSchema(keyEnum) as RenderEnum,
+              : toRenderSchema(keyEnum) as RenderStringEnum,
         );
       case ResolvedEmptyObject():
         return RenderEmptyObject(
@@ -3197,53 +3210,6 @@ abstract class RenderSchema extends Equatable implements ToTemplateContext {
     isConstConstructor: false,
   );
 
-  // --- Map-key wire bridging ---------------------------------------------
-  //
-  // JSON object keys are always strings on the wire, but a [RenderMap] key
-  // type's own wire form (its [jsonStorageDartType]) need not be: today an
-  // int-valued enum decodes from `int`. So a key whose wire form is
-  // non-string is bridged through `int.parse` on the way in and
-  // `.toString()` on the way out; a string-wire key passes straight
-  // through. Keyed off the general wire type rather than the concrete class
-  // so it reads as a property of any scalar key. Only meaningful on the
-  // schemas the resolver admits as map keys — like [_fromJsonCall], total
-  // on every schema but only ever called where valid.
-  //
-  // The non-string branch exists solely because an int-valued *enum* is the
-  // only non-string map-key type the generator produces. Once integer enums
-  // become validated int newtypes and stop being usable as typed map keys
-  // (https://github.com/eseidel/space_gen/issues/352), every remaining map
-  // key is a string enum and this bridging can be deleted.
-
-  /// Decode a JSON object key (always a `String`) into this schema's Dart
-  /// type, bridging the string to a non-string wire form first.
-  DartExpression fromJsonMapKey(DartExpression key) =>
-      _fromJsonCall(_stringKeyToWire(key), jsonIsNullable: false);
-
-  /// Encode this schema as a JSON object key, which must be a `String`.
-  /// `toJson` yields the wire value — already a `String` for a string-wire
-  /// key, a non-string (e.g. `int`) otherwise — so stringify the non-string
-  /// case back to a valid key. The inverse of [fromJsonMapKey].
-  DartExpression toJsonMapKey(DartExpression key) {
-    final wire = DartMethodCall(target: key, name: 'toJson');
-    return jsonStorageDartType == DartType.string
-        ? wire
-        : DartMethodCall(target: wire, name: 'toString');
-  }
-
-  /// Bridge a `String` JSON object key to this schema's wire type, so a
-  /// non-string wire type can parse it (e.g. `int.parse`). No-op for a
-  /// string-wire key.
-  DartExpression _stringKeyToWire(DartExpression key) =>
-      jsonStorageDartType == DartType.string
-      ? key
-      : DartInvocation(
-          type: jsonStorageDartType,
-          constructorName: 'parse',
-          arguments: [key],
-          isConstConstructor: false,
-        );
-
   /// A Dart expression that constructs a valid in-memory instance of
   /// this schema, used by generated round-trip tests. Returns `null`
   /// when the generator cannot produce a safe example — e.g. a
@@ -4619,9 +4585,27 @@ class RenderObject extends RenderNewType {
     required Object constValue,
     required SchemaRenderer context,
   }) {
-    final constExpression = property is RenderEnum
-        ? property.constExpression(constValue)
-        : serializeExpression(DartLiteral(constValue), isConstContext: true);
+    final String constExpression;
+    if (property is RenderEnum) {
+      constExpression = property.constExpression(constValue);
+    } else if (property is RenderIntNewtype) {
+      // Wrap the pinned int in the newtype's (validating, non-const)
+      // constructor so the getter's declared type matches its value —
+      // `CallbackType get type => CallbackType(1);`.
+      constExpression = serializeExpression(
+        DartInvocation(
+          type: property.dartType,
+          arguments: [DartLiteral(constValue)],
+          isConstConstructor: false,
+        ),
+        isConstContext: false,
+      );
+    } else {
+      constExpression = serializeExpression(
+        DartLiteral(constValue),
+        isConstContext: true,
+      );
+    }
     return {
       'dartName': dartName,
       'jsonName': quoteString(jsonName),
@@ -4935,19 +4919,21 @@ class RenderObject extends RenderNewType {
   bool rendersAsConstGetter(String jsonName, RenderSchema property) =>
       constProperties[jsonName] != null && _isConstGetterType(property);
 
-  /// The render types a const getter can pin: a named enum (returns
-  /// `E.member`) or a plain string/int scalar (returns the literal). The
-  /// bare-inline-`const` parser strips its property down to one of the
-  /// scalars, so those are the only extra shapes reachable here.
+  /// The render types a const getter can pin: a named string enum (returns
+  /// `E.member`), a closed-set int newtype (returns `E(value)`), or a plain
+  /// inline string/int scalar (returns the literal). The bare-inline-`const`
+  /// parser strips its property down to one of the scalars, so those are the
+  /// only extra shapes reachable here.
   ///
-  /// The scalars must be inline (`createsNewType == false`): the literal
-  /// getter is typed as the scalar's `typeName`, so `String get x => 'a'`
-  /// is only sound when that name is the built-in `String`/`int`. A named
-  /// scalar newtype (e.g. an `allOf: [{$ref: StringNewtype}]` + `const`)
-  /// would type the getter as the wrapper while returning a raw literal —
-  /// which wouldn't compile — so it keeps the stored-field shape.
+  /// [RenderIntNewtype] is admitted because its getter returns a properly
+  /// typed `E(value)`, not a raw literal. Other named scalar newtypes are
+  /// not: an inline scalar getter returns a raw literal (`String get x =>
+  /// 'a'`), which only type-checks when the getter's type is the built-in
+  /// `String`/`int`; a wrapper-typed getter returning a raw literal wouldn't
+  /// compile, so those keep the stored-field shape (`createsNewType` gate).
   static bool _isConstGetterType(RenderSchema property) =>
       property is RenderEnum ||
+      property is RenderIntNewtype ||
       ((property is RenderString || property is RenderInteger) &&
           !property.createsNewType);
 
@@ -5303,17 +5289,10 @@ class RenderMap extends RenderSchema {
 
   final RenderSchema valueSchema;
 
-  /// Optional typed key schema. JSON always uses string keys on the wire;
-  /// when non-null the generated Dart uses this schema as the map key and
-  /// its `fromJsonMapKey`/`toJsonMapKey` round-trips each key at the
-  /// boundary (bridging non-string wire forms — see [RenderSchema]).
-  ///
-  /// Typed as [RenderEnum] because the resolver admits only enums here. The
-  /// sole non-string case is an int-valued enum; once integer enums become
-  /// validated int newtypes and drop out as typed keys
-  /// (https://github.com/eseidel/space_gen/issues/352), every key is a
-  /// string enum and the non-string bridging goes away.
-  final RenderEnum? keySchema;
+  /// Optional typed key schema. JSON object keys are strings on the wire, so
+  /// only a string enum can type a key — its `fromJson`/`toJson` round-trip
+  /// each key directly. When null, the map has plain `String` keys.
+  final RenderStringEnum? keySchema;
 
   @override
   Iterable<RenderSchema> get children {
@@ -5362,10 +5341,9 @@ class RenderMap extends RenderSchema {
         toJson: 'value',
       );
     }
-    const k = DartIdentifier('k');
     final keyFromJson = keyEnum == null
         ? 'k'
-        : _runtimeSource(keyEnum.fromJsonMapKey(k));
+        : '${keyEnum.typeName}.fromJson(k)';
     final valueFromJson = _runtimeSource(
       value.requireFromJsonExpression(
         const DartIdentifier('val'),
@@ -5374,9 +5352,7 @@ class RenderMap extends RenderSchema {
         dartIsNullable: false,
       ),
     );
-    final keyToJson = keyEnum == null
-        ? 'k'
-        : _runtimeSource(keyEnum.toJsonMapKey(k));
+    final keyToJson = keyEnum == null ? 'k' : 'k.toJson()';
     final valueToJson = value.toJsonExpression(
       const DartIdentifier('val'),
       context,
@@ -5417,8 +5393,11 @@ class RenderMap extends RenderSchema {
   }) {
     const key = DartIdentifier('key');
     const value = DartIdentifier('value');
-    final keySchema = this.keySchema;
-    final keyToJson = keySchema == null ? key : keySchema.toJsonMapKey(key);
+    // A string-enum key serializes via its `toJson`; a plain String key is
+    // already the wire form.
+    final keyToJson = keySchema == null
+        ? key
+        : const DartMethodCall(target: key, name: 'toJson');
     final valueToJson = valueSchema.toJsonExpression(
       value,
       context,
@@ -5457,7 +5436,11 @@ class RenderMap extends RenderSchema {
     const key = DartIdentifier('key');
     const value = DartIdentifier('value');
     final keySchema = this.keySchema;
-    final keyFromJson = keySchema == null ? key : keySchema.fromJsonMapKey(key);
+    // A string-enum key parses via its `fromJson`; a plain String key is
+    // already the wire form.
+    final keyFromJson = keySchema == null
+        ? key
+        : keySchema._fromJsonCall(key, jsonIsNullable: false);
     final valueFromJson = valueSchema.requireFromJsonExpression(
       value,
       context,
@@ -5513,11 +5496,12 @@ class RenderMap extends RenderSchema {
   }
 }
 
-/// Render-tree counterpart to [ResolvedEnum]. Same generic-with-typed-
-/// subclasses pattern: parameterized abstract base, [RenderStringEnum]
-/// and [RenderIntEnum] pin [T]. Branch points where Dart-emission
-/// differs (literal form, JSON storage type, invalid-JSON sentinel)
-/// become abstract methods on the parent.
+/// Render-tree counterpart to [ResolvedEnum], for the enums that stay Dart
+/// enums: string enums, and integer enums whose members have meaningful
+/// spec-provided names ([RenderStringEnum] / [RenderIntEnum]). A nameless
+/// integer enum renders as a [RenderIntNewtype] instead (#352). Branch points
+/// where Dart-emission differs (literal form, JSON storage type, invalid-JSON
+/// sentinel) become abstract methods on the parent.
 abstract class RenderEnum<T extends Object> extends RenderNewType {
   const RenderEnum({
     required super.common,
@@ -5564,8 +5548,7 @@ abstract class RenderEnum<T extends Object> extends RenderNewType {
   /// non-ASCII `μ` is dropped; the second becomes `g2`. The first
   /// occurrence keeps the bare name; each later duplicate takes the
   /// smallest free numeric suffix (`g`, `g2`, `g3`). No underscore — the
-  /// suffix stays lowerCamelCase, matching [variableNamesForInts]'
-  /// `value<N>` form.
+  /// suffix stays lowerCamelCase.
   static List<String> _uniqueNames(List<String> names) {
     final seen = <String>{};
     final result = <String>[];
@@ -5579,16 +5562,6 @@ abstract class RenderEnum<T extends Object> extends RenderNewType {
       result.add(unique);
     }
     return result;
-  }
-
-  /// Variable names for an int-valued enum. Defaults to `value<N>`
-  /// (e.g. `value1`, `value11`) — not great for multi-value enums in
-  /// principle, but in the common case (single-value discriminator
-  /// tags) this is unambiguous and the variant is rarely referenced
-  /// by name in user code anyway.
-  @visibleForTesting
-  static List<String> variableNamesForInts(List<int> values) {
-    return values.map((v) => v >= 0 ? 'value$v' : 'valueNeg${-v}').toList();
   }
 
   @override
@@ -5751,6 +5724,11 @@ class RenderStringEnum extends RenderEnum<String> {
       "'__invalid_enum_value__'";
 }
 
+/// An integer `enum` whose members have meaningful spec-provided names
+/// (Discord's `oneOf` of `const`s with a `title:`), so it stays a Dart enum
+/// — the same call as a string enum. A nameless integer enum, whose only
+/// names would be synthetic `value<N>`, renders as a [RenderIntNewtype]
+/// instead (see the routing in `toRenderSchema` and #352).
 class RenderIntEnum extends RenderEnum<int> {
   const RenderIntEnum({
     required super.common,
@@ -5777,6 +5755,85 @@ class RenderIntEnum extends RenderEnum<int> {
     if (!values.contains(-1)) return '-1';
     return '-999999';
   }
+}
+
+/// A nameless integer `enum` — a closed set of allowed int values — rendered
+/// as a validated int newtype rather than a Dart enum. Emits the same
+/// `schema_number_newtype` `extension type` as a bounded integer newtype
+/// (it *is* a [RenderInteger]), but with a set-membership validation and
+/// the oneOf-variant behavior of the enum it replaces.
+///
+/// A bounded numeric newtype gates [wrapperTag]/[jsonShapeKey]/
+/// [_variantConversion] on `!createsNewType` (a plain scalar newtype is
+/// referenced by name, not shape-dispatched). A closed-set int, like the
+/// Dart enum it supersedes, *is* shape-dispatchable — matched by
+/// `json is int` and wrapped under its own type name in a oneOf — so these
+/// are un-gated here. Keeping [ResolvedIntEnum] through the resolve layer
+/// means the oneOf dispatch/naming is unchanged; only this type's own file
+/// flips from `enum` to `extension type`. See #352.
+class RenderIntNewtype extends RenderInteger {
+  const RenderIntNewtype({
+    required super.common,
+    required this.allowedValues,
+    super.defaultValue,
+    super.assignedName,
+    super.assignedSnakeName,
+  }) : super(
+         maximum: null,
+         minimum: null,
+         exclusiveMaximum: null,
+         exclusiveMinimum: null,
+         multipleOf: null,
+         createsNewType: true,
+       );
+
+  /// The set of int values the spec's `enum` allows, in spec order.
+  /// Rendered as a `value.validate(enumValues: [...])` membership check.
+  final List<int> allowedValues;
+
+  @override
+  List<Object?> get props => [super.props, allowedValues];
+
+  // A dedicated membership check rather than the multi-bound `validate(...)`
+  // sugar: an int enum never carries min/max/multipleOf (the parser routes
+  // `enum` away from the bounded-numeric path), so membership is the sole
+  // rule and reads better called directly.
+  @override
+  String? get validationCall =>
+      'validateEnumValues([${allowedValues.join(', ')}])';
+
+  @override
+  String? get wrapperTag => typeName;
+
+  @override
+  String? get jsonShapeKey => 'int';
+
+  @override
+  _VariantConversion? _variantConversion(SchemaRenderer context) =>
+      _newtypeConversion(typeName);
+
+  @override
+  DartExpression? exampleValue(SchemaRenderer context) =>
+      newtypeWrappedExample(DartLiteral(allowedValues.first));
+
+  @override
+  String? invalidJsonExample(SchemaRenderer context) {
+    // A value outside the allowed set. -1 works for almost every real spec
+    // (int enums use small non-negative values — bitfield flags, tags);
+    // fall back to a distinctly-large negative if -1 is itself allowed.
+    if (!allowedValues.contains(-1)) return '-1';
+    return '-999999';
+  }
+
+  // The allowed set is what distinguishes one closed-set int from another
+  // (and from a plain bounded integer), so structural equality must compare
+  // it — otherwise two different int enums would dedupe together in the
+  // import-collection pass. RenderNumeric.equalsIgnoringName ignores it.
+  @override
+  bool equalsIgnoringName(RenderSchema other) =>
+      other is RenderIntNewtype &&
+      const ListEquality<int>().equals(allowedValues, other.allowedValues) &&
+      super.equalsIgnoringName(other);
 }
 
 class RenderOneOf extends RenderNewType {

--- a/lib/src/render/schema_renderer.dart
+++ b/lib/src/render/schema_renderer.dart
@@ -67,11 +67,12 @@ class SchemaUsage {
     );
   }
 
-  /// Matches the `validate(...)` extension-method call. The
-  /// `api_exception.dart` file declares `validate` as extensions on
-  /// `String` / `num` / `List<T>`; a body that calls one needs to
-  /// import that file.
-  static final _validationCallPattern = RegExp(r'\.validate\(');
+  /// Matches an `api_exception.dart` validation extension call — the
+  /// combined `validate(...)` or a single-rule variant like
+  /// `validateEnumValues(...)`. Those are declared as extensions on
+  /// `String` / `num` / `List<T>`; a body that calls one needs to import
+  /// that file.
+  static final _validationCallPattern = RegExp(r'\.validate[A-Za-z]*\(');
 
   final bool usesMetaAnnotations;
 

--- a/lib/src/resolver.dart
+++ b/lib/src/resolver.dart
@@ -533,19 +533,34 @@ ResolvedSchema _resolveSchemaFully(
   }
   if (schema is SchemaMap) {
     final keyRef = schema.keySchema;
-    final keySchema = keyRef == null ? null : resolveSchemaRef(keyRef, context);
-    if (keySchema != null && keySchema is! ResolvedEnum) {
+    final resolvedKey = keyRef == null
+        ? null
+        : resolveSchemaRef(keyRef, context);
+    // Only a string enum can type a JSON map key: keys are strings on the
+    // wire, and a string enum's fromJson/toJson round-trip them directly.
+    ResolvedStringEnum? keySchema;
+    if (resolvedKey is ResolvedStringEnum) {
+      keySchema = resolvedKey;
+    } else if (resolvedKey is ResolvedIntEnum) {
+      // An int enum renders as a value newtype, not an enum, and can't
+      // carry a string key; drop back to plain String keys.
+      _warn(
+        'propertyNames resolves to an integer enum, which cannot type a '
+        'map key (JSON object keys are strings). Using String keys instead.',
+        schema.pointer,
+      );
+    } else if (resolvedKey != null) {
       _error(
-        'propertyNames must resolve to an enum for a map-typed '
-        r'schema. Either use a $ref to a named enum or an inline '
-        'enum. Got: ${keySchema.runtimeType}',
+        'propertyNames must resolve to a string enum for a map-typed '
+        r'schema. Either use a $ref to a named string enum or an inline '
+        'string enum. Got: ${resolvedKey.runtimeType}',
         schema.pointer,
       );
     }
     return ResolvedMap(
       common: resolvedCommon,
       valueSchema: resolveSchemaRef(schema.valueSchema, context),
-      keySchema: keySchema as ResolvedEnum?,
+      keySchema: keySchema,
       createsNewType: createsNewType,
     );
   }
@@ -1875,10 +1890,10 @@ class ResolvedMap extends ResolvedSchema {
 
   final ResolvedSchema valueSchema;
 
-  /// Optional typed key schema. Must resolve to an enum (string- or
-  /// int-valued); an int enum's string JSON key is bridged through
-  /// `int.parse` at the render layer.
-  final ResolvedEnum? keySchema;
+  /// Optional typed key schema. Must resolve to a string enum — JSON object
+  /// keys are strings, and only a string enum can round-trip them as a typed
+  /// key. Int enums render as value newtypes and fall back to `String` keys.
+  final ResolvedStringEnum? keySchema;
 
   @override
   ResolvedMap copyWith({CommonProperties? common}) {

--- a/lib/templates/api_exception.dart
+++ b/lib/templates/api_exception.dart
@@ -70,6 +70,19 @@ extension ValidateNumber on num {
     if (multipleOf != null) validateMultipleOf(multipleOf);
   }
 
+  /// Validates that the value is one of [enumValues] — the members of a
+  /// nameless integer `enum`, which is generated as a newtype over `int`.
+  /// This is its own call rather than a [validate] argument: an int enum
+  /// never also carries range bounds, so membership is the only rule. Unlike
+  /// the range checks, an out-of-set value is a parse failure (the wire
+  /// carried a value the type does not name), so it throws [FormatException]
+  /// to match how a generated `fromJson` reports malformed input.
+  void validateEnumValues(List<num> enumValues) {
+    if (!enumValues.contains(this)) {
+      throw FormatException('$this is not one of $enumValues');
+    }
+  }
+
   void validateMinimum(num minimum) {
     if (this < minimum) {
       throw Exception('must be greater than or equal to $minimum');

--- a/test/render/file_renderer_test.dart
+++ b/test/render/file_renderer_test.dart
@@ -741,12 +741,13 @@ void main() {
     });
 
     test(
-      'int enum toString test compares against the stringified value',
+      'named int enum toString test compares against the stringified value',
       () async {
-        // For an int enum `toString()` is a String but `toJson()` is an int, so
-        // comparing them directly is a type category error that always fails.
-        // Compare against the stringified wire value instead — type-safe, and
-        // it keeps `toString()` covered.
+        // A named int enum (member titles) stays a Dart enum, so it gets the
+        // value-iteration round-trip test. There `toString()` is a String but
+        // `toJson()` is an int, so comparing them directly is a type category
+        // error that always fails. Compare against the stringified wire value
+        // instead — type-safe, and it keeps `toString()` covered.
         final fs = MemoryFileSystem.test();
         final spec = {
           'openapi': '3.1.0',
@@ -775,7 +776,11 @@ void main() {
             'schemas': {
               'Level': {
                 'type': 'integer',
-                'enum': [1, 2, 3],
+                'oneOf': [
+                  {'title': 'LOW', 'const': 1},
+                  {'title': 'MEDIUM', 'const': 2},
+                  {'title': 'HIGH', 'const': 3},
+                ],
               },
             },
           },
@@ -788,10 +793,7 @@ void main() {
         // The toString test is present (so toString() stays covered)...
         expect(body, contains('toString matches toJson for every value'));
         // ...comparing against the stringified wire value, not the raw int...
-        expect(
-          body,
-          contains('equals(value.toJson().toString())'),
-        );
+        expect(body, contains('equals(value.toJson().toString())'));
         // ...and the fromJson round-trip check stays too.
         expect(body, contains('fromJson round-trips every value'));
         expect(body, contains('Level.fromJson(value.toJson())'));

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -189,6 +189,38 @@ void main() {
       expect(r, contains('MapEntry(key.toJson(), value.toJson())'));
     });
 
+    test(
+      'a typed-map-keyed map round-trips its key enum as a oneOf variant',
+      () {
+        // A map with a string-enum key appearing as a `oneOf` variant exercises
+        // RenderMap._variantConversion: the key round-trips through the enum's
+        // fromJson/toJson inside the union's conversion.
+        final schemas = <String, Map<String, dynamic>>{
+          'Platform': {
+            'type': 'string',
+            'enum': ['android', 'ios'],
+          },
+          'U': {
+            'oneOf': [
+              {
+                'type': 'object',
+                'additionalProperties': {'type': 'string'},
+                'propertyNames': {r'$ref': '#/components/schemas/Platform'},
+              },
+              {'type': 'integer'},
+            ],
+          },
+        };
+        final rendered = renderTestSchemas(
+          schemas,
+          specUrl: Uri.parse('file:///spec.yaml'),
+        );
+        final u = rendered['U']!;
+        expect(u, contains('Platform.fromJson(k)'));
+        expect(u, contains('k.toJson()'));
+      },
+    );
+
     test('propertyNames with an int enum falls back to String keys', () {
       // An integer enum renders as a value newtype, not an enum, so it can't
       // type a JSON map key (keys are strings on the wire). The map degrades
@@ -1296,6 +1328,36 @@ void main() {
       expect(rule, contains('TriggerType get triggerType =>'));
       expect(rule, contains("'trigger_type': triggerType.toJson()"));
       expect(rule, isNot(contains('triggerType?.toJson()')));
+    });
+
+    test('const getter pins a named string enum to its member', () {
+      // A string enum pinned to one value via the allOf-ref idiom renders a
+      // fixed getter returning the enum member (`State.active`) — the
+      // Dart-enum const-getter branch, distinct from the int-newtype `E(v)`
+      // form used for a nameless int enum.
+      final results = renderTestSchemas(
+        {
+          'Thing': {
+            'type': 'object',
+            'required': ['state'],
+            'properties': {
+              'state': {
+                'type': 'string',
+                'enum': ['active'],
+                'allOf': [
+                  {r'$ref': '#/components/schemas/State'},
+                ],
+              },
+            },
+          },
+          'State': {
+            'type': 'string',
+            'enum': ['active', 'inactive'],
+          },
+        },
+        specUrl: Uri.parse('file:///spec.yaml'),
+      );
+      expect(results['Thing'], contains('State get state => State.active;'));
     });
 
     // A bare inline lone `const` on a property renders as a fixed getter

--- a/test/render/render_schema_test.dart
+++ b/test/render/render_schema_test.dart
@@ -189,10 +189,10 @@ void main() {
       expect(r, contains('MapEntry(key.toJson(), value.toJson())'));
     });
 
-    test('propertyNames with an int enum bridges the string JSON key', () {
-      // JSON object keys are always strings on the wire, but an int-valued
-      // enum's fromJson/toJson speak int, so the key is bridged through
-      // int.parse on decode and stringified on encode.
+    test('propertyNames with an int enum falls back to String keys', () {
+      // An integer enum renders as a value newtype, not an enum, so it can't
+      // type a JSON map key (keys are strings on the wire). The map degrades
+      // to plain String keys rather than a Map<NovaGroup, ...>.
       final schemas = <String, Map<String, dynamic>>{
         'NovaGroup': {
           'type': 'integer',
@@ -212,14 +212,16 @@ void main() {
           },
         },
       };
-      final rendered = renderTestSchemas(
-        schemas,
-        specUrl: Uri.parse('file:///spec.yaml'),
+      // Resolving the dropped int-enum key emits a warning, which needs a
+      // logger in scope.
+      final rendered = runWithLogger(
+        _MockLogger(),
+        () =>
+            renderTestSchemas(schemas, specUrl: Uri.parse('file:///spec.yaml')),
       );
       final r = rendered['R']!;
-      expect(r, contains('final Map<NovaGroup, String> markers;'));
-      expect(r, contains('MapEntry(NovaGroup.fromJson(int.parse(key)),'));
-      expect(r, contains('MapEntry(key.toJson().toString(),'));
+      expect(r, contains('final Map<String, String> markers;'));
+      expect(r, isNot(contains('NovaGroup')));
     });
 
     test('propertyNames without an enum ref is a spec error', () {
@@ -240,7 +242,7 @@ void main() {
           isA<FormatException>().having(
             (e) => e.message,
             'message',
-            contains('must resolve to an enum'),
+            contains('must resolve to a string enum'),
           ),
         ),
       );
@@ -3197,11 +3199,11 @@ void main() {
       // ActionType value set.
       expect(action, contains('1 => BlockAction.fromJson(json)'));
       expect(action, contains('2 => FlagAction.fromJson(json)'));
-      // The pinned tag renders as a fixed getter of the shared enum — one
-      // per variant, mapping to the pinned member — not a constructor
+      // The pinned tag renders as a fixed getter of the shared int newtype —
+      // one per variant, constructing the pinned value — not a constructor
       // parameter, so the caller neither passes it nor can set it wrong.
-      expect(action, contains('ActionType get type => ActionType.value1;'));
-      expect(action, contains('ActionType get type => ActionType.value2;'));
+      expect(action, contains('ActionType get type => ActionType(1);'));
+      expect(action, contains('ActionType get type => ActionType(2);'));
       // `type` is never a constructor field, nor decoded from JSON...
       expect(action, isNot(contains('this.type')));
       expect(action, isNot(contains('type: ActionType.fromJson')));
@@ -4284,36 +4286,31 @@ void main() {
       );
     });
 
-    test('integer enum renders as a Dart enum with int-typed value', () {
-      // Discord uses single-value `type: integer, enum: [N]` enums as
-      // oneOf discriminator markers (component types). Verify the
-      // generated Dart enum stores the value as `int`, the
-      // factory/maybeFromJson accept `int`/`int?`, and `toJson()`
-      // returns `int`.
+    test('nameless integer enum renders as a validated int newtype', () {
+      // A plain integer `enum` has no member names — only synthetic
+      // `value<N>` — so it renders as an `extension type` over `int` whose
+      // constructor validates membership, not a Dart enum (see #352).
       final json = {
         'type': 'integer',
         'enum': [1, 2, 11],
       };
       final result = renderTestSchema(json);
-      // Variants get name `value<N>` since int values aren't valid
-      // Dart identifiers on their own.
-      expect(result, contains('value1._(1)'));
-      expect(result, contains('value2._(2)'));
-      expect(result, contains('value11._(11)'));
-      // JSON wire types are `int`, not `String`.
-      expect(result, contains('factory Test.fromJson(int json)'));
+      expect(result, contains('extension type const Test._(int value)'));
+      expect(result, contains('value.validateEnumValues([1, 2, 11]);'));
+      expect(result, contains('factory Test.fromJson(int json) => Test(json)'));
       expect(result, contains('static Test? maybeFromJson(int? json)'));
-      expect(result, contains('final int value;'));
       expect(result, contains('int toJson() => value;'));
-      // No String-typed survivors anywhere in the body.
-      expect(result, isNot(contains('final String value;')));
-      expect(result, isNot(contains('factory Test.fromJson(String')));
+      // No Dart-enum artifacts: no synthetic members, no enum keyword.
+      expect(result, isNot(contains('enum Test')));
+      expect(result, isNot(contains('value1._(1)')));
     });
 
-    test('oneOf-of-consts enum names members from the spec titles', () {
-      // Discord spells typed int enums as `oneOf` of `const` variants,
-      // each with a `title:` — the spec's own member name. Use it
-      // (`blockMessage`) rather than the value-derived fallback (`value1`).
+    test('oneOf-of-consts enum names members from the spec titles '
+        '(stays a Dart enum)', () {
+      // Discord spells typed int enums as a `oneOf` of `const` variants,
+      // each with a `title:` — the spec's own member name. Those names are
+      // meaningful, so this stays a Dart enum with `blockMessage`/
+      // `flagToChannel`, not a nameless-int newtype.
       final json = {
         'type': 'integer',
         'oneOf': [
@@ -4324,16 +4321,13 @@ void main() {
       final result = renderTestSchema(json);
       expect(result, contains('blockMessage._(1)'));
       expect(result, contains('flagToChannel._(2)'));
-      // The meaningless value-derived fallback must not appear.
-      expect(result, isNot(contains('value1._(1)')));
-      expect(result, isNot(contains('value2._(2)')));
+      expect(result, isNot(contains('extension type')));
     });
 
-    test('oneOf-of-consts enum falls back to value names when a title is '
-        'missing', () {
-      // Names are all-or-nothing: a partially-titled enum would mix
-      // `blockMessage` with `value2`, so fall back to value-derived names
-      // for the whole enum.
+    test('oneOf-of-consts falls back to a newtype when a title is missing', () {
+      // Names are all-or-nothing: a partially-titled enum has no usable
+      // member names, so it renders as the nameless-int newtype rather than
+      // mixing `blockMessage` with a synthetic `value2`.
       final json = {
         'type': 'integer',
         'oneOf': [
@@ -4342,22 +4336,20 @@ void main() {
         ],
       };
       final result = renderTestSchema(json);
-      expect(result, contains('value1._(1)'));
-      expect(result, contains('value2._(2)'));
+      expect(result, contains('extension type const Test._(int value)'));
+      expect(result, contains('value.validateEnumValues([1, 2]);'));
       expect(result, isNot(contains('blockMessage')));
     });
 
-    test('integer enum with negative values uses safe variable names', () {
+    test('nameless integer enum with negative values renders the check', () {
+      // Negative values were awkward as Dart-enum member names (`value-1`);
+      // as a newtype they are just entries in the membership check.
       final json = {
         'type': 'integer',
         'enum': [-1, 0, 1],
       };
       final result = renderTestSchema(json);
-      // Negative values would be invalid Dart identifiers (`value-1`);
-      // generator falls back to `valueNeg<abs>`.
-      expect(result, contains('valueNeg1._(-1)'));
-      expect(result, contains('value0._(0)'));
-      expect(result, contains('value1._(1)'));
+      expect(result, contains('value.validateEnumValues([-1, 0, 1]);'));
     });
 
     test('properties with invalid names', () {

--- a/test/render/render_tree_test.dart
+++ b/test/render/render_tree_test.dart
@@ -785,6 +785,9 @@ void main() {
       const same = RenderIntNewtype(common: common, allowedValues: [1, 2]);
       expect(a.equalsIgnoringName(b), isFalse);
       expect(a.equalsIgnoringName(same), isTrue);
+      // Equatable `==`/props include the allowed set too.
+      expect(a, equals(same));
+      expect(a, isNot(equals(b)));
       // A plain bounded integer newtype is never a closed-set int.
       const plainInt = RenderInteger(
         common: common,
@@ -1267,6 +1270,18 @@ void main() {
     test('date format produces a Date value-class literal', () {
       const schema = RenderDate(common: common, defaultValue: null);
       expect(schema.exampleValue(context)?.source, 'Date(2024, 1, 1)');
+    });
+
+    test('int newtype example constructs the first allowed value', () {
+      const schema = RenderIntNewtype(
+        common: common,
+        allowedValues: [3, 4],
+        assignedName: 'NovaGroup',
+        assignedSnakeName: 'nova_group',
+      );
+      // Non-const: the validating constructor has a body, so the example is
+      // `NovaGroup(3)`, not `const NovaGroup(3)`.
+      expect(schema.exampleValue(context)?.source, 'NovaGroup(3)');
     });
 
     // `number` examples land in a statically-`double` destination, where an

--- a/test/render/render_tree_test.dart
+++ b/test/render/render_tree_test.dart
@@ -749,11 +749,11 @@ void main() {
       expect(a.equalsIgnoringName(c), isFalse);
     });
 
-    test('RenderStringEnum and RenderIntEnum with same shape do not '
-        'compare equal (different concrete subtypes)', () {
-      // The runtime-type guard in RenderEnum.equalsIgnoringName keeps
-      // a String-valued enum from being treated as semantically equal
-      // to an Int-valued one even when the names happen to coincide.
+    test('a string enum and the int newtype for the same values do not '
+        'compare equal (different concrete types)', () {
+      // A string enum stays a Dart enum; an integer enum renders as an int
+      // newtype (RenderIntNewtype). They are different render types, so
+      // equalsIgnoringName never conflates them even at the same shape.
       const common = CommonProperties.test(
         snakeName: 'foo',
         pointer: JsonPointer.empty(),
@@ -764,41 +764,66 @@ void main() {
         values: const ['a'],
         descriptions: null,
       );
-      final intEnum = RenderIntEnum(
+      const intNewtype = RenderIntNewtype(
         common: common,
-        names: const ['a'],
-        values: const [1],
-        descriptions: null,
+        allowedValues: [1],
       );
-      expect(stringEnum.equalsIgnoringName(intEnum), isFalse);
+      expect(stringEnum.equalsIgnoringName(intNewtype), isFalse);
     });
 
-    test('RenderIntEnum.invalidJsonExample picks an out-of-range int', () {
-      // The default fallback is `-1` since most spec int enums use
-      // small non-negative values (bitfield flags, component types).
-      // When -1 is somehow in the value set, we step further out.
+    test('int newtypes are distinguished by their allowed set', () {
+      // The allowed values are the only thing separating one closed-set int
+      // from another (their numeric bounds are all null), so structural
+      // equality must compare them — otherwise distinct int enums would
+      // dedupe together in the import-collection pass.
       const common = CommonProperties.test(
         snakeName: 'foo',
         pointer: JsonPointer.empty(),
       );
-      final context = SchemaRenderer(
-        templates: TemplateProvider.defaultLocation(),
-      );
-      final ordinary = RenderIntEnum(
+      const a = RenderIntNewtype(common: common, allowedValues: [1, 2]);
+      const b = RenderIntNewtype(common: common, allowedValues: [3, 4]);
+      const same = RenderIntNewtype(common: common, allowedValues: [1, 2]);
+      expect(a.equalsIgnoringName(b), isFalse);
+      expect(a.equalsIgnoringName(same), isTrue);
+      // A plain bounded integer newtype is never a closed-set int.
+      const plainInt = RenderInteger(
         common: common,
-        names: const ['value1', 'value2'],
-        values: const [1, 2],
-        descriptions: null,
+        defaultValue: null,
+        maximum: null,
+        minimum: null,
+        exclusiveMaximum: null,
+        exclusiveMinimum: null,
+        multipleOf: null,
+        createsNewType: true,
       );
-      expect(ordinary.invalidJsonExample(context), '-1');
-      final includesNegOne = RenderIntEnum(
-        common: common,
-        names: const ['valueNeg1', 'value0', 'value1'],
-        values: const [-1, 0, 1],
-        descriptions: null,
-      );
-      expect(includesNegOne.invalidJsonExample(context), '-999999');
+      expect(a.equalsIgnoringName(plainInt), isFalse);
     });
+
+    test(
+      'RenderIntNewtype.invalidJsonExample picks a value outside the set',
+      () {
+        // The default fallback is `-1` since most spec int enums use
+        // small non-negative values (bitfield flags, component types).
+        // When -1 is itself allowed, we step further out.
+        const common = CommonProperties.test(
+          snakeName: 'foo',
+          pointer: JsonPointer.empty(),
+        );
+        final context = SchemaRenderer(
+          templates: TemplateProvider.defaultLocation(),
+        );
+        const ordinary = RenderIntNewtype(
+          common: common,
+          allowedValues: [1, 2],
+        );
+        expect(ordinary.invalidJsonExample(context), '-1');
+        const includesNegOne = RenderIntNewtype(
+          common: common,
+          allowedValues: [-1, 0, 1],
+        );
+        expect(includesNegOne.invalidJsonExample(context), '-999999');
+      },
+    );
 
     test('RenderOneOf', () {
       const a = RenderOneOf(

--- a/test/templates/api_exception_test.dart
+++ b/test/templates/api_exception_test.dart
@@ -47,6 +47,21 @@ void main() {
       6.validateMultipleOf(3);
       expect(() => 7.validateMultipleOf(3), throwsMessage('multiple of 3'));
     });
+
+    test('validateEnumValues accepts a member and rejects a non-member', () {
+      3.validateEnumValues([3, 4]);
+      // Out-of-set is a parse failure, so it throws FormatException.
+      expect(
+        () => 5.validateEnumValues([3, 4]),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            contains('5 is not one of [3, 4]'),
+          ),
+        ),
+      );
+    });
   });
 
   group('ValidateString', () {


### PR DESCRIPTION
## Summary

An integer `enum` (`type: integer` + `enum: [...]`) whose members have **no
spec-provided names** is a closed set whose only Dart-enum members would be
synthetic `value<N>` — names carrying nothing the int itself doesn't. Those
now render as a validated int newtype: an `extension type const E._(int value)`
whose constructor calls `value.validateEnumValues([...])`.

Integer enums **with** meaningful names — Discord's `oneOf` of `const`s with a
`title:` (`BLOCK_MESSAGE` → `blockMessage`) — **stay Dart enums**, exactly as
string enums do. Only the nameless ones change (6 Discord single-value flag
types). Closes #352.

```dart
// nameless: type: integer, enum: [1]        // named: title: BLOCK_MESSAGE, const: 1
extension type const Flags._(int value) {     enum ActionType {
  Flags(this.value) {                           blockMessage._(1),
    value.validateEnumValues([1]);              flagToChannel._(2);
  }                                             ...
  ...                                         }
}
```

## How it stays low-risk

Render-only: `ResolvedIntEnum` is kept through the resolve layer and
`toRenderSchema` routes on `names` (`RenderIntEnum` vs the new
`RenderIntNewtype`), so oneOf shape-dispatch and wrapper naming are unchanged.
Every *reference* site is byte-identical — only the nameless type's own file
flips from `enum` to `extension type`. `RenderIntNewtype extends RenderInteger`
(reusing the `schema_number_newtype` template), un-gates the oneOf-variant
getters the enum provided, and overrides `equalsIgnoringName` to compare the
allowed set.

## A dedicated membership validator

Membership is its own `value.validateEnumValues([...])` call on
`ValidateNumber`, **not** an argument to the multi-bound `validate(...)` sugar:
a nameless int enum never also carries `min`/`max`/`multipleOf` (the parser
routes `enum` away from the bounded-numeric path), so membership is the sole
rule and reads better called directly. It throws `FormatException` (a parse
error, as the enum's `fromJson` did), so the generated negative round-trip
test still asserts `throwsFormatException`. (The import-detection regex now
matches `.validate<Name>(` too.)

## Map-key bridge retired (as #344 promised)

An int enum is no longer a usable typed map key, so `propertyNames` resolving
to one now warns and falls back to `String` keys. `RenderMap.keySchema` and the
resolver check narrow to string enums, and the non-string
`int.parse`/`.toString()` bridging from #344 is deleted.

## Single-value pins

A nameless int enum pinned to one value (the `allOf: [{$ref: E}]` idiom)
renders `E get x => E(1);`; a named one still pins to `E.member`.

## Testing

- Unit tests: nameless→newtype, named→Dart enum, partial-titles→newtype,
  the allowed-set equality, the map-key fallback, single-value-pin getter,
  and the named-int-enum `toString`-iteration round-trip test.
- New `types` fixture member `Priority` exercises the newtype end to end
  (round-trip + negative `throwsFormatException`) under `--verify`.
- Corpus regenerated: **29 files** (6 nameless Discord flag types + the shared
  `api_exception.dart` per package + the `types` fixture). Every changed
  third_party package + all synthetic fixtures analyze clean and pass `--verify`.

## Follow-up

`RenderEnum<T>` still carries `variableNamesForInts`-shaped generic machinery
that only string + named-int enums use now; no cleanup needed, noting for context.