### PR TITLE
fix: namespace external-document pointers so same-named schemas don't conflate (#358)

### DIFF
--- a/lib/src/assemble.dart
+++ b/lib/src/assemble.dart
@@ -104,12 +104,18 @@ Future<void> _loadExternalRefs({
     final componentsJson = doc['components'];
     if (componentsJson is Map<String, dynamic>) {
       // OpenAPI-shaped components library: index every component by its
-      // in-document pointer (`docUri#/components/schemas/Foo`).
+      // in-document pointer (`docUri#/components/schemas/Foo`). The parse
+      // carries [docUri] as the pointer base so a component here keeps a
+      // distinct identity from a same-named component in the root (or
+      // another external) document — otherwise two `Foo`s conflate into
+      // one type (#358). The base is identity-only; the registry key stays
+      // the document-relative `docUri#/...` that `$ref`s resolve against.
       fullyIndexedDocs.add(docUri);
       final componentsContext = MapContext(
         pointerParts: ['components'],
         snakeNameStack: const [],
         json: componentsJson,
+        baseUri: docUri,
       );
       final components = parseComponents(componentsContext);
 

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -2410,6 +2410,7 @@ class MapContext extends ParseContext {
     required super.pointerParts,
     required super.snakeNameStack,
     required this.json,
+    super.baseUri,
     // Only exposed in the constructor so that addSnakeName can pass it to
     // prevent resetting the usedKeys set.
     Set<String>? usedKeys,
@@ -2423,6 +2424,7 @@ class MapContext extends ParseContext {
          pointerParts: [...parent.pointerParts, key],
          snakeNameStack: parent.snakeNameStack,
          json: json,
+         baseUri: parent.baseUri,
        );
 
   MapContext.initial(Json json)
@@ -2459,6 +2461,7 @@ class MapContext extends ParseContext {
     pointerParts: pointerParts,
     snakeNameStack: [...snakeNameStack, snakeName],
     json: json,
+    baseUri: baseUri,
     usedKeys: usedKeys,
   );
 
@@ -2498,6 +2501,7 @@ class ListContext extends ParseContext {
     required super.pointerParts,
     required super.snakeNameStack,
     required this.json,
+    super.baseUri,
   });
 
   ListContext.fromParent({
@@ -2508,6 +2512,7 @@ class ListContext extends ParseContext {
          pointerParts: [...parent.pointerParts, key],
          snakeNameStack: parent.snakeNameStack,
          json: json,
+         baseUri: parent.baseUri,
        );
 
   MapContext indexAsMap(int index) {
@@ -2533,7 +2538,16 @@ class ListContext extends ParseContext {
 /// Immutable context for parsing a spec.
 /// SchemaRegistry is internally mutable, so this is not truly immutable.
 abstract class ParseContext {
-  ParseContext({required this.pointerParts, required this.snakeNameStack});
+  ParseContext({
+    required this.pointerParts,
+    required this.snakeNameStack,
+    // Null for the root document (the common single-document case) and set
+    // only when parsing an external document, so its pointers carry a
+    // distinct identity — see [JsonPointer.fromParts]. Optional rather than
+    // `required` because nearly every call site parses the root; the
+    // external-document path threads it explicitly.
+    this.baseUri,
+  });
 
   /// Json pointer location of the current schema.
   final List<String> pointerParts;
@@ -2541,7 +2555,13 @@ abstract class ParseContext {
   /// Stack of name parts for the current schema.
   final List<String> snakeNameStack;
 
-  JsonPointer get pointer => JsonPointer.fromParts(pointerParts);
+  /// The document being parsed, or null for the root document. Flows into
+  /// every [pointer] so external-document pointers don't collide with the
+  /// root's (#358).
+  final Uri? baseUri;
+
+  JsonPointer get pointer =>
+      JsonPointer.fromParts(pointerParts, baseUri: baseUri);
 
   String get snakeName {
     // To match OpenAPI, we don't put a _ before numbers.

--- a/lib/src/resolver.dart
+++ b/lib/src/resolver.dart
@@ -1057,10 +1057,29 @@ class _NameCollector extends Visitor {
   }
 }
 
-Map<String, List<JsonPointer>> _collectNames(OpenApi spec) {
+Map<String, List<JsonPointer>> _collectNames(
+  OpenApi spec,
+  RefRegistry? registry,
+) {
   final nameToPointers = <String, List<JsonPointer>>{};
   final collector = _NameCollector(nameToPointers);
   SpecWalker(collector).walkRoot(spec);
+  // Schemas defined in an *external* document (`baseUri != null`) aren't
+  // reached by the root walk, but they get inlined at resolution and must
+  // disambiguate against a same-named root schema the same way an
+  // in-document collision does (#358): a shared `Foo` becomes `Foo` +
+  // `Foo1` (the `_1` convention), not the name allocator's fallback `Foo2`.
+  // The root walk already added the root's schemas first — so the root keeps
+  // the bare name and the external one takes the suffix — and we fold in only
+  // the registry's external schemas here (its copies of root schemas would
+  // double-count into a false self-collision).
+  if (registry != null) {
+    for (final object in registry.objectsByUri.values) {
+      if (object is Schema && object.pointer.baseUri != null) {
+        collector.visitSchema(object);
+      }
+    }
+  }
   return nameToPointers;
 }
 
@@ -1100,8 +1119,11 @@ Map<JsonPointer, String> _resolveCollisions(
   return changedNames;
 }
 
-Map<JsonPointer, String> resolveNameCollisions(OpenApi spec) {
-  final nameToPointers = _collectNames(spec);
+Map<JsonPointer, String> resolveNameCollisions(
+  OpenApi spec, {
+  RefRegistry? refRegistry,
+}) {
+  final nameToPointers = _collectNames(spec, refRegistry);
   return _resolveCollisions(nameToPointers);
 }
 
@@ -1112,8 +1134,10 @@ ResolvedSpec resolveSpec(
   Map<JsonPointer, String> nameOverrides = const {},
   RefRegistry? refRegistry,
 }) {
-  // Walk and look for snake_name collisions.
-  final nameOverrides = resolveNameCollisions(spec);
+  // Walk and look for snake_name collisions. Pass the assembled registry so
+  // schemas from external documents disambiguate against the root's the same
+  // way in-document collisions do (#358).
+  final nameOverrides = resolveNameCollisions(spec, refRegistry: refRegistry);
   if (nameOverrides.isNotEmpty) {
     logger.detail('Resolved ${nameOverrides.length} naming collisions');
   }

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -54,10 +54,20 @@ enum Method {
 /// https://spec.openapis.org/oas/v3.1.0#json-pointer
 @immutable
 class JsonPointer extends Equatable {
-  const JsonPointer.empty() : parts = const [];
+  const JsonPointer.empty() : parts = const [], baseUri = null;
 
   /// Create a new JsonPointer from a list of parts.
-  const JsonPointer.fromParts(this.parts);
+  ///
+  /// [baseUri] is the document the pointer lives in. It is null for the
+  /// primary (root) document — the common single-document case — and set
+  /// only for a pointer parsed out of an *external* document, so that two
+  /// documents each defining, say, `#/components/schemas/Foo` produce
+  /// distinct pointers (distinct identity) rather than conflating into one
+  /// type (#358). It participates in equality but never in
+  /// [urlEncodedFragment], which stays document-relative: the fragment is
+  /// what the ref registry resolves a `$ref` against, and what any
+  /// diagnostic prints.
+  const JsonPointer.fromParts(this.parts, {this.baseUri});
 
   /// Create a new JsonPointer from a string.
   factory JsonPointer.parse(String string) {
@@ -67,10 +77,15 @@ class JsonPointer extends Equatable {
     return JsonPointer.fromParts(string.substring(2).split('/'));
   }
 
-  JsonPointer add(String part) => JsonPointer.fromParts([...parts, part]);
+  JsonPointer add(String part) =>
+      JsonPointer.fromParts([...parts, part], baseUri: baseUri);
 
   /// The parts of the json pointer.
   final List<String> parts;
+
+  /// The document this pointer resolves within, or null for the root
+  /// document. See [JsonPointer.fromParts].
+  final Uri? baseUri;
 
   String get urlEncodedFragment {
     /// This pointer encoded as a url-ready string.
@@ -86,7 +101,7 @@ class JsonPointer extends Equatable {
   String toString() => urlEncodedFragment;
 
   @override
-  List<Object?> get props => [parts];
+  List<Object?> get props => [parts, baseUri];
 }
 
 /// Known supported mime types for this library.

--- a/test/render/file_renderer_test.dart
+++ b/test/render/file_renderer_test.dart
@@ -406,7 +406,9 @@ void main() {
         // both defining `#/components/schemas/Foo` used to conflate into one
         // `foo.dart` (whichever the walk reached first won). Namespacing the
         // external pointer by its document keeps the two identities distinct,
-        // so both types render — the second disambiguated to `foo2`.
+        // so both types render — the root keeps `Foo`, the external one
+        // disambiguates to `Foo1` (`foo_1.dart`), the same `_1` convention an
+        // in-document name collision uses.
         final out = MemoryFileSystem.test().directory('pkg');
         out.fileSystem.file('shared.json')
           ..createSync(recursive: true)
@@ -479,15 +481,15 @@ void main() {
         );
 
         final foo = out.childFile('lib/models/foo.dart');
-        final foo2 = out.childFile('lib/models/foo2.dart');
+        final foo1 = out.childFile('lib/models/foo_1.dart');
         expect(foo.existsSync(), isTrue);
-        expect(foo2.existsSync(), isTrue);
-        // Each document's fields land in exactly one of the two files —
-        // the two schemas are not merged.
-        final bodies = [foo.readAsStringSync(), foo2.readAsStringSync()];
-        expect(bodies.where((b) => b.contains('localField')), hasLength(1));
-        expect(bodies.where((b) => b.contains('externalField')), hasLength(1));
-        expect(bodies.every((b) => b.contains('class Foo')), isTrue);
+        expect(foo1.existsSync(), isTrue);
+        // The root schema keeps the bare `Foo`; the external one takes the
+        // `_1` suffix, matching how an in-document collision disambiguates.
+        expect(foo.readAsStringSync(), contains('class Foo {'));
+        expect(foo.readAsStringSync(), contains('localField'));
+        expect(foo1.readAsStringSync(), contains('class Foo1 {'));
+        expect(foo1.readAsStringSync(), contains('externalField'));
       },
     );
 

--- a/test/render/file_renderer_test.dart
+++ b/test/render/file_renderer_test.dart
@@ -400,6 +400,98 @@ void main() {
     });
 
     test(
+      'two documents defining the same schema name emit distinct types',
+      () async {
+        // Regression for #358: a root spec and an external components-library
+        // both defining `#/components/schemas/Foo` used to conflate into one
+        // `foo.dart` (whichever the walk reached first won). Namespacing the
+        // external pointer by its document keeps the two identities distinct,
+        // so both types render — the second disambiguated to `foo2`.
+        final out = MemoryFileSystem.test().directory('pkg');
+        out.fileSystem.file('shared.json')
+          ..createSync(recursive: true)
+          ..writeAsStringSync(
+            jsonEncode({
+              'openapi': '3.0.0',
+              'info': {'title': 'Shared', 'version': '1.0.0'},
+              'components': {
+                'schemas': {
+                  'Foo': {
+                    'type': 'object',
+                    'properties': {
+                      'externalField': {'type': 'integer'},
+                    },
+                  },
+                },
+              },
+            }),
+          );
+        await renderToDirectory(
+          outDir: out,
+          spec: {
+            'openapi': '3.0.0',
+            'info': {'title': 'Multi Doc', 'version': '1.0.0'},
+            'paths': {
+              '/local': {
+                'get': {
+                  'operationId': 'getLocal',
+                  'responses': {
+                    '200': {
+                      'description': 'ok',
+                      'content': {
+                        'application/json': {
+                          'schema': {r'$ref': '#/components/schemas/Foo'},
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+              '/external': {
+                'get': {
+                  'operationId': 'getExternal',
+                  'responses': {
+                    '200': {
+                      'description': 'ok',
+                      'content': {
+                        'application/json': {
+                          'schema': {
+                            r'$ref': './shared.json#/components/schemas/Foo',
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            'components': {
+              'schemas': {
+                'Foo': {
+                  'type': 'object',
+                  'properties': {
+                    'localField': {'type': 'string'},
+                  },
+                },
+              },
+            },
+          },
+        );
+
+        final foo = out.childFile('lib/models/foo.dart');
+        final foo2 = out.childFile('lib/models/foo2.dart');
+        expect(foo.existsSync(), isTrue);
+        expect(foo2.existsSync(), isTrue);
+        // Each document's fields land in exactly one of the two files —
+        // the two schemas are not merged.
+        final bodies = [foo.readAsStringSync(), foo2.readAsStringSync()];
+        expect(bodies.where((b) => b.contains('localField')), hasLength(1));
+        expect(bodies.where((b) => b.contains('externalField')), hasLength(1));
+        expect(bodies.every((b) => b.contains('class Foo')), isTrue);
+      },
+    );
+
+    test(
       'default response schema is emitted even when no explicit status '
       'code references it',
       () async {

--- a/test/types_test.dart
+++ b/test/types_test.dart
@@ -2,6 +2,35 @@ import 'package:space_gen/src/types.dart';
 import 'package:test/test.dart';
 
 void main() {
+  group('JsonPointer', () {
+    test('baseUri disambiguates identity but not the emitted fragment', () {
+      const root = JsonPointer.fromParts(['components', 'schemas', 'Foo']);
+      final external = JsonPointer.fromParts(
+        const ['components', 'schemas', 'Foo'],
+        baseUri: Uri.parse('file:///shared.json'),
+      );
+      // Same parts in two documents are distinct types (#358), so `$ref`s
+      // into each resolve, name, and file separately.
+      expect(external, isNot(equals(root)));
+      expect({root, external}, hasLength(2));
+      // The base is identity-only: the ref-resolvable fragment is unchanged,
+      // so the registry key (`specUrl.resolve(fragment)`) still lands on the
+      // right document.
+      expect(external.urlEncodedFragment, root.urlEncodedFragment);
+      expect(external.urlEncodedFragment, '#/components/schemas/Foo');
+    });
+
+    test('add preserves baseUri', () {
+      final external = JsonPointer.fromParts(
+        const ['components'],
+        baseUri: Uri.parse('file:///shared.json'),
+      );
+      final child = external.add('schemas');
+      expect(child.baseUri, Uri.parse('file:///shared.json'));
+      expect(child.parts, ['components', 'schemas']);
+    });
+  });
+
   group('CommonProperties', () {
     test('copyWith', () {
       const common = CommonProperties.test(


### PR DESCRIPTION
## Summary

Fix multi-document schema-name collision (#358): two documents each
defining `#/components/schemas/Foo` used to conflate into one type. The
pipeline keys identity on `JsonPointer`, but an external OpenAPI-shaped
components library was parsed with a **document-relative** pointer, so
its `Foo` got the same `#/components/schemas/Foo` the root's `Foo` has.
Generation didn't fail — it silently emitted one `foo.dart` for two
types (whichever the walk reached first won).

`JsonPointer` gains an optional `baseUri` — the document it lives in —
that participates in **equality** but never in `urlEncodedFragment`.
Root pointers keep `baseUri: null`; the external components-library
parse threads `baseUri: docUri`. The two `Foo`s become distinct
pointers → distinct types → distinct files, while the ref-resolvable
fragment (hence the registry key a `$ref` resolves against) is unchanged.

The root keeps the bare `Foo`; the external one disambiguates to `Foo1`
(`foo_1.dart`) — the same `_1` convention an in-document name collision
already uses (`Foo-Bar` + `Foo_Bar` → `FooBar` + `FooBar1`), rather than
the name allocator's generic `Foo2` fallback.

## Details

- `lib/src/types.dart` — `JsonPointer.fromParts({Uri? baseUri})`, carried
  through `add`, added to `props`, left out of `urlEncodedFragment`.
- `lib/src/parser.dart` — `ParseContext.baseUri` threads through
  `MapContext`/`ListContext` child contexts into the `pointer` getter.
- `lib/src/assemble.dart` — the OpenAPI-shaped components-library parse
  sets `baseUri: docUri`. Split-spec targets already avoided this by
  keying on the full URI; this brings the components-library branch in
  line.
- `lib/src/resolver.dart` — `_collectNames` folds external-document
  schemas from the assembled registry into collision resolution, so a
  cross-document collision disambiguates through the same `_1` path as an
  in-document one (root keeps the bare name; only external schemas are
  folded in, so the registry's copies of root schemas don't double-count).

## Verification

- New unit tests on `JsonPointer` identity (`baseUri` disambiguates
  equality but not the emitted fragment) and `add` preservation.
- New end-to-end test: a root spec + external components library both
  defining `Foo` now emit `Foo` (`localField`, `foo.dart`) and `Foo1`
  (`externalField`, `foo_1.dart`) as distinct, analyze-clean types.
  Confirmed the test fails without the fix and passes with it.
- **Byte-identical** on every tracked fixture — `tool/gen_tests.dart`
  regens github/discord/backstage/petstore/spacetraders/train-travel
  with zero diff (single-document specs are all `baseUri: null` with no
  external schemas to fold in).

## Known limitation (follow-up)

A discriminator mapping still rebuilds its match pointer from the ref
string (`JsonPointer.parse`, base-null), so a discriminator declared in
an *external* document remains a separate, pre-existing limitation
untouched here.
