### PR TITLE
feat: validate maxProperties/minProperties as map entry-count bounds (#370)

### DIFF
--- a/gen_tests/const_property/lib/api_exception.dart
+++ b/gen_tests/const_property/lib/api_exception.dart
@@ -171,3 +171,28 @@ extension ValidateArray<T> on List<T> {
     }
   }
 }
+
+/// Validates a map against the constraints a schema declares for it.
+///
+/// See [ValidateNumber] — [validate] is sugar over the single-rule methods.
+/// `maxProperties`/`minProperties` bound the entry count of a map-shaped
+/// object (arbitrary string keys), the map analog of a list's
+/// `maxItems`/`minItems`.
+extension ValidateMap<K, V> on Map<K, V> {
+  void validate({int? minProperties, int? maxProperties}) {
+    if (minProperties != null) validateMinimumProperties(minProperties);
+    if (maxProperties != null) validateMaximumProperties(maxProperties);
+  }
+
+  void validateMinimumProperties(int minimum) {
+    if (length < minimum) {
+      throw Exception('must have at least $minimum entries');
+    }
+  }
+
+  void validateMaximumProperties(int maximum) {
+    if (length > maximum) {
+      throw Exception('must have at most $maximum entries');
+    }
+  }
+}

--- a/gen_tests/form_urlencoded/lib/api_exception.dart
+++ b/gen_tests/form_urlencoded/lib/api_exception.dart
@@ -171,3 +171,28 @@ extension ValidateArray<T> on List<T> {
     }
   }
 }
+
+/// Validates a map against the constraints a schema declares for it.
+///
+/// See [ValidateNumber] — [validate] is sugar over the single-rule methods.
+/// `maxProperties`/`minProperties` bound the entry count of a map-shaped
+/// object (arbitrary string keys), the map analog of a list's
+/// `maxItems`/`minItems`.
+extension ValidateMap<K, V> on Map<K, V> {
+  void validate({int? minProperties, int? maxProperties}) {
+    if (minProperties != null) validateMinimumProperties(minProperties);
+    if (maxProperties != null) validateMaximumProperties(maxProperties);
+  }
+
+  void validateMinimumProperties(int minimum) {
+    if (length < minimum) {
+      throw Exception('must have at least $minimum entries');
+    }
+  }
+
+  void validateMaximumProperties(int maximum) {
+    if (length > maximum) {
+      throw Exception('must have at most $maximum entries');
+    }
+  }
+}

--- a/gen_tests/multipart/lib/api_exception.dart
+++ b/gen_tests/multipart/lib/api_exception.dart
@@ -171,3 +171,28 @@ extension ValidateArray<T> on List<T> {
     }
   }
 }
+
+/// Validates a map against the constraints a schema declares for it.
+///
+/// See [ValidateNumber] — [validate] is sugar over the single-rule methods.
+/// `maxProperties`/`minProperties` bound the entry count of a map-shaped
+/// object (arbitrary string keys), the map analog of a list's
+/// `maxItems`/`minItems`.
+extension ValidateMap<K, V> on Map<K, V> {
+  void validate({int? minProperties, int? maxProperties}) {
+    if (minProperties != null) validateMinimumProperties(minProperties);
+    if (maxProperties != null) validateMaximumProperties(maxProperties);
+  }
+
+  void validateMinimumProperties(int minimum) {
+    if (length < minimum) {
+      throw Exception('must have at least $minimum entries');
+    }
+  }
+
+  void validateMaximumProperties(int maximum) {
+    if (length > maximum) {
+      throw Exception('must have at most $maximum entries');
+    }
+  }
+}

--- a/gen_tests/security/lib/api_exception.dart
+++ b/gen_tests/security/lib/api_exception.dart
@@ -171,3 +171,28 @@ extension ValidateArray<T> on List<T> {
     }
   }
 }
+
+/// Validates a map against the constraints a schema declares for it.
+///
+/// See [ValidateNumber] — [validate] is sugar over the single-rule methods.
+/// `maxProperties`/`minProperties` bound the entry count of a map-shaped
+/// object (arbitrary string keys), the map analog of a list's
+/// `maxItems`/`minItems`.
+extension ValidateMap<K, V> on Map<K, V> {
+  void validate({int? minProperties, int? maxProperties}) {
+    if (minProperties != null) validateMinimumProperties(minProperties);
+    if (maxProperties != null) validateMaximumProperties(maxProperties);
+  }
+
+  void validateMinimumProperties(int minimum) {
+    if (length < minimum) {
+      throw Exception('must have at least $minimum entries');
+    }
+  }
+
+  void validateMaximumProperties(int maximum) {
+    if (length > maximum) {
+      throw Exception('must have at most $maximum entries');
+    }
+  }
+}

--- a/gen_tests/third_party/backstage/lib/api_exception.dart
+++ b/gen_tests/third_party/backstage/lib/api_exception.dart
@@ -171,3 +171,28 @@ extension ValidateArray<T> on List<T> {
     }
   }
 }
+
+/// Validates a map against the constraints a schema declares for it.
+///
+/// See [ValidateNumber] — [validate] is sugar over the single-rule methods.
+/// `maxProperties`/`minProperties` bound the entry count of a map-shaped
+/// object (arbitrary string keys), the map analog of a list's
+/// `maxItems`/`minItems`.
+extension ValidateMap<K, V> on Map<K, V> {
+  void validate({int? minProperties, int? maxProperties}) {
+    if (minProperties != null) validateMinimumProperties(minProperties);
+    if (maxProperties != null) validateMaximumProperties(maxProperties);
+  }
+
+  void validateMinimumProperties(int minimum) {
+    if (length < minimum) {
+      throw Exception('must have at least $minimum entries');
+    }
+  }
+
+  void validateMaximumProperties(int maximum) {
+    if (length > maximum) {
+      throw Exception('must have at most $maximum entries');
+    }
+  }
+}

--- a/gen_tests/third_party/discord/lib/api_exception.dart
+++ b/gen_tests/third_party/discord/lib/api_exception.dart
@@ -171,3 +171,28 @@ extension ValidateArray<T> on List<T> {
     }
   }
 }
+
+/// Validates a map against the constraints a schema declares for it.
+///
+/// See [ValidateNumber] — [validate] is sugar over the single-rule methods.
+/// `maxProperties`/`minProperties` bound the entry count of a map-shaped
+/// object (arbitrary string keys), the map analog of a list's
+/// `maxItems`/`minItems`.
+extension ValidateMap<K, V> on Map<K, V> {
+  void validate({int? minProperties, int? maxProperties}) {
+    if (minProperties != null) validateMinimumProperties(minProperties);
+    if (maxProperties != null) validateMaximumProperties(maxProperties);
+  }
+
+  void validateMinimumProperties(int minimum) {
+    if (length < minimum) {
+      throw Exception('must have at least $minimum entries');
+    }
+  }
+
+  void validateMaximumProperties(int maximum) {
+    if (length > maximum) {
+      throw Exception('must have at most $maximum entries');
+    }
+  }
+}

--- a/gen_tests/third_party/discord/lib/messages/add_lobby_member_request.dart
+++ b/gen_tests/third_party/discord/lib/messages/add_lobby_member_request.dart
@@ -1,10 +1,13 @@
+import 'package:discord/api_exception.dart';
 import 'package:discord/model_helpers.dart';
 import 'package:discord/models/add_lobby_member_request_flags_one_of_1.dart';
 import 'package:meta/meta.dart';
 
 @immutable
 class AddLobbyMemberRequest {
-  const AddLobbyMemberRequest({this.metadata, this.flags});
+  AddLobbyMemberRequest({this.metadata, this.flags}) {
+    metadata?.validate(maxProperties: 25);
+  }
 
   /// Converts a `Map<String, dynamic>` to an [AddLobbyMemberRequest].
   factory AddLobbyMemberRequest.fromJson(Map<String, dynamic> json) {

--- a/gen_tests/third_party/discord/lib/messages/application_command_create_request.dart
+++ b/gen_tests/third_party/discord/lib/messages/application_command_create_request.dart
@@ -29,7 +29,9 @@ class ApplicationCommandCreateRequest {
     this.type,
   }) {
     name.validate(minLength: 1, maxLength: 32);
+    nameLocalizations?.validate(maxProperties: 34);
     description?.validate(maxLength: 100);
+    descriptionLocalizations?.validate(maxProperties: 34);
     options?.validate(maxItems: 25);
     defaultMemberPermissions?.validate(min: 0, max: 18014398509481983);
     contexts?.validate(minItems: 1, unique: true);

--- a/gen_tests/third_party/discord/lib/messages/application_command_update_request.dart
+++ b/gen_tests/third_party/discord/lib/messages/application_command_update_request.dart
@@ -31,7 +31,9 @@ class ApplicationCommandUpdateRequest {
     this.id,
   }) {
     name.validate(minLength: 1, maxLength: 32);
+    nameLocalizations?.validate(maxProperties: 34);
     description?.validate(maxLength: 100);
+    descriptionLocalizations?.validate(maxProperties: 34);
     options?.validate(maxItems: 25);
     defaultMemberPermissions?.validate(min: 0, max: 18014398509481983);
     contexts?.validate(minItems: 1, unique: true);

--- a/gen_tests/third_party/discord/lib/messages/application_role_connections_metadata_item_request.dart
+++ b/gen_tests/third_party/discord/lib/messages/application_role_connections_metadata_item_request.dart
@@ -15,7 +15,9 @@ class ApplicationRoleConnectionsMetadataItemRequest {
   }) {
     key.validate(minLength: 1, maxLength: 50);
     name.validate(minLength: 1, maxLength: 100);
+    nameLocalizations?.validate(maxProperties: 1521);
     description.validate(minLength: 1, maxLength: 200);
+    descriptionLocalizations?.validate(maxProperties: 1521);
   }
 
   /// Converts a `Map<String, dynamic>` to an

--- a/gen_tests/third_party/discord/lib/messages/bulk_lobby_member_request.dart
+++ b/gen_tests/third_party/discord/lib/messages/bulk_lobby_member_request.dart
@@ -1,3 +1,4 @@
+import 'package:discord/api_exception.dart';
 import 'package:discord/model_helpers.dart';
 import 'package:discord/models/bulk_lobby_member_request_flags_one_of_1.dart';
 import 'package:discord/models/snowflake_type.dart';
@@ -5,12 +6,14 @@ import 'package:meta/meta.dart';
 
 @immutable
 class BulkLobbyMemberRequest {
-  const BulkLobbyMemberRequest({
+  BulkLobbyMemberRequest({
     required this.id,
     this.metadata,
     this.flags,
     this.removeMember,
-  });
+  }) {
+    metadata?.validate(maxProperties: 25);
+  }
 
   /// Converts a `Map<String, dynamic>` to a [BulkLobbyMemberRequest].
   factory BulkLobbyMemberRequest.fromJson(Map<String, dynamic> json) {

--- a/gen_tests/third_party/discord/lib/messages/create_lobby_request.dart
+++ b/gen_tests/third_party/discord/lib/messages/create_lobby_request.dart
@@ -15,6 +15,7 @@ class CreateLobbyRequest {
   }) {
     idleTimeoutSeconds?.validate(min: 5, max: 604800);
     members?.validate(maxItems: 25);
+    metadata?.validate(maxProperties: 25);
   }
 
   /// Converts a `Map<String, dynamic>` to a [CreateLobbyRequest].

--- a/gen_tests/third_party/discord/lib/messages/create_or_join_lobby_request.dart
+++ b/gen_tests/third_party/discord/lib/messages/create_or_join_lobby_request.dart
@@ -13,6 +13,8 @@ class CreateOrJoinLobbyRequest {
     this.flags,
   }) {
     idleTimeoutSeconds?.validate(min: 5, max: 604800);
+    lobbyMetadata?.validate(maxProperties: 25);
+    memberMetadata?.validate(maxProperties: 25);
     secret.validate(maxLength: 250);
   }
 

--- a/gen_tests/third_party/discord/lib/messages/create_private_channel_request.dart
+++ b/gen_tests/third_party/discord/lib/messages/create_private_channel_request.dart
@@ -11,6 +11,7 @@ class CreatePrivateChannelRequest {
     this.nicks,
   }) {
     accessTokens?.validate(maxItems: 1521, unique: true);
+    nicks?.validate(maxProperties: 1521);
   }
 
   /// Converts a `Map<String, dynamic>` to a [CreatePrivateChannelRequest].

--- a/gen_tests/third_party/discord/lib/messages/edit_lobby_request.dart
+++ b/gen_tests/third_party/discord/lib/messages/edit_lobby_request.dart
@@ -14,6 +14,7 @@ class EditLobbyRequest {
     this.overrideEventWebhooksUrl,
   }) {
     idleTimeoutSeconds?.validate(min: 5, max: 604800);
+    metadata?.validate(maxProperties: 25);
     members?.validate(maxItems: 25);
   }
 

--- a/gen_tests/third_party/discord/lib/messages/lobby_member_request.dart
+++ b/gen_tests/third_party/discord/lib/messages/lobby_member_request.dart
@@ -1,3 +1,4 @@
+import 'package:discord/api_exception.dart';
 import 'package:discord/model_helpers.dart';
 import 'package:discord/models/lobby_member_request_flags_one_of_1.dart';
 import 'package:discord/models/snowflake_type.dart';
@@ -5,7 +6,9 @@ import 'package:meta/meta.dart';
 
 @immutable
 class LobbyMemberRequest {
-  const LobbyMemberRequest({required this.id, this.metadata, this.flags});
+  LobbyMemberRequest({required this.id, this.metadata, this.flags}) {
+    metadata?.validate(maxProperties: 25);
+  }
 
   /// Converts a `Map<String, dynamic>` to a [LobbyMemberRequest].
   factory LobbyMemberRequest.fromJson(Map<String, dynamic> json) {

--- a/gen_tests/third_party/discord/lib/messages/update_application_user_role_connection_request.dart
+++ b/gen_tests/third_party/discord/lib/messages/update_application_user_role_connection_request.dart
@@ -11,6 +11,7 @@ class UpdateApplicationUserRoleConnectionRequest {
   }) {
     platformName?.validate(maxLength: 50);
     platformUsername?.validate(maxLength: 100);
+    metadata?.validate(maxProperties: 5);
   }
 
   /// Converts a `Map<String, dynamic>` to a

--- a/gen_tests/third_party/discord/lib/models/application_command_attachment_option.dart
+++ b/gen_tests/third_party/discord/lib/models/application_command_attachment_option.dart
@@ -13,7 +13,9 @@ class ApplicationCommandAttachmentOption {
     this.required_,
   }) {
     name.validate(minLength: 1, maxLength: 32);
+    nameLocalizations?.validate(maxProperties: 34);
     description.validate(minLength: 1, maxLength: 100);
+    descriptionLocalizations?.validate(maxProperties: 34);
   }
 
   /// Converts a `Map<String, dynamic>` to an

--- a/gen_tests/third_party/discord/lib/models/application_command_boolean_option.dart
+++ b/gen_tests/third_party/discord/lib/models/application_command_boolean_option.dart
@@ -13,7 +13,9 @@ class ApplicationCommandBooleanOption {
     this.required_,
   }) {
     name.validate(minLength: 1, maxLength: 32);
+    nameLocalizations?.validate(maxProperties: 34);
     description.validate(minLength: 1, maxLength: 100);
+    descriptionLocalizations?.validate(maxProperties: 34);
   }
 
   /// Converts a `Map<String, dynamic>` to an [ApplicationCommandBooleanOption].

--- a/gen_tests/third_party/discord/lib/models/application_command_channel_option.dart
+++ b/gen_tests/third_party/discord/lib/models/application_command_channel_option.dart
@@ -15,7 +15,9 @@ class ApplicationCommandChannelOption {
     this.channelTypes,
   }) {
     name.validate(minLength: 1, maxLength: 32);
+    nameLocalizations?.validate(maxProperties: 34);
     description.validate(minLength: 1, maxLength: 100);
+    descriptionLocalizations?.validate(maxProperties: 34);
     channelTypes?.validate(unique: true);
   }
 

--- a/gen_tests/third_party/discord/lib/models/application_command_integer_option.dart
+++ b/gen_tests/third_party/discord/lib/models/application_command_integer_option.dart
@@ -19,7 +19,9 @@ class ApplicationCommandIntegerOption {
     this.maxValue,
   }) {
     name.validate(minLength: 1, maxLength: 32);
+    nameLocalizations?.validate(maxProperties: 34);
     description.validate(minLength: 1, maxLength: 100);
+    descriptionLocalizations?.validate(maxProperties: 34);
     choices?.validate(maxItems: 25);
   }
 

--- a/gen_tests/third_party/discord/lib/models/application_command_mentionable_option.dart
+++ b/gen_tests/third_party/discord/lib/models/application_command_mentionable_option.dart
@@ -13,7 +13,9 @@ class ApplicationCommandMentionableOption {
     this.required_,
   }) {
     name.validate(minLength: 1, maxLength: 32);
+    nameLocalizations?.validate(maxProperties: 34);
     description.validate(minLength: 1, maxLength: 100);
+    descriptionLocalizations?.validate(maxProperties: 34);
   }
 
   /// Converts a `Map<String, dynamic>` to an

--- a/gen_tests/third_party/discord/lib/models/application_command_number_option.dart
+++ b/gen_tests/third_party/discord/lib/models/application_command_number_option.dart
@@ -18,7 +18,9 @@ class ApplicationCommandNumberOption {
     this.maxValue,
   }) {
     name.validate(minLength: 1, maxLength: 32);
+    nameLocalizations?.validate(maxProperties: 34);
     description.validate(minLength: 1, maxLength: 100);
+    descriptionLocalizations?.validate(maxProperties: 34);
     choices?.validate(maxItems: 25);
   }
 

--- a/gen_tests/third_party/discord/lib/models/application_command_option_integer_choice.dart
+++ b/gen_tests/third_party/discord/lib/models/application_command_option_integer_choice.dart
@@ -11,6 +11,7 @@ class ApplicationCommandOptionIntegerChoice {
     this.nameLocalizations,
   }) {
     name.validate(minLength: 1, maxLength: 100);
+    nameLocalizations?.validate(maxProperties: 34);
   }
 
   /// Converts a `Map<String, dynamic>` to an

--- a/gen_tests/third_party/discord/lib/models/application_command_option_number_choice.dart
+++ b/gen_tests/third_party/discord/lib/models/application_command_option_number_choice.dart
@@ -10,6 +10,7 @@ class ApplicationCommandOptionNumberChoice {
     this.nameLocalizations,
   }) {
     name.validate(minLength: 1, maxLength: 100);
+    nameLocalizations?.validate(maxProperties: 34);
   }
 
   /// Converts a `Map<String, dynamic>` to an

--- a/gen_tests/third_party/discord/lib/models/application_command_option_string_choice.dart
+++ b/gen_tests/third_party/discord/lib/models/application_command_option_string_choice.dart
@@ -10,6 +10,7 @@ class ApplicationCommandOptionStringChoice {
     this.nameLocalizations,
   }) {
     name.validate(minLength: 1, maxLength: 100);
+    nameLocalizations?.validate(maxProperties: 34);
     value.validate(maxLength: 6000);
   }
 

--- a/gen_tests/third_party/discord/lib/models/application_command_patch_request_partial.dart
+++ b/gen_tests/third_party/discord/lib/models/application_command_patch_request_partial.dart
@@ -27,7 +27,9 @@ class ApplicationCommandPatchRequestPartial {
     this.handler,
   }) {
     name?.validate(minLength: 1, maxLength: 32);
+    nameLocalizations?.validate(maxProperties: 34);
     description?.validate(maxLength: 100);
+    descriptionLocalizations?.validate(maxProperties: 34);
     options?.validate(maxItems: 25);
     defaultMemberPermissions?.validate(min: 0, max: 18014398509481983);
     contexts?.validate(minItems: 1, unique: true);

--- a/gen_tests/third_party/discord/lib/models/application_command_role_option.dart
+++ b/gen_tests/third_party/discord/lib/models/application_command_role_option.dart
@@ -13,7 +13,9 @@ class ApplicationCommandRoleOption {
     this.required_,
   }) {
     name.validate(minLength: 1, maxLength: 32);
+    nameLocalizations?.validate(maxProperties: 34);
     description.validate(minLength: 1, maxLength: 100);
+    descriptionLocalizations?.validate(maxProperties: 34);
   }
 
   /// Converts a `Map<String, dynamic>` to an [ApplicationCommandRoleOption].

--- a/gen_tests/third_party/discord/lib/models/application_command_string_option.dart
+++ b/gen_tests/third_party/discord/lib/models/application_command_string_option.dart
@@ -18,7 +18,9 @@ class ApplicationCommandStringOption {
     this.choices,
   }) {
     name.validate(minLength: 1, maxLength: 32);
+    nameLocalizations?.validate(maxProperties: 34);
     description.validate(minLength: 1, maxLength: 100);
+    descriptionLocalizations?.validate(maxProperties: 34);
     minLength?.validate(min: 0, max: 6000);
     maxLength?.validate(min: 1, max: 6000);
     choices?.validate(maxItems: 25);

--- a/gen_tests/third_party/discord/lib/models/application_command_subcommand_group_option.dart
+++ b/gen_tests/third_party/discord/lib/models/application_command_subcommand_group_option.dart
@@ -15,7 +15,9 @@ class ApplicationCommandSubcommandGroupOption {
     this.options,
   }) {
     name.validate(minLength: 1, maxLength: 32);
+    nameLocalizations?.validate(maxProperties: 34);
     description.validate(minLength: 1, maxLength: 100);
+    descriptionLocalizations?.validate(maxProperties: 34);
     options?.validate(maxItems: 25);
   }
 

--- a/gen_tests/third_party/discord/lib/models/application_command_subcommand_option.dart
+++ b/gen_tests/third_party/discord/lib/models/application_command_subcommand_option.dart
@@ -15,7 +15,9 @@ class ApplicationCommandSubcommandOption {
     this.options,
   }) {
     name.validate(minLength: 1, maxLength: 32);
+    nameLocalizations?.validate(maxProperties: 34);
     description.validate(minLength: 1, maxLength: 100);
+    descriptionLocalizations?.validate(maxProperties: 34);
     options?.validate(maxItems: 25);
   }
 

--- a/gen_tests/third_party/discord/lib/models/application_command_user_option.dart
+++ b/gen_tests/third_party/discord/lib/models/application_command_user_option.dart
@@ -13,7 +13,9 @@ class ApplicationCommandUserOption {
     this.required_,
   }) {
     name.validate(minLength: 1, maxLength: 32);
+    nameLocalizations?.validate(maxProperties: 34);
     description.validate(minLength: 1, maxLength: 100);
+    descriptionLocalizations?.validate(maxProperties: 34);
   }
 
   /// Converts a `Map<String, dynamic>` to an [ApplicationCommandUserOption].

--- a/gen_tests/third_party/discord/lib/models/application_form_partial.dart
+++ b/gen_tests/third_party/discord/lib/models/application_form_partial.dart
@@ -34,6 +34,7 @@ class ApplicationFormPartial {
   }) {
     maxParticipants?.validate(min: -1);
     tags?.validate(maxItems: 5, unique: true);
+    integrationTypesConfig?.validate(minProperties: 1, maxProperties: 2);
     eventWebhooksTypes?.validate(unique: true);
   }
 

--- a/gen_tests/third_party/discord/test/gen/messages/add_lobby_member_request_test.dart
+++ b/gen_tests/third_party/discord/test/gen/messages/add_lobby_member_request_test.dart
@@ -5,7 +5,7 @@ import 'package:test/test.dart';
 void main() {
   group('AddLobbyMemberRequest', () {
     test('round-trips via maybeFromJson/toJson', () {
-      const instance = AddLobbyMemberRequest();
+      final instance = AddLobbyMemberRequest();
       final parsed = AddLobbyMemberRequest.maybeFromJson(instance.toJson())!;
       expect(parsed, equals(instance));
       expect(parsed.hashCode, equals(instance.hashCode));

--- a/gen_tests/third_party/github/lib/api_exception.dart
+++ b/gen_tests/third_party/github/lib/api_exception.dart
@@ -171,3 +171,28 @@ extension ValidateArray<T> on List<T> {
     }
   }
 }
+
+/// Validates a map against the constraints a schema declares for it.
+///
+/// See [ValidateNumber] — [validate] is sugar over the single-rule methods.
+/// `maxProperties`/`minProperties` bound the entry count of a map-shaped
+/// object (arbitrary string keys), the map analog of a list's
+/// `maxItems`/`minItems`.
+extension ValidateMap<K, V> on Map<K, V> {
+  void validate({int? minProperties, int? maxProperties}) {
+    if (minProperties != null) validateMinimumProperties(minProperties);
+    if (maxProperties != null) validateMaximumProperties(maxProperties);
+  }
+
+  void validateMinimumProperties(int minimum) {
+    if (length < minimum) {
+      throw Exception('must have at least $minimum entries');
+    }
+  }
+
+  void validateMaximumProperties(int maximum) {
+    if (length > maximum) {
+      throw Exception('must have at most $maximum entries');
+    }
+  }
+}

--- a/gen_tests/third_party/github/lib/messages/actions_create_workflow_dispatch_request.dart
+++ b/gen_tests/third_party/github/lib/messages/actions_create_workflow_dispatch_request.dart
@@ -1,9 +1,12 @@
+import 'package:github/api_exception.dart';
 import 'package:github/model_helpers.dart';
 import 'package:meta/meta.dart';
 
 @immutable
 class ActionsCreateWorkflowDispatchRequest {
-  const ActionsCreateWorkflowDispatchRequest({required this.ref, this.inputs});
+  ActionsCreateWorkflowDispatchRequest({required this.ref, this.inputs}) {
+    inputs?.validate(maxProperties: 10);
+  }
 
   /// Converts a `Map<String, dynamic>` to an
   /// [ActionsCreateWorkflowDispatchRequest].

--- a/gen_tests/third_party/github/lib/messages/repos_create_dispatch_event_request.dart
+++ b/gen_tests/third_party/github/lib/messages/repos_create_dispatch_event_request.dart
@@ -9,6 +9,7 @@ class ReposCreateDispatchEventRequest {
     this.clientPayload,
   }) {
     eventType.validate(minLength: 1, maxLength: 100);
+    clientPayload?.validate(maxProperties: 10);
   }
 
   /// Converts a `Map<String, dynamic>` to a [ReposCreateDispatchEventRequest].

--- a/gen_tests/third_party/github/lib/models/dependency.dart
+++ b/gen_tests/third_party/github/lib/models/dependency.dart
@@ -15,6 +15,7 @@ class Dependency {
     this.dependencies,
   }) {
     packageUrl?.validate(pattern: '^pkg');
+    metadata?.validate(maxProperties: 8);
   }
 
   /// Converts a `Map<String, dynamic>` to a [Dependency].

--- a/gen_tests/third_party/github/lib/models/manifest.dart
+++ b/gen_tests/third_party/github/lib/models/manifest.dart
@@ -1,3 +1,4 @@
+import 'package:github/api_exception.dart';
 import 'package:github/model_helpers.dart';
 import 'package:github/models/dependency.dart';
 import 'package:github/models/manifest_file.dart';
@@ -6,7 +7,9 @@ import 'package:meta/meta.dart';
 
 @immutable
 class Manifest {
-  const Manifest({required this.name, this.file, this.metadata, this.resolved});
+  Manifest({required this.name, this.file, this.metadata, this.resolved}) {
+    metadata?.validate(maxProperties: 8);
+  }
 
   /// Converts a `Map<String, dynamic>` to a [Manifest].
   factory Manifest.fromJson(Map<String, dynamic> json) {

--- a/gen_tests/third_party/github/lib/models/snapshot.dart
+++ b/gen_tests/third_party/github/lib/models/snapshot.dart
@@ -25,6 +25,7 @@ class Snapshot {
   }) {
     sha.validate(minLength: 40, maxLength: 40);
     ref.validate(pattern: '^refs/');
+    metadata?.validate(maxProperties: 8);
   }
 
   /// Converts a `Map<String, dynamic>` to a [Snapshot].

--- a/gen_tests/third_party/github/test/gen/messages/actions_create_workflow_dispatch_request_test.dart
+++ b/gen_tests/third_party/github/test/gen/messages/actions_create_workflow_dispatch_request_test.dart
@@ -5,7 +5,7 @@ import 'package:test/test.dart';
 void main() {
   group('ActionsCreateWorkflowDispatchRequest', () {
     test('round-trips via maybeFromJson/toJson', () {
-      const instance = ActionsCreateWorkflowDispatchRequest(ref: 'example');
+      final instance = ActionsCreateWorkflowDispatchRequest(ref: 'example');
       final parsed = ActionsCreateWorkflowDispatchRequest.maybeFromJson(
         instance.toJson(),
       )!;

--- a/gen_tests/third_party/github/test/gen/models/manifest_test.dart
+++ b/gen_tests/third_party/github/test/gen/models/manifest_test.dart
@@ -5,7 +5,7 @@ import 'package:test/test.dart';
 void main() {
   group('Manifest', () {
     test('round-trips via maybeFromJson/toJson', () {
-      const instance = Manifest(name: 'package-lock.json');
+      final instance = Manifest(name: 'package-lock.json');
       final parsed = Manifest.maybeFromJson(instance.toJson())!;
       expect(parsed, equals(instance));
       expect(parsed.hashCode, equals(instance.hashCode));

--- a/gen_tests/third_party/petstore/lib/api_exception.dart
+++ b/gen_tests/third_party/petstore/lib/api_exception.dart
@@ -171,3 +171,28 @@ extension ValidateArray<T> on List<T> {
     }
   }
 }
+
+/// Validates a map against the constraints a schema declares for it.
+///
+/// See [ValidateNumber] — [validate] is sugar over the single-rule methods.
+/// `maxProperties`/`minProperties` bound the entry count of a map-shaped
+/// object (arbitrary string keys), the map analog of a list's
+/// `maxItems`/`minItems`.
+extension ValidateMap<K, V> on Map<K, V> {
+  void validate({int? minProperties, int? maxProperties}) {
+    if (minProperties != null) validateMinimumProperties(minProperties);
+    if (maxProperties != null) validateMaximumProperties(maxProperties);
+  }
+
+  void validateMinimumProperties(int minimum) {
+    if (length < minimum) {
+      throw Exception('must have at least $minimum entries');
+    }
+  }
+
+  void validateMaximumProperties(int maximum) {
+    if (length > maximum) {
+      throw Exception('must have at most $maximum entries');
+    }
+  }
+}

--- a/gen_tests/third_party/spacetraders/lib/api_exception.dart
+++ b/gen_tests/third_party/spacetraders/lib/api_exception.dart
@@ -171,3 +171,28 @@ extension ValidateArray<T> on List<T> {
     }
   }
 }
+
+/// Validates a map against the constraints a schema declares for it.
+///
+/// See [ValidateNumber] — [validate] is sugar over the single-rule methods.
+/// `maxProperties`/`minProperties` bound the entry count of a map-shaped
+/// object (arbitrary string keys), the map analog of a list's
+/// `maxItems`/`minItems`.
+extension ValidateMap<K, V> on Map<K, V> {
+  void validate({int? minProperties, int? maxProperties}) {
+    if (minProperties != null) validateMinimumProperties(minProperties);
+    if (maxProperties != null) validateMaximumProperties(maxProperties);
+  }
+
+  void validateMinimumProperties(int minimum) {
+    if (length < minimum) {
+      throw Exception('must have at least $minimum entries');
+    }
+  }
+
+  void validateMaximumProperties(int maximum) {
+    if (length > maximum) {
+      throw Exception('must have at most $maximum entries');
+    }
+  }
+}

--- a/gen_tests/third_party/train_travel/lib/api_exception.dart
+++ b/gen_tests/third_party/train_travel/lib/api_exception.dart
@@ -171,3 +171,28 @@ extension ValidateArray<T> on List<T> {
     }
   }
 }
+
+/// Validates a map against the constraints a schema declares for it.
+///
+/// See [ValidateNumber] — [validate] is sugar over the single-rule methods.
+/// `maxProperties`/`minProperties` bound the entry count of a map-shaped
+/// object (arbitrary string keys), the map analog of a list's
+/// `maxItems`/`minItems`.
+extension ValidateMap<K, V> on Map<K, V> {
+  void validate({int? minProperties, int? maxProperties}) {
+    if (minProperties != null) validateMinimumProperties(minProperties);
+    if (maxProperties != null) validateMaximumProperties(maxProperties);
+  }
+
+  void validateMinimumProperties(int minimum) {
+    if (length < minimum) {
+      throw Exception('must have at least $minimum entries');
+    }
+  }
+
+  void validateMaximumProperties(int maximum) {
+    if (length > maximum) {
+      throw Exception('must have at most $maximum entries');
+    }
+  }
+}

--- a/gen_tests/types/lib/api_exception.dart
+++ b/gen_tests/types/lib/api_exception.dart
@@ -171,3 +171,28 @@ extension ValidateArray<T> on List<T> {
     }
   }
 }
+
+/// Validates a map against the constraints a schema declares for it.
+///
+/// See [ValidateNumber] — [validate] is sugar over the single-rule methods.
+/// `maxProperties`/`minProperties` bound the entry count of a map-shaped
+/// object (arbitrary string keys), the map analog of a list's
+/// `maxItems`/`minItems`.
+extension ValidateMap<K, V> on Map<K, V> {
+  void validate({int? minProperties, int? maxProperties}) {
+    if (minProperties != null) validateMinimumProperties(minProperties);
+    if (maxProperties != null) validateMaximumProperties(maxProperties);
+  }
+
+  void validateMinimumProperties(int minimum) {
+    if (length < minimum) {
+      throw Exception('must have at least $minimum entries');
+    }
+  }
+
+  void validateMaximumProperties(int maximum) {
+    if (length > maximum) {
+      throw Exception('must have at most $maximum entries');
+    }
+  }
+}

--- a/gen_tests/unsupported_auth/lib/api_exception.dart
+++ b/gen_tests/unsupported_auth/lib/api_exception.dart
@@ -171,3 +171,28 @@ extension ValidateArray<T> on List<T> {
     }
   }
 }
+
+/// Validates a map against the constraints a schema declares for it.
+///
+/// See [ValidateNumber] — [validate] is sugar over the single-rule methods.
+/// `maxProperties`/`minProperties` bound the entry count of a map-shaped
+/// object (arbitrary string keys), the map analog of a list's
+/// `maxItems`/`minItems`.
+extension ValidateMap<K, V> on Map<K, V> {
+  void validate({int? minProperties, int? maxProperties}) {
+    if (minProperties != null) validateMinimumProperties(minProperties);
+    if (maxProperties != null) validateMaximumProperties(maxProperties);
+  }
+
+  void validateMinimumProperties(int minimum) {
+    if (length < minimum) {
+      throw Exception('must have at least $minimum entries');
+    }
+  }
+
+  void validateMaximumProperties(int maximum) {
+    if (length > maximum) {
+      throw Exception('must have at most $maximum entries');
+    }
+  }
+}

--- a/lib/src/parse/spec.dart
+++ b/lib/src/parse/spec.dart
@@ -226,6 +226,8 @@ class SchemaMap extends Schema {
     required super.common,
     required this.valueSchema,
     required this.keySchema,
+    required this.maxProperties,
+    required this.minProperties,
   });
 
   final SchemaRef valueSchema;
@@ -237,6 +239,15 @@ class SchemaMap extends Schema {
   /// Dart use a richer key type (currently only string enums) with
   /// automatic encode/decode at the boundary.
   final SchemaRef? keySchema;
+
+  /// The maximum number of entries this map may carry (`maxProperties`).
+  /// The map analog of [SchemaArray.maxItems]; validated at the JSON
+  /// boundary. Null when unconstrained.
+  final int? maxProperties;
+
+  /// The minimum number of entries this map must carry (`minProperties`).
+  /// Null when unconstrained.
+  final int? minProperties;
 }
 
 class SchemaBinary extends Schema {

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -936,10 +936,17 @@ SchemaMap _mapSchema(
   final keySchema = propertyNamesJson == null
       ? null
       : parseSchemaOrRef(propertyNamesJson);
+  // `maxProperties`/`minProperties` bound the entry count. On a map the
+  // count is dynamic, so these are real validation constraints (the map
+  // analog of an array's `maxItems`/`minItems`). On a fixed-property
+  // object they're static and meaningless — dropped there, see the
+  // object return path.
   return SchemaMap(
     common: common,
     valueSchema: valueSchema,
     keySchema: keySchema,
+    maxProperties: _optional<int>(json, 'maxProperties'),
+    minProperties: _optional<int>(json, 'minProperties'),
   );
 }
 
@@ -1507,12 +1514,6 @@ Schema _createCorrectSchemaSubtype(MapContext json) {
 
   final additionalPropertiesSchema = _handleAdditionalProperties(json);
 
-  // Object-size validation we don't enforce. Detail-log so the
-  // verbose-log mining workflow can find specs that lean on these
-  // constraints; no behavior to act on.
-  _ignored<int>(json, 'maxProperties');
-  _ignored<int>(json, 'minProperties');
-
   final propertiesJson = _optionalMap(json, 'properties');
   if (propertiesJson == null) {
     if (additionalPropertiesSchema == null) {
@@ -1618,6 +1619,12 @@ Schema _createCorrectSchemaSubtype(MapContext json) {
   _ignored<dynamic>(json, 'discriminator');
   _ignored<dynamic>(json, 'xml');
   _ignored<dynamic>(json, 'externalDocs');
+  // On a fixed-property object the property count is static, so
+  // `maxProperties`/`minProperties` carry no runtime meaning — drop and
+  // detail-log them. On a *map* they're validated instead (see
+  // `_mapSchema`).
+  _ignored<int>(json, 'maxProperties');
+  _ignored<int>(json, 'minProperties');
 
   final declaredRequired = _optionalList<String>(json, 'required') ?? [];
   // OpenAPI lets `required` name any string, but the only meaningful

--- a/lib/src/render/render_tree.dart
+++ b/lib/src/render/render_tree.dart
@@ -884,6 +884,8 @@ class SpecResolver {
           common: schema.common,
           valueSchema: toRenderSchema(schema.valueSchema),
           keySchema: keySchema == null ? null : toRenderSchema(keySchema),
+          maxProperties: schema.maxProperties,
+          minProperties: schema.minProperties,
         );
       case ResolvedEmptyObject():
         return RenderEmptyObject(
@@ -5487,10 +5489,27 @@ class RenderMap extends RenderSchema {
     required super.common,
     required this.valueSchema,
     required this.keySchema,
+    required this.maxProperties,
+    required this.minProperties,
     this.defaultValue,
   }) : super(createsNewType: false);
 
   final RenderSchema valueSchema;
+
+  /// The maximum number of entries this map may carry (`maxProperties`), or
+  /// null when unconstrained. Emitted as a `validate(maxProperties: ...)`
+  /// argument — the map analog of [RenderArray.maxItems].
+  final int? maxProperties;
+
+  /// The minimum number of entries this map must carry (`minProperties`), or
+  /// null when unconstrained.
+  final int? minProperties;
+
+  @override
+  String? get validationCall => validateCall([
+    if (minProperties != null) 'minProperties: $minProperties',
+    if (maxProperties != null) 'maxProperties: $maxProperties',
+  ]);
 
   /// Optional typed key schema. JSON object keys are strings on the wire, so
   /// a key can only be typed by a schema whose wire form is a string that

--- a/lib/src/resolver.dart
+++ b/lib/src/resolver.dart
@@ -591,6 +591,8 @@ ResolvedSchema _resolveSchemaFully(
       common: resolvedCommon,
       valueSchema: resolveSchemaRef(schema.valueSchema, context),
       keySchema: keySchema,
+      maxProperties: schema.maxProperties,
+      minProperties: schema.minProperties,
       createsNewType: createsNewType,
     );
   }
@@ -1915,6 +1917,8 @@ class ResolvedMap extends ResolvedSchema {
     required super.common,
     required this.valueSchema,
     required this.keySchema,
+    required this.maxProperties,
+    required this.minProperties,
     required super.createsNewType,
   });
 
@@ -1928,12 +1932,23 @@ class ResolvedMap extends ResolvedSchema {
   /// fall back to `String` keys.
   final ResolvedSchema? keySchema;
 
+  /// The maximum number of entries this map may carry (`maxProperties`), or
+  /// null when unconstrained. Validated at the JSON boundary — the map analog
+  /// of [ResolvedArray.maxItems].
+  final int? maxProperties;
+
+  /// The minimum number of entries this map must carry (`minProperties`), or
+  /// null when unconstrained.
+  final int? minProperties;
+
   @override
   ResolvedMap copyWith({CommonProperties? common}) {
     return ResolvedMap(
       common: common ?? this.common,
       valueSchema: valueSchema,
       keySchema: keySchema,
+      maxProperties: maxProperties,
+      minProperties: minProperties,
       createsNewType: createsNewType,
     );
   }

--- a/lib/templates/api_exception.dart
+++ b/lib/templates/api_exception.dart
@@ -171,3 +171,28 @@ extension ValidateArray<T> on List<T> {
     }
   }
 }
+
+/// Validates a map against the constraints a schema declares for it.
+///
+/// See [ValidateNumber] — [validate] is sugar over the single-rule methods.
+/// `maxProperties`/`minProperties` bound the entry count of a map-shaped
+/// object (arbitrary string keys), the map analog of a list's
+/// `maxItems`/`minItems`.
+extension ValidateMap<K, V> on Map<K, V> {
+  void validate({int? minProperties, int? maxProperties}) {
+    if (minProperties != null) validateMinimumProperties(minProperties);
+    if (maxProperties != null) validateMaximumProperties(maxProperties);
+  }
+
+  void validateMinimumProperties(int minimum) {
+    if (length < minimum) {
+      throw Exception('must have at least $minimum entries');
+    }
+  }
+
+  void validateMaximumProperties(int maximum) {
+    if (length > maximum) {
+      throw Exception('must have at most $maximum entries');
+    }
+  }
+}

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -552,17 +552,41 @@ void main() {
         ).called(1);
       });
 
-      test('maxProperties on an object/map is detail-logged', () {
-        // github's `metadata` and `dispatches.inputs` set
-        // `maxProperties: N`. We don't validate object size.
+      test('maxProperties/minProperties on a map are carried, not dropped', () {
+        // github's `metadata` and `dispatches.inputs`, and discord's lobby
+        // `metadata`, set `maxProperties: N` on a map (arbitrary string
+        // keys). The entry count is dynamic, so it's a real validation
+        // constraint — carried on the SchemaMap, not detail-logged.
         final json = {
           'type': 'object',
           'maxProperties': 10,
+          'minProperties': 1,
           'additionalProperties': true,
         };
         final logger = _MockLogger();
         final schema = runWithLogger(logger, () => parseTestSchema(json));
-        expect(schema, isA<SchemaMap>());
+        if (schema is! SchemaMap) fail('expected a SchemaMap, got $schema');
+        expect(schema.maxProperties, 10);
+        expect(schema.minProperties, 1);
+        verifyNever(
+          () => logger.detail(any(that: contains('maxProperties'))),
+        );
+      });
+
+      test('maxProperties on a fixed-property object is detail-logged', () {
+        // On an object with named properties the count is static, so
+        // `maxProperties` carries no runtime meaning — dropped and
+        // detail-logged (unlike the map case above).
+        final json = {
+          'type': 'object',
+          'maxProperties': 10,
+          'properties': {
+            'id': {'type': 'string'},
+          },
+        };
+        final logger = _MockLogger();
+        final schema = runWithLogger(logger, () => parseTestSchema(json));
+        expect(schema, isA<SchemaObject>());
         verify(
           () => logger.detail(
             any(that: contains('Ignoring: maxProperties=10')),

--- a/test/render/render_tree_test.dart
+++ b/test/render/render_tree_test.dart
@@ -933,6 +933,8 @@ void main() {
         ),
         valueSchema: boolValue,
         keySchema: null,
+        maxProperties: null,
+        minProperties: null,
       );
       final withKey = RenderMap(
         common: const CommonProperties.test(
@@ -942,12 +944,65 @@ void main() {
         ),
         valueSchema: boolValue,
         keySchema: enumKey,
+        maxProperties: null,
+        minProperties: null,
       );
       expect(noKey.equalsIgnoringName(noKey), isTrue);
       expect(withKey.equalsIgnoringName(withKey), isTrue);
       // Different keySchema (null vs enum) => not equal.
       expect(noKey.equalsIgnoringName(withKey), isFalse);
       expect(withKey.equalsIgnoringName(noKey), isFalse);
+    });
+
+    test('RenderMap emits a validate call for maxProperties/minProperties', () {
+      const boolValue = RenderPod(
+        common: CommonProperties.test(
+          snakeName: 'v',
+          pointer: JsonPointer.empty(),
+          description: 'v',
+        ),
+        type: PodType.boolean,
+        createsNewType: false,
+      );
+      const common = CommonProperties.test(
+        snakeName: 'a',
+        pointer: JsonPointer.empty(),
+        description: 'm',
+      );
+      // Both bounds: one combined call, min before max (matching the
+      // array/number ordering).
+      expect(
+        const RenderMap(
+          common: common,
+          valueSchema: boolValue,
+          keySchema: null,
+          maxProperties: 25,
+          minProperties: 1,
+        ).validationCall,
+        'validate(minProperties: 1, maxProperties: 25)',
+      );
+      // Only one bound present.
+      expect(
+        const RenderMap(
+          common: common,
+          valueSchema: boolValue,
+          keySchema: null,
+          maxProperties: 5,
+          minProperties: null,
+        ).validationCall,
+        'validate(maxProperties: 5)',
+      );
+      // No bounds => no call (unconstrained map).
+      expect(
+        const RenderMap(
+          common: common,
+          valueSchema: boolValue,
+          keySchema: null,
+          maxProperties: null,
+          minProperties: null,
+        ).validationCall,
+        isNull,
+      );
     });
   });
 
@@ -1313,6 +1368,8 @@ void main() {
         common: common,
         valueSchema: void_,
         keySchema: null,
+        maxProperties: null,
+        minProperties: null,
       );
       expect(
         () => map.fromJsonExpression(
@@ -1416,6 +1473,8 @@ void main() {
         common: common,
         valueSchema: inner,
         keySchema: keySchema,
+        maxProperties: null,
+        minProperties: null,
       );
       // Key example names the enum's first member; value is the string
       // example.
@@ -1997,6 +2056,8 @@ void main() {
           common: common,
           valueSchema: nonConstValue,
           keySchema: null,
+          maxProperties: null,
+          minProperties: null,
         ).exampleValue(context)?.canBeConst,
         isFalse,
       );

--- a/test/render/tree_visitor_test.dart
+++ b/test/render/tree_visitor_test.dart
@@ -186,6 +186,8 @@ void main() {
         ),
         valueSchema: value,
         keySchema: keyEnum,
+        maxProperties: null,
+        minProperties: null,
       );
       final outer = _object('Outer', properties: {'map': map});
 

--- a/test/resolver_test.dart
+++ b/test/resolver_test.dart
@@ -2408,6 +2408,8 @@ void main() {
             type: PodType.boolean,
           ),
           keySchema: null,
+          maxProperties: null,
+          minProperties: null,
         );
         testCopyWith(schema, (schema, copy) {
           expect(copy.valueSchema, equals(schema.valueSchema));


### PR DESCRIPTION
## Summary

`maxProperties`/`minProperties` were parsed then discarded
(`_ignored` in `parser.dart`), dropping a real constraint on
**map-shaped** schemas (`type: object` + `additionalProperties`, no
fixed `properties`) — a `-v` regen tallies 49 sites in discord and 3 in
github. For a `Map<String, T>` the entry count is dynamic, so these are
the map analog of an array's `maxItems`/`minItems`, which we already
validate.

This threads both bounds through every layer
(`SchemaMap` → `ResolvedMap` → `RenderMap`), mirroring the existing
`maxItems`/`minItems` path, and emits a combined
`validate(minProperties: ..., maxProperties: ...)` call on the map
field. A new `ValidateMap` extension in the shipped `api_exception.dart`
enforces it via `Map.length`, matching `ValidateArray`.

On a fixed-property object the property count is static, so the
constraint carries no runtime meaning — it stays dropped-and-detail-
logged there (the resolver owns the semantics).

Generated output (optional map → `?.`, required map → `.`):

```dart
Lobby({required this.requiredMeta, this.metadata}) {
  metadata?.validate(minProperties: 1, maxProperties: 25);
  requiredMeta.validate(maxProperties: 5);
}
```

Closes #370.

## Validation

- Unit tests: parser (a map carries the bounds and is not detail-logged;
  a fixed-property object drops + detail-logs them), render
  (`RenderMap.validationCall` combines both bounds, omits the absent
  one, is null when unconstrained).
- End-to-end repro: analyze-clean, correct `?.`/`.` receiver per
  optional/required.
- Regenerated the rotation: discord (29 files) and github (8 files) now
  emit `validate(maxProperties: N)` on map fields; github, discord, and
  backstage third_party packages stay analyze-clean; the
  `minProperties: 1` model's generated round-trip test passes (the
  single-entry map example satisfies the bound).
