### PR TITLE
fix: resolve allOf with metadata-only members instead of crashing

### DIFF
--- a/lib/src/resolver.dart
+++ b/lib/src/resolver.dart
@@ -462,10 +462,14 @@ ResolvedSchema _resolveSchemaFully(
     final members = schemas.where((s) => s is! ResolvedUnknown).toList();
     final nullable =
         resolvedCommon.nullable || metadataOnly.any((s) => s.common.nullable);
+    CommonProperties withNullable(CommonProperties common) =>
+        nullable ? common.copyWith(nullable: true) : common;
     // Elide to the sole substantive member. Covers `allOf: [X]` (a single
     // member — often a scalar wrapped to attach metadata) and
     // `allOf: [X, {nullable: true}]` (the nullable-$ref idiom): both reduce
-    // to X, marked nullable when any member asked for it.
+    // to X, marked nullable when any member asked for it. Return the
+    // resolved instance untouched when no member forced nullability, so
+    // the common single-element `allOf: [X]` case keeps its identity.
     if (members.length == 1) {
       final member = members.first;
       return nullable
@@ -476,7 +480,7 @@ ResolvedSchema _resolveSchemaFully(
     // as an unconstrained value, nullable if any member said so.
     if (members.isEmpty) {
       return ResolvedUnknown(
-        common: resolvedCommon.copyWith(nullable: nullable),
+        common: withNullable(resolvedCommon),
         createsNewType: createsNewType,
       );
     }
@@ -498,9 +502,7 @@ ResolvedSchema _resolveSchemaFully(
       _error('allOf only supports objects: $schema', allOf.pointer);
     }
     return ResolvedAllOf(
-      common: nullable
-          ? resolvedCommon.copyWith(nullable: true)
-          : resolvedCommon,
+      common: withNullable(resolvedCommon),
       schemas: members,
     );
   }

--- a/lib/src/resolver.dart
+++ b/lib/src/resolver.dart
@@ -450,13 +450,37 @@ ResolvedSchema _resolveSchemaFully(
     final schemas = allOf.schemas
         .map((e) => resolveSchemaRef(e, context))
         .toList();
-    // Elide the allOf if there is only one schema.
-    // Probably should only do this for the pod case?  Since in the object
-    // case allOf should probably create a new object?
-    if (schemas.length == 1) {
-      return schemas.first;
+    // Metadata-only members carry no shape to merge — they exist only to
+    // attach `nullable`/`description`/etc. to their siblings. The canonical
+    // case is the OpenAPI 3.0 nullable-$ref idiom: 3.0 forbids `nullable`
+    // as a sibling of `$ref`, so specs wrap both in an allOf —
+    // `allOf: [{$ref: X}, {nullable: true}]`. A bare `{nullable: true}` (or
+    // a lone `{description: ...}`) resolves to `ResolvedUnknown`. Set these
+    // aside as modifiers rather than schemas to merge, folding their
+    // `nullable` into the composition (issues #347, #356).
+    final metadataOnly = schemas.whereType<ResolvedUnknown>().toList();
+    final members = schemas.where((s) => s is! ResolvedUnknown).toList();
+    final nullable =
+        resolvedCommon.nullable || metadataOnly.any((s) => s.common.nullable);
+    // Elide to the sole substantive member. Covers `allOf: [X]` (a single
+    // member — often a scalar wrapped to attach metadata) and
+    // `allOf: [X, {nullable: true}]` (the nullable-$ref idiom): both reduce
+    // to X, marked nullable when any member asked for it.
+    if (members.length == 1) {
+      final member = members.first;
+      return nullable
+          ? member.copyWith(common: member.common.copyWith(nullable: true))
+          : member;
     }
-    for (final schema in schemas) {
+    // An allOf of pure metadata has no substantive member to merge; treat it
+    // as an unconstrained value, nullable if any member said so.
+    if (members.isEmpty) {
+      return ResolvedUnknown(
+        common: resolvedCommon.copyWith(nullable: nullable),
+        createsNewType: createsNewType,
+      );
+    }
+    for (final schema in members) {
       // allOf members must be object-shaped. Besides plain objects, admit an
       // open map member (e.g. a `JsonObject`: `type: object` with only
       // `additionalProperties`, which resolves to `ResolvedMap`) — it
@@ -473,7 +497,12 @@ ResolvedSchema _resolveSchemaFully(
       }
       _error('allOf only supports objects: $schema', allOf.pointer);
     }
-    return ResolvedAllOf(common: resolvedCommon, schemas: schemas);
+    return ResolvedAllOf(
+      common: nullable
+          ? resolvedCommon.copyWith(nullable: true)
+          : resolvedCommon,
+      schemas: members,
+    );
   }
   if (schema is SchemaAnyOf) {
     assert(createsNewType, 'SchemaAnyOf should create a new type');

--- a/test/resolver_test.dart
+++ b/test/resolver_test.dart
@@ -628,6 +628,87 @@ void main() {
       expect(outer.schemas.first, isA<ResolvedAllOf>());
     });
 
+    test(
+      'allOf with a nullable-ref metadata member elides, marks nullable',
+      () {
+        // OpenAPI 3.0 nullable-$ref idiom (#356): 3.0 forbids `nullable`
+        // beside a `$ref`, so specs wrap both in an allOf. The `{nullable:
+        // true}` member resolves to `ResolvedUnknown` — a metadata-only
+        // modifier. The composition elides to the sole substantive member,
+        // marked nullable, rather than crashing on the non-object member.
+        final json = {
+          'allOf': [
+            {
+              'type': 'object',
+              'properties': {
+                'name': {'type': 'string'},
+              },
+            },
+            {'nullable': true},
+          ],
+        };
+        final logger = _MockLogger();
+        final schema = runWithLogger(
+          logger,
+          () => parseAndResolveTestSchema(json),
+        );
+        expect(schema, isA<ResolvedObject>());
+        expect(schema.common.nullable, isTrue);
+      },
+    );
+
+    test('allOf wrapping a scalar with a metadata member elides', () {
+      // A scalar refined by a metadata-only sibling (#347): `allOf:
+      // [<scalar>, {description: ...}]`. The description member resolves to
+      // `ResolvedUnknown` and is set aside; the composition elides to the
+      // scalar rather than crashing with "allOf only supports objects".
+      final json = {
+        'allOf': [
+          {'type': 'string', 'nullable': true},
+          {'description': 'refines the string above'},
+        ],
+      };
+      final logger = _MockLogger();
+      final schema = runWithLogger(
+        logger,
+        () => parseAndResolveTestSchema(json),
+      );
+      expect(schema, isA<ResolvedString>());
+      expect(schema.common.nullable, isTrue);
+    });
+
+    test('allOf keeps multiple objects, folds in metadata nullable', () {
+      // Two real object members plus a `{nullable: true}` modifier: the
+      // objects still merge into a `ResolvedAllOf` (the metadata member is
+      // dropped, not merged) and the whole composition is nullable.
+      final json = {
+        'allOf': [
+          {
+            'type': 'object',
+            'properties': {
+              'foo': {'type': 'string'},
+            },
+          },
+          {
+            'type': 'object',
+            'properties': {
+              'bar': {'type': 'integer'},
+            },
+          },
+          {'nullable': true},
+        ],
+      };
+      final logger = _MockLogger();
+      final schema = runWithLogger(
+        logger,
+        () => parseAndResolveTestSchema(json),
+      );
+      expect(schema, isA<ResolvedAllOf>());
+      final allOf = schema as ResolvedAllOf;
+      expect(allOf.schemas.length, 2);
+      expect(allOf.common.nullable, isTrue);
+    });
+
     test('resolve anyOf', () {
       final json = {
         'anyOf': [

--- a/test/resolver_test.dart
+++ b/test/resolver_test.dart
@@ -709,6 +709,96 @@ void main() {
       expect(allOf.common.nullable, isTrue);
     });
 
+    test('allOf of pure metadata resolves to a nullable unknown', () {
+      // No substantive member — every entry is metadata-only. There is
+      // nothing to merge, so the composition is an unconstrained value,
+      // nullable because a member asked for it.
+      final json = {
+        'allOf': [
+          {'description': 'just a description'},
+          {'nullable': true},
+        ],
+      };
+      final logger = _MockLogger();
+      final schema = runWithLogger(
+        logger,
+        () => parseAndResolveTestSchema(json),
+      );
+      expect(schema, isA<ResolvedUnknown>());
+      expect(schema.common.nullable, isTrue);
+    });
+
+    test('allOf with a non-nullable metadata member is not nullable', () {
+      // A metadata-only member that does not ask for nullability (a bare
+      // `{description}`) must not spuriously make the elided member
+      // nullable.
+      final json = {
+        'allOf': [
+          {
+            'type': 'object',
+            'properties': {
+              'name': {'type': 'string'},
+            },
+          },
+          {'description': 'refines the object above'},
+        ],
+      };
+      final logger = _MockLogger();
+      final schema = runWithLogger(
+        logger,
+        () => parseAndResolveTestSchema(json),
+      );
+      expect(schema, isA<ResolvedObject>());
+      expect(schema.common.nullable, isFalse);
+    });
+
+    test('allOf nullable as a sibling marks the elided member nullable', () {
+      // `nullable` sits on the allOf itself (not a member): `{allOf: [X],
+      // nullable: true}`. The elided member picks up the composition's own
+      // nullability.
+      final json = {
+        'allOf': [
+          {
+            'type': 'object',
+            'properties': {
+              'name': {'type': 'string'},
+            },
+          },
+        ],
+        'nullable': true,
+      };
+      final logger = _MockLogger();
+      final schema = runWithLogger(
+        logger,
+        () => parseAndResolveTestSchema(json),
+      );
+      expect(schema, isA<ResolvedObject>());
+      expect(schema.common.nullable, isTrue);
+    });
+
+    test('allOf admits a bare empty-schema member', () {
+      // A bare `{}` member carries neither shape nor metadata; it resolves
+      // to `ResolvedUnknown` and is set aside like any metadata-only
+      // member, leaving the object to elide cleanly.
+      final json = {
+        'allOf': [
+          {
+            'type': 'object',
+            'properties': {
+              'name': {'type': 'string'},
+            },
+          },
+          <String, dynamic>{},
+        ],
+      };
+      final logger = _MockLogger();
+      final schema = runWithLogger(
+        logger,
+        () => parseAndResolveTestSchema(json),
+      );
+      expect(schema, isA<ResolvedObject>());
+    });
+
     test('resolve anyOf', () {
       final json = {
         'anyOf': [


### PR DESCRIPTION
## Summary

The resolver required every `allOf` member to be object-shaped and
crashed with `allOf only supports objects` otherwise. This broke two
of the most common real-spec `allOf` idioms:

- The OpenAPI 3.0 nullable-`$ref` idiom (#356): 3.0 forbids `nullable`
  beside a `$ref`, so specs wrap both in an allOf —
  `allOf: [{$ref: X}, {nullable: true}]`. The `{nullable: true}` member
  resolves to `ResolvedUnknown` and hit the crash. OpenAI's spec uses
  this at dozens of sites.
- A scalar wrapped in an allOf to attach metadata (#347):
  `allOf: [<scalar>, {description: ...}]`. Box's spec uses this.

Metadata-only members (`{nullable: true}`, a bare `{description}`, an
empty `{}`) carry no shape to merge. They are now set aside as
modifiers rather than schemas: their `nullable` folds into the
composition, and an allOf that reduces to a single substantive member
elides to that member (marked nullable when any member asked for it).
`allOf: [{$ref: X}, {nullable: true}]` now resolves to `X?`.

## Validation

- New resolver unit tests cover the nullable-`$ref` idiom, the
  scalar-plus-metadata case, and multiple-object members with a
  trailing `{nullable: true}` modifier.
- Both motivating specs advance past the allOf crash to their next
  distinct blocker: Box to an unrelated request-body-schema error,
  OpenAI to the `propertyNames`-string crash already handled by #355.
- All tracked spec goldens (github, discord, backstage, petstore,
  spacetraders, train_travel) regenerate byte-identical — the change
  only affects inputs that previously crashed.

Fixes #347, #356.
