### PR TITLE
fix: resolve bare mutable-model fields in comment_references scan (#363)

### DIFF
--- a/lib/src/render/formatting.dart
+++ b/lib/src/render/formatting.dart
@@ -412,6 +412,14 @@ final _memberRe = RegExp(
 /// `comment_references` lint would then fire in generated code). All
 /// keyword-prefixed field declarations are handled by [_memberRe]
 /// above, so excluding leading keywords here costs no field matches.
+///
+/// Bare fields are only emitted under the `mutableModels` quirk; in
+/// immutable output every field carries `final`, so this matches
+/// nothing there. It runs unguarded regardless — the scan takes raw
+/// content, not the quirks — because a bare-field declaration is a
+/// text-level fact worth resolving wherever it appears, and its
+/// false-positive surface (method bodies, getters) is shared with
+/// immutable output and already excluded above.
 final _bareFieldRe = RegExp(
   r'^\s+(?!(?:return|throw|yield|await|library)\b)'
   r'[A-Za-z_][\w.]*(?:<[\w\s,<>?.]*>)?\??\s+'

--- a/lib/src/render/formatting.dart
+++ b/lib/src/render/formatting.dart
@@ -357,6 +357,12 @@ final _commentReferenceRe = RegExp(
 ///   to a `final String hash;` field, which the analyzer's
 ///   `comment_references` lint follows through enclosing class
 ///   scope.
+/// - **Bare fields** the renderer emits *without* a leading keyword
+///   for mutable models (`Quirks.openapi()`): `String? workflows;`,
+///   `Map<String, String> attributes;`. [_memberRe] above only sees
+///   keyword-prefixed fields, so in mutable output a `[workflows]`
+///   ref that the analyzer *would* resolve was treated as unresolved
+///   and tripped the directive (#363).
 ///
 /// Methods and getters / setters aren't tracked (the regex would
 /// over-match too easily). A `[fooMethod]` ref that resolves only
@@ -364,22 +370,54 @@ final _commentReferenceRe = RegExp(
 /// positive, but harmless: the directive is per-file and only
 /// suppresses `comment_references`.
 Set<String> _topLevelDeclarations(String content) {
-  final declRe = RegExp(
-    r'(?:class|enum|mixin|extension type(?:\s+const)?)\s+'
-    '([A-Z][A-Za-z0-9_]*)',
-  );
-  final memberRe = RegExp(
-    r'(?:final|late\s+final|const|var|static)\s+\S+\s+([a-zA-Z_]\w*)',
-  );
   final names = <String>{};
-  for (final m in declRe.allMatches(content)) {
+  for (final m in _declRe.allMatches(content)) {
     names.add(m.group(1)!);
   }
-  for (final m in memberRe.allMatches(content)) {
+  for (final m in _memberRe.allMatches(content)) {
+    names.add(m.group(1)!);
+  }
+  for (final m in _bareFieldRe.allMatches(content)) {
     names.add(m.group(1)!);
   }
   return names;
 }
+
+/// Top-level types the renderer emits — `class`, `enum`, `mixin`,
+/// `extension type [const] Foo._(...)`. Captures the type name.
+final _declRe = RegExp(
+  r'(?:class|enum|mixin|extension type(?:\s+const)?)\s+'
+  '([A-Z][A-Za-z0-9_]*)',
+);
+
+/// Keyword-prefixed field declarations (`final String hash;`).
+/// Captures the field name after the type.
+final _memberRe = RegExp(
+  r'(?:final|late\s+final|const|var|static)\s+\S+\s+([a-zA-Z_]\w*)',
+);
+
+/// Bare (keyword-less) field declarations, as emitted for mutable
+/// models: `String? workflows;`, `Map<String, dynamic> entries;`.
+/// The whole line must be `<type> <name>;` — a type (identifier,
+/// optional generic arguments, optional `?`), the field name, then
+/// `;` with nothing after. That end-anchor excludes getters
+/// (`T get x => ...;`), methods (`T x() {`) and assignments
+/// (`x = y;`, also lacking the two-token shape), leaving only
+/// declarations.
+///
+/// The leading negative lookahead drops keyword-led statements that
+/// share the two-token shape — `return foo;`, `throw foo;` — which
+/// would otherwise add a method-local name to the resolved set and
+/// *wrongly* suppress the directive (the dangerous direction: a real
+/// `comment_references` lint would then fire in generated code). All
+/// keyword-prefixed field declarations are handled by [_memberRe]
+/// above, so excluding leading keywords here costs no field matches.
+final _bareFieldRe = RegExp(
+  r'^\s+(?!(?:return|throw|yield|await|library)\b)'
+  r'[A-Za-z_][\w.]*(?:<[\w\s,<>?.]*>)?\??\s+'
+  r'([a-zA-Z_]\w*)\s*;\s*$',
+  multiLine: true,
+);
 
 /// Signature for the function [Formatter] uses to spawn `dart`
 /// subprocesses. Defaults to [Process.runSync]; tests can swap in a

--- a/test/render/formatting_test.dart
+++ b/test/render/formatting_test.dart
@@ -274,6 +274,69 @@ void main() {
         startsWith('$commentReferencesIgnoreBlock\n'),
       );
     });
+
+    test('passes through refs to bare (keyword-less) mutable-model fields', () {
+      // Mutable models (`Quirks.openapi()`) emit fields with no leading
+      // keyword: `String? workflows;`. The analyzer resolves a
+      // `[workflows]` ref against that field, so no directive is
+      // needed. Before #363 the keyword-only member scan missed these
+      // and the file got a spurious directive.
+      const content =
+          '/// The [workflows] to run.\n'
+          'class Pipeline {\n'
+          '  String? workflows;\n'
+          '}\n';
+      expect(maybeAddCommentReferencesIgnore(content), content);
+    });
+
+    test('passes through refs to bare fields with generic types', () {
+      // `Map<String, dynamic> entries;` — the generic arguments (with
+      // their embedded spaces and commas) must not throw off the
+      // field-name capture.
+      const content =
+          '/// The [entries] and [attributes] of this object.\n'
+          'class Bag {\n'
+          '  Map<String, dynamic> entries;\n'
+          '  Map<String, String> attributes;\n'
+          '}\n';
+      expect(maybeAddCommentReferencesIgnore(content), content);
+    });
+
+    test('does not treat a `return foo;` statement as a field declaration', () {
+      // A bare-field matcher must not pick up keyword-led statements
+      // that share the `<word> <word>;` shape. Here `[result]` resolves
+      // to nothing (it is only a method-local return value), so the
+      // directive is still required — adding it to the resolved set
+      // would wrongly suppress a real `comment_references` lint.
+      const content =
+          '/// Returns the [result].\n'
+          'class Runner {\n'
+          '  Object run() {\n'
+          '    final result = compute();\n'
+          '    return result;\n'
+          '  }\n'
+          '}\n';
+      expect(
+        maybeAddCommentReferencesIgnore(content),
+        startsWith('$commentReferencesIgnoreBlock\n'),
+      );
+    });
+
+    test('does not treat a getter as a bare field declaration', () {
+      // `int get hashCode => ...;` is a getter, not a field. The
+      // bare-field scan must not add `hashCode`; getters remain
+      // untracked, so a ref resolving only via one still needs the
+      // directive (documents the boundary, matches pre-#363 behavior).
+      const content =
+          '/// Mirrors [answer].\n'
+          'class Thing {\n'
+          '  int get answer => 42;\n'
+          '}\n';
+      expect(
+        maybeAddCommentReferencesIgnore(content),
+        startsWith('$commentReferencesIgnoreBlock\n'),
+      );
+    });
   });
 
   group('maybeAddUnintendedHtmlIgnore', () {


### PR DESCRIPTION
## Summary

`maybeAddCommentReferencesIgnore` decides whether to prepend a
file-wide `// ignore_for_file: comment_references` by checking that
every bracketed `[token]` in a file's dartdoc resolves to a same-file
declaration. Its field matcher (`_memberRe`) only recognized
*keyword-prefixed* fields (`final String hash;`). Mutable models
(`Quirks.openapi()`) emit fields bare — `String? workflows;` — so a
dartdoc `[workflows]` reference that the analyzer *would* resolve was
treated as unresolved, and the file got a spurious directive.

Adds a `_bareFieldRe` that matches keyword-less field declarations
(`<type> <name>;`, generics and `?` allowed). The whole-line end-anchor
excludes getters (`T get x => ...;`), methods and assignments; a leading
negative lookahead drops keyword-led statements that share the two-token
shape (`return foo;`, `throw foo;`) so a method-local name never leaks
into the resolved set — the dangerous direction, where a real
`comment_references` lint would then fire in generated code.

Surfaced by #360, which worked around it with a code span instead of a
`[apiVersion]` link. Closes #363.

## Validation

- New unit tests in `formatting_test.dart` cover: bare field refs
  resolving, bare fields with generic types (`Map<String, dynamic>`),
  `return foo;` not being mistaken for a field, and a getter not being
  mistaken for a field.
- All existing fixtures regenerate **byte-identically** — the scan can
  only ever *add* resolved names (i.e. remove directives), never add
  them, and no current fixture carried a spurious directive.
- End-to-end `--openapi` repro (a mutable model whose description
  references its own fields): pre-fix output carried the directive,
  post-fix omits it and stays analyze-clean.

Note: this touches `_topLevelDeclarations`'s field matcher, adjacent to
#142's dormant remaining item-1 (Map-field generics). The bare-field
matcher here handles generics too, but I've kept this scoped to the
bare-field gap and left #142 for its owner.
